### PR TITLE
refactor(ui): extract CollapsibleAside primitive shared by rail and panel

### DIFF
--- a/src/lib/components/panel/options-panel.svelte
+++ b/src/lib/components/panel/options-panel.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-	import { ChevronLeft, Settings2 } from '@lucide/svelte';
 	import type { Snippet } from 'svelte';
-	import { Button } from '$lib/components/ui/button/index.js';
-	import * as ScrollArea from '$lib/components/ui/scroll-area/index.js';
+	import { CollapsibleAside } from '$lib/components/ui/collapsible-aside';
 
 	interface Props {
 		title?: string;
@@ -16,48 +14,13 @@
 	let {
 		title = 'Options',
 		width = 'w-64',
-		show = true,
+		show = $bindable(true),
 		onclose,
 		onopen,
 		children,
 	}: Props = $props();
 </script>
 
-{#if show}
-	<aside
-		class="flex h-full {width} flex-col overflow-hidden border-r border-border/50 bg-surface-2"
-	>
-		<ScrollArea.Root class="min-h-0 flex-1">
-			<div class="py-3">
-				{@render children?.()}
-			</div>
-		</ScrollArea.Root>
-		{#if onclose}
-			<div class="flex h-8 shrink-0 items-center justify-end border-t border-border/30 px-2">
-				<Button
-					variant="ghost"
-					size="icon"
-					class="h-6 w-6"
-					onclick={onclose}
-					aria-label="Collapse {title}"
-					title="Collapse {title}"
-				>
-					<ChevronLeft class="h-3.5 w-3.5" />
-				</Button>
-			</div>
-		{/if}
-	</aside>
-{:else if onopen}
-	<aside class="flex w-11 shrink-0 flex-col border-r border-border/50 bg-surface-2">
-		<Button
-			variant="ghost"
-			size="icon"
-			class="m-1.5 h-8 w-8"
-			onclick={onopen}
-			aria-label="Show options"
-			title="Show options"
-		>
-			<Settings2 class="h-4 w-4" />
-		</Button>
-	</aside>
-{/if}
+<CollapsibleAside bind:show {title} background="bg-surface-2" {width} {onclose} {onopen}>
+	{@render children?.()}
+</CollapsibleAside>

--- a/src/lib/components/shell/options-rail.svelte
+++ b/src/lib/components/shell/options-rail.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-	import { ChevronLeft, Settings2 } from '@lucide/svelte';
 	import type { Snippet } from 'svelte';
-	import { Button } from '$lib/components/ui/button/index.js';
-	import * as ScrollArea from '$lib/components/ui/scroll-area/index.js';
+	import { CollapsibleAside } from '$lib/components/ui/collapsible-aside';
 
 	interface Props {
 		show?: boolean;
@@ -15,47 +13,13 @@
 	let { show = $bindable(true), title = 'Options', children, onclose, onopen }: Props = $props();
 </script>
 
-{#if show}
-	<aside
-		class="flex h-full w-[var(--rail-w)] flex-col overflow-hidden border-r border-border/50 bg-sidebar"
-	>
-		<ScrollArea.Root class="min-h-0 flex-1">
-			<div class="py-3">
-				{@render children?.()}
-			</div>
-		</ScrollArea.Root>
-		{#if onclose}
-			<div class="flex h-8 shrink-0 items-center justify-end border-t border-border/30 px-2">
-				<Button
-					variant="ghost"
-					size="icon"
-					class="h-6 w-6"
-					onclick={() => {
-						show = false;
-						onclose?.();
-					}}
-					aria-label="Collapse {title}"
-					title="Collapse {title}"
-				>
-					<ChevronLeft class="h-3.5 w-3.5" />
-				</Button>
-			</div>
-		{/if}
-	</aside>
-{:else}
-	<aside class="flex flex-1 w-11 shrink-0 flex-col border-r border-border/50 bg-sidebar">
-		<Button
-			variant="ghost"
-			size="icon"
-			class="m-1.5 h-8 w-8"
-			onclick={() => {
-				show = true;
-				onopen?.();
-			}}
-			aria-label="Show options"
-			title="Show options"
-		>
-			<Settings2 class="h-4 w-4" />
-		</Button>
-	</aside>
-{/if}
+<CollapsibleAside
+	bind:show
+	{title}
+	background="bg-sidebar"
+	width="w-[var(--rail-w)]"
+	{onclose}
+	{onopen}
+>
+	{@render children?.()}
+</CollapsibleAside>

--- a/src/lib/components/ui/collapsible-aside/collapsible-aside.svelte
+++ b/src/lib/components/ui/collapsible-aside/collapsible-aside.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	import { ChevronLeft, Settings2 } from '@lucide/svelte';
+	import type { Snippet } from 'svelte';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as ScrollArea from '$lib/components/ui/scroll-area/index.js';
+
+	interface Props {
+		/** Whether the aside is expanded. Bindable. */
+		show?: boolean;
+		/** Accessible label, used for collapse-button aria-label/title. */
+		readonly title?: string;
+		/** Background tone utility class (e.g., 'bg-sidebar', 'bg-surface-2'). */
+		readonly background?: string;
+		/** Width utility class for the expanded state (e.g., 'w-64'). */
+		readonly width?: string;
+		/** Content rendered inside the scrollable expanded body. */
+		readonly children?: Snippet;
+		/** Optional side-effect callback fired after the user collapses the aside. */
+		readonly onclose?: () => void;
+		/** Optional side-effect callback fired after the user re-expands the aside. */
+		readonly onopen?: () => void;
+	}
+
+	let {
+		show = $bindable(true),
+		title = 'Options',
+		background = 'bg-surface-2',
+		width = 'w-64',
+		children,
+		onclose,
+		onopen,
+	}: Props = $props();
+
+	const handleClose = () => {
+		show = false;
+		onclose?.();
+	};
+
+	const handleOpen = () => {
+		show = true;
+		onopen?.();
+	};
+</script>
+
+{#if show}
+	<aside
+		class="flex h-full {width} flex-col overflow-hidden border-r border-border/50 {background}"
+		data-slot="collapsible-aside"
+		data-state="open"
+	>
+		<ScrollArea.Root class="min-h-0 flex-1">
+			<div class="py-3">
+				{@render children?.()}
+			</div>
+		</ScrollArea.Root>
+		<div class="flex h-8 shrink-0 items-center justify-end border-t border-border/30 px-2">
+			<Button
+				variant="ghost"
+				size="icon"
+				class="h-6 w-6"
+				onclick={handleClose}
+				aria-label="Collapse {title}"
+				title="Collapse {title}"
+			>
+				<ChevronLeft class="h-3.5 w-3.5" />
+			</Button>
+		</div>
+	</aside>
+{:else}
+	<aside
+		class="flex w-11 shrink-0 flex-col border-r border-border/50 {background}"
+		data-slot="collapsible-aside"
+		data-state="closed"
+	>
+		<Button
+			variant="ghost"
+			size="icon"
+			class="m-1.5 h-8 w-8"
+			onclick={handleOpen}
+			aria-label="Show {title}"
+			title="Show {title}"
+		>
+			<Settings2 class="h-4 w-4" />
+		</Button>
+	</aside>
+{/if}

--- a/src/lib/components/ui/collapsible-aside/index.ts
+++ b/src/lib/components/ui/collapsible-aside/index.ts
@@ -1,0 +1,1 @@
+export { default as CollapsibleAside } from './collapsible-aside.svelte';


### PR DESCRIPTION
## Summary

- `options-rail.svelte` (ToolShell-owned) and `options-panel.svelte` (tab-content embedded) were 95% structurally identical: same `<aside>` + `ScrollArea` + collapse chevron + Settings2 expand strip.
- Extract the shared visual primitive into `src/lib/components/ui/collapsible-aside/`. Both wrappers now compose the primitive with class-only overrides.
- Future design changes (animations, focus rings, kbd indicator) touch a single file instead of two.

## Changes

### Added

- `src/lib/components/ui/collapsible-aside/collapsible-aside.svelte` — the shared primitive (`<aside>` + ScrollArea + collapse / expand controls). `show` is `$bindable`; optional `onclose`/`onopen` callbacks fire after state changes.
- `src/lib/components/ui/collapsible-aside/index.ts` — barrel export.

### Changed

- `src/lib/components/shell/options-rail.svelte` — now a 25-line wrapper that pins `background="bg-sidebar"` and `width="w-[var(--rail-w)]"`.
- `src/lib/components/panel/options-panel.svelte` — now a 26-line wrapper that pins `background="bg-surface-2"` and forwards a configurable `width` prop.

## Why not a single drop-in component

- `OptionsRail` is grid-integrated with `ToolShell` via `--rail-w` and participates in the `Cmd+,` keyboard shortcut.
- `OptionsPanel` is a standalone aside embedded in tab content with consumer-managed state.

Collapsing these into one component would either require a props-explosion API or lose the lifecycle distinctions. The composition pattern keeps each consumer's specifics intact while sharing the visual surface.

## Test Plan

- [x] `bun run check` (svelte-check + validate-pages + audit-design)
- [x] Visual: Cron rail expand/collapse (ToolShell pattern) — strip + re-expand both work
- [x] Visual: JSON Formatter OptionsPanel expand/collapse (consumer-managed state) — same
- [x] Both surface tones preserved (rail = `bg-sidebar`, panel = `bg-surface-2`)