### PR TITLE
feat(curl-builder): add cURL builder page

### DIFF
--- a/src/lib/components/form/form-textarea.svelte
+++ b/src/lib/components/form/form-textarea.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import { cn } from '$lib/utils.js';
+
+	interface Props {
+		label: string;
+		value?: string;
+		placeholder?: string;
+		rows?: number;
+		hint?: string;
+		size?: 'default' | 'compact';
+		class?: string;
+		onchange?: (value: string) => void;
+	}
+
+	let {
+		label,
+		value = $bindable(''),
+		placeholder = '',
+		rows = 4,
+		hint,
+		size = 'default',
+		class: className,
+		onchange,
+	}: Props = $props();
+
+	const labelClass = $derived(
+		size === 'compact'
+			? 'text-xs uppercase tracking-wide text-muted-foreground'
+			: 'text-sm font-medium'
+	);
+</script>
+
+<div class="space-y-1.5">
+	<Label class={labelClass}>{label}</Label>
+	<Textarea
+		{placeholder}
+		{rows}
+		bind:value
+		class={cn(className)}
+		oninput={(e) => onchange?.((e.currentTarget as HTMLTextAreaElement).value)}
+	/>
+	{#if hint}
+		<p class="text-xs text-muted-foreground">{hint}</p>
+	{/if}
+</div>

--- a/src/lib/components/form/index.ts
+++ b/src/lib/components/form/index.ts
@@ -6,3 +6,4 @@ export { default as FormMode } from './form-mode.svelte';
 export { default as FormSection } from './form-section.svelte';
 export { default as FormSelect } from './form-select.svelte';
 export { default as FormSlider } from './form-slider.svelte';
+export { default as FormTextarea } from './form-textarea.svelte';

--- a/src/lib/services/curl.ts
+++ b/src/lib/services/curl.ts
@@ -1,0 +1,168 @@
+/**
+ * cURL request service.
+ * Pure helpers for building a `curl` command from a structured request,
+ * and a tokenizer-based parser that recognizes the most common flags.
+ */
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
+
+export const HTTP_METHODS: readonly HttpMethod[] = [
+	'GET',
+	'POST',
+	'PUT',
+	'PATCH',
+	'DELETE',
+	'HEAD',
+	'OPTIONS',
+];
+
+export type Result<T> =
+	| { readonly ok: true; readonly value: T }
+	| { readonly ok: false; readonly error: string };
+
+export interface KeyValue {
+	readonly key: string;
+	readonly value: string;
+}
+
+export interface CurlRequest {
+	readonly method: HttpMethod;
+	readonly url: string;
+	readonly headers: readonly KeyValue[];
+	readonly body: string;
+}
+
+export const DEFAULT_REQUEST: CurlRequest = {
+	method: 'GET',
+	url: 'https://api.example.com/users',
+	headers: [],
+	body: '',
+};
+
+export const isHttpMethod = (value: string): value is HttpMethod =>
+	HTTP_METHODS.includes(value as HttpMethod);
+
+const SAFE_PATTERN = /^[a-zA-Z0-9_./:?=&%@~+-]+$/;
+
+const shellEscape = (value: string): string => {
+	if (value === '') return "''";
+	if (SAFE_PATTERN.test(value)) return value;
+	// Single-quote, escape internal single quotes via the standard '\'' trick.
+	return `'${value.replaceAll("'", String.raw`'\''`)}'`;
+};
+
+const isMethodChangingFlag = (method: HttpMethod, hasBody: boolean): boolean =>
+	hasBody && method === 'GET';
+
+export interface BuildOptions {
+	readonly multiline: boolean;
+}
+
+export const DEFAULT_BUILD_OPTIONS: BuildOptions = { multiline: true };
+
+export const buildCurl = (request: CurlRequest, options: BuildOptions): string => {
+	const hasBody = request.body.length > 0;
+	const effectiveMethod = isMethodChangingFlag(request.method, hasBody) ? 'POST' : request.method;
+	const args: string[] = [];
+	if (effectiveMethod !== 'GET') args.push('-X', effectiveMethod);
+	args.push(shellEscape(request.url));
+	const headerArgs = request.headers
+		.filter((h) => h.key.length > 0)
+		.flatMap((h) => ['-H', shellEscape(`${h.key}: ${h.value}`)]);
+	args.push(...headerArgs);
+	if (hasBody) args.push('--data-raw', shellEscape(request.body));
+	const separator = options.multiline ? ' \\\n  ' : ' ';
+	return `curl ${args.join(separator)}`;
+};
+
+export const parseHeaderLines = (text: string): readonly KeyValue[] =>
+	text
+		.split('\n')
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0)
+		.map((line) => {
+			const idx = line.indexOf(':');
+			if (idx <= 0) return { key: line, value: '' };
+			return { key: line.slice(0, idx).trim(), value: line.slice(idx + 1).trim() };
+		});
+
+export const formatHeaderLines = (headers: readonly KeyValue[]): string =>
+	headers
+		.filter((h) => h.key.length > 0)
+		.map((h) => `${h.key}: ${h.value}`)
+		.join('\n');
+
+// Match a single-quoted string, a double-quoted string, or an unquoted token.
+const TOKEN_PATTERN = /'((?:[^'\\]|\\.)*)'|"((?:[^"\\]|\\.)*)"|(\S+)/g;
+
+const tokenize = (input: string): readonly string[] => {
+	const cleaned = input.replaceAll(/\\\n/g, ' ').trim();
+	return Array.from(cleaned.matchAll(TOKEN_PATTERN), (m) => m[1] ?? m[2] ?? m[3] ?? '');
+};
+
+const stripLeading = (value: string): string => value.replace(/^['"]|['"]$/g, '');
+
+export const parseCurl = (input: string): Result<CurlRequest> => {
+	const tokens = tokenize(input);
+	if (tokens.length === 0 || tokens[0] !== 'curl') {
+		return { ok: false, error: 'Input must start with `curl`' };
+	}
+	let method: HttpMethod = 'GET';
+	let url = '';
+	let body = '';
+	const headers: KeyValue[] = [];
+	let methodExplicit = false;
+	let i = 1;
+	while (i < tokens.length) {
+		const token = tokens[i] ?? '';
+		const next = tokens[i + 1] ?? '';
+		if (token === '-X' || token === '--request') {
+			const candidate = next.toUpperCase();
+			if (isHttpMethod(candidate)) {
+				method = candidate;
+				methodExplicit = true;
+			}
+			i += 2;
+			continue;
+		}
+		if (token === '-H' || token === '--header') {
+			const headerText = stripLeading(next);
+			const idx = headerText.indexOf(':');
+			if (idx > 0) {
+				headers.push({
+					key: headerText.slice(0, idx).trim(),
+					value: headerText.slice(idx + 1).trim(),
+				});
+			}
+			i += 2;
+			continue;
+		}
+		if (
+			token === '-d' ||
+			token === '--data' ||
+			token === '--data-raw' ||
+			token === '--data-binary'
+		) {
+			body = next;
+			if (!methodExplicit) method = 'POST';
+			i += 2;
+			continue;
+		}
+		if (token === '-G' || token === '--get') {
+			method = 'GET';
+			methodExplicit = true;
+			i += 1;
+			continue;
+		}
+		if (token.startsWith('-')) {
+			// Unsupported flag — skip it and its value if it looks like one takes a value.
+			i += token.startsWith('--') || token.length === 2 ? 2 : 1;
+			continue;
+		}
+		// Bare token: treat as URL (last one wins so `--data` followed by URL still parses).
+		if (url === '') url = token;
+		i += 1;
+	}
+	if (url === '') return { ok: false, error: 'No URL found in command' };
+	return { ok: true, value: { method, url, headers, body } };
+};

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -35,6 +35,7 @@ import {
 	Shield,
 	ShieldCheck,
 	Sparkles,
+	Terminal,
 } from '@lucide/svelte';
 
 /**
@@ -231,6 +232,19 @@ export const PAGES: readonly PageDefinition[] = [
 		icon: Clock,
 		description: 'Build and parse cron expressions with next-execution preview',
 		color: 'text-stone-500',
+		category: 'generators',
+		tabs: [
+			{ id: 'build', label: 'Build', icon: Pencil },
+			{ id: 'parse', label: 'Parse', icon: Search },
+		],
+	},
+	{
+		id: 'curl-builder',
+		title: 'cURL Builder',
+		url: '/curl-builder',
+		icon: Terminal,
+		description: 'Build and parse cURL commands with method, headers, and body',
+		color: 'text-zinc-500',
 		category: 'generators',
 		tabs: [
 			{ id: 'build', label: 'Build', icon: Pencil },

--- a/src/routes/curl-builder/+page.svelte
+++ b/src/routes/curl-builder/+page.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { Pencil, Search } from '@lucide/svelte';
+	import { ToolShell } from '$lib/components/shell';
+	import { StatItem } from '$lib/components/status';
+	import { BuildTab, ParseTab } from './tabs/index.js';
+
+	type CurlTab = 'build' | 'parse';
+
+	const TABS = [
+		{ id: 'build' as const, label: 'Build', icon: Pencil },
+		{ id: 'parse' as const, label: 'Parse', icon: Search },
+	] as const;
+
+	let activeTab = $state<CurlTab>('build');
+	let buildStats = $state<{ command: string; valid: boolean }>({ command: '', valid: true });
+	let parseStats = $state<{ command: string; valid: boolean }>({ command: '', valid: true });
+
+	const currentStats = $derived(activeTab === 'build' ? buildStats : parseStats);
+
+	const handleTabChange = (tab: string) => {
+		if (tab === 'build' || tab === 'parse') activeTab = tab;
+	};
+</script>
+
+<svelte:head>
+	<title>cURL Builder - Kogu</title>
+</svelte:head>
+
+<ToolShell
+	layout="tabbed"
+	tabs={TABS}
+	{activeTab}
+	ontabchange={handleTabChange}
+	valid={currentStats.valid}
+>
+	{#snippet statusContent()}
+		{#if currentStats.command}
+			<StatItem label="Length" value={currentStats.command.length} />
+		{/if}
+	{/snippet}
+
+	{#snippet tabContent(tab)}
+		{#if tab === 'build'}
+			<BuildTab onstatschange={(info) => (buildStats = info)} />
+		{:else if tab === 'parse'}
+			<ParseTab onstatschange={(info) => (parseStats = info)} />
+		{/if}
+	{/snippet}
+</ToolShell>

--- a/src/routes/curl-builder/tabs/build-tab.svelte
+++ b/src/routes/curl-builder/tabs/build-tab.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+	import { Terminal } from '@lucide/svelte';
+	import { CopyButton } from '$lib/components/action';
+	import { FormCheckbox, FormInput, FormSelect, FormTextarea } from '$lib/components/form';
+	import { SectionHeader } from '$lib/components/layout';
+	import {
+		buildCurl,
+		DEFAULT_BUILD_OPTIONS,
+		DEFAULT_REQUEST,
+		formatHeaderLines,
+		HTTP_METHODS,
+		type HttpMethod,
+		isHttpMethod,
+		parseHeaderLines,
+	} from '$lib/services/curl.js';
+
+	interface Props {
+		onstatschange?: (info: { command: string; valid: boolean }) => void;
+	}
+
+	let { onstatschange }: Props = $props();
+
+	let method = $state<HttpMethod>(DEFAULT_REQUEST.method);
+	let url = $state<string>(DEFAULT_REQUEST.url);
+	let headersText = $state<string>(formatHeaderLines(DEFAULT_REQUEST.headers));
+	let body = $state<string>(DEFAULT_REQUEST.body);
+	let multiline = $state<boolean>(DEFAULT_BUILD_OPTIONS.multiline);
+
+	const headers = $derived(parseHeaderLines(headersText));
+	const command = $derived(buildCurl({ method, url, headers, body }, { multiline }));
+	const isValid = $derived(url.length > 0);
+
+	const methodOptions = HTTP_METHODS.map((m) => ({ value: m, label: m }));
+
+	const handleMethodChange = (value: string) => {
+		if (isHttpMethod(value)) method = value;
+	};
+
+	$effect(() => {
+		onstatschange?.({ command, valid: isValid });
+	});
+</script>
+
+<div class="flex h-full flex-col overflow-hidden">
+	<SectionHeader title="Build cURL Command">
+		{#snippet trailing()}
+			<CopyButton text={command} toastLabel="Command" size="sm" class="h-7" />
+		{/snippet}
+	</SectionHeader>
+
+	<div class="flex-1 overflow-auto p-4">
+		<div class="space-y-4">
+			<div class="rounded-lg border bg-surface-3 p-4">
+				<div class="grid gap-3 sm:grid-cols-[140px_1fr]">
+					<FormSelect
+						label="Method"
+						value={method}
+						options={methodOptions}
+						onchange={handleMethodChange}
+					/>
+					<FormInput label="URL" bind:value={url} placeholder="https://api.example.com/users" />
+				</div>
+			</div>
+
+			<div class="rounded-lg border bg-surface-3 p-4">
+				<FormTextarea
+					label="Headers"
+					bind:value={headersText}
+					placeholder={`Authorization: Bearer xxx\nContent-Type: application/json`}
+					hint="One header per line, Key: Value format"
+					rows={4}
+					class="font-mono text-sm"
+				/>
+			</div>
+
+			<div class="rounded-lg border bg-surface-3 p-4">
+				<FormTextarea
+					label="Body"
+					bind:value={body}
+					placeholder={`{ "name": "alice" }`}
+					hint="Sent with --data-raw; methods default to POST when a body is present"
+					rows={6}
+					class="font-mono text-sm"
+				/>
+			</div>
+
+			<div class="rounded-lg border bg-surface-3 p-4">
+				<FormCheckbox
+					label="Multi-line output"
+					hint="Wraps each argument onto its own line with backslash continuations"
+					bind:checked={multiline}
+				/>
+			</div>
+
+			<div class="rounded-lg border bg-surface-3 p-4">
+				<div class="flex items-center gap-2">
+					<Terminal class="h-4 w-4 text-muted-foreground" />
+					<span class="text-sm font-medium">Generated command</span>
+				</div>
+				<pre class="mt-2 overflow-auto rounded bg-muted p-3 font-mono text-sm">{command}</pre>
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/routes/curl-builder/tabs/index.ts
+++ b/src/routes/curl-builder/tabs/index.ts
@@ -1,0 +1,2 @@
+export { default as BuildTab } from './build-tab.svelte';
+export { default as ParseTab } from './parse-tab.svelte';

--- a/src/routes/curl-builder/tabs/parse-tab.svelte
+++ b/src/routes/curl-builder/tabs/parse-tab.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+	import { Globe, Terminal } from '@lucide/svelte';
+	import { CopyButton } from '$lib/components/action';
+	import { FormTextarea } from '$lib/components/form';
+	import { SectionHeader } from '$lib/components/layout';
+	import { EmbeddedEmptyState } from '$lib/components/status';
+	import { parseCurl } from '$lib/services/curl.js';
+
+	interface Props {
+		onstatschange?: (info: { command: string; valid: boolean }) => void;
+	}
+
+	let { onstatschange }: Props = $props();
+
+	let command = $state<string>(
+		`curl -X POST 'https://api.example.com/login' \\\n  -H 'Content-Type: application/json' \\\n  --data-raw '{"username":"alice","password":"secret"}'`
+	);
+
+	const parsed = $derived(parseCurl(command));
+
+	$effect(() => {
+		onstatschange?.({ command, valid: parsed.ok });
+	});
+</script>
+
+<div class="flex h-full flex-col overflow-hidden">
+	<SectionHeader title="Parse cURL Command">
+		{#snippet trailing()}
+			<CopyButton text={command} toastLabel="Command" size="sm" class="h-7" />
+		{/snippet}
+	</SectionHeader>
+
+	<div class="flex-1 overflow-auto p-4">
+		<div class="space-y-4">
+			<div class="rounded-lg border bg-surface-3 p-4">
+				<FormTextarea
+					label="cURL command"
+					bind:value={command}
+					placeholder="curl -X GET 'https://example.com'"
+					hint="Supports -X, -H, -d / --data / --data-raw / --data-binary, -G; backslash continuations are joined."
+					rows={6}
+					class="font-mono text-sm"
+				/>
+			</div>
+
+			{#if parsed.ok}
+				<div class="rounded-lg border bg-surface-3 p-4">
+					<div class="flex items-center gap-2">
+						<Globe class="h-4 w-4 text-muted-foreground" />
+						<span class="text-sm font-medium">Request</span>
+					</div>
+					<div class="mt-2 grid gap-3 sm:grid-cols-[140px_1fr]">
+						<div class="rounded border bg-muted px-3 py-2 text-center font-mono text-sm">
+							{parsed.value.method}
+						</div>
+						<div class="rounded border bg-muted px-3 py-2 font-mono text-sm break-all">
+							{parsed.value.url}
+						</div>
+					</div>
+				</div>
+
+				<div class="rounded-lg border bg-surface-3 p-4">
+					<span class="mb-2 block text-sm font-medium">
+						Headers ({parsed.value.headers.length})
+					</span>
+					{#if parsed.value.headers.length > 0}
+						<div class="space-y-1 font-mono text-sm">
+							{#each parsed.value.headers as header, idx (idx)}
+								<div class="flex items-baseline gap-2 rounded border bg-muted px-3 py-2">
+									<span class="shrink-0 font-medium">{header.key}:</span>
+									<span class="break-all text-muted-foreground">{header.value}</span>
+								</div>
+							{/each}
+						</div>
+					{:else}
+						<EmbeddedEmptyState
+							icon={Globe}
+							title="No headers"
+							description="No -H flags were present in the command."
+						/>
+					{/if}
+				</div>
+
+				<div class="rounded-lg border bg-surface-3 p-4">
+					<div class="mb-2 flex items-center justify-between">
+						<span class="text-sm font-medium">Body</span>
+						{#if parsed.value.body.length > 0}
+							<CopyButton text={parsed.value.body} toastLabel="Body" size="sm" />
+						{/if}
+					</div>
+					{#if parsed.value.body.length > 0}
+						<pre class="overflow-auto rounded bg-muted p-3 font-mono text-sm">{parsed.value
+								.body}</pre>
+					{:else}
+						<p class="text-sm text-muted-foreground">No body.</p>
+					{/if}
+				</div>
+			{:else}
+				<div class="rounded-lg border border-destructive/30 bg-destructive/10 p-4">
+					<div class="flex items-center gap-2">
+						<Terminal class="h-4 w-4 text-destructive" />
+						<span class="text-sm font-medium text-destructive">Parse error</span>
+					</div>
+					<p class="mt-2 text-sm">{parsed.error}</p>
+				</div>
+			{/if}
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
## Summary

- Add new tabbed tool page `/curl-builder` with Build and Parse tabs.
- Build tab composes method, URL, header lines, and body into a shell-safe `curl` command (single-line or multi-line).
- Parse tab tokenizes a cURL string and extracts method, URL, headers, and body.

## Changes

### Added

- `src/lib/services/curl.ts` - pure helpers for building and parsing; tokenizer recognizes `-X`, `-H`, `-d` / `--data` / `--data-raw` / `--data-binary`, `-G`.
- `src/lib/components/form/form-textarea.svelte` - new `FormTextarea` wrapper (Label + Textarea rhythm) since this PR needs three textareas (build headers, build body, parse command).
- `src/routes/curl-builder/+page.svelte` - tabbed `ToolShell` orchestrator.
- `src/routes/curl-builder/tabs/{build,parse}-tab.svelte` - per-tab content.
- `src/routes/curl-builder/tabs/index.ts` - barrel export.

### Changed

- `src/lib/services/pages.ts` - register `curl-builder` with `Terminal` icon, `text-zinc-500` color, and Build / Parse tabs.
- `src/lib/components/form/index.ts` - export `FormTextarea`.

## Test Plan

- [x] Navigate to `/curl-builder`; entry shows under Generators with the Terminal icon.
- [x] Build tab default shows `curl https://api.example.com/users` (multi-line off would collapse to one line).
- [x] Switch method to POST; command updates to `curl -X POST ...`.
- [x] Add header `Authorization: Bearer xxx`; command gains `-H 'Authorization: Bearer xxx'`.
- [x] Add body `{"a":1}`; command gains `--data-raw '{\"a\":1}'`.
- [x] Toggle multi-line off; command renders on a single line.
- [x] Parse tab default sample parses cleanly: method POST, URL `https://api.example.com/login`, two headers (or one for the sample), body JSON.
- [x] Replace with `curl -G 'https://example.com' -H 'X: 1'`; method shows GET; one header parsed; no body.
- [x] Replace with `not-curl`; parse error shows in the error card; status bar `valid` flips to invalid.
- [x] Cmd+1 / Cmd+2 switch tabs.
- [x] Light + dark mode visual parity.
