### PR TITLE
refactor(regex-tester): align rail with FormSection + FormInfo pattern

### DIFF
--- a/src/routes/regex-tester/+page.svelte
+++ b/src/routes/regex-tester/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Eye, GitBranch, Info, Search, Sparkles } from '@lucide/svelte';
 	import { CopyButton } from '$lib/components/action';
-	import { FormTextarea } from '$lib/components/form';
+	import { FormInfo, FormSection, FormTextarea } from '$lib/components/form';
 	import { PatternEditor } from '$lib/components/regex';
 	import { ToolShell } from '$lib/components/shell';
 	import { EmbeddedEmptyState, StatItem } from '$lib/components/status';
@@ -196,28 +196,38 @@ Also see https://kogu.io/docs and http://test.local:3000/.`
 	{/snippet}
 
 	{#snippet rail()}
-		<div class="space-y-3 text-xs text-muted-foreground">
-			<div>
-				<div class="mb-1 font-semibold uppercase tracking-wide">Pattern</div>
-				<p>Regex literal in JavaScript syntax. Forward slashes don't need escaping.</p>
-			</div>
-			<div>
-				<div class="mb-1 font-semibold uppercase tracking-wide">Capture groups</div>
-				<p>
-					Each capture group is assigned a color used across the pattern, test text, and structure
-					panels.
-				</p>
-			</div>
-			<div>
-				<div class="mb-1 font-semibold uppercase tracking-wide">Replace mode</div>
-				<p>
-					Toggle the switch in the Test Text card to replace matches. Use
-					<code class="rounded bg-muted px-1 font-mono">$1</code>,
-					<code class="rounded bg-muted px-1 font-mono">$&lt;name&gt;</code>, or
-					<code class="rounded bg-muted px-1 font-mono">$&amp;</code> placeholders.
-				</p>
-			</div>
-		</div>
+		<FormSection title="Pattern">
+			<FormInfo>Regex literal in JavaScript syntax. Forward slashes don't need escaping.</FormInfo>
+		</FormSection>
+
+		<FormSection title="Capture groups">
+			<FormInfo>
+				Each capture group is assigned a color used across the pattern, test text, and structure
+				panels.
+			</FormInfo>
+		</FormSection>
+
+		<FormSection title="Replace mode">
+			<FormInfo>
+				Toggle the switch in the Test Text card to replace matches. Use
+				<code class="rounded bg-muted px-1 font-mono">$1</code>,
+				<code class="rounded bg-muted px-1 font-mono">$&lt;name&gt;</code>, or
+				<code class="rounded bg-muted px-1 font-mono">$&amp;</code> placeholders.
+			</FormInfo>
+		</FormSection>
+
+		<FormSection title="Flags">
+			<FormInfo>
+				<ul class="list-inside list-disc space-y-0.5">
+					<li><code class="font-mono">g</code> — find all matches, not just the first</li>
+					<li><code class="font-mono">i</code> — case-insensitive matching</li>
+					<li><code class="font-mono">m</code> — ^ and $ match line boundaries</li>
+					<li><code class="font-mono">s</code> — . matches newline characters</li>
+					<li><code class="font-mono">u</code> — Unicode code point parsing</li>
+					<li><code class="font-mono">y</code> — sticky, match only at lastIndex</li>
+				</ul>
+			</FormInfo>
+		</FormSection>
 	{/snippet}
 
 	<div class="flex h-full flex-col overflow-hidden">


### PR DESCRIPTION
## Summary

- The Regex Tester rail was the only tool-page rail still using raw `<div>` wrappers with hand-rolled `uppercase tracking-wide` headings, which gave it slightly larger top padding and heavier label typography than every other rail in the app.
- Replace the ad-hoc markup with `FormSection` + `FormInfo` so the section labels, spacing, and helper-text typography stay in lockstep with the rest of the tool pages.
- Add a "Flags" section now that the rail has visual room left over after collapsing the bespoke heading styles.

## Changes

### Changed

- `src/routes/regex-tester/+page.svelte`: rewrite the `rail` snippet to use the canonical `FormSection` + `FormInfo` wrappers; add a new `Flags` section.

## Test Plan

- [x] `bun run check` (svelte-check + validate-pages + audit-design)
- [x] Visual verification in Tauri dev: rail labels and spacing match the rest of the app (UUID / Password / QR / Cron / cURL).
- [x] Regex Tester functionality unchanged (pattern, replace toggle, matches, structure).