### PR TITLE
refactor(generators,encoders,text): migrate cards to Card.Root (Phase 2)

### DIFF
--- a/src/routes/bcrypt-generator/+page.svelte
+++ b/src/routes/bcrypt-generator/+page.svelte
@@ -6,6 +6,7 @@
 	import { SectionHeader } from '$lib/components/layout';
 	import { ToolShell } from '$lib/components/shell';
 	import { EmptyState, ErrorDisplay, LoadingOverlay, StatItem } from '$lib/components/status';
+	import * as Card from '$lib/components/ui/card';
 	import {
 		type BcryptCostInfo,
 		type BcryptHashResult,
@@ -344,10 +345,9 @@
 			{#if activeTab === 'generate'}
 				{#if hashResult}
 					<div class="space-y-4">
-						<!-- Hash Result -->
-						<div class="rounded-lg border bg-surface-3 p-4">
-							<div class="mb-2 flex items-center justify-between">
-								<span class="text-sm font-medium">BCrypt Hash</span>
+						<Card.Root>
+							<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
+								<Card.Title class="text-sm font-medium">BCrypt Hash</Card.Title>
 								<CopyButton
 									text={hashResult.hash}
 									toastLabel="Hash"
@@ -355,34 +355,39 @@
 									showLabel
 									class="h-7"
 								/>
-							</div>
-							<code class="block break-all rounded bg-muted p-3 font-mono text-sm">
-								{hashResult.hash}
-							</code>
-						</div>
+							</Card.Header>
+							<Card.Content>
+								<code class="block break-all rounded bg-muted p-3 font-mono text-sm">
+									{hashResult.hash}
+								</code>
+							</Card.Content>
+						</Card.Root>
 
-						<!-- Hash Details -->
-						<div class="rounded-lg border bg-surface-3 p-4">
-							<span class="mb-3 block text-sm font-medium">Hash Details</span>
-							<div class="space-y-2 text-sm">
-								<div class="flex justify-between">
-									<span class="text-muted-foreground">Algorithm</span>
-									<span class="font-mono">${hashResult.algorithm}$</span>
+						<Card.Root>
+							<Card.Header class="pb-3">
+								<Card.Title class="text-sm font-medium">Hash Details</Card.Title>
+							</Card.Header>
+							<Card.Content>
+								<div class="space-y-2 text-sm">
+									<div class="flex justify-between">
+										<span class="text-muted-foreground">Algorithm</span>
+										<span class="font-mono">${hashResult.algorithm}$</span>
+									</div>
+									<div class="flex justify-between">
+										<span class="text-muted-foreground">Cost Factor</span>
+										<span class="font-mono">{hashResult.cost}</span>
+									</div>
+									<div class="flex justify-between">
+										<span class="text-muted-foreground">Security Level</span>
+										<span>{costInfo?.security_level ?? 'Unknown'}</span>
+									</div>
+									<div class="flex justify-between">
+										<span class="text-muted-foreground">Hash Length</span>
+										<span class="font-mono">{hashResult.hash.length} chars</span>
+									</div>
 								</div>
-								<div class="flex justify-between">
-									<span class="text-muted-foreground">Cost Factor</span>
-									<span class="font-mono">{hashResult.cost}</span>
-								</div>
-								<div class="flex justify-between">
-									<span class="text-muted-foreground">Security Level</span>
-									<span>{costInfo?.security_level ?? 'Unknown'}</span>
-								</div>
-								<div class="flex justify-between">
-									<span class="text-muted-foreground">Hash Length</span>
-									<span class="font-mono">{hashResult.hash.length} chars</span>
-								</div>
-							</div>
-						</div>
+							</Card.Content>
+						</Card.Root>
 					</div>
 				{:else if generateError}
 					<ErrorDisplay variant="centered" message={generateError} />

--- a/src/routes/gpg-key-generator/+page.svelte
+++ b/src/routes/gpg-key-generator/+page.svelte
@@ -13,6 +13,7 @@
 	import { SectionHeader } from '$lib/components/layout';
 	import { ToolShell } from '$lib/components/shell';
 	import { EmptyState, ErrorDisplay, LoadingOverlay, StatItem } from '$lib/components/status';
+	import * as Card from '$lib/components/ui/card';
 	import {
 		buildGpgUserId,
 		cancelWorkerOperation,
@@ -166,13 +167,15 @@
 
 		{#if name || email}
 			<FormSection title="User ID Preview">
-				<div class="rounded-md border bg-surface-3 p-2">
-					<div class="mb-1 flex items-center gap-1.5 text-xs text-muted-foreground">
-						<User class="h-3 w-3" />
-						Preview
-					</div>
-					<code class="text-xs">{userIdPreview}</code>
-				</div>
+				<Card.Root class="bg-muted/30">
+					<Card.Content class="p-3">
+						<div class="mb-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+							<User class="h-3 w-3" />
+							Preview
+						</div>
+						<code class="text-xs">{userIdPreview}</code>
+					</Card.Content>
+				</Card.Root>
 			</FormSection>
 		{/if}
 
@@ -297,40 +300,42 @@
 		<div class="flex-1 overflow-auto p-4">
 			{#if keyResult}
 				<div class="space-y-4">
-					<!-- User ID & Fingerprint -->
 					{#if showKeyInfo}
-						<div class="rounded-lg border bg-surface-3 p-4">
-							<div class="mb-3 flex items-center gap-2">
-								<User class="h-4 w-4" />
-								<span class="text-sm font-medium">Key Information</span>
-							</div>
-							<div class="space-y-2">
-								<div class="flex items-start justify-between">
-									<span class="text-xs text-muted-foreground">User ID</span>
-									<code class="text-xs">{keyResult.user_id}</code>
+						<Card.Root>
+							<Card.Header class="pb-3">
+								<div class="flex items-center gap-2">
+									<User class="h-4 w-4" />
+									<Card.Title class="text-sm font-medium">Key Information</Card.Title>
 								</div>
-								<div class="flex items-start justify-between">
-									<span class="text-xs text-muted-foreground">Fingerprint</span>
-									<div class="flex items-center gap-2">
-										<code class="text-xs">{keyResult.fingerprint}</code>
-										<CopyButton
-											text={keyResult.fingerprint}
-											toastLabel="Fingerprint"
-											size="icon"
-											class="h-6 w-6"
-										/>
+							</Card.Header>
+							<Card.Content>
+								<div class="space-y-2">
+									<div class="flex items-start justify-between">
+										<span class="text-xs text-muted-foreground">User ID</span>
+										<code class="text-xs">{keyResult.user_id}</code>
+									</div>
+									<div class="flex items-start justify-between">
+										<span class="text-xs text-muted-foreground">Fingerprint</span>
+										<div class="flex items-center gap-2">
+											<code class="text-xs">{keyResult.fingerprint}</code>
+											<CopyButton
+												text={keyResult.fingerprint}
+												toastLabel="Fingerprint"
+												size="icon"
+												class="h-6 w-6"
+											/>
+										</div>
 									</div>
 								</div>
-							</div>
-						</div>
+							</Card.Content>
+						</Card.Root>
 					{/if}
 
-					<!-- Public Key -->
-					<div class="rounded-lg border bg-surface-3 p-4">
-						<div class="mb-2 flex items-center justify-between">
+					<Card.Root>
+						<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 							<div class="flex items-center gap-2">
 								<Unlock class="h-4 w-4 text-success" />
-								<span class="text-sm font-medium">Public Key (PGP Armor)</span>
+								<Card.Title class="text-sm font-medium">Public Key (PGP Armor)</Card.Title>
 							</div>
 							<CopyButton
 								text={keyResult.public_key}
@@ -339,13 +344,15 @@
 								showLabel
 								class="h-7"
 							/>
-						</div>
-						<pre
-							class="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs">{keyResult.public_key}</pre>
-						<p class="mt-2 text-xs text-muted-foreground">
-							Share this key with others so they can encrypt messages to you
-						</p>
-					</div>
+						</Card.Header>
+						<Card.Content>
+							<pre
+								class="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs">{keyResult.public_key}</pre>
+							<p class="mt-2 text-xs text-muted-foreground">
+								Share this key with others so they can encrypt messages to you
+							</p>
+						</Card.Content>
+					</Card.Root>
 
 					<!-- Private Key -->
 					<div class="rounded-lg border border-warning/30 bg-warning/5 p-4">
@@ -370,45 +377,47 @@
 						</p>
 					</div>
 
-					<!-- GPG Commands -->
 					{#if showGpgCommands}
-						<div class="rounded-lg border bg-surface-3 p-4">
-							<div class="mb-3 flex items-center gap-2">
-								<Terminal class="h-4 w-4" />
-								<span class="text-sm font-medium">Equivalent GPG Commands</span>
-							</div>
-
-							<div class="space-y-3">
-								<div>
-									<div class="mb-1 flex items-center justify-between">
-										<span class="text-xs text-muted-foreground">Interactive</span>
-										<CopyButton
-											text={keyResult.gpg_command_interactive}
-											toastLabel="Command"
-											size="icon"
-											class="h-6 w-6"
-										/>
-									</div>
-									<code class="block rounded bg-muted p-2 font-mono text-xs">
-										{keyResult.gpg_command_interactive}
-									</code>
+						<Card.Root>
+							<Card.Header class="pb-3">
+								<div class="flex items-center gap-2">
+									<Terminal class="h-4 w-4" />
+									<Card.Title class="text-sm font-medium">Equivalent GPG Commands</Card.Title>
 								</div>
-
-								<div>
-									<div class="mb-1 flex items-center justify-between">
-										<span class="text-xs text-muted-foreground">Batch Mode</span>
-										<CopyButton
-											text={keyResult.gpg_command_batch}
-											toastLabel="Command"
-											size="icon"
-											class="h-6 w-6"
-										/>
+							</Card.Header>
+							<Card.Content>
+								<div class="space-y-3">
+									<div>
+										<div class="mb-1 flex items-center justify-between">
+											<span class="text-xs text-muted-foreground">Interactive</span>
+											<CopyButton
+												text={keyResult.gpg_command_interactive}
+												toastLabel="Command"
+												size="icon"
+												class="h-6 w-6"
+											/>
+										</div>
+										<code class="block rounded bg-muted p-2 font-mono text-xs">
+											{keyResult.gpg_command_interactive}
+										</code>
 									</div>
-									<pre
-										class="max-h-32 overflow-auto whitespace-pre-wrap rounded bg-muted p-2 font-mono text-xs">{keyResult.gpg_command_batch}</pre>
+
+									<div>
+										<div class="mb-1 flex items-center justify-between">
+											<span class="text-xs text-muted-foreground">Batch Mode</span>
+											<CopyButton
+												text={keyResult.gpg_command_batch}
+												toastLabel="Command"
+												size="icon"
+												class="h-6 w-6"
+											/>
+										</div>
+										<pre
+											class="max-h-32 overflow-auto whitespace-pre-wrap rounded bg-muted p-2 font-mono text-xs">{keyResult.gpg_command_batch}</pre>
+									</div>
 								</div>
-							</div>
-						</div>
+							</Card.Content>
+						</Card.Root>
 					{/if}
 				</div>
 			{:else if error}

--- a/src/routes/hash-generator/+page.svelte
+++ b/src/routes/hash-generator/+page.svelte
@@ -6,6 +6,8 @@
 	import { SectionHeader } from '$lib/components/layout';
 	import { ToolShell } from '$lib/components/shell';
 	import { EmptyState, StatItem } from '$lib/components/status';
+	import { Badge } from '$lib/components/ui/badge';
+	import * as Card from '$lib/components/ui/card';
 	import {
 		formatBytes,
 		generateAllHashes,
@@ -126,21 +128,21 @@
 				{#if textHashes.length > 0}
 					<div class="space-y-3">
 						{#each textHashes as result}
-							<div class="rounded-lg border bg-surface-3 p-3">
-								<div class="mb-2 flex items-center justify-between">
+							<Card.Root>
+								<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 									<div class="flex items-center gap-2">
-										<span class="font-mono text-sm font-medium">{result.algorithm}</span>
+										<Card.Title class="font-mono text-sm">{result.algorithm}</Card.Title>
 										<span class="text-xs text-muted-foreground">({result.bits} bits)</span>
 										{#if getSecurityBadge(result.algorithm)}
-											<span class="flex items-center gap-1 text-xs text-success">
+											<Badge variant="outline" class="gap-1 bg-success/10 text-success">
 												<ShieldCheck class="h-3 w-3" />
 												Secure
-											</span>
+											</Badge>
 										{:else}
-											<span class="flex items-center gap-1 text-xs text-warning">
+											<Badge variant="outline" class="gap-1 bg-warning/10 text-warning">
 												<ShieldAlert class="h-3 w-3" />
 												Weak
-											</span>
+											</Badge>
 										{/if}
 									</div>
 									<CopyButton
@@ -150,11 +152,13 @@
 										showLabel
 										class="h-6"
 									/>
-								</div>
-								<code class="block break-all rounded bg-muted p-2 font-mono text-xs"
-									>{result.hash}</code
-								>
-							</div>
+								</Card.Header>
+								<Card.Content>
+									<code class="block break-all rounded bg-muted p-2 font-mono text-xs">
+										{result.hash}
+									</code>
+								</Card.Content>
+							</Card.Root>
 						{/each}
 					</div>
 				{:else}

--- a/src/routes/jwt-decoder/+page.svelte
+++ b/src/routes/jwt-decoder/+page.svelte
@@ -6,6 +6,7 @@
 	import { SectionHeader } from '$lib/components/layout';
 	import { ToolShell } from '$lib/components/shell';
 	import { EmptyState } from '$lib/components/status';
+	import * as Card from '$lib/components/ui/card';
 	import {
 		decodeJwt,
 		JWT_STANDARD_CLAIMS,
@@ -198,10 +199,9 @@
 						</div>
 					{/if}
 
-					<!-- Header section -->
-					<div class="rounded-lg border bg-surface-3">
-						<div class="flex items-center justify-between border-b px-4 py-2">
-							<h3 class="text-sm font-medium text-destructive">Header</h3>
+					<Card.Root>
+						<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
+							<Card.Title class="text-sm font-medium text-destructive">Header</Card.Title>
 							<CopyButton
 								text={formatJson(decoded.header)}
 								toastLabel="Header"
@@ -209,18 +209,17 @@
 								showLabel
 								class="h-6"
 							/>
-						</div>
-						<div class="p-4">
+						</Card.Header>
+						<Card.Content>
 							<pre class="overflow-auto rounded bg-muted p-3 font-mono text-xs">{formatJson(
 									decoded.header
 								)}</pre>
-						</div>
-					</div>
+						</Card.Content>
+					</Card.Root>
 
-					<!-- Payload section -->
-					<div class="rounded-lg border bg-surface-3">
-						<div class="flex items-center justify-between border-b px-4 py-2">
-							<h3 class="text-sm font-medium text-primary">Payload</h3>
+					<Card.Root>
+						<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
+							<Card.Title class="text-sm font-medium text-primary">Payload</Card.Title>
 							<CopyButton
 								text={formatJson(decoded.payload)}
 								toastLabel="Payload"
@@ -228,43 +227,43 @@
 								showLabel
 								class="h-6"
 							/>
-						</div>
-						<div class="p-4">
+						</Card.Header>
+						<Card.Content>
 							<pre class="overflow-auto rounded bg-muted p-3 font-mono text-xs">{formatJson(
 									decoded.payload
 								)}</pre>
-						</div>
-					</div>
+						</Card.Content>
+					</Card.Root>
 
-					<!-- Standard Claims -->
 					{#if Object.keys(decoded.payload).some( (k) => JWT_STANDARD_CLAIMS.some((c) => c.claim === k) )}
-						<div class="rounded-lg border bg-surface-3">
-							<div class="border-b px-4 py-2">
-								<h3 class="text-sm font-medium">Standard Claims</h3>
-							</div>
-							<div class="divide-y">
-								{#each Object.entries(decoded.payload).filter( ([k]) => JWT_STANDARD_CLAIMS.some((c) => c.claim === k) ) as [key, value]}
-									<div class="flex items-center gap-4 px-4 py-2 text-xs">
-										<span class="w-20 font-mono font-medium text-primary">{key}</span>
-										<span class="w-32 text-muted-foreground">{getClaimDescription(key)}</span>
-										<span class="flex-1 font-mono">
-											{#if key === 'exp' || key === 'iat' || key === 'nbf'}
-												{formatDate(new Date(Number(value) * 1000))}
-												<span class="ml-2 text-muted-foreground">({value})</span>
-											{:else}
-												{JSON.stringify(value)}
-											{/if}
-										</span>
-									</div>
-								{/each}
-							</div>
-						</div>
+						<Card.Root>
+							<Card.Header class="pb-3">
+								<Card.Title class="text-sm font-medium">Standard Claims</Card.Title>
+							</Card.Header>
+							<Card.Content class="p-0">
+								<div class="divide-y border-t">
+									{#each Object.entries(decoded.payload).filter( ([k]) => JWT_STANDARD_CLAIMS.some((c) => c.claim === k) ) as [key, value]}
+										<div class="flex items-center gap-4 px-4 py-2 text-xs">
+											<span class="w-20 font-mono font-medium text-primary">{key}</span>
+											<span class="w-32 text-muted-foreground">{getClaimDescription(key)}</span>
+											<span class="flex-1 font-mono">
+												{#if key === 'exp' || key === 'iat' || key === 'nbf'}
+													{formatDate(new Date(Number(value) * 1000))}
+													<span class="ml-2 text-muted-foreground">({value})</span>
+												{:else}
+													{JSON.stringify(value)}
+												{/if}
+											</span>
+										</div>
+									{/each}
+								</div>
+							</Card.Content>
+						</Card.Root>
 					{/if}
 
-					<!-- Signature section -->
-					<div class="rounded-lg border bg-surface-3">
-						<div class="flex items-center justify-between border-b px-4 py-2">
-							<h3 class="text-sm font-medium text-info">Signature</h3>
+					<Card.Root>
+						<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
+							<Card.Title class="text-sm font-medium text-info">Signature</Card.Title>
 							<CopyButton
 								text={decoded.signature}
 								toastLabel="Signature"
@@ -272,17 +271,17 @@
 								showLabel
 								class="h-6"
 							/>
-						</div>
-						<div class="p-4">
-							<code class="block break-all rounded bg-muted p-3 font-mono text-xs"
-								>{decoded.signature}</code
-							>
+						</Card.Header>
+						<Card.Content>
+							<code class="block break-all rounded bg-muted p-3 font-mono text-xs">
+								{decoded.signature}
+							</code>
 							<p class="mt-2 text-xs text-muted-foreground">
 								Note: Signature verification requires the secret key and is not performed
 								client-side.
 							</p>
-						</div>
-					</div>
+						</Card.Content>
+					</Card.Root>
 				</div>
 			{:else}
 				<div class="flex-1">

--- a/src/routes/ssh-key-generator/+page.svelte
+++ b/src/routes/ssh-key-generator/+page.svelte
@@ -13,6 +13,7 @@
 	import { SectionHeader } from '$lib/components/layout';
 	import { ToolShell } from '$lib/components/shell';
 	import { EmptyState, ErrorDisplay, LoadingOverlay, StatItem } from '$lib/components/status';
+	import * as Card from '$lib/components/ui/card';
 	import {
 		cancelWorkerOperation,
 		type CliAvailability,
@@ -285,11 +286,10 @@
 		<div class="flex-1 overflow-auto p-4">
 			{#if keyResult}
 				<div class="space-y-4">
-					<!-- Fingerprint -->
 					{#if showFingerprint}
-						<div class="rounded-lg border bg-surface-3 p-4">
-							<div class="mb-2 flex items-center justify-between">
-								<span class="text-sm font-medium">Fingerprint (SHA-256)</span>
+						<Card.Root>
+							<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
+								<Card.Title class="text-sm font-medium">Fingerprint (SHA-256)</Card.Title>
 								<CopyButton
 									text={keyResult.fingerprint}
 									toastLabel="Fingerprint"
@@ -297,19 +297,20 @@
 									showLabel
 									class="h-7"
 								/>
-							</div>
-							<code class="block rounded bg-muted p-2 font-mono text-sm">
-								{keyResult.fingerprint}
-							</code>
-						</div>
+							</Card.Header>
+							<Card.Content>
+								<code class="block rounded bg-muted p-2 font-mono text-sm">
+									{keyResult.fingerprint}
+								</code>
+							</Card.Content>
+						</Card.Root>
 					{/if}
 
-					<!-- Public Key -->
-					<div class="rounded-lg border bg-surface-3 p-4">
-						<div class="mb-2 flex items-center justify-between">
+					<Card.Root>
+						<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 							<div class="flex items-center gap-2">
 								<Unlock class="h-4 w-4 text-success" />
-								<span class="text-sm font-medium">Public Key</span>
+								<Card.Title class="text-sm font-medium">Public Key</Card.Title>
 							</div>
 							<CopyButton
 								text={keyResult.public_key}
@@ -318,13 +319,15 @@
 								showLabel
 								class="h-7"
 							/>
-						</div>
-						<pre
-							class="max-h-32 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs">{keyResult.public_key}</pre>
-						<p class="mt-2 text-xs text-muted-foreground">
-							Add this to <code>~/.ssh/authorized_keys</code> on remote servers
-						</p>
-					</div>
+						</Card.Header>
+						<Card.Content>
+							<pre
+								class="max-h-32 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs">{keyResult.public_key}</pre>
+							<p class="mt-2 text-xs text-muted-foreground">
+								Add this to <code>~/.ssh/authorized_keys</code> on remote servers
+							</p>
+						</Card.Content>
+					</Card.Root>
 
 					<!-- Private Key -->
 					<div class="rounded-lg border border-warning/30 bg-warning/5 p-4">
@@ -355,13 +358,12 @@
 						</p>
 					</div>
 
-					<!-- ssh-keygen Command -->
 					{#if showEquivalentCommand}
-						<div class="rounded-lg border bg-surface-3 p-4">
-							<div class="mb-2 flex items-center justify-between">
+						<Card.Root>
+							<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 								<div class="flex items-center gap-2">
 									<Terminal class="h-4 w-4" />
-									<span class="text-sm font-medium">Equivalent ssh-keygen Command</span>
+									<Card.Title class="text-sm font-medium">Equivalent ssh-keygen Command</Card.Title>
 								</div>
 								<CopyButton
 									text={keyResult.ssh_keygen_command}
@@ -370,11 +372,13 @@
 									showLabel
 									class="h-7"
 								/>
-							</div>
-							<code class="block rounded bg-muted p-2 font-mono text-xs">
-								{keyResult.ssh_keygen_command}
-							</code>
-						</div>
+							</Card.Header>
+							<Card.Content>
+								<code class="block rounded bg-muted p-2 font-mono text-xs">
+									{keyResult.ssh_keygen_command}
+								</code>
+							</Card.Content>
+						</Card.Root>
 					{/if}
 				</div>
 			{:else if error}

--- a/src/routes/string-case-converter/+page.svelte
+++ b/src/routes/string-case-converter/+page.svelte
@@ -13,6 +13,7 @@
 	import { SectionHeader } from '$lib/components/layout';
 	import { ToolShell } from '$lib/components/shell';
 	import { EmptyState, StatItem } from '$lib/components/status';
+	import * as Card from '$lib/components/ui/card';
 	import {
 		CASE_DEFINITIONS,
 		type CaseResult,
@@ -178,22 +179,24 @@
 				{#if caseResults.length > 0}
 					<div class="space-y-2">
 						{#each caseResults as result}
-							<div class="flex items-start gap-3 rounded-lg border bg-surface-3 px-3 py-2">
-								<span class="w-32 shrink-0 pt-0.5 font-mono text-xs font-medium"
-									>{result.label}</span
-								>
-								<code
-									class="min-w-0 flex-1 whitespace-pre-wrap break-all font-mono text-xs text-muted-foreground"
-								>
-									{result.value}
-								</code>
-								<CopyButton
-									text={result.value}
-									toastLabel={result.label}
-									size="sm"
-									class="h-6 shrink-0"
-								/>
-							</div>
+							<Card.Root>
+								<Card.Content class="flex items-start gap-3 px-3 py-2">
+									<span class="w-32 shrink-0 pt-0.5 font-mono text-xs font-medium">
+										{result.label}
+									</span>
+									<code
+										class="min-w-0 flex-1 whitespace-pre-wrap break-all font-mono text-xs text-muted-foreground"
+									>
+										{result.value}
+									</code>
+									<CopyButton
+										text={result.value}
+										toastLabel={result.label}
+										size="sm"
+										class="h-6 shrink-0"
+									/>
+								</Card.Content>
+							</Card.Root>
 						{/each}
 					</div>
 				{:else}


### PR DESCRIPTION
## Summary

Phase 2 of the app-wide design unification effort. Migrates the form-results style pages from \`<div class=\"rounded-lg border bg-surface-3 ...\">\` ad-hoc cards to shadcn \`Card.Root\` per the rule in PR #201.

| Page | Cards migrated |
|---|---:|
| Hash Generator | 1 |
| BCrypt Generator | 2 |
| SSH Key Generator | 3 |
| GPG Key Generator | 4 |
| JWT Decoder | 4 |
| String Case Converter | 1 |
| **Total** | **15** |

Settings had no matching cards (audit returned 0), so it is unchanged.

## Notable changes

- Hash Generator: Weak / Secure status spans become semantic \`Badge\` variants (\`bg-warning/10 text-warning\` / \`bg-success/10 text-success\`).
- Private-key cards in SSH/GPG keep their destructive \`border-warning/30 bg-warning/5\` treatment — the warning border carries semantic meaning beyond a regular Card surface.
- JWT Standard Claims card uses \`Card.Content class=\"p-0\"\` so the internal \`divide-y\` borders extend edge-to-edge.

## Verification

- [ ] Hash Generator: enter sample → 6 hash cards render with secure/weak Badges
- [ ] BCrypt Generator: generate hash → hash + details cards
- [ ] SSH Key Generator: generate Ed25519 → fingerprint + public + ssh-keygen command cards
- [ ] GPG Key Generator: fill name/email → user ID preview card; generate → key info + public + gpg commands cards
- [ ] JWT Decoder: paste sample token → header / payload / claims / signature cards
- [ ] String Case Converter: enter text → per-case rows
- [ ] \`bun run check\` passes
- [ ] No \`bg-surface-3 rounded\` grep hits in any Phase 2 file

## Phase progress

- [x] Phase 0 — rules baseline (PR #201, merged)
- [x] Phase 1 — URL Encoder (PR #202, merged)
- [x] Phase 2 — this PR (6 pages × 15 cards)
- [ ] Phase 3 — Network Interfaces + Network Scanner
- [ ] Phase 4 — JSON / YAML / XML Formatter (\`useFormatterPage\` refactor)
- [ ] Phase 5/6 — Badge / Accordion polish + final audit