### PR TITLE
refactor(tools): unify Sample-button pattern across regex/cron/curl

### DIFF
--- a/src/lib/services/cron.ts
+++ b/src/lib/services/cron.ts
@@ -155,6 +155,7 @@ export const validateField = (field: keyof CronParts, value: string): Result<tru
 
 export const nextExecutions = (expression: string, count: number): Result<readonly Date[]> => {
 	if (count <= 0) return { ok: true, value: [] };
+	if (expression.trim().length === 0) return { ok: false, error: 'Empty expression' };
 	try {
 		const interval = CronExpressionParser.parse(expression);
 		const dates = Array.from({ length: count }, () => interval.next().toDate());
@@ -211,3 +212,5 @@ export const formatDate = (date: Date): string => {
 	const parts = formatDateParts(date);
 	return `${parts.date} (${parts.dayLabel}) ${parts.time}`;
 };
+
+export const SAMPLE_CRON_EXPRESSION = '*/5 * * * *';

--- a/src/lib/services/curl.ts
+++ b/src/lib/services/curl.ts
@@ -418,3 +418,8 @@ export const generateGoCode = (request: CurlRequest): string => {
 	lines.push('}');
 	return lines.join('\n');
 };
+
+export const SAMPLE_CURL_COMMAND = `curl -X POST 'https://api.example.com/login' \\
+  -H 'Content-Type: application/json' \\
+  -L --max-time 30 \\
+  --data-raw '{"username":"alice","password":"secret"}'`;

--- a/src/lib/services/regex.ts
+++ b/src/lib/services/regex.ts
@@ -61,6 +61,7 @@ const withIndicesFlag = (flagString: string): string =>
 	flagString.includes('d') ? flagString : `${flagString}d`;
 
 export const compileRegex = (pattern: string, flags: RegexFlags): Result<RegExp> => {
+	if (pattern.length === 0) return { ok: false, error: 'Empty pattern' };
 	try {
 		const flagString = withIndicesFlag(flagsToString(flags));
 		return { ok: true, value: new RegExp(pattern, flagString) };
@@ -194,3 +195,11 @@ export const countCaptureGroups = (pattern: string): number => {
 	const matches = stripped.matchAll(/\((?!\?[:=!]|\?<[=!])/g);
 	return Array.from(matches).length;
 };
+
+export const SAMPLE_PATTERN =
+	'(?<protocol>https?)://(?<host>[\\w.-]+)(?::(?<port>\\d+))?(?<path>/[^?#\\s]*)?';
+
+export const SAMPLE_TEST_TEXT = `Visit https://example.com and http://example.org:8080/path?query=1.
+Also see https://kogu.io/docs and http://test.local:3000/.`;
+
+export const SAMPLE_REPLACEMENT = '[$<host>]';

--- a/src/routes/cron-expression-builder/tabs/parse-tab.svelte
+++ b/src/routes/cron-expression-builder/tabs/parse-tab.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-	import { Calendar, Clock, Sparkles } from '@lucide/svelte';
+	import { Calendar, Clock, FlaskConical, Sparkles } from '@lucide/svelte';
 	import { CopyButton } from '$lib/components/action';
 	import { FormInput } from '$lib/components/form';
 	import { SectionHeader } from '$lib/components/layout';
+	import { EmbeddedEmptyState } from '$lib/components/status';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
@@ -14,6 +15,7 @@
 		formatDateParts,
 		nextExecutions,
 		parseExpression,
+		SAMPLE_CRON_EXPRESSION,
 	} from '$lib/services/cron.js';
 
 	interface Props {
@@ -22,7 +24,11 @@
 
 	let { onstatschange }: Props = $props();
 
-	let expression = $state<string>('*/5 * * * *');
+	let expression = $state<string>('');
+
+	const loadSample = () => {
+		expression = SAMPLE_CRON_EXPRESSION;
+	};
 
 	const parsed = $derived(parseExpression(expression));
 	const description = $derived(explainExpression(expression));
@@ -51,102 +57,120 @@
 	<div class="flex-1 overflow-auto p-4">
 		<div class="mx-auto flex max-w-5xl flex-col gap-4">
 			<Card.Root>
-				<Card.Header class="pb-3">
-					<Card.Title class="text-sm font-medium">Expression</Card.Title>
-					<Card.Description class="text-xs">
-						Paste a 5-field cron expression — minute, hour, day-of-month, month, day-of-week.
-					</Card.Description>
+				<Card.Header class="flex flex-row items-start justify-between space-y-0 pb-3">
+					<div class="space-y-1.5">
+						<Card.Title class="text-sm font-medium">Expression</Card.Title>
+						<Card.Description class="text-xs">
+							Paste a 5-field cron expression — minute, hour, day-of-month, month, day-of-week.
+						</Card.Description>
+					</div>
+					<Button variant="outline" size="sm" class="h-7" onclick={loadSample}>
+						<FlaskConical class="mr-1.5 h-3.5 w-3.5" />
+						Sample
+					</Button>
 				</Card.Header>
 				<Card.Content>
 					<FormInput label="" bind:value={expression} placeholder="*/5 * * * *" class="font-mono" />
 				</Card.Content>
 			</Card.Root>
 
-			<Card.Root>
-				<Card.Header class="pb-3">
-					<div class="flex items-center gap-2">
-						<Clock class="h-4 w-4 text-muted-foreground" />
-						<Card.Title class="text-sm font-medium">Fields</Card.Title>
-					</div>
-				</Card.Header>
-				<Card.Content>
-					{#if parsed.ok}
-						<div class="grid gap-2 sm:grid-cols-5">
-							{#each CRON_FIELDS as field, idx (field.id)}
-								{@const value = [
-									parsed.value.minute,
-									parsed.value.hour,
-									parsed.value.dayOfMonth,
-									parsed.value.month,
-									parsed.value.dayOfWeek,
-								][idx]}
-								<div class="rounded-md border bg-card p-3">
-									<div class="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
-										{field.label}
-									</div>
-									<div class="mt-1 font-mono text-sm">{value}</div>
-									<div class="mt-0.5 text-2xs text-muted-foreground">{field.hint}</div>
-								</div>
-							{/each}
+			{#if expression.trim().length === 0}
+				<Card.Root>
+					<Card.Content class="py-10">
+						<EmbeddedEmptyState
+							icon={Clock}
+							title="Enter a cron expression"
+							description="Click Sample to load a representative expression, choose a preset below, or type your own."
+						/>
+					</Card.Content>
+				</Card.Root>
+			{:else}
+				<Card.Root>
+					<Card.Header class="pb-3">
+						<div class="flex items-center gap-2">
+							<Clock class="h-4 w-4 text-muted-foreground" />
+							<Card.Title class="text-sm font-medium">Fields</Card.Title>
 						</div>
-					{:else}
-						<p class="text-sm text-destructive">{parsed.error}</p>
-					{/if}
-				</Card.Content>
-			</Card.Root>
-
-			<Card.Root>
-				<Card.Header class="pb-3">
-					<div class="flex items-center gap-2">
-						<Sparkles class="h-4 w-4 text-muted-foreground" />
-						<Card.Title class="text-sm font-medium">Description</Card.Title>
-					</div>
-				</Card.Header>
-				<Card.Content>
-					{#if description.ok}
-						<p class="text-sm">{description.value}</p>
-					{:else}
-						<p class="text-sm text-destructive">{description.error}</p>
-					{/if}
-				</Card.Content>
-			</Card.Root>
-
-			<Card.Root>
-				<Card.Header class="pb-3">
-					<div class="flex items-center gap-2">
-						<Calendar class="h-4 w-4 text-muted-foreground" />
-						<Card.Title class="text-sm font-medium">Next 8 executions</Card.Title>
-					</div>
-				</Card.Header>
-				<Card.Content>
-					{#if nextRuns.ok}
-						{#if nextRuns.value.length > 0}
-							<ul class="space-y-1.5">
-								{#each nextRuns.value as date, idx (idx)}
-									{@const fmt = formatDateParts(date)}
-									<li class="flex items-center gap-3 rounded-md border bg-card px-3 py-2">
-										<span class="w-6 text-xs tabular-nums text-muted-foreground">{idx + 1}.</span>
-										<Badge
-											class={cn('text-2xs font-mono', dayBadgeClass(fmt.dayIndex, fmt.isWeekend))}
-										>
-											{fmt.dayLabel}
-										</Badge>
-										<span class="font-mono text-sm tabular-nums">{fmt.date}</span>
-										<span class="font-mono text-sm tabular-nums text-muted-foreground">
-											{fmt.time}
-										</span>
-										<span class="ml-auto text-xs text-muted-foreground">{fmt.relative}</span>
-									</li>
+					</Card.Header>
+					<Card.Content>
+						{#if parsed.ok}
+							<div class="grid gap-2 sm:grid-cols-5">
+								{#each CRON_FIELDS as field, idx (field.id)}
+									{@const value = [
+										parsed.value.minute,
+										parsed.value.hour,
+										parsed.value.dayOfMonth,
+										parsed.value.month,
+										parsed.value.dayOfWeek,
+									][idx]}
+									<div class="rounded-md border bg-card p-3">
+										<div class="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+											{field.label}
+										</div>
+										<div class="mt-1 font-mono text-sm">{value}</div>
+										<div class="mt-0.5 text-2xs text-muted-foreground">{field.hint}</div>
+									</div>
 								{/each}
-							</ul>
+							</div>
 						{:else}
-							<p class="text-sm text-muted-foreground">No upcoming executions.</p>
+							<p class="text-sm text-destructive">{parsed.error}</p>
 						{/if}
-					{:else}
-						<p class="text-sm text-destructive">{nextRuns.error}</p>
-					{/if}
-				</Card.Content>
-			</Card.Root>
+					</Card.Content>
+				</Card.Root>
+
+				<Card.Root>
+					<Card.Header class="pb-3">
+						<div class="flex items-center gap-2">
+							<Sparkles class="h-4 w-4 text-muted-foreground" />
+							<Card.Title class="text-sm font-medium">Description</Card.Title>
+						</div>
+					</Card.Header>
+					<Card.Content>
+						{#if description.ok}
+							<p class="text-sm">{description.value}</p>
+						{:else}
+							<p class="text-sm text-destructive">{description.error}</p>
+						{/if}
+					</Card.Content>
+				</Card.Root>
+
+				<Card.Root>
+					<Card.Header class="pb-3">
+						<div class="flex items-center gap-2">
+							<Calendar class="h-4 w-4 text-muted-foreground" />
+							<Card.Title class="text-sm font-medium">Next 8 executions</Card.Title>
+						</div>
+					</Card.Header>
+					<Card.Content>
+						{#if nextRuns.ok}
+							{#if nextRuns.value.length > 0}
+								<ul class="space-y-1.5">
+									{#each nextRuns.value as date, idx (idx)}
+										{@const fmt = formatDateParts(date)}
+										<li class="flex items-center gap-3 rounded-md border bg-card px-3 py-2">
+											<span class="w-6 text-xs tabular-nums text-muted-foreground">{idx + 1}.</span>
+											<Badge
+												class={cn('text-2xs font-mono', dayBadgeClass(fmt.dayIndex, fmt.isWeekend))}
+											>
+												{fmt.dayLabel}
+											</Badge>
+											<span class="font-mono text-sm tabular-nums">{fmt.date}</span>
+											<span class="font-mono text-sm tabular-nums text-muted-foreground">
+												{fmt.time}
+											</span>
+											<span class="ml-auto text-xs text-muted-foreground">{fmt.relative}</span>
+										</li>
+									{/each}
+								</ul>
+							{:else}
+								<p class="text-sm text-muted-foreground">No upcoming executions.</p>
+							{/if}
+						{:else}
+							<p class="text-sm text-destructive">{nextRuns.error}</p>
+						{/if}
+					</Card.Content>
+				</Card.Root>
+			{/if}
 
 			<Card.Root>
 				<Card.Header class="pb-3">

--- a/src/routes/curl-builder/tabs/parse-tab.svelte
+++ b/src/routes/curl-builder/tabs/parse-tab.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
-	import { Globe, Settings2, Terminal } from '@lucide/svelte';
+	import { FlaskConical, Globe, Settings2, Terminal } from '@lucide/svelte';
 	import { CopyButton } from '$lib/components/action';
 	import { FormTextarea } from '$lib/components/form';
 	import { SectionHeader } from '$lib/components/layout';
 	import { Badge } from '$lib/components/ui/badge';
+	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import { EmbeddedEmptyState } from '$lib/components/status';
-	import { parseCurl } from '$lib/services/curl.js';
+	import { parseCurl, SAMPLE_CURL_COMMAND } from '$lib/services/curl.js';
 
 	interface Props {
 		onstatschange?: (info: { command: string; valid: boolean }) => void;
@@ -14,11 +15,13 @@
 
 	let { onstatschange }: Props = $props();
 
-	let command = $state<string>(
-		`curl -X POST 'https://api.example.com/login' \\\n  -H 'Content-Type: application/json' \\\n  -L --max-time 30 \\\n  --data-raw '{"username":"alice","password":"secret"}'`
-	);
+	let command = $state<string>('');
 
 	const parsed = $derived(parseCurl(command));
+
+	const loadSample = () => {
+		command = SAMPLE_CURL_COMMAND;
+	};
 
 	$effect(() => {
 		onstatschange?.({ command, valid: parsed.ok });
@@ -35,21 +38,27 @@
 	<div class="flex-1 overflow-auto p-4">
 		<div class="mx-auto flex max-w-5xl flex-col gap-4">
 			<Card.Root>
-				<Card.Header class="pb-3">
-					<Card.Title class="text-sm font-medium">cURL command</Card.Title>
-					<Card.Description class="text-xs">
-						Supports <code class="rounded bg-muted px-1 font-mono">-X</code>,
-						<code class="rounded bg-muted px-1 font-mono">-H</code>,
-						<code class="rounded bg-muted px-1 font-mono"
-							>-d / --data / --data-raw / --data-binary</code
-						>,
-						<code class="rounded bg-muted px-1 font-mono">-G</code>,
-						<code class="rounded bg-muted px-1 font-mono">-L</code>,
-						<code class="rounded bg-muted px-1 font-mono">-k</code>,
-						<code class="rounded bg-muted px-1 font-mono">-i</code>,
-						<code class="rounded bg-muted px-1 font-mono">--max-time</code>; backslash continuations
-						are joined.
-					</Card.Description>
+				<Card.Header class="flex flex-row items-start justify-between space-y-0 pb-3">
+					<div class="space-y-1.5">
+						<Card.Title class="text-sm font-medium">cURL command</Card.Title>
+						<Card.Description class="text-xs">
+							Supports <code class="rounded bg-muted px-1 font-mono">-X</code>,
+							<code class="rounded bg-muted px-1 font-mono">-H</code>,
+							<code class="rounded bg-muted px-1 font-mono"
+								>-d / --data / --data-raw / --data-binary</code
+							>,
+							<code class="rounded bg-muted px-1 font-mono">-G</code>,
+							<code class="rounded bg-muted px-1 font-mono">-L</code>,
+							<code class="rounded bg-muted px-1 font-mono">-k</code>,
+							<code class="rounded bg-muted px-1 font-mono">-i</code>,
+							<code class="rounded bg-muted px-1 font-mono">--max-time</code>; backslash
+							continuations are joined.
+						</Card.Description>
+					</div>
+					<Button variant="outline" size="sm" class="h-7 shrink-0" onclick={loadSample}>
+						<FlaskConical class="mr-1.5 h-3.5 w-3.5" />
+						Sample
+					</Button>
 				</Card.Header>
 				<Card.Content>
 					<FormTextarea
@@ -62,7 +71,17 @@
 				</Card.Content>
 			</Card.Root>
 
-			{#if parsed.ok}
+			{#if command.trim().length === 0}
+				<Card.Root>
+					<Card.Content class="py-10">
+						<EmbeddedEmptyState
+							icon={Terminal}
+							title="Paste a cURL command"
+							description="Click Sample to load a representative request, or paste your own command."
+						/>
+					</Card.Content>
+				</Card.Root>
+			{:else if parsed.ok}
 				<div class="grid gap-4 lg:grid-cols-3">
 					<Card.Root>
 						<Card.Header class="pb-3">

--- a/src/routes/regex-tester/+page.svelte
+++ b/src/routes/regex-tester/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Eye, GitBranch, Info, Search, Sparkles, Workflow } from '@lucide/svelte';
+	import { Eye, FlaskConical, GitBranch, Info, Search, Sparkles, Workflow } from '@lucide/svelte';
 	import { CopyButton } from '$lib/components/action';
 	import { FormInfo, FormSection, FormTextarea } from '$lib/components/form';
 	import { PatternEditor, RailroadView } from '$lib/components/regex';
@@ -23,21 +23,25 @@
 		type RegexFlags,
 		type RegexMatch,
 		replaceText,
+		SAMPLE_PATTERN,
+		SAMPLE_REPLACEMENT,
+		SAMPLE_TEST_TEXT,
 	} from '$lib/services/regex.js';
 	import { type VizNode, type VizNodeKind, visualizeRegex } from '$lib/services/regex-viz.js';
 
 	// State
-	let pattern = $state<string>(
-		'(?<protocol>https?)://(?<host>[\\w.-]+)(?::(?<port>\\d+))?(?<path>/[^?#\\s]*)?'
-	);
+	let pattern = $state<string>('');
 	let flags = $state<RegexFlags>({ ...DEFAULT_FLAGS });
-	let testText = $state<string>(
-		`Visit https://example.com and http://example.org:8080/path?query=1.
-Also see https://kogu.io/docs and http://test.local:3000/.`
-	);
+	let testText = $state<string>('');
 	let replaceEnabled = $state<boolean>(false);
-	let replacement = $state<string>('[$<host>]');
+	let replacement = $state<string>('');
 	let showOptions = $state<boolean>(true);
+
+	const loadSample = () => {
+		pattern = SAMPLE_PATTERN;
+		testText = SAMPLE_TEST_TEXT;
+		replacement = SAMPLE_REPLACEMENT;
+	};
 
 	// Derived
 	const flagString = $derived(flagsToString(flags));
@@ -49,7 +53,9 @@ Also see https://kogu.io/docs and http://test.local:3000/.`
 	const features = $derived(findFeatures(pattern));
 	const captureGroupCount = $derived(countCaptureGroups(pattern));
 
-	const validity = $derived(compiled.ok ? 'valid' : 'invalid');
+	const validity = $derived<'empty' | 'valid' | 'invalid'>(
+		pattern.length === 0 ? 'empty' : compiled.ok ? 'valid' : 'invalid'
+	);
 
 	// Build inline-highlight segments for the test text.
 	interface Segment {
@@ -164,7 +170,9 @@ Also see https://kogu.io/docs and http://test.local:3000/.`
 		};
 	};
 
-	const errorMessage = $derived(compiled.ok ? undefined : compiled.error);
+	const errorMessage = $derived(
+		validity === 'invalid' && !compiled.ok ? compiled.error : undefined
+	);
 </script>
 
 <svelte:head>
@@ -197,7 +205,11 @@ Also see https://kogu.io/docs and http://test.local:3000/.`
 	</div>
 {/snippet}
 
-<ToolShell valid={validity === 'valid'} error={errorMessage} bind:showRail={showOptions}>
+<ToolShell
+	valid={validity === 'empty' ? null : validity === 'valid'}
+	error={errorMessage}
+	bind:showRail={showOptions}
+>
 	{#snippet statusContent()}
 		<StatItem label="Matches" value={matches.length} />
 		<StatItem label="Groups" value={captureGroupCount} />
@@ -267,7 +279,9 @@ Also see https://kogu.io/docs and http://test.local:3000/.`
 					</ToggleGroup.Root>
 				</div>
 				<div class="flex flex-wrap items-center gap-2 text-xs">
-					{#if compiled.ok}
+					{#if validity === 'empty'}
+						<Badge variant="outline" class="text-muted-foreground">empty</Badge>
+					{:else if compiled.ok}
 						<Badge variant="outline" class="bg-success/10 text-success">✓ valid</Badge>
 					{:else}
 						<Badge variant="outline" class="bg-destructive/10 text-destructive">
@@ -280,7 +294,11 @@ Also see https://kogu.io/docs and http://test.local:3000/.`
 					<Badge variant="outline"
 						>{features.length} feature{features.length === 1 ? '' : 's'}</Badge
 					>
-					<div class="ml-auto">
+					<div class="ml-auto flex items-center gap-1">
+						<Button variant="ghost" size="sm" class="h-7" onclick={loadSample}>
+							<FlaskConical class="mr-1.5 h-3.5 w-3.5" />
+							Sample
+						</Button>
 						<CopyButton text={`/${pattern}/${flagString}`} toastLabel="Pattern" size="sm" />
 					</div>
 				</div>


### PR DESCRIPTION
## Summary

- Regex Tester, Cron Parse, and cURL Parse were the only tool pages that auto-populated input fields with sample content on first visit. Every other tool (base64, hash, jwt, markdown, sql, string-case, url, diff, json/xml/yaml formatter) starts empty and exposes an opt-in Sample button.
- Align the three outliers with the canonical **empty-start + Sample-button** pattern so the app speaks a single language.

## Survey of the 24 tool pages

| Category | Pattern | Pages |
| --- | --- | --- |
| **A. Auto-populated (before)** | Initial state holds sample content | regex-tester, cron-parse, curl-parse |
| **B. Empty + Sample button** | Canonical pattern, opt-in via Sample button | base64, hash, jwt, markdown, sql, string-case, url, diff, json/xml/yaml Format tab |
| **C. No sample concept** | Generators / network tools without sample semantics | uuid, password, bcrypt, ssh, gpg, qr, network-* |
| **D. Form initial state (not sample)** | Initial form defaults, demo via Presets / language generator | cron Build (`* * * * *`), cURL Build (`DEFAULT_REQUEST`) |

Categories C and D are intentionally untouched. This PR converts Category A → B for the three outliers.

## Changes

### Added

- `src/lib/services/regex.ts`: `SAMPLE_PATTERN`, `SAMPLE_TEST_TEXT`, `SAMPLE_REPLACEMENT` exports. Guard `compileRegex` against empty input.
- `src/lib/services/cron.ts`: `SAMPLE_CRON_EXPRESSION` export. Guard `nextExecutions` against empty input (cron-parser v5 silently interpreted `""` as `* * * * *`, producing confusing 1-minute-interval results on an empty page).
- `src/lib/services/curl.ts`: `SAMPLE_CURL_COMMAND` export.

### Changed

- **regex-tester**: pattern / testText / replacement all start empty. Sample button on the pattern bar (next to Copy) loads all three at once so the diagram, matches, and replacement preview populate together. Status badge now distinguishes empty / valid / invalid; the ToolShell error banner is suppressed on the empty case.
- **cron-expression-builder/parse**: expression starts empty. Sample button on the Expression card header loads `*/5 * * * *`. Empty state renders a single `EmbeddedEmptyState` ("Enter a cron expression / Click Sample to load a representative expression, choose a preset below, or type your own.") instead of three "must have 5 fields" error cards.
- **curl-builder/parse**: command starts empty. Sample button on the cURL command card header loads the previous sample request. Empty state renders an `EmbeddedEmptyState` instead of a destructive "Parse error" card.

## Test Plan

- [x] `bun run check` (svelte-check + validate-pages + audit-design).
- [x] Regex Tester: page opens empty; pattern bar shows "empty" badge; Railroad shows empty state; clicking Sample restores the full demo (pattern + test text + replacement) and matches/diagram render correctly.
- [x] Cron Parse: page opens empty with `EmbeddedEmptyState` and Sample / Presets still reachable; clicking Sample loads `*/5 * * * *` and the Fields/Description/Next 8 cards appear.
- [x] cURL Parse: page opens empty with `EmbeddedEmptyState`; clicking Sample loads the sample command and all parsed-detail cards appear.
- [x] No regression on the 11 Category B pages (existing Sample buttons untouched).
- [x] No regression on Build tabs of Cron / cURL (intentionally untouched).