### PR TITLE
feat: add CI workflow for frontend and backend checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,117 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-frontend:
+    name: Check Frontend (TypeScript, Svelte)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run check
+
+      - name: Build
+        run: bun run build
+
+  check-backend:
+    name: Check Backend (Rust, Clippy, Format)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src-tauri
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt, clippy
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Build
+        run: cargo build
+
+  build-tauri:
+    name: Build App (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: [check-frontend, check-backend]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install system dependencies (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build Tauri app
+        run: bun run tauri build
+
+  notify-build-failure:
+    name: Notify Build Failure
+    runs-on: ubuntu-latest
+    needs: [build-tauri]
+    if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Create issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `CI: Tauri build failed on main`,
+              body: `## Build Failure\n\nThe Tauri build failed on the main branch.\n\n**Commit:** ${context.sha}\n**Run:** ${runUrl}\n\nPlease investigate and fix the issue.`,
+              labels: ['bug', 'ci']
+            });


### PR DESCRIPTION
## Summary

This pull request introduces a comprehensive CI workflow for the Kogu project.

### Jobs

| Job | Description | Trigger |
|-----|-------------|---------|
| `check-frontend` | TypeScript type checking, Svelte build | PR, Push to main |
| `check-backend` | Rust format check, Clippy lint, cargo build | PR, Push to main |
| `build-tauri` | Cross-platform Tauri build (Ubuntu, macOS, Windows) | Push to main only |
| `notify-build-failure` | Auto-create GitHub issue on build failure | On build-tauri failure |

### Actions Used

| Action | Version | Provider |
|--------|---------|----------|
| `actions/checkout` | v4 | GitHub Official |
| `actions/github-script` | v7 | GitHub Official |
| `oven-sh/setup-bun` | v2 | Bun Official |
| `actions-rust-lang/setup-rust-toolchain` | v1 | Rust Community |

### Design Decisions

- **PR checks are lightweight**: Only static analysis and type checking run on PRs to provide fast feedback
- **Full builds on main only**: Cross-platform Tauri builds run after merge to main to detect platform-specific issues
- **Automatic issue creation**: Build failures on main trigger automatic issue creation for visibility

## Test Plan

- [x] Verify check-frontend job passes
- [x] Verify check-backend job passes
- [x] Verify build-tauri job triggers only on main push
- [ ] Verify notify-build-failure creates issue on failure