### PR TITLE
feat(password-generator): add password generator page

### DIFF
--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -186,6 +186,15 @@ export const PAGES: readonly PageDefinition[] = [
 		category: 'generators',
 	},
 	{
+		id: 'password-generator',
+		title: 'Password Generator',
+		url: '/password-generator',
+		icon: Lock,
+		description: 'Generate cryptographically secure passwords with entropy estimation',
+		color: 'text-lime-500',
+		category: 'generators',
+	},
+	{
 		id: 'ssh-key-generator',
 		title: 'SSH Key Generator',
 		url: '/ssh-key-generator',

--- a/src/lib/services/password.ts
+++ b/src/lib/services/password.ts
@@ -1,0 +1,109 @@
+/**
+ * Password generation service.
+ * Uses Web Crypto (`crypto.getRandomValues`) for entropy.
+ * Pure functions for character pool construction and entropy estimation;
+ * the random draw is the only impure boundary.
+ */
+
+const LOWERCASE_CHARS = 'abcdefghijklmnopqrstuvwxyz';
+const UPPERCASE_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const NUMBER_CHARS = '0123456789';
+const SYMBOL_CHARS = '!@#$%^&*()_+-=[]{}|;:,.<>?/~`';
+
+// Visually similar characters that are easy to misread on common fonts.
+const SIMILAR_CHARS = '0OoIl1|';
+// Characters that are structurally ambiguous in shells, regex, or quoted contexts.
+const AMBIGUOUS_CHARS = '{}[]()/\\\'"`~,;:.<>';
+
+export interface PasswordOptions {
+	readonly length: number;
+	readonly lowercase: boolean;
+	readonly uppercase: boolean;
+	readonly numbers: boolean;
+	readonly symbols: boolean;
+	readonly excludeSimilar: boolean;
+	readonly excludeAmbiguous: boolean;
+}
+
+export const DEFAULT_PASSWORD_OPTIONS: PasswordOptions = {
+	length: 16,
+	lowercase: true,
+	uppercase: true,
+	numbers: true,
+	symbols: true,
+	excludeSimilar: false,
+	excludeAmbiguous: false,
+};
+
+export const MIN_LENGTH = 4;
+export const MAX_LENGTH = 128;
+export const MIN_COUNT = 1;
+export const MAX_COUNT = 20;
+export const DEFAULT_COUNT = 1;
+
+export const buildCharacterPool = (options: PasswordOptions): string => {
+	const parts = [
+		options.lowercase ? LOWERCASE_CHARS : '',
+		options.uppercase ? UPPERCASE_CHARS : '',
+		options.numbers ? NUMBER_CHARS : '',
+		options.symbols ? SYMBOL_CHARS : '',
+	];
+	const base = parts.join('');
+	return [...base]
+		.filter((c) => !options.excludeSimilar || !SIMILAR_CHARS.includes(c))
+		.filter((c) => !options.excludeAmbiguous || !AMBIGUOUS_CHARS.includes(c))
+		.join('');
+};
+
+export const generatePassword = (options: PasswordOptions): string => {
+	if (options.length < MIN_LENGTH || options.length > MAX_LENGTH) {
+		throw new Error(`Length must be between ${MIN_LENGTH} and ${MAX_LENGTH}`);
+	}
+	const pool = buildCharacterPool(options);
+	if (pool.length === 0) {
+		throw new Error('At least one character class must be selected');
+	}
+	const buffer = new Uint32Array(options.length);
+	crypto.getRandomValues(buffer);
+	// Modulo bias is negligible for password pools (<128 chars) drawn from a
+	// 2^32 range; cryptographic guidance accepts it for password generation.
+	return Array.from(buffer, (value) => pool[value % pool.length] ?? '').join('');
+};
+
+export const generatePasswords = (options: PasswordOptions, count: number): readonly string[] => {
+	if (count < MIN_COUNT || count > MAX_COUNT) {
+		throw new Error(`Count must be between ${MIN_COUNT} and ${MAX_COUNT}`);
+	}
+	return Array.from({ length: count }, () => generatePassword(options));
+};
+
+export const calculateEntropy = (length: number, poolSize: number): number => {
+	if (poolSize <= 1 || length <= 0) return 0;
+	return Math.log2(poolSize) * length;
+};
+
+export type StrengthLabel = 'very-weak' | 'weak' | 'fair' | 'strong' | 'very-strong';
+
+export interface StrengthInfo {
+	readonly id: StrengthLabel;
+	readonly label: string;
+	readonly tone: 'destructive' | 'warning' | 'info' | 'success';
+}
+
+interface StrengthBreakpoint {
+	readonly threshold: number;
+	readonly info: StrengthInfo;
+}
+
+// Thresholds align with NIST guidance: <28 trivial, ≥60 strong against offline attacks.
+const STRENGTH_BREAKPOINTS: readonly StrengthBreakpoint[] = [
+	{ threshold: 28, info: { id: 'very-weak', label: 'Very weak', tone: 'destructive' } },
+	{ threshold: 36, info: { id: 'weak', label: 'Weak', tone: 'destructive' } },
+	{ threshold: 60, info: { id: 'fair', label: 'Fair', tone: 'warning' } },
+	{ threshold: 128, info: { id: 'strong', label: 'Strong', tone: 'success' } },
+];
+
+const VERY_STRONG: StrengthInfo = { id: 'very-strong', label: 'Very strong', tone: 'success' };
+
+export const classifyEntropy = (entropy: number): StrengthInfo =>
+	STRENGTH_BREAKPOINTS.find((bp) => entropy < bp.threshold)?.info ?? VERY_STRONG;

--- a/src/routes/password-generator/+page.svelte
+++ b/src/routes/password-generator/+page.svelte
@@ -1,0 +1,230 @@
+<script lang="ts">
+	import { Lock, RefreshCw } from '@lucide/svelte';
+	import { toast } from 'svelte-sonner';
+	import { ActionButton, CopyButton } from '$lib/components/action';
+	import {
+		FormCheckbox,
+		FormCheckboxGroup,
+		FormInfo,
+		FormSection,
+		FormSlider,
+	} from '$lib/components/form';
+	import { SectionHeader } from '$lib/components/layout';
+	import { ToolShell } from '$lib/components/shell';
+	import { EmptyState, StatItem } from '$lib/components/status';
+	import {
+		buildCharacterPool,
+		calculateEntropy,
+		classifyEntropy,
+		DEFAULT_COUNT,
+		DEFAULT_PASSWORD_OPTIONS,
+		generatePasswords,
+		MAX_COUNT,
+		MAX_LENGTH,
+		MIN_COUNT,
+		MIN_LENGTH,
+		type PasswordOptions,
+	} from '$lib/services/password.js';
+
+	// State
+	let options = $state<PasswordOptions>({ ...DEFAULT_PASSWORD_OPTIONS });
+	let count = $state<number>(DEFAULT_COUNT);
+	let results = $state<readonly string[]>([]);
+	let error = $state<string | null>(null);
+	let showOptions = $state(true);
+
+	// Derived
+	const pool = $derived(buildCharacterPool(options));
+	const entropy = $derived(calculateEntropy(options.length, pool.length));
+	const strength = $derived(classifyEntropy(entropy));
+	const canGenerate = $derived(pool.length > 0);
+
+	const strengthClass = $derived.by(() => {
+		if (strength.tone === 'destructive') return 'text-destructive';
+		if (strength.tone === 'warning') return 'text-warning';
+		if (strength.tone === 'success') return 'text-success';
+		return 'text-info';
+	});
+
+	const strengthBarClass = $derived.by(() => {
+		if (strength.tone === 'destructive') return 'bg-destructive';
+		if (strength.tone === 'warning') return 'bg-warning';
+		if (strength.tone === 'success') return 'bg-success';
+		return 'bg-info';
+	});
+
+	// Visualize entropy on a 0-128 bit scale; clamp above 128 to full.
+	const strengthPercent = $derived(Math.min(100, (entropy / 128) * 100));
+
+	// Handlers
+	const handleGenerate = () => {
+		error = null;
+		try {
+			results = generatePasswords(options, count);
+			toast.success(`Generated ${results.length} password${results.length > 1 ? 's' : ''}`);
+		} catch (e) {
+			const message = e instanceof Error ? e.message : String(e);
+			error = message;
+			results = [];
+			toast.error('Failed to generate password', { description: message });
+		}
+	};
+
+	const handleClear = () => {
+		results = [];
+		error = null;
+	};
+</script>
+
+<svelte:head>
+	<title>Password Generator - Kogu</title>
+</svelte:head>
+
+<ToolShell
+	valid={results.length > 0 ? true : null}
+	error={error ?? undefined}
+	bind:showRail={showOptions}
+>
+	{#snippet statusContent()}
+		{#if results.length > 0}
+			<StatItem label="Count" value={results.length} />
+			<StatItem label="Length" value={options.length} />
+			<StatItem label="Entropy" value={`${entropy.toFixed(1)} bits`} />
+		{/if}
+	{/snippet}
+
+	{#snippet rail()}
+		<FormSection title="Length">
+			<FormSlider
+				label="Length"
+				bind:value={options.length}
+				min={MIN_LENGTH}
+				max={MAX_LENGTH}
+				step={1}
+				valueLabel={String(options.length)}
+			/>
+		</FormSection>
+
+		<FormSection title="Character Classes">
+			<FormCheckboxGroup>
+				<FormCheckbox label="Lowercase (a-z)" bind:checked={options.lowercase} />
+				<FormCheckbox label="Uppercase (A-Z)" bind:checked={options.uppercase} />
+				<FormCheckbox label="Numbers (0-9)" bind:checked={options.numbers} />
+				<FormCheckbox label="Symbols (!@#$...)" bind:checked={options.symbols} />
+			</FormCheckboxGroup>
+		</FormSection>
+
+		<FormSection title="Exclusions">
+			<FormCheckboxGroup>
+				<FormCheckbox
+					label="Exclude similar characters"
+					hint="0/O, 1/l/I, |"
+					bind:checked={options.excludeSimilar}
+				/>
+				<FormCheckbox
+					label="Exclude ambiguous symbols"
+					hint="Brackets, quotes, slashes"
+					bind:checked={options.excludeAmbiguous}
+				/>
+			</FormCheckboxGroup>
+		</FormSection>
+
+		<FormSection title="Quantity">
+			<FormSlider
+				label="Count"
+				bind:value={count}
+				min={MIN_COUNT}
+				max={MAX_COUNT}
+				step={1}
+				valueLabel={String(count)}
+			/>
+		</FormSection>
+
+		<FormSection title="Strength">
+			<div class="space-y-2">
+				<div class="flex items-center justify-between text-sm">
+					<span class="text-muted-foreground">Pool size</span>
+					<span class="font-mono tabular-nums">{pool.length}</span>
+				</div>
+				<div class="flex items-center justify-between text-sm">
+					<span class="text-muted-foreground">Entropy</span>
+					<span class="font-mono tabular-nums">{entropy.toFixed(1)} bits</span>
+				</div>
+				<div class="flex items-center justify-between text-sm">
+					<span class="text-muted-foreground">Rating</span>
+					<span class="font-medium {strengthClass}">{strength.label}</span>
+				</div>
+				<div class="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+					<div
+						class="h-full transition-all duration-300 {strengthBarClass}"
+						style:width="{strengthPercent}%"
+					></div>
+				</div>
+			</div>
+		</FormSection>
+
+		<FormSection title="Actions">
+			<div class="space-y-2">
+				<ActionButton
+					label="Generate"
+					icon={Lock}
+					disabled={!canGenerate}
+					shortcut
+					onclick={handleGenerate}
+				/>
+				{#if results.length > 0}
+					<ActionButton
+						label="Regenerate"
+						icon={RefreshCw}
+						variant="outline"
+						onclick={handleGenerate}
+					/>
+					<ActionButton label="Clear" variant="outline" onclick={handleClear} />
+				{/if}
+			</div>
+		</FormSection>
+
+		<FormSection title="About">
+			<FormInfo>
+				<ul class="list-inside list-disc space-y-0.5">
+					<li>Cryptographically secure (Web Crypto)</li>
+					<li>Entropy is log2(pool) × length</li>
+					<li>≥ 60 bits resists offline attacks</li>
+					<li>≥ 128 bits is overkill for human use</li>
+				</ul>
+			</FormInfo>
+		</FormSection>
+	{/snippet}
+
+	<!-- Results Panel -->
+	<div class="flex h-full flex-col overflow-hidden">
+		<SectionHeader title="Generated Passwords" count={results.length || undefined}>
+			{#snippet trailing()}
+				{#if results.length > 0}
+					<CopyButton
+						text={results.join('\n')}
+						label="Copy All"
+						toastLabel={`${results.length} password${results.length > 1 ? 's' : ''}`}
+						size="sm"
+						class="h-7"
+					/>
+				{/if}
+			{/snippet}
+		</SectionHeader>
+
+		<div class="flex-1 overflow-auto p-4">
+			{#if results.length > 0}
+				<div class="space-y-2">
+					{#each results as password, idx (`${idx}-${password}`)}
+						<div class="flex items-center gap-2 rounded-lg border bg-surface-3 p-3">
+							<code class="flex-1 break-all font-mono text-sm">{password}</code>
+							<CopyButton text={password} toastLabel="Password" size="sm" showLabel={false} />
+						</div>
+					{/each}
+				</div>
+			{:else}
+				<EmptyState icon={Lock} title="Click Generate to create passwords" />
+			{/if}
+		</div>
+	</div>
+</ToolShell>


### PR DESCRIPTION
## Summary

- Add new tool page `/password-generator` that produces cryptographically secure passwords using Web Crypto.
- Configurable length (4-128), character classes, and exclusions for visually similar / structurally ambiguous characters.
- Live entropy bar (`log2(pool) * length`) with NIST-aligned strength tiers.

## Changes

### Added

- `src/lib/services/password.ts` - pure helpers for character pool, entropy, and strength classification; impure boundary is the `crypto.getRandomValues` call.
- `src/routes/password-generator/+page.svelte` - tool page using `ToolShell` (transform / form-results layout).

### Changed

- `src/lib/services/pages.ts` - register `password-generator` under the `generators` category with the `Lock` icon and `text-lime-500` color.

## Test Plan

- [x] Navigate to `/password-generator`; entry shows under Generators with the Lock icon.
- [x] Default options (length 16, all classes on), click Generate; one password renders, length 16, mixes lower/upper/digit/symbol.
- [x] Increase Count slider to 20, click Generate; 20 distinct passwords render and Copy All copies all of them.
- [x] Toggle off all character classes; Generate disables and the strength meter reads 0 bits.
- [x] Toggle "Exclude similar"; verify generated passwords contain none of `0 O o I l 1 |`.
- [x] Toggle "Exclude ambiguous"; verify generated passwords contain none of `{} [] () / \ ' \" \` ~ , ; : . < >`.
- [x] Slide length to 4 with only lowercase enabled; strength bar shows Very weak; entropy ≈ 18.8 bits.
- [x] Slide length to 64 with all classes enabled; strength bar shows Strong / Very strong; entropy > 128 bits.
- [x] Cmd+Enter triggers Generate while focus is inside the shell; Cmd+, toggles the rail.
- [x] Light + dark mode visual parity (strength bar color tones remain readable in both).
