### PR TITLE
refactor(network): align Network pages with Container Patterns (Phase 3)

### DIFF
--- a/src/routes/network-interfaces/+page.svelte
+++ b/src/routes/network-interfaces/+page.svelte
@@ -19,6 +19,7 @@
 	import { SectionHeader, SectionLabel } from '$lib/components/layout';
 	import { FormCheckbox, FormCheckboxGroup, FormSection, FormSelect } from '$lib/components/form';
 	import { CopyButton } from '$lib/components/action';
+	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
 	import { ListItemButton } from '$lib/components/ui/list-item-button';
 	import * as Resizable from '$lib/components/ui/resizable';
@@ -622,11 +623,12 @@
 											<SectionLabel icon={Flag}>Flags</SectionLabel>
 											<div class="flex flex-wrap gap-1.5">
 												{#each flags as flag}
-													<span
-														class="rounded border border-border/40 bg-surface-3 px-1.5 py-0.5 text-xs font-medium text-muted-foreground"
+													<Badge
+														variant="outline"
+														class="text-2xs font-medium text-muted-foreground"
 													>
 														{flag}
-													</span>
+													</Badge>
 												{/each}
 											</div>
 										</div>

--- a/src/routes/network-scanner/+page.svelte
+++ b/src/routes/network-scanner/+page.svelte
@@ -33,6 +33,7 @@
 	import { ToolShell } from '$lib/components/shell';
 	import { EmptyState, ErrorDisplay, StatItem } from '$lib/components/status';
 	import * as Accordion from '$lib/components/ui/accordion/index.js';
+	import * as Card from '$lib/components/ui/card';
 	import { ListItemButton } from '$lib/components/ui/list-item-button';
 	import * as Resizable from '$lib/components/ui/resizable';
 	import { Channel } from '@tauri-apps/api/core';
@@ -743,7 +744,7 @@
 
 			<!-- Name Resolution (collapsible) -->
 			<Accordion.Root type="multiple" value={['name-resolution']} class="mt-3">
-				<Accordion.Item value="name-resolution" class="rounded border border-border bg-surface-3">
+				<Accordion.Item value="name-resolution" class="rounded border border-border bg-card">
 					<Accordion.Trigger
 						class="px-2 py-1.5 text-xs font-medium hover:no-underline [&>svg]:h-3.5 [&>svg]:w-3.5"
 					>
@@ -792,24 +793,26 @@
 				</div>
 			{/if}
 			{#if discoveryResults.length > 0}
-				<div class="mt-2 rounded border border-border bg-surface-3 p-2">
-					<p class="text-xs font-medium text-muted-foreground">Results:</p>
-					<div class="mt-1 max-h-20 space-y-0.5 overflow-y-auto">
-						{#each discoveryResults as result (result.method)}
-							<div class="text-xs">
-								<span class="font-medium"
-									>{DISCOVERY_METHODS.find((m) => m.value === result.method)?.label ??
-										result.method}:</span
-								>
-								{#if result.error}
-									<span class="text-destructive">{result.error}</span>
-								{:else}
-									<span class="text-muted-foreground">{result.hosts.length} host(s)</span>
-								{/if}
-							</div>
-						{/each}
-					</div>
-				</div>
+				<Card.Root class="mt-2">
+					<Card.Content class="p-2">
+						<p class="text-xs font-medium text-muted-foreground">Results:</p>
+						<div class="mt-1 max-h-20 space-y-0.5 overflow-y-auto">
+							{#each discoveryResults as result (result.method)}
+								<div class="text-xs">
+									<span class="font-medium">
+										{DISCOVERY_METHODS.find((m) => m.value === result.method)?.label ??
+											result.method}:
+									</span>
+									{#if result.error}
+										<span class="text-destructive">{result.error}</span>
+									{:else}
+										<span class="text-muted-foreground">{result.hosts.length} host(s)</span>
+									{/if}
+								</div>
+							{/each}
+						</div>
+					</Card.Content>
+				</Card.Root>
 			{/if}
 		</FormSection>
 
@@ -831,7 +834,7 @@
 
 			<!-- Quick Scan Port Details -->
 			{#if scanMode === 'quick'}
-				<details class="mt-2 rounded border border-border bg-surface-3">
+				<details class="mt-2 rounded border border-border bg-card">
 					<summary
 						class="flex cursor-pointer items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
 					>
@@ -876,7 +879,7 @@
 					{#if portPreset === 'well_known'}
 						<p class="mt-1.5 text-xs text-muted-foreground">Standard ports 1-1024 (1,024 ports)</p>
 					{:else if portPreset === 'web'}
-						<details class="mt-2 rounded border border-border bg-surface-3">
+						<details class="mt-2 rounded border border-border bg-card">
 							<summary
 								class="flex cursor-pointer items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
 							>
@@ -900,7 +903,7 @@
 							</div>
 						</details>
 					{:else if portPreset === 'database'}
-						<details class="mt-2 rounded border border-border bg-surface-3">
+						<details class="mt-2 rounded border border-border bg-card">
 							<summary
 								class="flex cursor-pointer items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
 							>


### PR DESCRIPTION
## Summary

Phase 3 of the design unification effort. Network pages had fewer card-shaped containers than the form-results pages, so the changes here are tighter: replace card-style \`bg-surface-3\` divs with Card.Root, surface inline status chips as Badge, and rebalance the surface tone on disclosure primitives.

## Changes

- **network-interfaces** — flag chips in the host detail view were inline \`<span class=\"rounded border ... bg-surface-3 ...\">\`. They become \`<Badge variant=\"outline\">\`, which is the canonical small-status indicator per PR #201.
- **network-scanner** — discovery-results panel converts from \`<div class=\"rounded border ... bg-surface-3 p-2\">\` to \`Card.Root\` + \`Card.Content\`. Three \`<details>\` disclosures (Quick Scan / Web Ports / Database Ports) and one \`Accordion.Item\` (Name Resolution) switch their surface tone from \`bg-surface-3\` to \`bg-card\` so they visually align with Card.Root while keeping native disclosure semantics.
- **unified-host-detail-panel** — no changes. Its only \`bg-surface-3\` usage is the panel header strip (\`border-b bg-surface-3 px-4 py-3\`), which is panel chrome and remains valid.

## Out of scope (intentional)

Header / footer strips with patterns like \`border-b bg-surface-3 px-4 py-2\` are panel chrome, not cards. The Container Patterns rule targets \`bg-surface-3 rounded\` specifically. These remain unchanged across all Network pages.

## Verification

- [ ] Network Interfaces: open a host with flags → flag chips render as Badge.
- [ ] Network Scanner: enable any discovery method, observe Results card under \"Find Hosts\".
- [ ] Network Scanner: Name Resolution Accordion, Quick Scan / Web Ports / Database Ports \`<details>\` all share the Card.Root surface tone.
- [ ] \`bun run check\` passes.
- [ ] Grep \`rounded.*bg-surface-3\` in network pages returns zero.

## Phase progress

- [x] Phase 0 — rules baseline (PR #201, merged)
- [x] Phase 1 — URL Encoder (PR #202, merged)
- [x] Phase 2 — form-results pages × 6 (PR #203, merged)
- [x] Phase 3 — this PR
- [ ] Phase 4 — JSON / YAML / XML Formatter (\`useFormatterPage\` refactor)
- [ ] Phase 5/6 — Badge / Accordion polish + final audit