### PR TITLE
refactor(formatter,shared): finish Container Patterns audit (Phase 4)

### DIFF
--- a/.claude/rules/svelte/components.md
+++ b/.claude/rules/svelte/components.md
@@ -491,7 +491,21 @@ Use `type="multiple"` when independent toggling makes sense, `type="single"` whe
 
 ### Auditing
 
-`bg-surface-3` is reserved for **rail** and **status bar** backgrounds. A grep across `src/routes/` for `bg-surface-3 rounded` or `bg-surface-3.*p-4` should return zero hits — any match is a card masquerading as a div and should be migrated to `Card.Root`.
+`bg-surface-3` is reserved for **rail backgrounds**, **status bar backgrounds**, **panel header / footer strips** (e.g. `border-b bg-surface-3 px-4 py-2`), and **interactive hover/focus states** (e.g. `hover:bg-surface-3`).
+
+A grep across `src/routes/` and `src/lib/components/` for **static** `bg-surface-3` paired with `rounded` (e.g. `rounded-(lg|md|xl) border ... bg-surface-3`) should return zero hits — any match is a card masquerading as a div and should be migrated to `Card.Root`, or its surface tone changed to `bg-card` if it is an inline list row that does not warrant the full Card.Root primitive (Card.Root, Card.Content with compact padding is preferred for rows that contain multiple semantic parts; `bg-card` alone is acceptable for tiny single-value pills or kbd indicators).
+
+The grep that catches violations is:
+
+```sh
+grep -rEn 'rounded(-(lg|md|xl))? (border [^ ]+ )?bg-surface-3|bg-surface-3 rounded(-(lg|md|xl))?' src/routes src/lib/components
+```
+
+The grep that ignores `hover:` and `focus:` prefixes (acceptable usage) is:
+
+```sh
+grep -rEn '(?<!hover:)(?<!focus:)(?<!group-hover:)bg-surface-3 .*rounded' src/routes src/lib/components
+```
 
 ## Accessibility
 

--- a/.claude/rules/svelte/layouts.md
+++ b/.claude/rules/svelte/layouts.md
@@ -402,11 +402,16 @@ CSS Grid layout with areas: toolbar, rail, content, status.
 
 ## Pattern Overview Table
 
-| Pattern            | Tabs?    | Rail?    | Body layout                  | Card system |
-| ------------------ | -------- | -------- | ---------------------------- | ----------- |
-| Tabbed             | Required | Optional | Tab content panels           | `Card.Root` |
-| Transform          | No       | Required | Single split                 | `Card.Root` |
-| ReactiveSinglePage | No       | Optional | Pattern bar + 2-col + accord | `Card.Root` |
-| MasterDetail       | No       | Required | Resizable list + detail      | `Card.Root` |
+| Pattern            | Tabs?    | Rail?    | Body layout                  | Card system                        |
+| ------------------ | -------- | -------- | ---------------------------- | ---------------------------------- |
+| Tabbed (Formatter) | Required | No       | OptionsPanel + SplitPane     | OptionsPanel chrome (editor-heavy) |
+| Tabbed (General)   | Required | Optional | Tab content panels           | `Card.Root`                        |
+| Transform          | No       | Required | Single split                 | `Card.Root`                        |
+| ReactiveSinglePage | No       | Optional | Pattern bar + 2-col + accord | `Card.Root`                        |
+| MasterDetail       | No       | Required | Resizable list + detail      | `Card.Root`                        |
 
-Every pattern uses **`Card.Root` for sectioned content**. The legacy `<div class="rounded-lg border bg-surface-3 ...">` ad-hoc card is deprecated in favor of the shadcn primitive — see `components.md` § Container Patterns for the canonical mapping.
+Every pattern uses **`Card.Root` for sectioned content**, with one principled exception:
+
+- **Tabbed (Formatter)** — JSON / YAML / XML / URL Encoder formatter tabs are editor-heavy: the canonical body is a `CodeEditor` (or two via `SplitPane`) with an `OptionsPanel` (project-owned shell component) on the left. The OptionsPanel uses `bg-surface-2` and stacks `FormSection`s; cards inside the editor pane would compete with the editor for visual weight. This is a deliberate divergence — see the `useFormatterPage` hook + `OptionsPanel` for the shared infrastructure.
+
+For all other patterns, the legacy `<div class="rounded-lg border bg-surface-3 ...">` ad-hoc card is deprecated in favor of the shadcn primitive — see `components.md` § Container Patterns for the canonical mapping.

--- a/src/lib/components/layout/keyboard-shortcuts-dialog.svelte
+++ b/src/lib/components/layout/keyboard-shortcuts-dialog.svelte
@@ -81,7 +81,7 @@
 								<div class="flex items-center gap-1">
 									{#each shortcut.keys.split('+') as part}
 										<kbd
-											class="rounded border border-border/40 bg-surface-3 px-1.5 py-0.5 font-mono text-2xs text-muted-foreground"
+											class="rounded border border-border/40 bg-card px-1.5 py-0.5 font-mono text-2xs text-muted-foreground"
 										>
 											{part.trim()}
 										</kbd>

--- a/src/lib/components/layout/title-bar.svelte
+++ b/src/lib/components/layout/title-bar.svelte
@@ -29,7 +29,7 @@
 		<Search class="h-3.5 w-3.5 shrink-0" />
 		<span class="flex-1 text-left">Search pages...</span>
 		<kbd
-			class="pointer-events-none hidden shrink-0 rounded border border-border/40 bg-surface-3 px-1.5 py-0.5 font-mono text-2xs text-muted-foreground sm:inline"
+			class="pointer-events-none hidden shrink-0 rounded border border-border/40 bg-card px-1.5 py-0.5 font-mono text-2xs text-muted-foreground sm:inline"
 		>
 			{formatShortcut('K', true)}
 		</kbd>

--- a/src/lib/components/panel/diff-legend.svelte
+++ b/src/lib/components/panel/diff-legend.svelte
@@ -1,20 +1,23 @@
 <script lang="ts">
 	import { FormSection } from '$lib/components/form';
+	import * as Card from '$lib/components/ui/card';
 </script>
 
 <FormSection title="Legend">
-	<div class="space-y-1.5 rounded-md bg-surface-3 p-2">
-		<div class="flex items-center gap-2 text-xs">
-			<span class="h-2.5 w-2.5 rounded-sm bg-success/40"></span>
-			<span class="text-muted-foreground">Added</span>
-		</div>
-		<div class="flex items-center gap-2 text-xs">
-			<span class="h-2.5 w-2.5 rounded-sm bg-destructive/40"></span>
-			<span class="text-muted-foreground">Removed</span>
-		</div>
-		<div class="flex items-center gap-2 text-xs">
-			<span class="h-2.5 w-2.5 rounded-sm bg-warning/40"></span>
-			<span class="text-muted-foreground">Changed</span>
-		</div>
-	</div>
+	<Card.Root>
+		<Card.Content class="space-y-1.5 p-2">
+			<div class="flex items-center gap-2 text-xs">
+				<span class="h-2.5 w-2.5 rounded-sm bg-success/40"></span>
+				<span class="text-muted-foreground">Added</span>
+			</div>
+			<div class="flex items-center gap-2 text-xs">
+				<span class="h-2.5 w-2.5 rounded-sm bg-destructive/40"></span>
+				<span class="text-muted-foreground">Removed</span>
+			</div>
+			<div class="flex items-center gap-2 text-xs">
+				<span class="h-2.5 w-2.5 rounded-sm bg-warning/40"></span>
+				<span class="text-muted-foreground">Changed</span>
+			</div>
+		</Card.Content>
+	</Card.Root>
 </FormSection>

--- a/src/routes/cron-expression-builder/tabs/build-tab.svelte
+++ b/src/routes/cron-expression-builder/tabs/build-tab.svelte
@@ -159,7 +159,7 @@
 							<ul class="space-y-1.5">
 								{#each nextRuns.value as date, idx (idx)}
 									{@const fmt = formatDateParts(date)}
-									<li class="flex items-center gap-3 rounded-md border bg-surface-3 px-3 py-2">
+									<li class="flex items-center gap-3 rounded-md border bg-card px-3 py-2">
 										<span class="w-6 text-xs tabular-nums text-muted-foreground">{idx + 1}.</span>
 										<Badge
 											class={cn('text-2xs font-mono', dayBadgeClass(fmt.dayIndex, fmt.isWeekend))}

--- a/src/routes/cron-expression-builder/tabs/parse-tab.svelte
+++ b/src/routes/cron-expression-builder/tabs/parse-tab.svelte
@@ -80,7 +80,7 @@
 									parsed.value.month,
 									parsed.value.dayOfWeek,
 								][idx]}
-								<div class="rounded-md border bg-surface-3 p-3">
+								<div class="rounded-md border bg-card p-3">
 									<div class="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
 										{field.label}
 									</div>
@@ -124,7 +124,7 @@
 							<ul class="space-y-1.5">
 								{#each nextRuns.value as date, idx (idx)}
 									{@const fmt = formatDateParts(date)}
-									<li class="flex items-center gap-3 rounded-md border bg-surface-3 px-3 py-2">
+									<li class="flex items-center gap-3 rounded-md border bg-card px-3 py-2">
 										<span class="w-6 text-xs tabular-nums text-muted-foreground">{idx + 1}.</span>
 										<Badge
 											class={cn('text-2xs font-mono', dayBadgeClass(fmt.dayIndex, fmt.isWeekend))}

--- a/src/routes/curl-builder/tabs/parse-tab.svelte
+++ b/src/routes/curl-builder/tabs/parse-tab.svelte
@@ -99,7 +99,7 @@
 						{#if parsed.value.headers.length > 0}
 							<div class="space-y-1.5">
 								{#each parsed.value.headers as header, idx (idx)}
-									<div class="flex items-baseline gap-2 rounded-md border bg-surface-3 px-3 py-2">
+									<div class="flex items-baseline gap-2 rounded-md border bg-card px-3 py-2">
 										<Badge variant="outline" class="font-mono text-2xs">{header.key}</Badge>
 										<span class="break-all font-mono text-xs text-muted-foreground">
 											{header.value}

--- a/src/routes/password-generator/+page.svelte
+++ b/src/routes/password-generator/+page.svelte
@@ -216,7 +216,7 @@
 			{#if results.length > 0}
 				<div class="space-y-2">
 					{#each results as password, idx (`${idx}-${password}`)}
-						<div class="flex items-center gap-2 rounded-lg border bg-surface-3 p-3">
+						<div class="flex items-center gap-2 rounded-lg border bg-card p-3">
 							<code class="flex-1 break-all font-mono text-sm">{password}</code>
 							<CopyButton text={password} toastLabel="Password" size="sm" showLabel={false} />
 						</div>

--- a/src/routes/qr-code-generator/+page.svelte
+++ b/src/routes/qr-code-generator/+page.svelte
@@ -523,7 +523,7 @@
 				class="block w-full cursor-pointer rounded-md border bg-background px-3 py-1.5 text-xs file:mr-3 file:rounded file:border-0 file:bg-muted file:px-2 file:py-1 file:text-xs file:font-medium hover:bg-accent"
 			/>
 			{#if style.logoDataUrl}
-				<div class="flex items-center gap-2 rounded-md border bg-surface-3 p-2">
+				<div class="flex items-center gap-2 rounded-md border bg-card p-2">
 					<img
 						src={style.logoDataUrl}
 						alt="logo preview"

--- a/src/routes/regex-tester/+page.svelte
+++ b/src/routes/regex-tester/+page.svelte
@@ -164,7 +164,7 @@ Also see https://kogu.io/docs and http://test.local:3000/.`
 
 {#snippet renderNode(node: VizNode, depth: number)}
 	{@const meta = KIND_BADGE[node.kind]}
-	<div class={cn('flex flex-col gap-1.5 rounded-md border bg-surface-3 p-2', depth > 0 && 'ml-3')}>
+	<div class={cn('flex flex-col gap-1.5 rounded-md border bg-card p-2', depth > 0 && 'ml-3')}>
 		<div class="flex items-center gap-2">
 			<Badge class={cn('font-mono text-2xs', meta.className)}>{meta.label}</Badge>
 			<code class="break-all font-mono text-xs">{node.label}</code>
@@ -372,7 +372,7 @@ Also see https://kogu.io/docs and http://test.local:3000/.`
 							{#if matches.length > 0}
 								<div class="space-y-2">
 									{#each matches as match, mIdx (mIdx)}
-										<div class="rounded-md border bg-surface-3 p-2">
+										<div class="rounded-md border bg-card p-2">
 											<div class="flex items-center gap-2">
 												<Badge variant="outline" class="font-mono text-2xs">@{match.index}</Badge>
 												<code class="break-all font-mono text-xs">{match.fullMatch}</code>
@@ -451,7 +451,7 @@ Also see https://kogu.io/docs and http://test.local:3000/.`
 						</Accordion.Trigger>
 						<Accordion.Content>
 							<div class="space-y-3">
-								<div class="rounded-md border bg-surface-3 p-2">
+								<div class="rounded-md border bg-card p-2">
 									<div class="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
 										Active flags
 									</div>
@@ -467,7 +467,7 @@ Also see https://kogu.io/docs and http://test.local:3000/.`
 										{/if}
 									</div>
 								</div>
-								<div class="rounded-md border bg-surface-3 p-2">
+								<div class="rounded-md border bg-card p-2">
 									<div class="flex items-center justify-between">
 										<span
 											class="text-2xs font-medium uppercase tracking-wide text-muted-foreground"
@@ -477,7 +477,7 @@ Also see https://kogu.io/docs and http://test.local:3000/.`
 										<Badge variant="outline" class="font-mono text-2xs">{captureGroupCount}</Badge>
 									</div>
 								</div>
-								<div class="rounded-md border bg-surface-3 p-2">
+								<div class="rounded-md border bg-card p-2">
 									<div class="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
 										Detected features
 									</div>

--- a/src/routes/uuid-generator/+page.svelte
+++ b/src/routes/uuid-generator/+page.svelte
@@ -208,7 +208,7 @@
 			{#if results.length > 0}
 				<div class="space-y-2">
 					{#each results as uuid, idx (`${idx}-${uuid}`)}
-						<div class="flex items-center gap-2 rounded-lg border bg-surface-3 p-3">
+						<div class="flex items-center gap-2 rounded-lg border bg-card p-3">
 							<code class="flex-1 break-all font-mono text-sm">{uuid}</code>
 							<CopyButton text={uuid} toastLabel="UUID" size="sm" showLabel={false} />
 						</div>


### PR DESCRIPTION
## Summary

Phase 4 of the design unification effort. The original plan called for a Formatter architecture refactor, but the audit found the formatter pages (JSON / YAML / XML) are already aligned with shadcn primitives — their editor-heavy layout intentionally avoids Card.Root in the editor pane. That deliberate divergence is now formalized in \`layouts.md\` as the \"Tabbed (Formatter)\" sub-pattern.

The remaining work was tightening the audit across **all** pages — including my own newly-added pages from PR #200 — that still had \`bg-surface-3 rounded\` patterns on inline list rows.

## Changes

### Card.Root migration

- \`diff-legend\` (shared panel): legend swatches move from \`<div class=\"... rounded-md bg-surface-3 p-2\">\` to \`Card.Root\` + \`Card.Content\`.

### Surface token cleanup (bg-surface-3 → bg-card on inline rows)

- UUID Generator: 1 row
- Password Generator: 1 row
- QR Code Generator: 1 row
- Cron Expression Builder (Build + Parse tabs): 3 rows
- cURL Builder (Parse tab): 1 row
- Regex Tester: 5 rows (Visualize node, per-match cards)
- title-bar + keyboard-shortcuts-dialog: kbd hint badges

These are inline list rows or kbd-style indicators that do not warrant the full Card.Root primitive (Card would add too much padding for a single-row pill). Using \`bg-card\` aligns their surface token with Card.Root while keeping the compact form.

### Rule sharpening

- \`components.md\` § Auditing: distinguishes forbidden (static \`bg-surface-3 rounded\`) from allowed (panel chrome, hover/focus states, rail/status bar backgrounds, kbd indicators on \`bg-card\`).
- \`layouts.md\` Pattern Overview Table: adds the \"Tabbed (Formatter)\" row noting it uses OptionsPanel chrome rather than Card.Root in the editor pane — a principled exception with rationale.

## Verification

After this PR:

\`\`\`sh
grep -rEn 'rounded(-(lg|md|xl))? (border [^ ]+ )?bg-surface-3' src/routes src/lib/components
\`\`\`

returns **zero hits**. The audit rule is now self-enforcing across the entire app.

## Phase progress

- [x] Phase 0 — rules baseline (PR #201)
- [x] Phase 1 — URL Encoder (PR #202)
- [x] Phase 2 — form-results pages × 6 (PR #203)
- [x] Phase 3 — Network pages (PR #204)
- [x] Phase 4 — this PR (rules sharpening + audit cleanup)
- [ ] Phase 5/6 — Badge / Accordion polish + final audit + audit script