### PR TITLE
chore: add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: bun
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: cargo
+    directory: /src-tauri
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "deps"


### PR DESCRIPTION
## Summary

Configure Dependabot for automated dependency version updates.

### Configuration

| Ecosystem | Directory | Schedule | Commit Prefix |
|-----------|-----------|----------|---------------|
| GitHub Actions | `/` | Weekly (Monday) | `ci:` |
| Bun | `/` | Weekly (Monday) | `deps:` |
| Cargo | `/src-tauri` | Weekly (Monday) | `deps:` |

### Features

- **Weekly updates**: All ecosystems checked every Monday
- **Conventional Commits**: Prefixes align with project commit conventions
- **Native Bun support**: Uses `bun` ecosystem (requires Bun >= 1.2.5)

### Reference

- [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference)

## Test Plan

- [ ] Verify Dependabot is enabled after merge
- [ ] Verify PRs are created on next scheduled run