### PR TITLE
feat(regex-tester): add Hero Railroad diagram with custom SVG renderer

### DIFF
--- a/src/lib/components/regex/index.ts
+++ b/src/lib/components/regex/index.ts
@@ -1,1 +1,2 @@
 export { default as PatternEditor } from './pattern-editor.svelte';
+export { default as RailroadView } from './railroad-view.svelte';

--- a/src/lib/components/regex/railroad-view.svelte
+++ b/src/lib/components/regex/railroad-view.svelte
@@ -1,0 +1,322 @@
+<script lang="ts">
+	import {
+		type ChoiceNode,
+		type GroupNode,
+		layoutRailroad,
+		type QuantifierNode,
+		RAIL_CONSTANTS,
+		type RailroadNode,
+		type SequenceNode,
+		type TerminalKind,
+		type TerminalNode,
+	} from '$lib/services/regex-railroad.js';
+	import type { VizNode } from '$lib/services/regex-viz.js';
+
+	interface Props {
+		readonly node: VizNode;
+	}
+
+	let { node }: Props = $props();
+
+	const diagram = $derived(layoutRailroad(node));
+
+	interface Tone {
+		readonly fill: string;
+		readonly stroke: string;
+		readonly text: string;
+	}
+
+	const TERMINAL_TONE: Record<TerminalKind, Tone> = {
+		char: { fill: 'fill-card', stroke: 'stroke-border', text: 'fill-foreground' },
+		'char-class': {
+			fill: 'fill-info/10',
+			stroke: 'stroke-info/40',
+			text: 'fill-info',
+		},
+		meta: {
+			fill: 'fill-violet-500/10',
+			stroke: 'stroke-violet-500/40',
+			text: 'fill-violet-500',
+		},
+		anchor: {
+			fill: 'fill-amber-500/10',
+			stroke: 'stroke-amber-500/40',
+			text: 'fill-amber-500',
+		},
+		backreference: {
+			fill: 'fill-rose-500/10',
+			stroke: 'stroke-rose-500/40',
+			text: 'fill-rose-500',
+		},
+		unknown: {
+			fill: 'fill-muted',
+			stroke: 'stroke-border',
+			text: 'fill-muted-foreground',
+		},
+	};
+
+	const NEUTRAL_TONE: Tone = {
+		fill: 'fill-muted',
+		stroke: 'stroke-border',
+		text: 'fill-muted-foreground',
+	};
+
+	const terminalTone = (kind: TerminalKind): Tone => TERMINAL_TONE[kind] ?? NEUTRAL_TONE;
+
+	interface GroupTone {
+		readonly stroke: string;
+		readonly title: string;
+		readonly fill: string;
+	}
+
+	const GROUP_PALETTE: readonly GroupTone[] = [
+		{ stroke: 'stroke-blue-500/50', title: 'fill-blue-500', fill: 'fill-blue-500/[0.03]' },
+		{
+			stroke: 'stroke-emerald-500/50',
+			title: 'fill-emerald-500',
+			fill: 'fill-emerald-500/[0.03]',
+		},
+		{
+			stroke: 'stroke-fuchsia-500/50',
+			title: 'fill-fuchsia-500',
+			fill: 'fill-fuchsia-500/[0.03]',
+		},
+		{ stroke: 'stroke-amber-500/50', title: 'fill-amber-500', fill: 'fill-amber-500/[0.03]' },
+		{ stroke: 'stroke-rose-500/50', title: 'fill-rose-500', fill: 'fill-rose-500/[0.03]' },
+		{ stroke: 'stroke-cyan-500/50', title: 'fill-cyan-500', fill: 'fill-cyan-500/[0.03]' },
+		{ stroke: 'stroke-violet-500/50', title: 'fill-violet-500', fill: 'fill-violet-500/[0.03]' },
+		{ stroke: 'stroke-lime-500/50', title: 'fill-lime-500', fill: 'fill-lime-500/[0.03]' },
+	];
+
+	const NEUTRAL_GROUP: GroupTone = {
+		stroke: 'stroke-border',
+		title: 'fill-muted-foreground',
+		fill: 'fill-card',
+	};
+
+	const groupPaletteEntry = (oneBasedIndex: number): GroupTone =>
+		GROUP_PALETTE[(Math.max(1, oneBasedIndex) - 1) % GROUP_PALETTE.length] ?? NEUTRAL_GROUP;
+
+	const groupTone = (g: GroupNode): GroupTone =>
+		g.variant === 'capture' && g.groupNumber !== undefined
+			? groupPaletteEntry(g.groupNumber)
+			: NEUTRAL_GROUP;
+
+	const horizontalRail = (x1: number, y1: number, x2: number, y2: number): string => {
+		if (Math.abs(y1 - y2) < 0.5) return `M ${x1} ${y1} L ${x2} ${y2}`;
+		const midX = (x1 + x2) / 2;
+		return `M ${x1} ${y1} C ${midX} ${y1} ${midX} ${y2} ${x2} ${y2}`;
+	};
+
+	const loopPath = (
+		leftEntryX: number,
+		rightExitX: number,
+		entryY: number,
+		bottomY: number
+	): string => {
+		const arc = RAIL_CONSTANTS.LOOP_ARC;
+		return [
+			`M ${leftEntryX} ${entryY}`,
+			`A ${arc} ${arc} 0 0 1 ${leftEntryX - arc} ${entryY + arc}`,
+			`L ${leftEntryX - arc} ${bottomY - arc}`,
+			`A ${arc} ${arc} 0 0 1 ${leftEntryX} ${bottomY}`,
+			`L ${rightExitX} ${bottomY}`,
+			`A ${arc} ${arc} 0 0 1 ${rightExitX + arc} ${bottomY - arc}`,
+			`L ${rightExitX + arc} ${entryY + arc}`,
+			`A ${arc} ${arc} 0 0 1 ${rightExitX} ${entryY}`,
+		].join(' ');
+	};
+
+	const skipPath = (
+		leftEntryX: number,
+		rightExitX: number,
+		entryY: number,
+		topY: number
+	): string => {
+		const arc = RAIL_CONSTANTS.SKIP_ARC;
+		return [
+			`M ${leftEntryX} ${entryY}`,
+			`A ${arc} ${arc} 0 0 0 ${leftEntryX - arc} ${entryY - arc}`,
+			`L ${leftEntryX - arc} ${topY + arc}`,
+			`A ${arc} ${arc} 0 0 0 ${leftEntryX} ${topY}`,
+			`L ${rightExitX} ${topY}`,
+			`A ${arc} ${arc} 0 0 0 ${rightExitX + arc} ${topY + arc}`,
+			`L ${rightExitX + arc} ${entryY - arc}`,
+			`A ${arc} ${arc} 0 0 0 ${rightExitX} ${entryY}`,
+		].join(' ');
+	};
+
+	const quantifierLabelText = (q: QuantifierNode): string => {
+		const greedy = q.greedy ? '' : ' ?';
+		if (q.min === 0 && q.max === null) return `0+${greedy}`;
+		if (q.min === 1 && q.max === null) return `1+${greedy}`;
+		if (q.min === 0 && q.max === 1) return `0–1${greedy}`;
+		if (q.max === null) return `${q.min}+${greedy}`;
+		if (q.min === q.max) return `${q.min}×${greedy}`;
+		return `${q.min}–${q.max}${greedy}`;
+	};
+</script>
+
+<svg
+	viewBox="0 0 {diagram.width} {diagram.height}"
+	width={diagram.width}
+	height={diagram.height}
+	class="text-foreground"
+	role="img"
+	aria-label="Railroad diagram of regex pattern"
+>
+	{@render railNode(diagram.root)}
+</svg>
+
+{#snippet railNode(n: RailroadNode)}
+	{#if n.kind === 'terminal'}
+		{@render terminalSnippet(n)}
+	{:else if n.kind === 'sequence'}
+		{@render sequenceSnippet(n)}
+	{:else if n.kind === 'choice'}
+		{@render choiceSnippet(n)}
+	{:else if n.kind === 'group'}
+		{@render groupSnippet(n)}
+	{:else if n.kind === 'quantifier'}
+		{@render quantifierSnippet(n)}
+	{/if}
+{/snippet}
+
+{#snippet terminalSnippet(n: TerminalNode)}
+	{@const tone = terminalTone(n.nodeKind)}
+	<rect
+		x={n.x}
+		y={n.y}
+		width={n.width}
+		height={n.height}
+		rx={n.nodeKind === 'char' ? 13 : 4}
+		class={`${tone.fill} ${tone.stroke}`}
+		stroke-width="1"
+	/>
+	<text
+		x={n.x + n.width / 2}
+		y={n.entryY}
+		text-anchor="middle"
+		dominant-baseline="middle"
+		class={`${tone.text} font-mono text-[11px]`}
+	>
+		{n.label}
+	</text>
+{/snippet}
+
+{#snippet sequenceSnippet(n: SequenceNode)}
+	{#each n.children as child, i (i)}
+		{@const prev = i > 0 ? n.children[i - 1] : undefined}
+		{#if prev}
+			<path
+				d={horizontalRail(prev.x + prev.width, prev.exitY, child.x, child.entryY)}
+				class="stroke-muted-foreground/60 fill-none"
+				stroke-width="1.5"
+			/>
+		{/if}
+		{@render railNode(child)}
+	{/each}
+{/snippet}
+
+{#snippet choiceSnippet(n: ChoiceNode)}
+	{#each n.children as child, i (i)}
+		<path
+			d={horizontalRail(n.x, n.entryY, child.x, child.entryY)}
+			class="stroke-muted-foreground/60 fill-none"
+			stroke-width="1.5"
+		/>
+		<path
+			d={horizontalRail(child.x + child.width, child.exitY, n.x + n.width, n.exitY)}
+			class="stroke-muted-foreground/60 fill-none"
+			stroke-width="1.5"
+		/>
+		{@render railNode(child)}
+	{/each}
+{/snippet}
+
+{#snippet groupSnippet(n: GroupNode)}
+	{@const tone = groupTone(n)}
+	<rect
+		x={n.x}
+		y={n.y + 4}
+		width={n.width}
+		height={n.height - 4}
+		rx={6}
+		class={`${tone.fill} ${tone.stroke}`}
+		stroke-width="1"
+		stroke-dasharray={n.variant === 'capture' || n.variant === 'named' ? undefined : '4 3'}
+	/>
+	<text
+		x={n.x + 10}
+		y={n.y + 14}
+		class={`${tone.title} font-mono text-[10px]`}
+		dominant-baseline="middle"
+	>
+		{n.title}
+	</text>
+	<path
+		d={horizontalRail(n.x, n.entryY, n.child.x, n.child.entryY)}
+		class="stroke-muted-foreground/60 fill-none"
+		stroke-width="1.5"
+	/>
+	<path
+		d={horizontalRail(n.child.x + n.child.width, n.child.exitY, n.x + n.width, n.exitY)}
+		class="stroke-muted-foreground/60 fill-none"
+		stroke-width="1.5"
+	/>
+	{@render railNode(n.child)}
+{/snippet}
+
+{#snippet quantifierSnippet(n: QuantifierNode)}
+	{@const inner = n.child}
+	{@const hasSkip = n.min === 0}
+	{@const hasLoop = n.max === null || n.max > 1}
+	{@const loopY = n.y + n.height - RAIL_CONSTANTS.QUANT_LABEL_HEIGHT - RAIL_CONSTANTS.LOOP_ARC}
+	{@const skipY = n.y + RAIL_CONSTANTS.SKIP_ARC}
+	<path
+		d={horizontalRail(n.x, n.entryY, inner.x, inner.entryY)}
+		class="stroke-muted-foreground/60 fill-none"
+		stroke-width="1.5"
+	/>
+	<path
+		d={horizontalRail(inner.x + inner.width, inner.exitY, n.x + n.width, n.exitY)}
+		class="stroke-muted-foreground/60 fill-none"
+		stroke-width="1.5"
+	/>
+	{#if hasLoop}
+		<path
+			d={loopPath(inner.x, inner.x + inner.width, n.entryY, loopY)}
+			class="stroke-muted-foreground/50 fill-none"
+			stroke-width="1.5"
+			stroke-dasharray="3 3"
+		/>
+		<text
+			x={(inner.x + inner.x + inner.width) / 2}
+			y={loopY + RAIL_CONSTANTS.QUANT_LABEL_HEIGHT}
+			text-anchor="middle"
+			dominant-baseline="hanging"
+			class="fill-muted-foreground font-mono text-[9px]"
+		>
+			{quantifierLabelText(n)}
+		</text>
+	{:else}
+		<text
+			x={(inner.x + inner.x + inner.width) / 2}
+			y={n.y + n.height - 2}
+			text-anchor="middle"
+			dominant-baseline="ideographic"
+			class="fill-muted-foreground font-mono text-[9px]"
+		>
+			{quantifierLabelText(n)}
+		</text>
+	{/if}
+	{#if hasSkip}
+		<path
+			d={skipPath(inner.x, inner.x + inner.width, n.entryY, skipY)}
+			class="stroke-muted-foreground/50 fill-none"
+			stroke-width="1.5"
+			stroke-dasharray="3 3"
+		/>
+	{/if}
+	{@render railNode(inner)}
+{/snippet}

--- a/src/lib/services/regex-railroad.ts
+++ b/src/lib/services/regex-railroad.ts
@@ -1,0 +1,382 @@
+/**
+ * Railroad diagram layout engine for regex visualization.
+ *
+ * Converts a `VizNode` tree (from regex-viz.ts) into a positioned
+ * `RailroadNode` tree that a Svelte renderer can walk to emit SVG.
+ * Layout is conventional railroad geometry:
+ *
+ * - Each laid-out node exposes its bounding box (width, height) and the
+ *   Y-coordinate of its entry and exit rails. Parents place children on a
+ *   shared horizontal rail by aligning `entryY` / `exitY`.
+ * - Sequences place children left-to-right, padding each gap with a
+ *   straight rail segment.
+ * - Choices stack all branches vertically. The first branch sits on the
+ *   centerline; subsequent branches fan downward with a curved diverge
+ *   at the left and converge at the right.
+ * - Quantifiers wrap a child with a loop arc beneath (for `*` and `+`)
+ *   and a skip arc above (for `*` and `?`).
+ * - Groups wrap a child in a titled bordered box.
+ *
+ * The engine is pure: input `VizNode` -> output `RailroadDiagram`. No DOM,
+ * no SVG strings; the consumer walks the tree itself.
+ */
+
+import type { VizNode } from './regex-viz.js';
+
+const BOX_HEIGHT = 26;
+const CHAR_WIDTH = 7.2;
+const MIN_BOX_WIDTH = 32;
+const BOX_PADDING_X = 10;
+const SEQUENCE_GAP = 14;
+const CHOICE_VERT_GAP = 10;
+const CHOICE_DIVERGE = 18;
+const GROUP_PAD_X = 14;
+const GROUP_PAD_Y_TOP = 22;
+const GROUP_PAD_Y_BOTTOM = 10;
+const LOOP_ARC = 10;
+const LOOP_VERT = 14;
+const SKIP_ARC = 10;
+const SKIP_VERT = 14;
+const QUANT_LABEL_HEIGHT = 12;
+const DIAGRAM_PAD = 12;
+
+export type TerminalKind = 'char' | 'char-class' | 'meta' | 'anchor' | 'backreference' | 'unknown';
+
+export type RailroadNode = TerminalNode | SequenceNode | ChoiceNode | GroupNode | QuantifierNode;
+
+export interface BaseNode {
+	readonly x: number;
+	readonly y: number;
+	readonly width: number;
+	readonly height: number;
+	readonly entryY: number;
+	readonly exitY: number;
+}
+
+export interface TerminalNode extends BaseNode {
+	readonly kind: 'terminal';
+	readonly label: string;
+	readonly nodeKind: TerminalKind;
+}
+
+export interface SequenceNode extends BaseNode {
+	readonly kind: 'sequence';
+	readonly children: readonly RailroadNode[];
+}
+
+export interface ChoiceNode extends BaseNode {
+	readonly kind: 'choice';
+	readonly children: readonly RailroadNode[];
+}
+
+export type GroupVariant =
+	| 'capture'
+	| 'named'
+	| 'non-capture'
+	| 'lookahead'
+	| 'lookbehind'
+	| 'negative-lookahead'
+	| 'negative-lookbehind';
+
+export interface GroupNode extends BaseNode {
+	readonly kind: 'group';
+	readonly child: RailroadNode;
+	readonly title: string;
+	readonly variant: GroupVariant;
+	readonly groupNumber?: number;
+}
+
+export interface QuantifierNode extends BaseNode {
+	readonly kind: 'quantifier';
+	readonly child: RailroadNode;
+	readonly label: string;
+	readonly min: number;
+	readonly max: number | null;
+	readonly greedy: boolean;
+}
+
+export interface RailroadDiagram {
+	readonly width: number;
+	readonly height: number;
+	readonly root: RailroadNode;
+}
+
+interface SizedNode {
+	readonly width: number;
+	readonly up: number;
+	readonly down: number;
+}
+
+const EMPTY_VIZ_NODE: VizNode = { kind: 'unknown', label: '?', children: [] };
+const FALLBACK_SIZED: SizedNode = {
+	width: MIN_BOX_WIDTH,
+	up: BOX_HEIGHT / 2,
+	down: BOX_HEIGHT / 2,
+};
+
+const measureLabel = (label: string): number =>
+	Math.max(MIN_BOX_WIDTH, Math.ceil(label.length * CHAR_WIDTH) + BOX_PADDING_X * 2);
+
+const flattenChoice = (node: VizNode): readonly VizNode[] => {
+	if (node.kind !== 'alternation') return [node];
+	return node.children.flatMap(flattenChoice);
+};
+
+const groupVariant = (kind: VizNode['kind']): GroupVariant | null => {
+	if (kind === 'capture-group') return 'capture';
+	if (kind === 'named-group') return 'named';
+	if (kind === 'non-capture-group') return 'non-capture';
+	if (kind === 'lookahead') return 'lookahead';
+	if (kind === 'lookbehind') return 'lookbehind';
+	if (kind === 'negative-lookahead') return 'negative-lookahead';
+	if (kind === 'negative-lookbehind') return 'negative-lookbehind';
+	if (kind === 'group') return 'non-capture';
+	return null;
+};
+
+const groupTitle = (node: VizNode, variant: GroupVariant): string => {
+	if (variant === 'capture')
+		return node.groupNumber !== undefined ? `Group #${node.groupNumber}` : 'group';
+	if (variant === 'named') return node.groupName ? `<${node.groupName}>` : 'named group';
+	if (variant === 'non-capture') return '(?:…)';
+	if (variant === 'lookahead') return '(?=…)';
+	if (variant === 'lookbehind') return '(?<=…)';
+	if (variant === 'negative-lookahead') return '(?!…)';
+	if (variant === 'negative-lookbehind') return '(?<!…)';
+	return 'group';
+};
+
+const terminalKind = (kind: VizNode['kind']): TerminalKind => {
+	if (kind === 'char') return 'char';
+	if (kind === 'char-class') return 'char-class';
+	if (kind === 'meta') return 'meta';
+	if (kind === 'anchor') return 'anchor';
+	if (kind === 'backreference') return 'backreference';
+	return 'unknown';
+};
+
+const isTerminalKind = (kind: VizNode['kind']): boolean =>
+	kind === 'char' ||
+	kind === 'char-class' ||
+	kind === 'meta' ||
+	kind === 'anchor' ||
+	kind === 'backreference' ||
+	kind === 'unknown';
+
+const measure = (node: VizNode): SizedNode => {
+	if (isTerminalKind(node.kind)) {
+		const w = measureLabel(node.label);
+		return { width: w, up: BOX_HEIGHT / 2, down: BOX_HEIGHT / 2 };
+	}
+
+	if (node.kind === 'sequence') {
+		const measured = node.children.map(measure);
+		if (measured.length === 0) {
+			return { width: MIN_BOX_WIDTH, up: BOX_HEIGHT / 2, down: BOX_HEIGHT / 2 };
+		}
+		const width =
+			measured.reduce((sum, m) => sum + m.width, 0) + SEQUENCE_GAP * (measured.length - 1);
+		const up = Math.max(...measured.map((m) => m.up));
+		const down = Math.max(...measured.map((m) => m.down));
+		return { width, up, down };
+	}
+
+	if (node.kind === 'alternation') {
+		const branches = flattenChoice(node).map(measure);
+		const [first, ...rest] = branches;
+		if (!first) return FALLBACK_SIZED;
+		const innerWidth = Math.max(...branches.map((b) => b.width));
+		const width = innerWidth + CHOICE_DIVERGE * 2;
+		const up = first.up;
+		const restHeight = rest.reduce((sum, b) => sum + CHOICE_VERT_GAP + b.up + b.down, 0);
+		const down = first.down + restHeight;
+		return { width, up, down };
+	}
+
+	if (node.kind === 'repetition') {
+		const innerNode = node.children[0] ?? EMPTY_VIZ_NODE;
+		const inner = measure(innerNode);
+		const q = node.quantifier;
+		const min = q?.min ?? 1;
+		const max = q?.max ?? null;
+		const hasLoop = max === null || max > 1;
+		const hasSkip = min === 0;
+		const width = inner.width + LOOP_ARC * 2;
+		const up = inner.up + (hasSkip ? SKIP_VERT + SKIP_ARC : 0);
+		const down =
+			inner.down + (hasLoop ? LOOP_VERT + LOOP_ARC + QUANT_LABEL_HEIGHT : QUANT_LABEL_HEIGHT);
+		return { width, up, down };
+	}
+
+	const variant = groupVariant(node.kind);
+	if (variant) {
+		const innerNode = node.children[0] ?? EMPTY_VIZ_NODE;
+		const inner = measure(innerNode);
+		const width = inner.width + GROUP_PAD_X * 2;
+		const up = inner.up + GROUP_PAD_Y_TOP;
+		const down = inner.down + GROUP_PAD_Y_BOTTOM;
+		return { width, up, down };
+	}
+
+	const w = measureLabel(node.label);
+	return { width: w, up: BOX_HEIGHT / 2, down: BOX_HEIGHT / 2 };
+};
+
+const layoutNode = (node: VizNode, x: number, entryY: number): RailroadNode => {
+	if (isTerminalKind(node.kind)) {
+		const w = measureLabel(node.label);
+		return {
+			kind: 'terminal',
+			x,
+			y: entryY - BOX_HEIGHT / 2,
+			width: w,
+			height: BOX_HEIGHT,
+			entryY,
+			exitY: entryY,
+			label: node.label,
+			nodeKind: terminalKind(node.kind),
+		};
+	}
+
+	if (node.kind === 'sequence') {
+		if (node.children.length === 0) {
+			return layoutNode(EMPTY_VIZ_NODE, x, entryY);
+		}
+		const children: RailroadNode[] = [];
+		let cursorX = x;
+		for (const childNode of node.children) {
+			const child = layoutNode(childNode, cursorX, entryY);
+			children.push(child);
+			cursorX = child.x + child.width + SEQUENCE_GAP;
+		}
+		const totalWidth = cursorX - x - SEQUENCE_GAP;
+		const ups = children.map((c) => c.entryY - c.y);
+		const downs = children.map((c) => c.y + c.height - c.exitY);
+		const up = ups.reduce((a, b) => Math.max(a, b), BOX_HEIGHT / 2);
+		const down = downs.reduce((a, b) => Math.max(a, b), BOX_HEIGHT / 2);
+		return {
+			kind: 'sequence',
+			x,
+			y: entryY - up,
+			width: totalWidth,
+			height: up + down,
+			entryY,
+			exitY: entryY,
+			children,
+		};
+	}
+
+	if (node.kind === 'alternation') {
+		const branches = flattenChoice(node);
+		const sized = branches.map(measure);
+		const [firstBranch, ...restBranches] = branches;
+		const [firstSized, ...restSized] = sized;
+		if (!firstBranch || !firstSized) {
+			return layoutNode(EMPTY_VIZ_NODE, x, entryY);
+		}
+		const innerWidth = sized.reduce((acc, s) => Math.max(acc, s.width), 0);
+		const totalWidth = innerWidth + CHOICE_DIVERGE * 2;
+		const children: RailroadNode[] = [];
+		const firstChildX = x + CHOICE_DIVERGE + (innerWidth - firstSized.width) / 2;
+		children.push(layoutNode(firstBranch, firstChildX, entryY));
+		let cursorY = entryY + firstSized.down + CHOICE_VERT_GAP;
+		for (let i = 0; i < restBranches.length; i++) {
+			const branch = restBranches[i];
+			const s = restSized[i];
+			if (!branch || !s) continue;
+			const childEntryY = cursorY + s.up;
+			const childX = x + CHOICE_DIVERGE + (innerWidth - s.width) / 2;
+			children.push(layoutNode(branch, childX, childEntryY));
+			cursorY = childEntryY + s.down + CHOICE_VERT_GAP;
+		}
+		const up = firstSized.up;
+		const down = cursorY - entryY - CHOICE_VERT_GAP;
+		return {
+			kind: 'choice',
+			x,
+			y: entryY - up,
+			width: totalWidth,
+			height: up + down,
+			entryY,
+			exitY: entryY,
+			children,
+		};
+	}
+
+	if (node.kind === 'repetition') {
+		const childNode = node.children[0] ?? EMPTY_VIZ_NODE;
+		const innerSized = measure(childNode);
+		const q = node.quantifier;
+		const min = q?.min ?? 1;
+		const max = q?.max ?? null;
+		const hasSkip = min === 0;
+		const innerEntryY = entryY;
+		const child = layoutNode(childNode, x + LOOP_ARC, innerEntryY);
+		const totalWidth = innerSized.width + LOOP_ARC * 2;
+		const up = innerSized.up + (hasSkip ? SKIP_VERT + SKIP_ARC : 0);
+		const down = innerSized.down + LOOP_VERT + LOOP_ARC + QUANT_LABEL_HEIGHT;
+		return {
+			kind: 'quantifier',
+			x,
+			y: entryY - up,
+			width: totalWidth,
+			height: up + down,
+			entryY,
+			exitY: entryY,
+			child,
+			label: node.label,
+			min,
+			max,
+			greedy: q?.greedy ?? true,
+		};
+	}
+
+	const variant = groupVariant(node.kind);
+	if (variant) {
+		const childNode = node.children[0] ?? EMPTY_VIZ_NODE;
+		const innerSized = measure(childNode);
+		const child = layoutNode(childNode, x + GROUP_PAD_X, entryY);
+		const totalWidth = innerSized.width + GROUP_PAD_X * 2;
+		const up = innerSized.up + GROUP_PAD_Y_TOP;
+		const down = innerSized.down + GROUP_PAD_Y_BOTTOM;
+		return {
+			kind: 'group',
+			x,
+			y: entryY - up,
+			width: totalWidth,
+			height: up + down,
+			entryY,
+			exitY: entryY,
+			child,
+			title: groupTitle(node, variant),
+			variant,
+			groupNumber: node.groupNumber,
+		};
+	}
+
+	return layoutNode({ kind: 'unknown', label: node.label, children: [] }, x, entryY);
+};
+
+export const layoutRailroad = (node: VizNode): RailroadDiagram => {
+	const sized = measure(node);
+	const entryY = DIAGRAM_PAD + sized.up;
+	const root = layoutNode(node, DIAGRAM_PAD, entryY);
+	const width = root.width + DIAGRAM_PAD * 2;
+	const height = sized.up + sized.down + DIAGRAM_PAD * 2;
+	return { width, height, root };
+};
+
+export const RAIL_CONSTANTS = {
+	BOX_HEIGHT,
+	SEQUENCE_GAP,
+	CHOICE_DIVERGE,
+	LOOP_ARC,
+	LOOP_VERT,
+	SKIP_ARC,
+	SKIP_VERT,
+	GROUP_PAD_X,
+	GROUP_PAD_Y_TOP,
+	GROUP_PAD_Y_BOTTOM,
+	QUANT_LABEL_HEIGHT,
+	DIAGRAM_PAD,
+} as const;

--- a/src/lib/services/regex-viz.ts
+++ b/src/lib/services/regex-viz.ts
@@ -29,11 +29,20 @@ export type VizNodeKind =
 	| 'backreference'
 	| 'unknown';
 
+export interface QuantifierInfo {
+	readonly min: number;
+	readonly max: number | null;
+	readonly greedy: boolean;
+}
+
 export interface VizNode {
 	readonly kind: VizNodeKind;
 	readonly label: string;
 	readonly detail?: string;
 	readonly children: readonly VizNode[];
+	readonly groupNumber?: number;
+	readonly groupName?: string;
+	readonly quantifier?: QuantifierInfo;
 }
 
 const groupKind = (node: { capturing?: boolean; name?: string; kind?: string }): VizNodeKind => {
@@ -86,6 +95,23 @@ const repetitionLabel = (q: {
 		return `${q.from}-${q.to} times${greedy}`;
 	}
 	return q.kind;
+};
+
+const repetitionInfo = (q: {
+	kind: string;
+	from?: number;
+	to?: number;
+	greedy: boolean;
+}): QuantifierInfo => {
+	if (q.kind === '*') return { min: 0, max: null, greedy: q.greedy };
+	if (q.kind === '+') return { min: 1, max: null, greedy: q.greedy };
+	if (q.kind === '?') return { min: 0, max: 1, greedy: q.greedy };
+	if (q.kind === 'Range') {
+		const min = q.from ?? 0;
+		const max = q.to ?? null;
+		return { min, max, greedy: q.greedy };
+	}
+	return { min: 1, max: 1, greedy: q.greedy };
 };
 
 const characterClassLabel = (node: {
@@ -162,6 +188,8 @@ const buildVizNode = (node: any): VizNode => {
 			label: labelMap[kind],
 			detail: node.number !== undefined ? `#${node.number}` : undefined,
 			children: [buildVizNode(node.expression)],
+			groupNumber: typeof node.number === 'number' ? node.number : undefined,
+			groupName: typeof node.name === 'string' ? node.name : undefined,
 		};
 	}
 	if (type === 'Repetition') {
@@ -169,6 +197,7 @@ const buildVizNode = (node: any): VizNode => {
 			kind: 'repetition',
 			label: repetitionLabel(node.quantifier),
 			children: [buildVizNode(node.expression)],
+			quantifier: repetitionInfo(node.quantifier),
 		};
 	}
 	if (type === 'Char') {

--- a/src/routes/regex-tester/+page.svelte
+++ b/src/routes/regex-tester/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { Eye, GitBranch, Info, Search, Sparkles } from '@lucide/svelte';
+	import { Eye, GitBranch, Info, Search, Sparkles, Workflow } from '@lucide/svelte';
 	import { CopyButton } from '$lib/components/action';
 	import { FormInfo, FormSection, FormTextarea } from '$lib/components/form';
-	import { PatternEditor } from '$lib/components/regex';
+	import { PatternEditor, RailroadView } from '$lib/components/regex';
 	import { ToolShell } from '$lib/components/shell';
 	import { EmbeddedEmptyState, StatItem } from '$lib/components/status';
 	import * as Accordion from '$lib/components/ui/accordion';
@@ -200,16 +200,17 @@ Also see https://kogu.io/docs and http://test.local:3000/.`
 			<FormInfo>Regex literal in JavaScript syntax. Forward slashes don't need escaping.</FormInfo>
 		</FormSection>
 
-		<FormSection title="Capture groups">
+		<FormSection title="Railroad">
 			<FormInfo>
-				Each capture group is assigned a color used across the pattern, test text, and structure
-				panels.
+				The diagram below the pattern bar is read left-to-right. Branches stack vertically; dashed
+				loops mark quantifiers. Each capture group is boxed with a unique color shared across the
+				pattern bar, test text, and match list.
 			</FormInfo>
 		</FormSection>
 
 		<FormSection title="Replace mode">
 			<FormInfo>
-				Toggle the switch in the Test Text card to replace matches. Use
+				Toggle the button in the Replace card to apply a substitution. Use
 				<code class="rounded bg-muted px-1 font-mono">$1</code>,
 				<code class="rounded bg-muted px-1 font-mono">$&lt;name&gt;</code>, or
 				<code class="rounded bg-muted px-1 font-mono">$&amp;</code> placeholders.
@@ -274,6 +275,38 @@ Also see https://kogu.io/docs and http://test.local:3000/.`
 						<CopyButton text={`/${pattern}/${flagString}`} toastLabel="Pattern" size="sm" />
 					</div>
 				</div>
+			</div>
+		</div>
+
+		<!-- Hero Railroad -->
+		<div class="shrink-0 border-b bg-background px-4 py-3">
+			<div class="mx-auto max-w-6xl">
+				<Card.Root>
+					<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-2 pt-3">
+						<div class="flex items-center gap-2">
+							<Workflow class="h-4 w-4 text-muted-foreground" />
+							<Card.Title class="text-sm font-medium">Railroad</Card.Title>
+							{#if captureGroupCount > 0}
+								<Badge variant="outline" class="font-mono text-2xs">
+									{captureGroupCount} group{captureGroupCount === 1 ? '' : 's'}
+								</Badge>
+							{/if}
+						</div>
+					</Card.Header>
+					<Card.Content class="max-h-80 overflow-auto p-3">
+						{#if pattern.length === 0}
+							<EmbeddedEmptyState
+								icon={Workflow}
+								title="Enter a pattern"
+								description="The railroad diagram appears here once you type a regex."
+							/>
+						{:else if visualization.ok}
+							<RailroadView node={visualization.value} />
+						{:else}
+							<p class="text-sm text-destructive">{visualization.error}</p>
+						{/if}
+					</Card.Content>
+				</Card.Root>
 			</div>
 		</div>
 
@@ -369,7 +402,7 @@ Also see https://kogu.io/docs and http://test.local:3000/.`
 
 			<!-- Right column: accordion -->
 			<div class="w-96 shrink-0 overflow-auto border-l bg-surface-2 p-4">
-				<Accordion.Root type="multiple" value={['matches', 'structure', 'explain']} class="w-full">
+				<Accordion.Root type="multiple" value={['matches', 'explain']} class="w-full">
 					<Accordion.Item value="matches">
 						<Accordion.Trigger>
 							<div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary

- Add a Railroad diagram as the hero visualization of the Regex Tester, rendered with a custom SVG layout engine that consumes the existing `VizNode` tree from `regex-viz.ts`.
- Restructure the page so the Railroad sits directly below the pattern bar (regexper.com / regex101.com hybrid), with the analytical accordion (Matches / Structure / Explain) on the right.
- Default the textual Structure tree to collapsed: it remains available for AST drill-downs but is no longer the primary view of pattern structure.

## Changes

### Added

- `src/lib/services/regex-railroad.ts` — pure layout engine. Walks `VizNode` and produces a positioned `RailroadNode` tree (terminal / sequence / choice / quantifier / group). Nested binary `Disjunction`s flatten to a single N-way choice. Quantifier loop / skip arcs are added based on the new `quantifier` metadata.
- `src/lib/components/regex/railroad-view.svelte` — SVG renderer. Recursive Svelte 5 snippets emit `<rect>`, `<text>`, and rail / loop / skip `<path>` markup. Capturing groups colored via an 8-entry palette that mirrors `regex-design.ts`.
- New imports in `src/lib/components/regex/index.ts`.

### Changed

- `src/lib/services/regex-viz.ts` — extend `VizNode` with optional `groupNumber`, `groupName`, and `quantifier { min, max, greedy }`. The existing text-tree consumer ignores these; the railroad uses them for group coloring and loop / skip rendering.
- `src/routes/regex-tester/+page.svelte` — new Hero Railroad section between the pattern bar and the body. Structure accordion default-collapsed. Rail snippet updated to describe the railroad conventions (branches stack vertically, dashed loops mark quantifiers).

## Visual examples

- `(?<protocol>https?)://(?<host>[\w.-]+)(?::(?<port>\d+))?(?<path>/[^?#\s]*)?` → 4 colored named groups, two nested `(?:…)?` brackets with `0–1` loop labels, `\d+` and `[\w.-]+` with `1+` loops.
- `cat|dog|fish` → 3-way vertical choice with curved diverge / converge rails.

## Test Plan

- [x] `bun run check` (svelte-check + validate-pages + audit-design)
- [x] Visual: default complex named-group regex renders with 4 colored groups, nested quantifiers, and proper loop labels.
- [x] Visual: 3-way alternation (`cat|dog|fish`) stacks branches with diverge / converge rails.
- [x] Visual: tab switching and re-render across pattern edits.
- [x] Structure accordion still works (collapsed by default).
- [x] Capture group colors match the pattern bar / inline preview / match list.