### PR TITLE
chore(skills): add tauri-dev restart skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -77,3 +77,4 @@ See `.claude/rules/` for comprehensive guidelines. All rules use `paths:` frontm
 Procedural workflows are packaged as on-demand skills in `.claude/skills/`:
 
 - `release/` - Release process (`/release`, see `.claude/skills/release/SKILL.md`)
+- `tauri-dev/` - Tauri dev restart with cache cleanup (`/tauri-dev`, see `.claude/skills/tauri-dev/SKILL.md`)

--- a/.claude/skills/tauri-dev/SKILL.md
+++ b/.claude/skills/tauri-dev/SKILL.md
@@ -26,28 +26,28 @@ If the command returns one or more PIDs, a Tauri dev session is active. Proceed 
 
 ### 2. Stop the running session
 
-Find the top-level `bun run tauri:dev` PID and kill its process group so the bash wrapper, `tauri dev`, and `vite dev` children all exit together:
+Send `SIGTERM` directly to each of the three process-name patterns. Do **not** rely on parent-child relationships: the `vite dev` process is typically spawned with a parent outside the `bun run tauri:dev` tree, so `pkill -P <top-level-pid>` does not reach it, and `pgrep -f "bun run tauri:dev"` also matches the outer shell wrapper whose process group does not own the workers.
 
 ```bash
-TAURI_PID=$(pgrep -f "bun run tauri:dev" | head -1)
-if [ -n "$TAURI_PID" ]; then
-  pkill -TERM -P "$TAURI_PID" 2>/dev/null
-  kill -TERM "$TAURI_PID" 2>/dev/null
-fi
+pkill -TERM -f "bun run tauri:dev" 2>/dev/null
+pkill -TERM -f "tauri dev" 2>/dev/null
+pkill -TERM -f "vite dev" 2>/dev/null
+sleep 3
 ```
 
 Verify everything is gone (Vite listens on port 1420, so its absence is a good signal):
 
 ```bash
-sleep 2
-lsof -nP -iTCP:1420 -sTCP:LISTEN
-pgrep -af "bun run tauri:dev|tauri dev|vite dev"
+lsof -nP -iTCP:1420 -sTCP:LISTEN || echo "(port free)"
+pgrep -af "bun run tauri:dev|tauri dev|vite dev" | grep -v "$$" || echo "(no processes)"
 ```
 
 If processes remain after 5 seconds, escalate with `SIGKILL`:
 
 ```bash
-pkill -KILL -f "bun run tauri:dev|tauri dev|vite dev"
+pkill -KILL -f "bun run tauri:dev" 2>/dev/null
+pkill -KILL -f "tauri dev" 2>/dev/null
+pkill -KILL -f "vite dev" 2>/dev/null
 ```
 
 Do not use `kill -9` as the first move — it leaves the Cargo build lockfile and Vite's IPC socket in a dirty state, which makes the next start slower.
@@ -76,13 +76,21 @@ Run this via `Bash` with `run_in_background: true`. The bash wrapper runs `bun r
 Poll for the Vite dev port and report when it is listening:
 
 ```bash
-for i in {1..60}; do
-  lsof -nP -iTCP:1420 -sTCP:LISTEN >/dev/null 2>&1 && echo "ready" && break
+for i in $(seq 1 90); do
+  if lsof -nP -iTCP:1420 -sTCP:LISTEN >/dev/null 2>&1; then
+    echo "ready after $((i * 2))s"
+    break
+  fi
   sleep 2
 done
 ```
 
-If the loop times out (120 seconds), inspect the background task output for the first error before retrying.
+Expected timing:
+
+- **~15–30 seconds** when the Rust sidecar target is warm and only Vite needs a cold start.
+- **~60–120 seconds** after a cache wipe (Vite re-bundles the entire dep graph) or after a `Cargo.toml` change (sidecar rebuild).
+
+If the loop times out (180 seconds), inspect the background task output for the first error before retrying.
 
 ## Why clear caches
 

--- a/.claude/skills/tauri-dev/SKILL.md
+++ b/.claude/skills/tauri-dev/SKILL.md
@@ -1,0 +1,120 @@
+---
+description: Start Kogu in Tauri dev mode. If a Tauri dev session is already running, stop it (with its Vite child) and clear stale build caches before starting a fresh instance. Use when the user asks to start, restart, relaunch, or reboot Tauri, or when Vite SSR errors point to stale module caches.
+disable-model-invocation: true
+allowed-tools: Bash(pgrep *), Bash(pkill *), Bash(ps *), Bash(lsof *), Bash(rm -rf .vite), Bash(rm -rf .svelte-kit/cache), Bash(bun run tauri:dev *), Bash(sleep *)
+---
+
+# Tauri Dev Restart
+
+Run Kogu in Tauri dev mode with a clean Vite cache. The flow always lands in the same end state — a single fresh `tauri:dev` process — whether or not one was already running.
+
+## When to use
+
+- The user asks to start, restart, relaunch, reboot, or kick Tauri.
+- Vite returns `500 Internal Error` for routes that pass `bun run check` (a stale SSR module-runner cache, see "Why clear caches" below).
+- The user changes a shadcn / shell / panel primitive (e.g., `OptionsRail`, `OptionsPanel`, `CollapsibleAside`) and HMR fails to pick it up.
+
+## Steps
+
+### 1. Detect running Tauri dev session
+
+```bash
+pgrep -af "bun run tauri:dev|tauri dev|vite dev"
+```
+
+If the command returns one or more PIDs, a Tauri dev session is active. Proceed to step 2. Otherwise jump to step 3.
+
+### 2. Stop the running session
+
+Find the top-level `bun run tauri:dev` PID and kill its process group so the bash wrapper, `tauri dev`, and `vite dev` children all exit together:
+
+```bash
+TAURI_PID=$(pgrep -f "bun run tauri:dev" | head -1)
+if [ -n "$TAURI_PID" ]; then
+  pkill -TERM -P "$TAURI_PID" 2>/dev/null
+  kill -TERM "$TAURI_PID" 2>/dev/null
+fi
+```
+
+Verify everything is gone (Vite listens on port 1420, so its absence is a good signal):
+
+```bash
+sleep 2
+lsof -nP -iTCP:1420 -sTCP:LISTEN
+pgrep -af "bun run tauri:dev|tauri dev|vite dev"
+```
+
+If processes remain after 5 seconds, escalate with `SIGKILL`:
+
+```bash
+pkill -KILL -f "bun run tauri:dev|tauri dev|vite dev"
+```
+
+Do not use `kill -9` as the first move — it leaves the Cargo build lockfile and Vite's IPC socket in a dirty state, which makes the next start slower.
+
+### 3. Clear stale build caches
+
+```bash
+rm -rf .vite
+rm -rf .svelte-kit/cache
+```
+
+Do **not** delete `.svelte-kit` wholesale or `src-tauri/target` — those caches are expensive to rebuild and rarely cause SSR errors.
+
+### 4. Start a fresh dev session
+
+Launch in the background so the agent stays interactive:
+
+```bash
+bun run tauri:dev
+```
+
+Run this via `Bash` with `run_in_background: true`. The bash wrapper runs `bun run build:sidecar` first (rebuilds the Rust sidecar) and then `tauri dev --no-watch`. Initial start typically takes 30–60 seconds (Cargo + Vite warm-up).
+
+### 5. Confirm readiness
+
+Poll for the Vite dev port and report when it is listening:
+
+```bash
+for i in {1..60}; do
+  lsof -nP -iTCP:1420 -sTCP:LISTEN >/dev/null 2>&1 && echo "ready" && break
+  sleep 2
+done
+```
+
+If the loop times out (120 seconds), inspect the background task output for the first error before retrying.
+
+## Why clear caches
+
+Vite's SSR module-runner keeps a per-route dependency graph in `.vite/`. When a long-lived dev session straddles multiple PR cycles that touch shadcn primitives or shell components (e.g., `OptionsRail` → `CollapsibleAside`), the cached graph diverges from disk. The symptom is `Preloading data for /<route> failed with the following error: Internal Error` in Tauri logs — these are warnings from SvelteKit's `data-sveltekit-preload-data="hover"`, not real navigation failures, but they still poison subsequent navigations. Wiping `.vite` forces a clean transform pass.
+
+`.svelte-kit/cache` is wiped for the same reason: SvelteKit memoizes route manifests there and can hold references to deleted exports.
+
+## Safety rules
+
+- Never `kill -9` as the first move. `SIGTERM` first, `SIGKILL` only after a 5-second grace period.
+- Never delete `src-tauri/target` or `.svelte-kit` wholesale to "fix" cache issues. They are not the source of dev-mode SSR cache bugs and rebuilding them takes minutes.
+- Do not start a second `tauri:dev` if one is already running. Two Vite instances will fight over port 1420 and produce confusing logs.
+- Do not run this skill while a Cargo / Vite build is finishing — wait for the previous start to settle (Vite listening on 1420) before issuing another restart, otherwise the sidecar build can corrupt the target directory.
+
+## Troubleshooting
+
+### Vite stays on port 1420 after kill
+
+A leftover `node` or `bun` process is holding the port. Identify and kill it:
+
+```bash
+lsof -nP -iTCP:1420 -sTCP:LISTEN
+kill -TERM <PID>
+```
+
+### Cargo build fails immediately after restart
+
+If the sidecar build fails with a file-locking error, an old `cargo build` was still running. Wait 10 seconds and retry. If it persists, check `src-tauri/target/.rustc_info.json` for stale process IDs.
+
+### Browser shows old content after restart
+
+The Tauri webview caches the previous URL. Either:
+
+- Navigate to a different route via the sidebar, or
+- Force a reload with `window.location.reload()` from the webview console.


### PR DESCRIPTION
## Summary

- Add a Claude Code skill at `.claude/skills/tauri-dev/` that runs Tauri in dev mode with idempotent semantics: if a session is already running, it is stopped (with its Vite child) and stale build caches are cleared before launching a fresh instance.
- Document the skill in the project CLAUDE.md skill index.

## Motivation

Long-lived Tauri dev sessions that straddle multiple PR cycles touching shadcn / shell / panel primitives accumulate a stale SSR module-runner cache in `.vite/`. The symptom is Tauri warnings:

```
[ WARN ] Preloading data for /<route> failed with the following error: Internal Error
```

for routes that pass `bun run check`. We hit this twice in the last session (after `qr-code-styling` library swap and again after the `CollapsibleAside` primitive extraction). The fix has been a manual checklist (kill processes, wipe `.vite` + `.svelte-kit/cache`, restart); this skill packages the procedure.

## Skill behavior

| Phase | Action |
| --- | --- |
| Detect | `pgrep -af "bun run tauri:dev\|tauri dev\|vite dev"` |
| Stop | `pkill -TERM -f` against each of the three process-name patterns directly (the workers do not share a single ancestor reachable from the top-level PID — see "Test 1 finding" below); escalate to `SIGKILL` after 5s grace |
| Cache | `rm -rf .vite .svelte-kit/cache` (only these — not `.svelte-kit` wholesale or `src-tauri/target`) |
| Start | `bun run tauri:dev` in background |
| Verify | Poll port 1420 with 2s intervals for up to 180s |

## Configuration

- `disable-model-invocation: true` — runs only via `/tauri-dev`, not auto-triggered (it terminates a running process)
- `allowed-tools` scoped to process inspection, signal sending, cache deletion, and the start script

## Test Plan

- [x] Skill markdown follows the same frontmatter format as `release/SKILL.md`
- [x] Process detection commands verified against the current Tauri session (`bun run tauri:dev` parent + `bash` wrapper + `tauri dev --no-watch` + `vite dev` children)
- [x] **Manual: run the skill against a live Tauri session and verify a clean restart**
  - Initial procedure (kill via parent PID + pkill -P) **left `tauri dev` and `vite dev` as orphans**: see "Test 1 finding" below.
  - Fixed procedure (`pkill -TERM -f` against each pattern) **terminated all 5 processes cleanly**; port 1420 became free within 3 seconds.
  - Cache wipe + restart completed in 112s; Hash Generator route loaded successfully after restart.
- [x] **Manual: run the skill against an absent Tauri session and verify a fresh start**
  - Detect step reported no processes; cache was empty.
  - Background `bun run tauri:dev` reached `LISTEN` on port 1420 in 18s (Rust target was warm); Hash Generator loaded successfully.
- [x] **Re-verified the fixed stop logic against a third live session**: all 6 processes cleared in a single `pkill -TERM -f` pass; port 1420 freed; subsequent restart completed in 18s.

## Test 1 finding (bug fixed in second commit)

The original stop logic walked the process tree from `pgrep -f "bun run tauri:dev"` and called `pkill -P` on its children. Two latent bugs surfaced under real conditions:

1. `pgrep -f "bun run tauri:dev"` also matches the outer **zsh wrapper** that holds the `eval 'bun run tauri:dev'` invocation. Its process group does not own the workers, so `pkill -P` reached only the bun and bash wrappers.
2. The `vite dev` process is spawned with a parent (`PID 85256` in this session) **outside the `bun run tauri:dev` tree** — its real parent is an intermediate Cargo / Vite helper that has already exited. No amount of correct tree-walking would have reached it.

Replaced with three direct `pkill -TERM -f` calls against each of `bun run tauri:dev`, `tauri dev`, and `vite dev`. This eliminates the orphan problem and removes a class of timing assumptions about ancestor signalling.

Also bumped the readiness-poll budget from 60 → 90 iterations (120s → 180s). The cold-cache restart in Test 1 landed at 112s — uncomfortably close to the original timeout — so the budget now leaves clear headroom and the skill documents the expected timing band (`~15–30s` warm, `~60–120s` after cache wipe).

## Changes

### Added

- `.claude/skills/tauri-dev/SKILL.md`

### Changed

- `.claude/CLAUDE.md` — add `tauri-dev` to the skill index next to `release`