### PR TITLE
feat(uuid-generator): add UUID generator page

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
         "node-sql-parser": "^5.4.0",
         "sql-formatter": "^15.7.3",
         "tailwindcss": "4.2.4",
+        "uuid": "^14.0.0",
         "xml-formatter": "^3.7.0",
         "yaml": "^2.8.3",
       },
@@ -58,6 +59,7 @@
         "@types/crypto-js": "^4.2.2",
         "@types/katex": "^0.16.8",
         "@types/markdown-it": "^14.1.2",
+        "@types/uuid": "^11.0.0",
         "bits-ui": "^2.18.0",
         "bun-types": "^1.3.13",
         "clsx": "^2.1.1",
@@ -505,6 +507,8 @@
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
 
     "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
@@ -1034,7 +1038,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "vite": ["vite@8.0.9", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.16", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw=="],
 
@@ -1113,6 +1117,8 @@
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
 
     "langium/chevrotain": ["chevrotain@12.0.0", "", { "dependencies": { "@chevrotain/cst-dts-gen": "12.0.0", "@chevrotain/gast": "12.0.0", "@chevrotain/regexp-to-ast": "12.0.0", "@chevrotain/types": "12.0.0", "@chevrotain/utils": "12.0.0" } }, "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ=="],
+
+    "mermaid/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "mode-watcher/runed": ["runed@0.25.0", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-7+ma4AG9FT2sWQEA0Egf6mb7PBT2vHyuHail1ie8ropfSjvZGtEAx8YTmUjv/APCsdRRxEVvArNjALk9zFSOrg=="],
 

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 		"node-sql-parser": "^5.4.0",
 		"sql-formatter": "^15.7.3",
 		"tailwindcss": "4.2.4",
+		"uuid": "^14.0.0",
 		"xml-formatter": "^3.7.0",
 		"yaml": "^2.8.3"
 	},
@@ -97,6 +98,7 @@
 		"@types/crypto-js": "^4.2.2",
 		"@types/katex": "^0.16.8",
 		"@types/markdown-it": "^14.1.2",
+		"@types/uuid": "^11.0.0",
 		"bits-ui": "^2.18.0",
 		"bun-types": "^1.3.13",
 		"clsx": "^2.1.1",

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -15,6 +15,7 @@ import {
 	FileDiff,
 	FileJson2,
 	FileText,
+	Fingerprint,
 	GitCompare,
 	Hash,
 	House,
@@ -156,6 +157,15 @@ export const PAGES: readonly PageDefinition[] = [
 		description: 'Decode and inspect JWT tokens',
 		color: 'text-purple-500',
 		category: 'encoders',
+	},
+	{
+		id: 'uuid-generator',
+		title: 'UUID Generator',
+		url: '/uuid-generator',
+		icon: Fingerprint,
+		description: 'Generate UUIDs (v1, v3, v4, v5, v7) with formatting options',
+		color: 'text-fuchsia-500',
+		category: 'generators',
 	},
 	{
 		id: 'hash-generator',

--- a/src/lib/services/uuid.ts
+++ b/src/lib/services/uuid.ts
@@ -1,0 +1,111 @@
+/**
+ * UUID generation service.
+ * Wraps the `uuid` npm package with project-specific options
+ * (formatting, version metadata, namespace presets).
+ */
+
+import { NIL, v1, v3, v4, v5, v7, validate, version as detectVersion } from 'uuid';
+
+export type UuidVersion = 'v1' | 'v3' | 'v4' | 'v5' | 'v7' | 'nil';
+
+export interface UuidVersionInfo {
+	readonly version: UuidVersion;
+	readonly label: string;
+	readonly description: string;
+}
+
+export const UUID_VERSIONS: readonly UuidVersionInfo[] = [
+	{ version: 'v1', label: 'v1', description: 'Time-based with MAC address' },
+	{ version: 'v3', label: 'v3', description: 'Namespace + name (MD5)' },
+	{ version: 'v4', label: 'v4', description: 'Random (most common)' },
+	{ version: 'v5', label: 'v5', description: 'Namespace + name (SHA-1)' },
+	{ version: 'v7', label: 'v7', description: 'Time-ordered (sortable)' },
+	{ version: 'nil', label: 'NIL', description: 'All zeros (placeholder)' },
+] as const;
+
+export interface NamespacePreset {
+	readonly id: string;
+	readonly label: string;
+	readonly value: string;
+}
+
+// RFC 4122 / RFC 9562 predefined namespace UUIDs.
+export const NAMESPACE_DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+export const NAMESPACE_URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
+export const NAMESPACE_OID = '6ba7b812-9dad-11d1-80b4-00c04fd430c8';
+export const NAMESPACE_X500 = '6ba7b814-9dad-11d1-80b4-00c04fd430c8';
+
+export const NAMESPACE_PRESETS: readonly NamespacePreset[] = [
+	{ id: 'dns', label: 'DNS', value: NAMESPACE_DNS },
+	{ id: 'url', label: 'URL', value: NAMESPACE_URL },
+	{ id: 'oid', label: 'OID', value: NAMESPACE_OID },
+	{ id: 'x500', label: 'X.500', value: NAMESPACE_X500 },
+] as const;
+
+export interface UuidFormatOptions {
+	readonly uppercase: boolean;
+	readonly hyphens: boolean;
+	readonly braces: boolean;
+}
+
+export const DEFAULT_FORMAT_OPTIONS: UuidFormatOptions = {
+	uppercase: false,
+	hyphens: true,
+	braces: false,
+};
+
+export interface UuidGenerateOptions {
+	readonly version: UuidVersion;
+	readonly count: number;
+	readonly namespace?: string;
+	readonly name?: string;
+	readonly format: UuidFormatOptions;
+}
+
+export const MIN_COUNT = 1;
+export const MAX_COUNT = 100;
+export const DEFAULT_COUNT = 1;
+
+export const isUuidVersion = (value: string): value is UuidVersion =>
+	UUID_VERSIONS.some((info) => info.version === value);
+
+export const requiresNamespace = (version: UuidVersion): boolean =>
+	version === 'v3' || version === 'v5';
+
+export const isValidUuid = (value: string): boolean => validate(value);
+
+export const detectUuidVersion = (value: string): number | null => {
+	if (!validate(value)) return null;
+	return detectVersion(value);
+};
+
+export const formatUuid = (uuid: string, options: UuidFormatOptions): string => {
+	const stripped = options.hyphens ? uuid : uuid.replaceAll('-', '');
+	const cased = options.uppercase ? stripped.toUpperCase() : stripped.toLowerCase();
+	return options.braces ? `{${cased}}` : cased;
+};
+
+const generateOneUuid = (version: UuidVersion, namespace?: string, name?: string): string => {
+	if (version === 'v1') return v1();
+	if (version === 'v4') return v4();
+	if (version === 'v7') return v7();
+	if (version === 'nil') return NIL;
+
+	if (!namespace || !validate(namespace)) {
+		throw new Error('Namespace must be a valid UUID for v3 / v5 generation');
+	}
+	if (name === undefined || name.length === 0) {
+		throw new Error('Name is required for v3 / v5 generation');
+	}
+	return version === 'v3' ? v3(name, namespace) : v5(name, namespace);
+};
+
+export const generateUuids = (options: UuidGenerateOptions): readonly string[] => {
+	const { version, count, namespace, name, format } = options;
+	if (count < MIN_COUNT || count > MAX_COUNT) {
+		throw new Error(`Count must be between ${MIN_COUNT} and ${MAX_COUNT}`);
+	}
+	// NIL has only one value; emit it `count` times so users see the same shape.
+	const raw = Array.from({ length: count }, () => generateOneUuid(version, namespace, name));
+	return raw.map((value) => formatUuid(value, format));
+};

--- a/src/routes/uuid-generator/+page.svelte
+++ b/src/routes/uuid-generator/+page.svelte
@@ -1,0 +1,222 @@
+<script lang="ts">
+	import { Fingerprint, RefreshCw } from '@lucide/svelte';
+	import { toast } from 'svelte-sonner';
+	import { ActionButton, CopyButton } from '$lib/components/action';
+	import {
+		FormCheckbox,
+		FormCheckboxGroup,
+		FormInfo,
+		FormInput,
+		FormSection,
+		FormSelect,
+		FormSlider,
+	} from '$lib/components/form';
+	import { SectionHeader } from '$lib/components/layout';
+	import { ToolShell } from '$lib/components/shell';
+	import { EmptyState, StatItem } from '$lib/components/status';
+	import {
+		DEFAULT_COUNT,
+		DEFAULT_FORMAT_OPTIONS,
+		generateUuids,
+		isUuidVersion,
+		MAX_COUNT,
+		MIN_COUNT,
+		NAMESPACE_DNS,
+		NAMESPACE_PRESETS,
+		requiresNamespace,
+		UUID_VERSIONS,
+		type UuidFormatOptions,
+		type UuidVersion,
+	} from '$lib/services/uuid.js';
+
+	// State
+	let version = $state<UuidVersion>('v4');
+	let count = $state<number>(DEFAULT_COUNT);
+	let namespace = $state<string>(NAMESPACE_DNS);
+	let nameInput = $state<string>('');
+	let format = $state<UuidFormatOptions>({ ...DEFAULT_FORMAT_OPTIONS });
+	let results = $state<readonly string[]>([]);
+	let error = $state<string | null>(null);
+	let showOptions = $state(true);
+
+	// Derived
+	const needsNamespace = $derived(requiresNamespace(version));
+	const canGenerate = $derived(!needsNamespace || (namespace.length > 0 && nameInput.length > 0));
+
+	const versionOptions = UUID_VERSIONS.map((info) => ({
+		value: info.version,
+		label: `${info.label} - ${info.description}`,
+	}));
+
+	const namespaceOptions = NAMESPACE_PRESETS.map((preset) => ({
+		value: preset.value,
+		label: `${preset.label} (${preset.value})`,
+	}));
+
+	// Handlers
+	const handleVersionChange = (value: string) => {
+		if (isUuidVersion(value)) version = value;
+	};
+
+	const handleNamespaceChange = (value: string) => {
+		namespace = value;
+	};
+
+	const handleGenerate = () => {
+		error = null;
+		try {
+			results = generateUuids({
+				version,
+				count,
+				namespace: needsNamespace ? namespace : undefined,
+				name: needsNamespace ? nameInput : undefined,
+				format,
+			});
+			toast.success(`Generated ${results.length} UUID${results.length > 1 ? 's' : ''}`);
+		} catch (e) {
+			const message = e instanceof Error ? e.message : String(e);
+			error = message;
+			results = [];
+			toast.error('Failed to generate UUID', { description: message });
+		}
+	};
+
+	const handleClear = () => {
+		results = [];
+		error = null;
+	};
+</script>
+
+<svelte:head>
+	<title>UUID Generator - Kogu</title>
+</svelte:head>
+
+<ToolShell
+	valid={results.length > 0 ? true : null}
+	error={error ?? undefined}
+	bind:showRail={showOptions}
+>
+	{#snippet statusContent()}
+		{#if results.length > 0}
+			<StatItem label="Count" value={results.length} />
+			<StatItem label="Version" value={version === 'nil' ? 'NIL' : version.toUpperCase()} />
+		{/if}
+	{/snippet}
+
+	{#snippet rail()}
+		<FormSection title="Version">
+			<FormSelect
+				label="UUID Version"
+				value={version}
+				options={versionOptions}
+				onchange={handleVersionChange}
+			/>
+		</FormSection>
+
+		{#if needsNamespace}
+			<FormSection title="Namespace & Name">
+				<FormSelect
+					label="Namespace Preset"
+					value={namespace}
+					options={namespaceOptions}
+					onchange={handleNamespaceChange}
+				/>
+				<FormInput
+					label="Custom Namespace UUID"
+					bind:value={namespace}
+					placeholder="Or enter a custom UUID..."
+					size="compact"
+				/>
+				<FormInput
+					label="Name"
+					bind:value={nameInput}
+					placeholder="e.g., example.com"
+					size="compact"
+				/>
+			</FormSection>
+		{/if}
+
+		<FormSection title="Quantity">
+			<FormSlider
+				label="Count"
+				bind:value={count}
+				min={MIN_COUNT}
+				max={MAX_COUNT}
+				step={1}
+				valueLabel={String(count)}
+			/>
+		</FormSection>
+
+		<FormSection title="Format">
+			<FormCheckboxGroup>
+				<FormCheckbox label="Uppercase" bind:checked={format.uppercase} />
+				<FormCheckbox label="Hyphens" bind:checked={format.hyphens} />
+				<FormCheckbox label="Wrap in braces" bind:checked={format.braces} />
+			</FormCheckboxGroup>
+		</FormSection>
+
+		<FormSection title="Actions">
+			<div class="space-y-2">
+				<ActionButton
+					label="Generate"
+					icon={Fingerprint}
+					disabled={!canGenerate}
+					shortcut
+					onclick={handleGenerate}
+				/>
+				{#if results.length > 0}
+					<ActionButton
+						label="Regenerate"
+						icon={RefreshCw}
+						variant="outline"
+						onclick={handleGenerate}
+					/>
+					<ActionButton label="Clear" variant="outline" onclick={handleClear} />
+				{/if}
+			</div>
+		</FormSection>
+
+		<FormSection title="About UUID">
+			<FormInfo>
+				<ul class="list-inside list-disc space-y-0.5">
+					<li>Universally Unique Identifier (RFC 9562)</li>
+					<li>v4 random is the most common choice</li>
+					<li>v7 is time-ordered, ideal for DB primary keys</li>
+					<li>v3 / v5 are deterministic from namespace + name</li>
+				</ul>
+			</FormInfo>
+		</FormSection>
+	{/snippet}
+
+	<!-- Results Panel -->
+	<div class="flex h-full flex-col overflow-hidden">
+		<SectionHeader title="Generated UUIDs" count={results.length || undefined}>
+			{#snippet trailing()}
+				{#if results.length > 0}
+					<CopyButton
+						text={results.join('\n')}
+						label="Copy All"
+						toastLabel={`${results.length} UUID${results.length > 1 ? 's' : ''}`}
+						size="sm"
+						class="h-7"
+					/>
+				{/if}
+			{/snippet}
+		</SectionHeader>
+
+		<div class="flex-1 overflow-auto p-4">
+			{#if results.length > 0}
+				<div class="space-y-2">
+					{#each results as uuid, idx (`${idx}-${uuid}`)}
+						<div class="flex items-center gap-2 rounded-lg border bg-surface-3 p-3">
+							<code class="flex-1 break-all font-mono text-sm">{uuid}</code>
+							<CopyButton text={uuid} toastLabel="UUID" size="sm" showLabel={false} />
+						</div>
+					{/each}
+				</div>
+			{:else}
+				<EmptyState icon={Fingerprint} title="Click Generate to create UUIDs" />
+			{/if}
+		</div>
+	</div>
+</ToolShell>


### PR DESCRIPTION
## Summary

- Add new tool page `/uuid-generator` for generating UUID v1, v3, v4, v5, v7, and NIL.
- Built on the `uuid` npm package; pure formatting helpers (case, hyphens, braces) live in `src/lib/services/uuid.ts`.
- Bulk generation up to 100, with namespace presets (DNS, URL, OID, X.500) for v3 / v5.

## Changes

### Added

- `src/lib/services/uuid.ts` - generation and formatting helpers, version metadata, namespace presets.
- `src/routes/uuid-generator/+page.svelte` - tool page using `ToolShell` (transform / form-results layout).
- `uuid` and `@types/uuid` dependencies.

### Changed

- `src/lib/services/pages.ts` - register `uuid-generator` under the `generators` category with the `Fingerprint` icon and `text-fuchsia-500` color.

## Test Plan

- [x] Navigate to `/uuid-generator` from the sidebar; entry shows under Generators with the Fingerprint icon.
- [x] Default version `v4`, click Generate, confirm a single lowercased hyphenated UUID appears.
- [x] Increase Count slider to 100, click Generate, confirm 100 distinct UUIDs render and Copy All copies all of them.
- [x] Switch version to `v7`, click Generate; confirm output starts with the timestamp prefix `0` followed by the version nibble `7` (`xxxxxxxx-xxxx-7xxx-xxxx-xxxxxxxxxxxx`).
- [x] Switch to `v3` (or `v5`); the Namespace & Name section appears. Pick the DNS preset, enter `example.com`, click Generate; v3 should produce `9073926b-929f-31c2-abc9-fad77ae3e8eb`, v5 `cfbff0d1-9375-5685-968a-48ce8b50e1cd`.
- [x] Toggle Uppercase, Hyphens, and Wrap in braces independently; verify the format updates on next Generate.
- [x] Switch to NIL; result is `00000000-0000-0000-0000-000000000000` (uppercase / no-hyphen options still apply).
- [x] Cmd+Enter triggers Generate while focus is inside the shell.
- [x] Cmd+, toggles the options rail.
- [x] Light + dark mode visual parity.
