### PR TITLE
feat(cron-curl): add guidance rail to align with other tool pages

### DIFF
--- a/src/routes/cron-expression-builder/+page.svelte
+++ b/src/routes/cron-expression-builder/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Pencil, Search } from '@lucide/svelte';
+	import { FormInfo, FormSection } from '$lib/components/form';
 	import { ToolShell } from '$lib/components/shell';
 	import { StatItem } from '$lib/components/status';
 	import { BuildTab, ParseTab } from './tabs/index.js';
@@ -41,6 +42,53 @@
 >
 	{#snippet statusContent()}
 		<StatItem label="Expression" value={currentStats.expression} />
+	{/snippet}
+
+	{#snippet rail()}
+		<FormSection title="Cron syntax">
+			<FormInfo>
+				A cron expression has five space-separated fields. From left to right:
+				<ul class="mt-1 list-inside list-disc space-y-0.5">
+					<li><code class="font-mono">minute</code> — 0–59</li>
+					<li><code class="font-mono">hour</code> — 0–23</li>
+					<li><code class="font-mono">day of month</code> — 1–31</li>
+					<li><code class="font-mono">month</code> — 1–12 or JAN–DEC</li>
+					<li><code class="font-mono">day of week</code> — 0–6 or SUN–SAT</li>
+				</ul>
+			</FormInfo>
+		</FormSection>
+
+		<FormSection title="Special characters">
+			<FormInfo>
+				<ul class="list-inside list-disc space-y-0.5">
+					<li><code class="font-mono">*</code> — any value</li>
+					<li><code class="font-mono">,</code> — value list (e.g., <code>1,15</code>)</li>
+					<li><code class="font-mono">-</code> — range (e.g., <code>9-17</code>)</li>
+					<li><code class="font-mono">/</code> — step (e.g., <code>*/5</code>)</li>
+					<li><code class="font-mono">?</code> — no specific value (day fields)</li>
+				</ul>
+			</FormInfo>
+		</FormSection>
+
+		<FormSection title="Common patterns">
+			<FormInfo>
+				<ul class="list-inside list-disc space-y-0.5">
+					<li><code class="font-mono">* * * * *</code> — every minute</li>
+					<li><code class="font-mono">*/5 * * * *</code> — every 5 minutes</li>
+					<li><code class="font-mono">0 * * * *</code> — top of every hour</li>
+					<li><code class="font-mono">0 0 * * *</code> — daily at midnight</li>
+					<li><code class="font-mono">0 9 * * 1-5</code> — weekdays at 9 AM</li>
+				</ul>
+			</FormInfo>
+		</FormSection>
+
+		<FormSection title="Tips">
+			<FormInfo>
+				When both <code class="font-mono">day of month</code> and
+				<code class="font-mono">day of week</code> are restricted, most engines run on either match, not
+				both. Schedules are evaluated in UTC unless your runtime says otherwise.
+			</FormInfo>
+		</FormSection>
 	{/snippet}
 
 	{#snippet tabContent(tab)}

--- a/src/routes/curl-builder/+page.svelte
+++ b/src/routes/curl-builder/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Code2, Pencil, Search } from '@lucide/svelte';
+	import { FormInfo, FormSection } from '$lib/components/form';
 	import { ToolShell } from '$lib/components/shell';
 	import { StatItem } from '$lib/components/status';
 	import { type CurlRequest, DEFAULT_REQUEST } from '$lib/services/curl.js';
@@ -45,6 +46,51 @@
 		{#if currentStats.command}
 			<StatItem label="Length" value={currentStats.command.length} />
 		{/if}
+	{/snippet}
+
+	{#snippet rail()}
+		<FormSection title="Tabs">
+			<FormInfo>
+				<ul class="list-inside list-disc space-y-0.5">
+					<li><strong>Build</strong> — compose a request with form controls</li>
+					<li><strong>Parse</strong> — paste an existing command to inspect it</li>
+					<li><strong>Code</strong> — convert the request to other languages</li>
+				</ul>
+			</FormInfo>
+		</FormSection>
+
+		<FormSection title="Authentication">
+			<FormInfo>
+				<ul class="list-inside list-disc space-y-0.5">
+					<li><strong>None</strong> — no auth header</li>
+					<li><strong>Basic</strong> — <code class="font-mono">user:password</code> via -u</li>
+					<li><strong>Bearer</strong> — <code class="font-mono">Authorization: Bearer …</code></li>
+					<li><strong>API key</strong> — custom header name + value</li>
+				</ul>
+			</FormInfo>
+		</FormSection>
+
+		<FormSection title="Body types">
+			<FormInfo>
+				<ul class="list-inside list-disc space-y-0.5">
+					<li><strong>JSON</strong> — application/json, raw payload via -d</li>
+					<li><strong>Form</strong> — urlencoded, --data-urlencode per field</li>
+					<li><strong>Multipart</strong> — -F for files and form parts</li>
+					<li><strong>Raw</strong> — arbitrary text body</li>
+				</ul>
+			</FormInfo>
+		</FormSection>
+
+		<FormSection title="Common flags">
+			<FormInfo>
+				<ul class="list-inside list-disc space-y-0.5">
+					<li><code class="font-mono">-i</code> — include response headers</li>
+					<li><code class="font-mono">-L</code> — follow redirects</li>
+					<li><code class="font-mono">-k</code> — skip TLS verification</li>
+					<li><code class="font-mono">--max-time</code> — total timeout in seconds</li>
+				</ul>
+			</FormInfo>
+		</FormSection>
 	{/snippet}
 
 	{#snippet tabContent(tab)}


### PR DESCRIPTION
## Summary

- Cron Expression Builder and cURL Builder were the only tool pages without a rail. They couldn't reuse the json/xml/yaml pattern (TabbedFormatterPage doesn't expose a rail, and they're not on that wrapper anyway).
- Add a static, tab-independent **guidance rail** to both pages using the canonical `FormSection` + `FormInfo` wrappers.
- Rail content is **pure reference**, not controls — so it stays useful across all tabs without needing per-tab adaptation.

## Changes

### Added

- **Cron Expression Builder rail** — 4 sections: Cron syntax (5 fields), Special characters, Common patterns, Tips (day-of-month vs day-of-week, UTC).
- **cURL Builder rail** — 4 sections: Tabs overview, Authentication schemes, Body types, Common flags.

### Visual alignment

Both rails now match the rest of the app (uuid / password / regex / network-* / etc.) in:

- Section heading style (`FormSection` title)
- Body typography (`FormInfo`)
- Spacing rhythm (`space-y-3` between sections)
- Surface tone (rail background driven by `ToolShell`)

## Test Plan

- [x] `bun run check` (svelte-check + validate-pages + audit-design)
- [x] Visual verification in Tauri: Cron + cURL rails render correctly with all sections
- [x] Tab switching unaffected — rail content is static
- [x] Rail collapse (Cmd+,) still works via `ToolShell.rail` plumbing