### PR TITLE
fix(release): write PR body via temp file to preserve markdown

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 
 import { execSync } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import * as readline from 'node:readline';
 
@@ -195,8 +196,17 @@ A tag \`v${newVersion}\` will be automatically created, triggering the release w
 
 // GitHub operations
 const createPullRequest = (version: string, body: string): string => {
-	const escapedBody = body.replace(/"/g, '\\"').replace(/\n/g, '\\n');
-	return exec(`gh pr create --title "chore: release v${version}" --body "${escapedBody}"`);
+	// Write the body to a temp file so newlines, quotes, and backticks pass
+	// through to GitHub unchanged. Inlining the body into a shell command
+	// caused literal "\n" text, command-substituted backticks, and broken
+	// markdown in the published PR description.
+	const tempFile = resolve(tmpdir(), `release-pr-${version}.md`);
+	writeFileSync(tempFile, body);
+	try {
+		return exec(`gh pr create --title "chore: release v${version}" --body-file "${tempFile}"`);
+	} finally {
+		unlinkSync(tempFile);
+	}
 };
 
 // Validation


### PR DESCRIPTION
## Summary

`scripts/release.ts` generated a PR body that rendered as broken markdown on GitHub. Switch to `--body-file` so the generated text reaches GitHub unchanged.

## Observed failure

PR #158 rendered with:

- All newlines as literal `\n` text (one paragraph)
- Empty `` `` `` code spans where file names should appear (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- Empty tag name in the "After Merge" section

## Root cause

```ts
const createPullRequest = (version: string, body: string): string => {
  const escapedBody = body.replace(/"/g, '\\"').replace(/\n/g, '\\n');
  return exec(`gh pr create --title "..." --body "${escapedBody}"`);
};
```

Two shell-escaping issues compounded:

1. `\n` in the argument string is not interpreted as a newline by `gh`, so the body reached GitHub as one long line with literal `\n` text.
2. The outer template literal passed backticks through to `sh -c`, which treated them as command substitution. `` `package.json` `` was executed as a shell command (and failed silently), leaving the surrounding markdown with empty backtick pairs.

## Fix

Write the body to a temp file and pass `--body-file`. No shell escaping required, and the markdown reaches GitHub byte-for-byte.

## Test plan

- [x] Locally run a dry-run of the replacement: body written to temp file and `gh pr edit 158 --body-file <file>` restored PR #158 markdown cleanly.
- [ ] Next release run (post-merge) produces a PR with proper markdown.