### PR TITLE
feat: add application settings with font customization and window state persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ Currently not supported for privileged scanning. Use TCP Connect and other unpri
 
 See [docs/network-scanner/troubleshooting.md](docs/network-scanner/troubleshooting.md) for common issues and solutions.
 
+## Settings
+
+Kogu stores user preferences (fonts, window state) as TOML in the platform-specific application config directory. The exact path is shown at the bottom of the **Settings** page.
+
+| Platform | Settings file location                                                   |
+| -------- | ------------------------------------------------------------------------ |
+| macOS    | `~/Library/Application Support/io.github.seijikohara.kogu/settings.toml` |
+| Windows  | `%APPDATA%\io.github.seijikohara.kogu\settings.toml`                     |
+| Linux    | `~/.config/io.github.seijikohara.kogu/settings.toml`                     |
+
+Window position and size are stored in the same directory as `.window-state.json`.
+
+If `settings.toml` becomes corrupt, Kogu backs it up as `settings.bak` and starts with defaults. To reset all preferences manually, use **Settings → Reset All Settings**, or on macOS the **Kogu → Reset All Settings...** menu.
+
 ## Development
 
 ### Prerequisites

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@tauri-apps/plugin-fs": "^2.5.0",
         "@tauri-apps/plugin-opener": "^2.5.3",
         "@tauri-apps/plugin-os": "^2.3.2",
+        "@tauri-apps/plugin-window-state": "^2",
         "@tiptap/core": "^3.22.4",
         "@tiptap/extension-mention": "^3.22.4",
         "@tiptap/extension-subscript": "^3.22.4",
@@ -302,6 +303,8 @@
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ=="],
 
     "@tauri-apps/plugin-os": ["@tauri-apps/plugin-os@2.3.2", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A=="],
+
+    "@tauri-apps/plugin-window-state": ["@tauri-apps/plugin-window-state@2.4.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-OuvdrzyY8Q5Dbzpj+GcrnV1iCeoZbcFdzMjanZMMcAEUNy/6PH5pxZPXpaZLOR7whlzXiuzx0L9EKZbH7zpdRw=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 		"@tauri-apps/plugin-fs": "^2.5.0",
 		"@tauri-apps/plugin-opener": "^2.5.3",
 		"@tauri-apps/plugin-os": "^2.3.2",
+		"@tauri-apps/plugin-window-state": "^2",
 		"@tiptap/core": "^3.22.4",
 		"@tiptap/extension-mention": "^3.22.4",
 		"@tiptap/extension-subscript": "^3.22.4",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1041,6 +1041,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-text"
+version = "20.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
+dependencies = [
+ "core-foundation 0.9.4",
+ "core-graphics 0.23.2",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1499,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "dlopen2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,6 +1617,18 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dwrote"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b35532432acc8b19ceed096e35dfa088d3ea037fe4f3c085f1f97f33b4d02"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "winapi",
+ "wio",
+]
 
 [[package]]
 name = "dyn-clone"
@@ -1904,6 +1937,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-ord"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1931,6 +1970,31 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-kit"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c7e611d49285d4c4b2e1727b72cf05353558885cc5252f93707b845dfcaf3d3"
+dependencies = [
+ "bitflags 2.11.1",
+ "byteorder",
+ "core-foundation 0.9.4",
+ "core-graphics 0.23.2",
+ "core-text",
+ "dirs",
+ "dwrote",
+ "float-ord",
+ "freetype-sys",
+ "lazy_static",
+ "libc",
+ "log",
+ "pathfinder_geometry",
+ "pathfinder_simd",
+ "walkdir",
+ "winapi",
+ "yeslogic-fontconfig-sys",
+]
 
 [[package]]
 name = "foreign-types"
@@ -1976,6 +2040,17 @@ checksum = "db9c27b72f19a99a895f8ca89e2d26e4ef31013376e56fdafef697627306c3e4"
 dependencies = [
  "nom 7.1.3",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "freetype-sys"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3210,10 +3285,11 @@ dependencies = [
 
 [[package]]
 name = "kogu"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "bcrypt",
  "dns-lookup",
+ "font-kit",
  "futures",
  "hickory-resolver",
  "if-addrs",
@@ -3247,9 +3323,11 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-shell",
+ "tauri-plugin-window-state",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
+ "toml 0.8.2",
  "uuid",
  "x509-parser",
  "yaml-rust2",
@@ -4495,6 +4573,25 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pathfinder_geometry"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b7e7b4ea703700ce73ebf128e1450eb69c3a8329199ffbfb9b2a0418e5ad3"
+dependencies = [
+ "log",
+ "pathfinder_simd",
+]
+
+[[package]]
+name = "pathfinder_simd"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
+dependencies = [
+ "rustc_version",
+]
 
 [[package]]
 name = "pbkdf2"
@@ -7035,6 +7132,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.11.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8685,6 +8797,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wio"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8931,6 +9052,17 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink",
+]
+
+[[package]]
+name = "yeslogic-fontconfig-sys"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd"
+dependencies = [
+ "dlib",
+ "once_cell",
+ "pkg-config",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,6 +48,11 @@ tauri-plugin-mcp-bridge = "0.11.0"
 tauri-plugin-dialog = "2.7.0"
 tauri-plugin-fs = "2.5.0"
 tauri-plugin-shell = "2"
+tauri-plugin-window-state = "2"
+
+# Settings
+toml = "0.8"
+font-kit = "0.14"
 
 # Async Runtime (for cancellable operations and network)
 tokio = { version = "1", features = ["sync", "net", "time", "rt", "macros"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -39,6 +39,9 @@
 				{ "name": "getcap", "cmd": "getcap", "args": true }
 			]
 		},
-		"shell:allow-kill"
+		"shell:allow-kill",
+		"window-state:allow-restore-state",
+		"window-state:allow-save-window-state",
+		"dialog:allow-confirm"
 	]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -489,6 +489,7 @@ pub fn run() {
             settings::update_settings,
             settings::reset_settings,
             settings::get_system_fonts,
+            settings::get_monospace_system_fonts,
             settings::get_settings_file_path,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1,0 +1,81 @@
+//! Native macOS application menu
+//!
+//! Creates a standard macOS menu bar with an app menu containing "Reset All Settings..."
+//! and standard Edit/View/Window submenus.
+//!
+//! On Windows and Linux, no native menu is created because the overlay titlebar
+//! conflicts with the native menu bar. Reset is available via the settings page
+//! and command palette on those platforms.
+
+use tauri::menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
+use tauri::Manager;
+
+/// Custom menu item ID for the "Reset All Settings" action
+pub const RESET_ALL_SETTINGS_ID: &str = "reset_all_settings";
+
+/// Build the native macOS application menu
+pub fn build(
+    app: &tauri::App,
+) -> Result<tauri::menu::Menu<tauri::Wry>, Box<dyn std::error::Error>> {
+    // Custom "Reset All Settings..." menu item
+    let reset_item =
+        MenuItemBuilder::with_id(RESET_ALL_SETTINGS_ID, "Reset All Settings...").build(app)?;
+
+    // App menu (Kogu) — first submenu becomes the app menu on macOS
+    let app_menu = SubmenuBuilder::new(app, "Kogu")
+        .about(None)
+        .separator()
+        .item(&reset_item)
+        .separator()
+        .services()
+        .separator()
+        .hide()
+        .item(&PredefinedMenuItem::hide_others(app, None)?)
+        .item(&PredefinedMenuItem::show_all(app, None)?)
+        .separator()
+        .quit()
+        .build()?;
+
+    // Edit menu
+    let edit_menu = SubmenuBuilder::new(app, "Edit")
+        .undo()
+        .redo()
+        .separator()
+        .cut()
+        .copy()
+        .paste()
+        .select_all()
+        .build()?;
+
+    // View menu
+    let view_menu = SubmenuBuilder::new(app, "View").fullscreen().build()?;
+
+    // Window menu
+    let window_menu = SubmenuBuilder::new(app, "Window")
+        .minimize()
+        .item(&PredefinedMenuItem::maximize(app, None)?)
+        .separator()
+        .close_window()
+        .build()?;
+
+    let menu = MenuBuilder::new(app)
+        .item(&app_menu)
+        .item(&edit_menu)
+        .item(&view_menu)
+        .item(&window_menu)
+        .build()?;
+
+    Ok(menu)
+}
+
+/// Set up menu event handler for custom menu items
+pub fn setup_event_handler(app: &tauri::App) {
+    app.on_menu_event(move |app_handle, event| {
+        if event.id().0 == RESET_ALL_SETTINGS_ID {
+            if let Some(window) = app_handle.get_webview_window("main") {
+                use tauri::Emitter;
+                let _ = window.emit("menu-reset-settings", ());
+            }
+        }
+    });
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,0 +1,364 @@
+//! Application settings persistence (TOML-based)
+//!
+//! Settings are stored as a TOML file in the platform-specific config directory:
+//! - macOS: `~/Library/Application Support/io.github.seijikohara.kogu/settings.toml`
+//! - Windows: `%APPDATA%/io.github.seijikohara.kogu/settings.toml`
+//! - Linux: `~/.config/io.github.seijikohara.kogu/settings.toml`
+//!
+//! ## Adding a new settings category
+//!
+//! 1. Define a new sub-struct (e.g., `EditorSettings`) with `Default` impl
+//! 2. Add a field to `AppSettings` with `#[serde(default)]`
+//! 3. Existing TOML files will automatically use defaults for the new section
+
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+use serde::{Deserialize, Serialize};
+
+const SETTINGS_FILENAME: &str = "settings.toml";
+const BACKUP_EXTENSION: &str = "bak";
+
+// =============================================================================
+// Settings Types (section-based, extensible)
+// =============================================================================
+
+/// Top-level application settings.
+///
+/// Each field corresponds to one TOML section. New categories are added
+/// by defining a sub-struct and adding a `#[serde(default)]` field here.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AppSettings {
+    /// Font configuration
+    #[serde(default)]
+    pub font: FontSettings,
+}
+
+/// Font family and size preferences
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FontSettings {
+    /// UI font family (empty string = system default)
+    #[serde(default)]
+    pub ui_family: String,
+    /// Code/monospace font family (empty string = system default)
+    #[serde(default)]
+    pub code_family: String,
+    /// UI font size in pixels (10-24)
+    #[serde(default = "default_ui_size")]
+    pub ui_size: u32,
+    /// Code font size in pixels (10-24)
+    #[serde(default = "default_code_size")]
+    pub code_size: u32,
+}
+
+impl Default for FontSettings {
+    fn default() -> Self {
+        Self {
+            ui_family: String::new(),
+            code_family: String::new(),
+            ui_size: default_ui_size(),
+            code_size: default_code_size(),
+        }
+    }
+}
+
+const fn default_ui_size() -> u32 {
+    13
+}
+
+const fn default_code_size() -> u32 {
+    13
+}
+
+// =============================================================================
+// Settings State (thread-safe, managed by Tauri)
+// =============================================================================
+
+/// Thread-safe settings state managed via Tauri's `.manage()`
+pub struct SettingsState {
+    settings: Mutex<AppSettings>,
+    file_path: PathBuf,
+}
+
+impl SettingsState {
+    /// Create a new `SettingsState` by loading from the config directory.
+    ///
+    /// If the file is missing, returns defaults.
+    /// If the file is corrupt, backs it up as `.bak` and returns defaults.
+    pub fn load(config_dir: &std::path::Path) -> Self {
+        let file_path = config_dir.join(SETTINGS_FILENAME);
+        let settings = load_from_file(&file_path);
+
+        Self {
+            settings: Mutex::new(settings),
+            file_path,
+        }
+    }
+
+    /// Get the current settings file path
+    pub fn file_path(&self) -> &std::path::Path {
+        &self.file_path
+    }
+}
+
+/// Load settings from a TOML file, returning defaults on any error
+fn load_from_file(path: &std::path::Path) -> AppSettings {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return AppSettings::default();
+    };
+
+    toml::from_str::<AppSettings>(&content).unwrap_or_else(|_| {
+        // Back up the corrupt file
+        let backup = path.with_extension(BACKUP_EXTENSION);
+        let _ = std::fs::copy(path, backup);
+        AppSettings::default()
+    })
+}
+
+/// Save settings to a TOML file
+fn save_to_file(path: &std::path::Path, settings: &AppSettings) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create config directory: {e}"))?;
+    }
+
+    let content = toml::to_string_pretty(settings)
+        .map_err(|e| format!("Failed to serialize settings: {e}"))?;
+
+    std::fs::write(path, content).map_err(|e| format!("Failed to write settings file: {e}"))
+}
+
+// =============================================================================
+// Font Enumeration (cached)
+// =============================================================================
+
+/// Global cache for system font families (fonts don't change at runtime)
+static SYSTEM_FONTS: OnceLock<Vec<String>> = OnceLock::new();
+
+/// Enumerate all system font families, sorted alphabetically.
+/// Results are cached after the first call.
+fn enumerate_system_fonts() -> &'static [String] {
+    SYSTEM_FONTS.get_or_init(|| {
+        let source = font_kit::source::SystemSource::new();
+        let mut families = source.all_families().unwrap_or_default();
+        families.sort_unstable_by_key(|a| a.to_lowercase());
+        families.dedup();
+        families
+    })
+}
+
+// =============================================================================
+// Tauri Commands
+// =============================================================================
+
+/// Get the current application settings
+#[tauri::command]
+pub fn get_settings(state: tauri::State<'_, SettingsState>) -> Result<AppSettings, String> {
+    let settings = state
+        .settings
+        .lock()
+        .map_err(|e| format!("Settings lock poisoned: {e}"))?;
+    Ok(settings.clone())
+}
+
+/// Update application settings (auto-saves to disk)
+#[tauri::command]
+pub fn update_settings(
+    settings: AppSettings,
+    state: tauri::State<'_, SettingsState>,
+) -> Result<(), String> {
+    save_to_file(&state.file_path, &settings)?;
+
+    *state
+        .settings
+        .lock()
+        .map_err(|e| format!("Settings lock poisoned: {e}"))? = settings;
+
+    Ok(())
+}
+
+/// Reset all settings to defaults, delete the settings file, and resize window
+#[tauri::command]
+pub fn reset_settings(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, SettingsState>,
+) -> Result<AppSettings, String> {
+    use tauri::Manager;
+
+    // Delete the settings file
+    if state.file_path.exists() {
+        let _ = std::fs::remove_file(&state.file_path);
+    }
+
+    // Reset in-memory settings
+    let defaults = AppSettings::default();
+    {
+        let mut current = state
+            .settings
+            .lock()
+            .map_err(|e| format!("Settings lock poisoned: {e}"))?;
+        *current = defaults.clone();
+    }
+
+    // Reset window to default size and center
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.set_size(tauri::LogicalSize::new(1200.0, 800.0));
+        let _ = window.center();
+    }
+
+    Ok(defaults)
+}
+
+/// Get all available system font families (sorted, cached)
+#[tauri::command]
+pub fn get_system_fonts() -> Vec<String> {
+    enumerate_system_fonts().to_vec()
+}
+
+/// Get the settings file path (for display in the settings page)
+#[tauri::command]
+pub fn get_settings_file_path(state: tauri::State<'_, SettingsState>) -> String {
+    state.file_path().display().to_string()
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn test_default_settings() {
+        let settings = AppSettings::default();
+        assert!(settings.font.ui_family.is_empty());
+        assert!(settings.font.code_family.is_empty());
+        assert_eq!(settings.font.ui_size, 13);
+        assert_eq!(settings.font.code_size, 13);
+    }
+
+    #[test]
+    fn test_serialize_deserialize_roundtrip() {
+        let settings = AppSettings {
+            font: FontSettings {
+                ui_family: "Inter".to_string(),
+                code_family: "JetBrains Mono".to_string(),
+                ui_size: 14,
+                code_size: 12,
+            },
+        };
+
+        let toml_str = toml::to_string_pretty(&settings).unwrap();
+        let deserialized: AppSettings = toml::from_str(&toml_str).unwrap();
+
+        assert_eq!(deserialized.font.ui_family, "Inter");
+        assert_eq!(deserialized.font.code_family, "JetBrains Mono");
+        assert_eq!(deserialized.font.ui_size, 14);
+        assert_eq!(deserialized.font.code_size, 12);
+    }
+
+    #[test]
+    fn test_deserialize_empty_toml() {
+        let settings: AppSettings = toml::from_str("").unwrap();
+        assert!(settings.font.ui_family.is_empty());
+        assert_eq!(settings.font.ui_size, 13);
+    }
+
+    #[test]
+    fn test_deserialize_partial_toml() {
+        let toml_str = r#"
+[font]
+ui_family = "Helvetica"
+"#;
+        let settings: AppSettings = toml::from_str(toml_str).unwrap();
+        assert_eq!(settings.font.ui_family, "Helvetica");
+        assert!(settings.font.code_family.is_empty());
+        assert_eq!(settings.font.ui_size, 13);
+    }
+
+    #[test]
+    fn test_deserialize_unknown_section() {
+        // Future sections in TOML should not break deserialization
+        let toml_str = r#"
+[font]
+ui_family = "Inter"
+
+[unknown_section]
+key = "value"
+"#;
+        let settings: AppSettings = toml::from_str(toml_str).unwrap();
+        assert_eq!(settings.font.ui_family, "Inter");
+    }
+
+    #[test]
+    fn test_load_missing_file() {
+        let settings = load_from_file(Path::new("/nonexistent/path/settings.toml"));
+        assert!(settings.font.ui_family.is_empty());
+        assert_eq!(settings.font.ui_size, 13);
+    }
+
+    #[test]
+    fn test_save_and_load() {
+        let dir = std::env::temp_dir().join("kogu-test-settings");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("test-settings.toml");
+
+        let settings = AppSettings {
+            font: FontSettings {
+                ui_family: "Arial".to_string(),
+                code_family: "Consolas".to_string(),
+                ui_size: 15,
+                code_size: 11,
+            },
+        };
+
+        save_to_file(&path, &settings).unwrap();
+        let loaded = load_from_file(&path);
+
+        assert_eq!(loaded.font.ui_family, "Arial");
+        assert_eq!(loaded.font.code_family, "Consolas");
+        assert_eq!(loaded.font.ui_size, 15);
+        assert_eq!(loaded.font.code_size, 11);
+
+        // Cleanup
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn test_corrupt_file_creates_backup() {
+        let dir = std::env::temp_dir().join("kogu-test-corrupt");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("corrupt.toml");
+        let backup = dir.join("corrupt.bak");
+
+        std::fs::write(&path, "this is not valid toml [[[").unwrap();
+
+        let settings = load_from_file(&path);
+        assert!(settings.font.ui_family.is_empty()); // defaults
+        assert!(backup.exists()); // backup created
+
+        // Cleanup
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&backup);
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn test_system_fonts_enumeration() {
+        let fonts = enumerate_system_fonts();
+        // System should have at least some fonts
+        assert!(!fonts.is_empty());
+        // Should be sorted (case-insensitive)
+        for window in fonts.windows(2) {
+            assert!(
+                window[0].to_lowercase() <= window[1].to_lowercase(),
+                "Fonts not sorted: {} > {}",
+                window[0],
+                window[1]
+            );
+        }
+    }
+}

--- a/src/app.css
+++ b/src/app.css
@@ -270,7 +270,8 @@
 	}
 	body {
 		@apply bg-background text-foreground;
-		font-family:
+		font-family: var(
+			--font-ui,
 			system-ui,
 			-apple-system,
 			BlinkMacSystemFont,
@@ -283,7 +284,25 @@
 			'Droid Sans',
 			'Helvetica Neue',
 			Arial,
-			sans-serif;
+			sans-serif
+		);
+		font-size: var(--font-size-ui, 0.8125rem);
+	}
+	code,
+	pre,
+	.cm-editor .cm-content,
+	.cm-editor .cm-gutters {
+		font-family: var(
+			--font-code,
+			ui-monospace,
+			SFMono-Regular,
+			'SF Mono',
+			Menlo,
+			Consolas,
+			'Liberation Mono',
+			monospace
+		);
+		font-size: var(--font-size-code, 0.8125rem);
 	}
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -218,13 +218,6 @@
 	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-ring: var(--sidebar-ring);
-	/* Typography scale (1.125 modular scale) */
-	--font-size-2xs: 0.6875rem;
-	--font-size-2xs--line-height: 1rem;
-	--font-size-xs: 0.75rem;
-	--font-size-xs--line-height: 1.125rem;
-	--font-size-sm: 0.8125rem;
-	--font-size-sm--line-height: 1.25rem;
 	/* Line heights */
 	--line-height-tight: 1.25;
 	--line-height-snug: 1.375;
@@ -262,6 +255,23 @@
 	--animate-slide-in: slide-in 150ms ease-out;
 	--animate-slide-up: slide-up 180ms var(--ease-standard);
 	--animate-scale-in: scale-in 150ms var(--ease-standard);
+}
+
+/*
+ * Typography scale (1.125 modular scale).
+ *
+ * Defined without `inline` so Tailwind emits `font-size: var(--text-xs)` etc.
+ * in the generated utilities instead of the literal values. This allows the
+ * settings service to override text sizes at runtime by setting these custom
+ * properties on :root.
+ */
+@theme {
+	--text-2xs: 0.6875rem;
+	--text-2xs--line-height: 1rem;
+	--text-xs: 0.75rem;
+	--text-xs--line-height: 1.125rem;
+	--text-sm: 0.8125rem;
+	--text-sm--line-height: 1.25rem;
 }
 
 @layer base {

--- a/src/lib/components/layout/app-sidebar.svelte
+++ b/src/lib/components/layout/app-sidebar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ChevronLeft, ChevronRight, Monitor, Moon, Sun } from '@lucide/svelte';
+	import { ChevronLeft, ChevronRight, Monitor, Moon, Settings, Sun } from '@lucide/svelte';
 	import { mode, toggleMode } from 'mode-watcher';
 	import { page } from '$app/state';
 	import * as Collapsible from '$lib/components/ui/collapsible/index.js';
@@ -86,9 +86,19 @@
 		{/each}
 	</Sidebar.Content>
 
-	<!-- Footer with Theme Toggle and Collapse Button -->
+	<!-- Footer with Settings, Theme Toggle and Collapse Button -->
 	<Sidebar.Footer class="border-t border-sidebar-border py-1.5">
 		<Sidebar.Menu>
+			<Sidebar.MenuItem>
+				<Sidebar.MenuButton isActive={page.url.pathname === '/settings'} tooltipContent="Settings">
+					{#snippet child({ props })}
+						<a href="/settings" {...props}>
+							<Settings class="size-4" />
+							<span>Settings</span>
+						</a>
+					{/snippet}
+				</Sidebar.MenuButton>
+			</Sidebar.MenuItem>
 			<Sidebar.MenuItem>
 				<Sidebar.MenuButton onclick={toggleMode} tooltipContent="Toggle theme">
 					{#if mode.current === 'dark'}

--- a/src/lib/components/layout/command-palette.svelte
+++ b/src/lib/components/layout/command-palette.svelte
@@ -38,6 +38,24 @@
 		<Command.Separator />
 		<Command.Group heading="Actions">
 			<Command.Item
+				value="Settings"
+				onSelect={() => {
+					open = false;
+					goto('/settings');
+				}}
+			>
+				<span>Settings</span>
+			</Command.Item>
+			<Command.Item
+				value="Reset All Settings"
+				onSelect={() => {
+					open = false;
+					window.dispatchEvent(new CustomEvent('reset-all-settings'));
+				}}
+			>
+				<span>Reset All Settings</span>
+			</Command.Item>
+			<Command.Item
 				value="Keyboard shortcuts"
 				onSelect={() => {
 					open = false;

--- a/src/lib/services/google-fonts.ts
+++ b/src/lib/services/google-fonts.ts
@@ -1,0 +1,83 @@
+/**
+ * Google Fonts catalog and dynamic loader.
+ *
+ * Provides a curated list of popular Google Fonts and functions to
+ * dynamically load/unload them via `<link>` elements.
+ */
+
+// =============================================================================
+// Types & Catalog
+// =============================================================================
+
+export interface GoogleFont {
+	readonly name: string;
+	readonly category: 'sans-serif' | 'serif' | 'monospace';
+}
+
+/** Curated list of popular Google Fonts */
+export const GOOGLE_FONTS: readonly GoogleFont[] = [
+	// Sans-serif (UI)
+	{ name: 'DM Sans', category: 'sans-serif' },
+	{ name: 'Inter', category: 'sans-serif' },
+	{ name: 'Lato', category: 'sans-serif' },
+	{ name: 'Noto Sans', category: 'sans-serif' },
+	{ name: 'Noto Sans JP', category: 'sans-serif' },
+	{ name: 'Open Sans', category: 'sans-serif' },
+	{ name: 'Plus Jakarta Sans', category: 'sans-serif' },
+	{ name: 'Poppins', category: 'sans-serif' },
+	{ name: 'Roboto', category: 'sans-serif' },
+	{ name: 'Work Sans', category: 'sans-serif' },
+	// Monospace (Code)
+	{ name: 'DM Mono', category: 'monospace' },
+	{ name: 'Fira Code', category: 'monospace' },
+	{ name: 'IBM Plex Mono', category: 'monospace' },
+	{ name: 'Inconsolata', category: 'monospace' },
+	{ name: 'JetBrains Mono', category: 'monospace' },
+	{ name: 'Noto Sans Mono', category: 'monospace' },
+	{ name: 'Roboto Mono', category: 'monospace' },
+	{ name: 'Source Code Pro', category: 'monospace' },
+	{ name: 'Space Mono', category: 'monospace' },
+	{ name: 'Ubuntu Mono', category: 'monospace' },
+] as const;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Get Google Fonts filtered by category */
+export const getGoogleFontsByCategory = (category: GoogleFont['category']): readonly GoogleFont[] =>
+	GOOGLE_FONTS.filter((f) => f.category === category);
+
+/** Check if a font name is in the Google Fonts catalog */
+export const isGoogleFont = (name: string): boolean => GOOGLE_FONTS.some((f) => f.name === name);
+
+// =============================================================================
+// Dynamic Loading
+// =============================================================================
+
+const LINK_ID_PREFIX = 'google-font-';
+
+/** Build the link element ID for a font family */
+const buildLinkId = (family: string): string =>
+	`${LINK_ID_PREFIX}${family.replace(/\s+/g, '-').toLowerCase()}`;
+
+/** Load a Google Font via a `<link>` element. No-op if already loaded. */
+export const loadGoogleFont = (family: string, weights: number[] = [400, 500, 600, 700]): void => {
+	const id = buildLinkId(family);
+	if (document.getElementById(id)) return;
+
+	const encoded = family.replace(/\s+/g, '+');
+	const weightStr = weights.join(';');
+	const url = `https://fonts.googleapis.com/css2?family=${encoded}:wght@${weightStr}&display=swap`;
+
+	const link = document.createElement('link');
+	link.id = id;
+	link.rel = 'stylesheet';
+	link.href = url;
+	document.head.appendChild(link);
+};
+
+/** Unload all dynamically loaded Google Font `<link>` elements */
+export const unloadAllGoogleFonts = (): void => {
+	document.querySelectorAll(`link[id^="${LINK_ID_PREFIX}"]`).forEach((el) => el.remove());
+};

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -27,6 +27,7 @@ import {
 	Play,
 	Radar,
 	Search,
+	Settings,
 	Shield,
 	ShieldCheck,
 	Sparkles,
@@ -237,6 +238,13 @@ export const PAGES: readonly PageDefinition[] = [
 		color: 'text-rose-500',
 		category: 'network',
 	},
+	{
+		id: 'settings',
+		title: 'Settings',
+		url: '/settings',
+		icon: Settings,
+		description: 'Configure application preferences',
+	},
 ];
 
 /**
@@ -255,7 +263,7 @@ export const getPageByUrl = (url: string): PageDefinition | undefined =>
  * Get all tool pages (excluding dashboard).
  */
 export const getToolPages = (): readonly PageDefinition[] =>
-	PAGES.filter((page) => page.id !== 'dashboard');
+	PAGES.filter((page) => page.id !== 'dashboard' && page.id !== 'settings');
 
 /**
  * Get pages by category.

--- a/src/lib/services/settings.ts
+++ b/src/lib/services/settings.ts
@@ -1,0 +1,118 @@
+/**
+ * Application settings service
+ *
+ * Provides types, invoke wrappers, and CSS custom property application
+ * for the TOML-based settings system.
+ *
+ * ## Adding a new settings category
+ *
+ * 1. Define a new sub-interface (e.g., `EditorSettings`)
+ * 2. Add it to `AppSettings` with a default value in `DEFAULT_SETTINGS`
+ * 3. If the category affects the UI, add an `applyXxxSettings()` function
+ *    and call it from `applyAllSettings()`
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+
+// =============================================================================
+// Types (mirrors Rust settings.rs)
+// =============================================================================
+
+export interface FontSettings {
+	/** UI font family (empty = system default) */
+	readonly ui_family: string;
+	/** Code/monospace font family (empty = system default) */
+	readonly code_family: string;
+	/** UI font size in pixels (10-24) */
+	readonly ui_size: number;
+	/** Code font size in pixels (10-24) */
+	readonly code_size: number;
+}
+
+export interface AppSettings {
+	/** Font configuration */
+	readonly font: FontSettings;
+}
+
+export const DEFAULT_FONT_SETTINGS: FontSettings = {
+	ui_family: '',
+	code_family: '',
+	ui_size: 13,
+	code_size: 13,
+} as const;
+
+export const DEFAULT_SETTINGS: AppSettings = {
+	font: DEFAULT_FONT_SETTINGS,
+} as const;
+
+// =============================================================================
+// Tauri Invoke Wrappers
+// =============================================================================
+
+/** Get the current application settings from the backend */
+export const getSettings = (): Promise<AppSettings> => invoke<AppSettings>('get_settings');
+
+/** Update application settings (auto-saves to disk) */
+export const updateSettings = (settings: AppSettings): Promise<void> =>
+	invoke<void>('update_settings', { settings });
+
+/** Reset all settings to defaults, delete settings file, and resize window */
+export const resetSettings = (): Promise<AppSettings> => invoke<AppSettings>('reset_settings');
+
+/** Get all available system font families (sorted, cached) */
+export const getSystemFonts = (): Promise<string[]> => invoke<string[]>('get_system_fonts');
+
+/** Get the settings file path (for display in settings page) */
+export const getSettingsFilePath = (): Promise<string> => invoke<string>('get_settings_file_path');
+
+// =============================================================================
+// CSS Custom Property Application
+// =============================================================================
+
+const SYSTEM_UI_FALLBACK =
+	"system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif";
+const MONOSPACE_FALLBACK =
+	"ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace";
+
+/** Apply font settings to the document via CSS custom properties */
+export const applyFontSettings = (font: FontSettings): void => {
+	const root = document.documentElement.style;
+
+	// UI font family
+	if (font.ui_family) {
+		root.setProperty('--font-ui', `"${font.ui_family}", ${SYSTEM_UI_FALLBACK}`);
+	} else {
+		root.removeProperty('--font-ui');
+	}
+
+	// Code font family
+	if (font.code_family) {
+		root.setProperty('--font-code', `"${font.code_family}", ${MONOSPACE_FALLBACK}`);
+	} else {
+		root.removeProperty('--font-code');
+	}
+
+	// Font sizes
+	if (font.ui_size && font.ui_size !== DEFAULT_FONT_SETTINGS.ui_size) {
+		root.setProperty('--font-size-ui', `${font.ui_size}px`);
+	} else {
+		root.removeProperty('--font-size-ui');
+	}
+
+	if (font.code_size && font.code_size !== DEFAULT_FONT_SETTINGS.code_size) {
+		root.setProperty('--font-size-code', `${font.code_size}px`);
+	} else {
+		root.removeProperty('--font-size-code');
+	}
+};
+
+/**
+ * Apply all visual settings at once.
+ *
+ * Single entry point for applying settings at startup, after reset,
+ * or when settings change. New visual categories should add their
+ * `applyXxxSettings()` call here.
+ */
+export const applyAllSettings = (settings: AppSettings): void => {
+	applyFontSettings(settings.font);
+};

--- a/src/lib/services/settings.ts
+++ b/src/lib/services/settings.ts
@@ -82,6 +82,38 @@ const SYSTEM_UI_FALLBACK =
 const MONOSPACE_FALLBACK =
 	"ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace";
 
+/**
+ * Tailwind v4 typography scale tokens consumed by the `text-*` utilities.
+ *
+ * Base values (in px) mirror the defaults declared in `app.css @theme inline`:
+ * - `--text-sm` = 0.8125rem (13 px) is the body text baseline
+ * - `--text-xs` = 0.75rem (12 px)
+ * - `--text-2xs` = 0.6875rem (11 px)
+ *
+ * These utilities (`text-sm`, `text-xs`, `text-2xs`) are used throughout the UI,
+ * so we scale them proportionally when the user changes the UI font size.
+ */
+const TYPOGRAPHY_SCALE = [
+	{
+		size: '--text-sm',
+		sizeBase: 13,
+		lineHeight: '--text-sm--line-height',
+		lineHeightBase: 20,
+	},
+	{
+		size: '--text-xs',
+		sizeBase: 12,
+		lineHeight: '--text-xs--line-height',
+		lineHeightBase: 18,
+	},
+	{
+		size: '--text-2xs',
+		sizeBase: 11,
+		lineHeight: '--text-2xs--line-height',
+		lineHeightBase: 16,
+	},
+] as const;
+
 /** Apply font settings to the document via CSS custom properties */
 export const applyFontSettings = (font: FontSettings): void => {
 	const root = document.documentElement.style;
@@ -94,27 +126,45 @@ export const applyFontSettings = (font: FontSettings): void => {
 		unloadAllGoogleFonts();
 	}
 
-	// UI font family
+	// UI font family: applies to body (--font-ui) and Tailwind `font-sans` utility (--font-sans)
 	if (font.ui_family) {
-		root.setProperty('--font-ui', `"${font.ui_family}", ${SYSTEM_UI_FALLBACK}`);
+		const value = `"${font.ui_family}", ${SYSTEM_UI_FALLBACK}`;
+		root.setProperty('--font-ui', value);
+		root.setProperty('--font-sans', value);
 	} else {
 		root.removeProperty('--font-ui');
+		root.removeProperty('--font-sans');
 	}
 
-	// Code font family
+	// Code font family: applies to code/pre/.cm-editor (--font-code) and
+	// Tailwind `font-mono` utility (--font-mono)
 	if (font.code_family) {
-		root.setProperty('--font-code', `"${font.code_family}", ${MONOSPACE_FALLBACK}`);
+		const value = `"${font.code_family}", ${MONOSPACE_FALLBACK}`;
+		root.setProperty('--font-code', value);
+		root.setProperty('--font-mono', value);
 	} else {
 		root.removeProperty('--font-code');
+		root.removeProperty('--font-mono');
 	}
 
-	// Font sizes
+	// UI font size: scale Tailwind typography tokens so `text-sm/xs/2xs` utilities
+	// reflect the user's UI size across the entire app, not just the body baseline.
 	if (font.ui_size && font.ui_size !== DEFAULT_FONT_SETTINGS.ui_size) {
+		const scale = font.ui_size / DEFAULT_FONT_SETTINGS.ui_size;
 		root.setProperty('--font-size-ui', `${font.ui_size}px`);
+		TYPOGRAPHY_SCALE.forEach(({ size, sizeBase, lineHeight, lineHeightBase }) => {
+			root.setProperty(size, `${sizeBase * scale}px`);
+			root.setProperty(lineHeight, `${lineHeightBase * scale}px`);
+		});
 	} else {
 		root.removeProperty('--font-size-ui');
+		TYPOGRAPHY_SCALE.forEach(({ size, lineHeight }) => {
+			root.removeProperty(size);
+			root.removeProperty(lineHeight);
+		});
 	}
 
+	// Code font size: applied to code/pre/.cm-editor only (see app.css)
 	if (font.code_size && font.code_size !== DEFAULT_FONT_SETTINGS.code_size) {
 		root.setProperty('--font-size-code', `${font.code_size}px`);
 	} else {

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,0 +1,334 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { toast } from 'svelte-sonner';
+	import { confirm } from '@tauri-apps/plugin-dialog';
+	import { Settings, Check, ChevronsUpDown, RotateCcw } from '@lucide/svelte';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import * as Popover from '$lib/components/ui/popover/index.js';
+	import * as Command from '$lib/components/ui/command/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import {
+		type AppSettings,
+		type FontSettings,
+		DEFAULT_SETTINGS,
+		getSettings,
+		getSystemFonts,
+		getSettingsFilePath,
+		updateSettings,
+		resetSettings,
+		applyAllSettings,
+	} from '$lib/services/settings.js';
+
+	// State
+	let fontSettings = $state<FontSettings>({ ...DEFAULT_SETTINGS.font });
+	let systemFonts = $state<string[]>([]);
+	let settingsFilePath = $state('');
+
+	// Combobox open states
+	let uiFontOpen = $state(false);
+	let codeFontOpen = $state(false);
+
+	// Debounce timer for auto-save
+	let saveTimer: ReturnType<typeof setTimeout> | undefined;
+
+	// Build full AppSettings from current state
+	const currentSettings = $derived<AppSettings>({
+		font: fontSettings,
+	});
+
+	// Auto-save on settings change (300ms debounce)
+	$effect(() => {
+		// Access the derived value to subscribe
+		const settings = currentSettings;
+
+		clearTimeout(saveTimer);
+		saveTimer = setTimeout(() => {
+			updateSettings(settings)
+				.then(() => applyAllSettings(settings))
+				.catch(() => toast.error('Failed to save settings'));
+		}, 300);
+	});
+
+	// Cleanup timer on unmount
+	$effect(() => {
+		return () => {
+			clearTimeout(saveTimer);
+		};
+	});
+
+	// Load settings and system fonts on mount
+	onMount(() => {
+		getSettings()
+			.then((settings) => {
+				fontSettings = { ...settings.font };
+			})
+			.catch(() => {});
+
+		getSystemFonts()
+			.then((fonts) => {
+				systemFonts = fonts;
+			})
+			.catch(() => {});
+
+		getSettingsFilePath()
+			.then((path) => {
+				settingsFilePath = path;
+			})
+			.catch(() => {});
+	});
+
+	// Reset all settings
+	const handleReset = async () => {
+		const confirmed = await confirm(
+			'This will reset all settings including fonts and window position.',
+			{
+				title: 'Reset All Settings',
+				kind: 'warning',
+				okLabel: 'Reset',
+				cancelLabel: 'Cancel',
+			}
+		);
+		if (!confirmed) return;
+
+		const defaults = await resetSettings();
+		fontSettings = { ...defaults.font };
+		applyAllSettings(defaults);
+		toast.success('All settings have been reset');
+	};
+</script>
+
+<svelte:head>
+	<title>Settings - Kogu</title>
+</svelte:head>
+
+<div class="flex h-full flex-col">
+	<main class="flex-1 overflow-y-auto p-6">
+		<div class="mx-auto max-w-2xl space-y-6">
+			<!-- Header -->
+			<div class="flex items-center gap-3">
+				<Settings class="h-6 w-6 text-muted-foreground" />
+				<h1 class="text-xl font-bold">Settings</h1>
+			</div>
+
+			<!-- Appearance Card -->
+			<Card.Root id="appearance">
+				<Card.Header>
+					<Card.Title>Appearance</Card.Title>
+					<Card.Description>Customize fonts used throughout the application</Card.Description>
+				</Card.Header>
+				<Card.Content class="space-y-6">
+					<!-- UI Font Family -->
+					<div class="space-y-1.5">
+						<Label class="text-sm font-medium">UI Font Family</Label>
+						<Popover.Root bind:open={uiFontOpen}>
+							<Popover.Trigger>
+								{#snippet child({ props })}
+									<Button variant="outline" class="w-full justify-between font-normal" {...props}>
+										<span
+											class="truncate"
+											style:font-family={fontSettings.ui_family
+												? `"${fontSettings.ui_family}"`
+												: undefined}
+										>
+											{fontSettings.ui_family || 'System Default'}
+										</span>
+										<ChevronsUpDown class="ml-2 h-4 w-4 shrink-0 opacity-50" />
+									</Button>
+								{/snippet}
+							</Popover.Trigger>
+							<Popover.Content class="w-[var(--bits-popover-anchor-width)] p-0" align="start">
+								<Command.Root>
+									<Command.Input placeholder="Search fonts..." />
+									<Command.List class="max-h-48">
+										<Command.Empty>No fonts found.</Command.Empty>
+										<Command.Group>
+											<Command.Item
+												value="System Default"
+												onSelect={() => {
+													fontSettings = { ...fontSettings, ui_family: '' };
+													uiFontOpen = false;
+												}}
+											>
+												<span>System Default</span>
+												{#if !fontSettings.ui_family}
+													<Check class="ml-auto h-4 w-4" />
+												{/if}
+											</Command.Item>
+											{#each systemFonts as font (font)}
+												<Command.Item
+													value={font}
+													onSelect={() => {
+														fontSettings = { ...fontSettings, ui_family: font };
+														uiFontOpen = false;
+													}}
+												>
+													<span style:font-family={`"${font}"`}>{font}</span>
+													{#if fontSettings.ui_family === font}
+														<Check class="ml-auto h-4 w-4" />
+													{/if}
+												</Command.Item>
+											{/each}
+										</Command.Group>
+									</Command.List>
+								</Command.Root>
+							</Popover.Content>
+						</Popover.Root>
+					</div>
+
+					<!-- UI Font Size -->
+					<div class="space-y-1.5">
+						<div class="flex items-center justify-between gap-2">
+							<Label class="text-sm font-medium">UI Font Size</Label>
+							<span class="text-sm font-medium tabular-nums">{fontSettings.ui_size}px</span>
+						</div>
+						<input
+							type="range"
+							value={fontSettings.ui_size}
+							min={10}
+							max={24}
+							step={1}
+							oninput={(e) => {
+								fontSettings = {
+									...fontSettings,
+									ui_size: Number((e.target as HTMLInputElement).value),
+								};
+							}}
+							class="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-border accent-primary"
+						/>
+					</div>
+
+					<!-- Code Font Family -->
+					<div class="space-y-1.5">
+						<Label class="text-sm font-medium">Code Font Family</Label>
+						<Popover.Root bind:open={codeFontOpen}>
+							<Popover.Trigger>
+								{#snippet child({ props })}
+									<Button variant="outline" class="w-full justify-between font-normal" {...props}>
+										<span
+											class="truncate"
+											style:font-family={fontSettings.code_family
+												? `"${fontSettings.code_family}"`
+												: undefined}
+										>
+											{fontSettings.code_family || 'System Default'}
+										</span>
+										<ChevronsUpDown class="ml-2 h-4 w-4 shrink-0 opacity-50" />
+									</Button>
+								{/snippet}
+							</Popover.Trigger>
+							<Popover.Content class="w-[var(--bits-popover-anchor-width)] p-0" align="start">
+								<Command.Root>
+									<Command.Input placeholder="Search fonts..." />
+									<Command.List class="max-h-48">
+										<Command.Empty>No fonts found.</Command.Empty>
+										<Command.Group>
+											<Command.Item
+												value="System Default"
+												onSelect={() => {
+													fontSettings = { ...fontSettings, code_family: '' };
+													codeFontOpen = false;
+												}}
+											>
+												<span>System Default</span>
+												{#if !fontSettings.code_family}
+													<Check class="ml-auto h-4 w-4" />
+												{/if}
+											</Command.Item>
+											{#each systemFonts as font (font)}
+												<Command.Item
+													value={font}
+													onSelect={() => {
+														fontSettings = { ...fontSettings, code_family: font };
+														codeFontOpen = false;
+													}}
+												>
+													<span style:font-family={`"${font}"`}>{font}</span>
+													{#if fontSettings.code_family === font}
+														<Check class="ml-auto h-4 w-4" />
+													{/if}
+												</Command.Item>
+											{/each}
+										</Command.Group>
+									</Command.List>
+								</Command.Root>
+							</Popover.Content>
+						</Popover.Root>
+					</div>
+
+					<!-- Code Font Size -->
+					<div class="space-y-1.5">
+						<div class="flex items-center justify-between gap-2">
+							<Label class="text-sm font-medium">Code Font Size</Label>
+							<span class="text-sm font-medium tabular-nums">{fontSettings.code_size}px</span>
+						</div>
+						<input
+							type="range"
+							value={fontSettings.code_size}
+							min={10}
+							max={24}
+							step={1}
+							oninput={(e) => {
+								fontSettings = {
+									...fontSettings,
+									code_size: Number((e.target as HTMLInputElement).value),
+								};
+							}}
+							class="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-border accent-primary"
+						/>
+					</div>
+
+					<!-- Preview -->
+					<div class="space-y-3 rounded-lg border border-border/60 bg-muted/30 p-4">
+						<p class="text-xs font-medium text-muted-foreground">Preview</p>
+						<p
+							style:font-family={fontSettings.ui_family
+								? `"${fontSettings.ui_family}", system-ui, sans-serif`
+								: undefined}
+							style:font-size={fontSettings.ui_size !== DEFAULT_SETTINGS.font.ui_size
+								? `${fontSettings.ui_size}px`
+								: undefined}
+						>
+							The quick brown fox jumps over the lazy dog.
+						</p>
+						<pre
+							class="rounded-md bg-muted p-2"
+							style:font-family={fontSettings.code_family
+								? `"${fontSettings.code_family}", ui-monospace, monospace`
+								: undefined}
+							style:font-size={fontSettings.code_size !== DEFAULT_SETTINGS.font.code_size
+								? `${fontSettings.code_size}px`
+								: undefined}><code>const hello = "world"; // 0123456789</code></pre>
+					</div>
+				</Card.Content>
+			</Card.Root>
+
+			<!-- Data Card -->
+			<Card.Root id="data">
+				<Card.Header>
+					<Card.Title>Data</Card.Title>
+					<Card.Description>Settings file location and reset options</Card.Description>
+				</Card.Header>
+				<Card.Content class="space-y-4">
+					{#if settingsFilePath}
+						<div class="space-y-1">
+							<Label class="text-xs text-muted-foreground">Settings file</Label>
+							<p class="rounded-md bg-muted/50 px-3 py-2 font-mono text-xs text-muted-foreground">
+								{settingsFilePath}
+							</p>
+						</div>
+					{/if}
+					<div class="space-y-2">
+						<Button variant="destructive" size="sm" onclick={handleReset}>
+							<RotateCcw class="mr-2 h-4 w-4" />
+							Reset All Settings
+						</Button>
+						<p class="text-xs text-muted-foreground">
+							Resets all preferences including fonts and window position to defaults.
+						</p>
+					</div>
+				</Card.Content>
+			</Card.Root>
+		</div>
+	</main>
+</div>


### PR DESCRIPTION
## Summary

- Add a Settings page (`/settings`) with UI and code font family/size customization
- Add TOML-based settings persistence with auto-save (300ms debounce)
- Add window position/size save & restore via `tauri-plugin-window-state`
- Add macOS native app menu with "Reset All Settings" option
- Add system font enumeration via `font-kit` with `OnceLock` caching
- Add CSS custom properties for dynamic font application with fallback chains
- Add Settings navigation in sidebar footer and command palette
- Design extensible section-based architecture for future settings categories

## Changes

### Added

- `src-tauri/src/settings.rs` — Settings types (`AppSettings`, `FontSettings`), thread-safe state, TOML persistence, font enumeration, 5 Tauri commands, 9 unit tests
- `src-tauri/src/menu.rs` — macOS native app menu with "Reset All Settings..." custom item
- `src/lib/services/settings.ts` — Frontend settings service with invoke wrappers and CSS custom property application
- `src/routes/settings/+page.svelte` — Settings page with font comboboxes (Popover + Command), sliders, live preview, auto-save, and reset functionality

### Changed

- `src-tauri/Cargo.toml` — Added `tauri-plugin-window-state`, `toml`, `font-kit` dependencies
- `src-tauri/capabilities/default.json` — Added `window-state` and `dialog:allow-confirm` permissions
- `src-tauri/src/lib.rs` — Registered window-state plugin, settings state, macOS menu, and 5 settings commands
- `src/app.css` — Added CSS custom properties (`--font-ui`, `--font-code`, `--font-size-ui`, `--font-size-code`) with fallback chains
- `src/routes/+layout.svelte` — Load and apply settings on startup, handle reset events from menu and command palette
- `src/lib/components/layout/app-sidebar.svelte` — Added Settings gear icon in sidebar footer
- `src/lib/components/layout/command-palette.svelte` — Added "Settings" and "Reset All Settings" actions
- `src/lib/services/pages.ts` — Registered Settings page definition
- `package.json` / `bun.lock` — Added `@tauri-apps/plugin-window-state`

## Architecture

The settings system uses a section-based extensible pattern:

- **Rust**: `AppSettings` has one sub-struct per category with `#[serde(default)]` — adding a new category is one struct + one field
- **TOML**: Section-based format (`[font]`, future `[editor]`, etc.) maps naturally to sub-structs
- **TypeScript**: Mirrors Rust structure with sub-interfaces
- **UI**: Each category is a separate Card section — new categories = new cards

## Test Plan

### Automated checks (CI passed)

- [x] `cargo check` — 0 errors, 0 warnings
- [x] `cargo clippy` — 0 errors, 0 warnings
- [x] `cargo test` — settings tests (9) pass
- [x] `bun run check` — 0 type errors
- [x] `bun run format:check` — all files Prettier-clean

### Post-rebase verification

- [x] Rebased on latest `origin/main` with dependency bumps (tiptap suite, `@viz-js/viz`, `@vizel/*`, etc.)
- [x] `bun.lock` and `Cargo.lock` regenerated and included in the first commit
- [x] `cargo check --all-targets` succeeds
- [x] Tauri dev starts after clean rebuild
- [x] Sidebar navigation verified across all 11 tool pages:
  - Encoders: Base64 / URL / JWT
  - Generators: Hash / BCrypt / SSH / GPG
  - Text: Markdown / Diff / String Case
  - Network: Network Interfaces
  - Settings page loads without errors

### Functional tests (verified via Tauri MCP)

- [x] Move/resize window → restart → window restores at saved position/size
  - Resized to 1024×700 → graceful close → `~/Library/Application Support/io.github.seijikohara.kogu/.window-state.json` written → restart → window reopened at 1024×700 @ (1320, 359)
- [x] Open Settings → change UI font → all text updates immediately
  - `update_settings` via IPC + `applyAllSettings` → `--font-ui` CSS variable set to `"Arial", system-ui, …`; `--font-size-ui` set to `18px`; persisted to TOML
- [x] Open Settings → change code font → editors use new monospace font
  - `--font-code` set to `"Courier New", ui-monospace, …`; `get_monospace_system_fonts` returned 13 filtered monospace families (font-kit `is_monospace()` filter works)
- [x] Open Settings → adjust font sizes → preview and app reflect changes
  - `--font-size-ui` / `--font-size-code` set when values differ from default (13); CSS variables removed when value returns to default — boundary condition verified
- [x] Click "Reset All Settings" → confirm → fonts reset, window resets to 1200×800 centered
  - Button renders as enabled destructive variant; `reset_settings` IPC deletes TOML, clears state, and resizes window to 1200×800 (verified end-to-end except the native confirm dialog click, which is OS-level)
- [x] macOS: Kogu menu → "Reset All Settings..." → same reset flow
  - Not automatable via MCP (AppKit native menu bar). Verified in source: `menu.rs` emits `menu-reset-settings` event; `+layout.svelte` listens and calls `handleResetAllSettings`
- [x] Command palette → "Settings" → navigates to settings page
  - `Cmd+K` → click "Settings" item → `/settings` (title: "Settings - Kogu"); 16 IPC calls on page mount complete successfully
- [x] Command palette → "Reset All Settings" → triggers reset flow
  - Action registered in `command-palette.svelte` dispatches `reset-all-settings` CustomEvent; `+layout.svelte` listener routes to `handleResetAllSettings` (same path as button; confirm dialog is OS-level)
- [x] Delete `settings.toml` manually → app starts with defaults
  - Wrote non-default settings (Arial / Menlo / 22 / 14) → closed → `rm settings.toml` → restart → `get_settings` returned defaults (empty family, size 13)
- [x] Corrupt `settings.toml` → app creates `.bak`, starts with defaults
  - Wrote non-default settings → closed → overwrote with invalid TOML (`[font\nthis is = "broken" !!!`) → restart → `settings.bak` created containing the corrupt content, `get_settings` returned defaults
