### PR TITLE
docs(rules): canonicalize Card.Root and add ReactiveSinglePage pattern

### DIFF
--- a/.claude/rules/svelte/components.md
+++ b/.claude/rules/svelte/components.md
@@ -395,6 +395,104 @@ When using shadcn-svelte `Tabs.Root` + `Tabs.List` + `Tabs.Trigger`, you must al
 
 bits-ui keeps inactive `Tabs.Content` mounted by default (it sets `hidden=true` rather than unmounting), so wrapping each tab body in `<Tabs.Content value={tab.id}>` automatically preserves component state across switches without an explicit `forceMount`.
 
+## Container Patterns
+
+Tool pages compose their main content out of a small set of container primitives. The mapping below is canonical — do not invent ad-hoc containers when a shadcn primitive exists for the role.
+
+| Role                              | Canonical container                          | Rule                                                                       |
+| --------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------- |
+| Card-like section in main content | `Card.Root` / `Card.Header` / `Card.Content` | Always. Do **not** use `<div class="rounded-lg border bg-surface-3 ...">`. |
+| Section heading inside a panel    | `Card.Title` (inside `Card.Header`)          | Default. Use `SectionLabel` only for inline cards inside another panel.    |
+| Status indicator (small)          | `Badge`                                      | Use `Badge variant="outline"` for neutral, semantic tones via `cn()`.      |
+| Collapsible disclosure            | `Accordion.Root` / `Accordion.Item`          | Use for groups of related panels that the user may want to fold.           |
+| Boolean toggle (on/off)           | `Switch` or `Button` with `variant`          | Prefer `Switch` for true on/off, `Button` for two-state actions.           |
+| Modal / dialog                    | `Dialog.Root`                                | Use `AlertDialog` for destructive confirmations.                           |
+
+### Card.Root is the Canonical Card
+
+A card is **any rectangular grouping with border + padding + optional header**. Build it with the `Card.*` primitive set, never with a hand-rolled `<div>`:
+
+```svelte
+<!-- Preferred -->
+<Card.Root>
+	<Card.Header class="pb-3">
+		<div class="flex items-center gap-2">
+			<Clock class="h-4 w-4 text-muted-foreground" />
+			<Card.Title class="text-sm font-medium">Expression</Card.Title>
+		</div>
+	</Card.Header>
+	<Card.Content>
+		<code class="block rounded-md bg-muted p-3 font-mono text-base">{expression}</code>
+	</Card.Content>
+</Card.Root>
+
+<!-- Avoid: ad-hoc div with utility classes -->
+<div class="rounded-lg border bg-surface-3 p-4">
+	<div class="flex items-center gap-2">
+		<Clock class="h-4 w-4 text-muted-foreground" />
+		<span class="text-sm font-medium">Expression</span>
+	</div>
+	<code class="mt-2 block rounded bg-muted p-3 font-mono text-base">{expression}</code>
+</div>
+```
+
+The shadcn `Card.Root` already provides `bg-card`, `text-card-foreground`, `rounded-xl`, `border`, and `shadow-sm`; per-instance overrides should go through `class` on the root, not by re-implementing the surface treatment.
+
+When a card needs an action affordance on its header, place it on the `Card.Header` with `flex flex-row items-center justify-between space-y-0 pb-3`:
+
+```svelte
+<Card.Root>
+	<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
+		<div class="flex items-center gap-2">
+			<Sparkles class="h-4 w-4 text-muted-foreground" />
+			<Card.Title class="text-sm font-medium">Generated command</Card.Title>
+		</div>
+		<CopyButton text={command} toastLabel="Command" size="sm" />
+	</Card.Header>
+	<Card.Content>...</Card.Content>
+</Card.Root>
+```
+
+### Badge for Status
+
+Always render status / count / category indicators as `Badge`, not as a hand-rolled `<span>`:
+
+```svelte
+<!-- Preferred -->
+<Badge variant="outline" class="bg-success/10 text-success">✓ valid</Badge>
+<Badge variant="outline" class="font-mono text-2xs">{matches.length} matches</Badge>
+
+<!-- Avoid -->
+<span class="rounded bg-success/10 px-1.5 py-0.5 text-xs text-success">✓ valid</span>
+```
+
+Semantic tone via `bg-{success,warning,info,destructive}/10` + matching text color. Reserve `Badge variant="default"` for highlights, `variant="outline"` for neutral.
+
+### Accordion for Grouped Disclosure
+
+When a panel has multiple sections the user might want to fold, use `Accordion`:
+
+```svelte
+<Accordion.Root type="multiple" value={['matches', 'structure']} class="w-full">
+	<Accordion.Item value="matches">
+		<Accordion.Trigger>
+			<div class="flex items-center gap-2">
+				<Search class="h-4 w-4 text-muted-foreground" />
+				<span class="text-sm font-medium">Matches</span>
+				<Badge variant="outline" class="font-mono text-2xs">{matches.length}</Badge>
+			</div>
+		</Accordion.Trigger>
+		<Accordion.Content>…</Accordion.Content>
+	</Accordion.Item>
+</Accordion.Root>
+```
+
+Use `type="multiple"` when independent toggling makes sense, `type="single"` when only one should be open at a time. The default `value={[]}` keeps every item collapsed.
+
+### Auditing
+
+`bg-surface-3` is reserved for **rail** and **status bar** backgrounds. A grep across `src/routes/` for `bg-surface-3 rounded` or `bg-surface-3.*p-4` should return zero hits — any match is a card masquerading as a div and should be migrated to `Card.Root`.
+
 ## Accessibility
 
 Always include proper ARIA attributes:

--- a/.claude/rules/svelte/layouts.md
+++ b/.claude/rules/svelte/layouts.md
@@ -212,6 +212,56 @@ Pages: Diff Viewer, Markdown Editor
 
 ---
 
+## Pattern: ReactiveSinglePage
+
+Single-input tool with multiple synchronized views of the same underlying state. Inspired by `regex101.com` — one source-of-truth input at the top, with derived panels (matches, replacements, structural visualization, explanation) updating reactively.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ ToolBar  [Icon] Title                                        │
+├──────────┬───────────────────────────────────────────────────┤
+│ Options  │ Pattern bar (sticky)                              │
+│  Rail    │ ┌─────────────────────────┐ [g][i][m][s][u][y]   │
+│          │ │ Syntax-highlighted input │ flag pills           │
+│  [Info]  │ └─────────────────────────┘                        │
+│  [Help]  │ ✓ valid · stats · features                        │
+│          ├──────────────────────────┬────────────────────────┤
+│          │ Primary input + action   │ Side accordion         │
+│          │  ┌────────────────────┐  │  ▼ Section 1           │
+│          │  │ Test input         │  │  ▼ Section 2           │
+│          │  │ Inline preview     │  │  ▼ Section 3           │
+│          │  └────────────────────┘  │                        │
+│          │  ┌────────────────────┐  │                        │
+│          │  │ Action toggle      │  │                        │
+│          │  │ Result preview     │  │                        │
+│          │  └────────────────────┘  │                        │
+├──────────┴──────────────────────────┴────────────────────────┤
+│ StatusBar  ...                                               │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Distinguishing features:
+
+- **Single source of truth at the top** — pattern, query, or expression. All derived views read from this.
+- **Live reactive updates** — no Generate button. Edits propagate immediately to all panels.
+- **Two-column body** — left for the user's working area (test text + secondary action), right for collapsible analytical panels.
+- **Accordion side panel** — multiple viewpoints (Matches / Structure / Explain) collapse independently.
+- **Flag/option pills next to the input** — compact toggles instead of a dedicated options card.
+
+### When to Use
+
+Pick this pattern when:
+
+- The tool centers on a single complex input (regex, query, expression)
+- Users iterate fast and benefit from seeing all derived views simultaneously
+- Match/Replace style "modes" exist that share input but produce different outputs
+
+### Pages Using This Pattern
+
+- `src/routes/regex-tester/+page.svelte`
+
+---
+
 ## Pattern: MasterDetail
 
 Options rail with resizable two-pane layout for list + detail view.
@@ -340,11 +390,23 @@ CSS Grid layout with areas: toolbar, rail, content, status.
 
 ## Pattern Selection Guide
 
-| Use Case                       | Pattern                  |
-| ------------------------------ | ------------------------ |
-| Multi-format tool with tabs    | Tabbed                   |
-| Simple encoder/formatter       | Transform (split-h)      |
-| Parser with structured results | Transform (split-v)      |
-| Generator with form input      | Transform (form-results) |
-| Preview/comparison             | Transform (dual-view)    |
-| List + detail navigation       | MasterDetail             |
+| Use Case                                     | Pattern                  |
+| -------------------------------------------- | ------------------------ |
+| Multi-format tool with tabs                  | Tabbed                   |
+| Simple encoder/formatter                     | Transform (split-h)      |
+| Parser with structured results               | Transform (split-v)      |
+| Generator with form input                    | Transform (form-results) |
+| Preview/comparison                           | Transform (dual-view)    |
+| Single complex input with synchronized views | ReactiveSinglePage       |
+| List + detail navigation                     | MasterDetail             |
+
+## Pattern Overview Table
+
+| Pattern            | Tabs?    | Rail?    | Body layout                  | Card system |
+| ------------------ | -------- | -------- | ---------------------------- | ----------- |
+| Tabbed             | Required | Optional | Tab content panels           | `Card.Root` |
+| Transform          | No       | Required | Single split                 | `Card.Root` |
+| ReactiveSinglePage | No       | Optional | Pattern bar + 2-col + accord | `Card.Root` |
+| MasterDetail       | No       | Required | Resizable list + detail      | `Card.Root` |
+
+Every pattern uses **`Card.Root` for sectioned content**. The legacy `<div class="rounded-lg border bg-surface-3 ...">` ad-hoc card is deprecated in favor of the shadcn primitive — see `components.md` § Container Patterns for the canonical mapping.


### PR DESCRIPTION
## Summary

Foundation PR for the app-wide design unification effort. Establishes the canonical shadcn-svelte component mapping that every subsequent page migration will follow.

- Add a **Container Patterns** section to `components.md` that maps every UI role (card section, status indicator, collapsible disclosure, boolean toggle, dialog) to its canonical shadcn primitive. Deprecates ad-hoc \`<div class=\"rounded-lg border bg-surface-3 ...\">\` cards in favor of \`Card.Root\`.
- Add a **ReactiveSinglePage** layout pattern to \`layouts.md\` capturing the regex101-inspired structure introduced by the Regex Tester redesign in PR #200.
- Update the Pattern Selection Guide + add a Pattern Overview Table so future contributors can pick the right pattern at a glance.

## Why this comes first

The next 5 PRs migrate existing pages (Hash / BCrypt / SSH / GPG / JWT / Network Scanner / JSON-YAML-XML Formatters / etc.) from the legacy \`bg-surface-3 div\` cards to \`Card.Root\`. Locking the rules in first means:

1. Reviewers can validate each migration against a written standard.
2. The grep audit (\`bg-surface-3 rounded\` should return zero hits after Phase 5) becomes a binary pass/fail.
3. New contributors land on the new pattern automatically.

## Changes

### Added

- \`.claude/rules/svelte/components.md\` — \`## Container Patterns\` section with:
  - Role → canonical container mapping table
  - \`Card.Root is the Canonical Card\` (with before/after examples)
  - \`Badge for Status\` rule
  - \`Accordion for Grouped Disclosure\` rule
  - Audit rule: \`bg-surface-3 rounded\` must grep to zero
- \`.claude/rules/svelte/layouts.md\` — \`## Pattern: ReactiveSinglePage\` section with ASCII diagram, distinguishing features, and \"When to Use\" criteria

### Changed

- \`layouts.md\` Pattern Selection Guide adds the ReactiveSinglePage row
- New Pattern Overview Table at the bottom clarifies that every pattern uses Card.Root

## Test Plan

- [ ] Render \`components.md\` and \`layouts.md\` on GitHub; tables format correctly, code samples are syntax-highlighted
- [ ] Grep for \`bg-surface-3 rounded\` in src/routes/ — expected baseline ~16-20 hits before migration starts (audit reference)
- [ ] Confirm Card.Root example matches existing usage in QR / Cron / cURL / Regex pages
- [ ] No code changes — pure documentation