### PR TITLE
refactor(ui/card): add density="compact" variant for tool UI

### DIFF
--- a/.claude/rules/svelte/components.md
+++ b/.claude/rules/svelte/components.md
@@ -453,6 +453,42 @@ When a card needs an action affordance on its header, place it on the `Card.Head
 </Card.Root>
 ```
 
+### `density="compact"` for Tool UI
+
+`Card.Root` accepts `density?: 'default' | 'compact'`:
+
+- `default` (Root `py-6 gap-6`, Header / Content / Footer `px-6`) — the shadcn baseline, intended for marketing-style spacious surfaces. Reserve for the home page and any deliberately-airy layout.
+- `compact` (Root `py-4 gap-3`, Header / Content / Footer `px-4`, `[.border-b]` / `[.border-t]` strip drops to `pb-4` / `pt-4`) — the tool-UI default. Use on every tool page card.
+
+```svelte
+<!-- Preferred for tool pages -->
+<Card.Root density="compact">
+	<Card.Header>
+		<Card.Title>Test text</Card.Title>
+	</Card.Header>
+	<Card.Content>...</Card.Content>
+</Card.Root>
+
+<!-- Reserve default for marketing-style surfaces -->
+<Card.Root>
+	<Card.Header>
+		<Card.Title>Home tile</Card.Title>
+	</Card.Header>
+	<Card.Content>...</Card.Content>
+</Card.Root>
+```
+
+Density propagates from `Card.Root` to its descendants via `data-density` + a named Tailwind group (`group/card`), so child slots react without prop drilling. Override `density` at the call site rather than reaching for ad-hoc `class="p-3"` / `class="py-4"` overrides — these were the previous workaround and produce inconsistent vertical rhythm across pages.
+
+Specialised exceptions where a class override is still appropriate (after switching to `compact`):
+
+| Override                                         | Use case                                                                |
+| ------------------------------------------------ | ----------------------------------------------------------------------- |
+| `Card.Content class="py-10"`                     | Embedded empty states that want generous vertical breathing             |
+| `Card.Content class="p-2"` / `class="px-3 py-2"` | Inline list-row cards that are denser than `compact`                    |
+| `Card.Content class="p-0"`                       | Editor wrappers that must reach the card border                         |
+| `Card.Content class="p-8"`                       | Preview surfaces (e.g. QR code) where the artifact wants generous frame |
+
 ### Badge for Status
 
 Always render status / count / category indicators as `Badge`, not as a hand-rolled `<span>`:

--- a/src/lib/components/panel/diff-legend.svelte
+++ b/src/lib/components/panel/diff-legend.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <FormSection title="Legend">
-	<Card.Root>
+	<Card.Root density="compact">
 		<Card.Content class="space-y-1.5 p-2">
 			<div class="flex items-center gap-2 text-xs">
 				<span class="h-2.5 w-2.5 rounded-sm bg-success/40"></span>

--- a/src/lib/components/ui/card/card-content.svelte
+++ b/src/lib/components/ui/card/card-content.svelte
@@ -10,6 +10,11 @@
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
 </script>
 
-<div bind:this={ref} data-slot="card-content" class={cn('px-6', className)} {...restProps}>
+<div
+	bind:this={ref}
+	data-slot="card-content"
+	class={cn('px-6 group-data-[density=compact]/card:px-4', className)}
+	{...restProps}
+>
 	{@render children?.()}
 </div>

--- a/src/lib/components/ui/card/card-footer.svelte
+++ b/src/lib/components/ui/card/card-footer.svelte
@@ -13,7 +13,12 @@
 <div
 	bind:this={ref}
 	data-slot="card-footer"
-	class={cn('[.border-t]:pt-6 flex items-center px-6', className)}
+	class={cn(
+		'flex items-center [.border-t]:pt-6',
+		'px-6',
+		'group-data-[density=compact]/card:px-4 group-data-[density=compact]/card:[.border-t]:pt-4',
+		className
+	)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/src/lib/components/ui/card/card-header.svelte
+++ b/src/lib/components/ui/card/card-header.svelte
@@ -14,7 +14,9 @@
 	bind:this={ref}
 	data-slot="card-header"
 	class={cn(
-		'@container/card-header has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6 grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6',
+		'@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+		'px-6',
+		'group-data-[density=compact]/card:px-4 group-data-[density=compact]/card:[.border-b]:pb-4',
 		className
 	)}
 	{...restProps}

--- a/src/lib/components/ui/card/card.svelte
+++ b/src/lib/components/ui/card/card.svelte
@@ -2,19 +2,29 @@
 	import type { HTMLAttributes } from 'svelte/elements';
 	import { cn, type WithElementRef } from '$lib/utils.js';
 
+	type CardDensity = 'default' | 'compact';
+
+	interface CardProps extends HTMLAttributes<HTMLDivElement> {
+		readonly density?: CardDensity;
+	}
+
 	let {
 		ref = $bindable(null),
 		class: className,
+		density = 'default',
 		children,
 		...restProps
-	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+	}: WithElementRef<CardProps> = $props();
 </script>
 
 <div
 	bind:this={ref}
 	data-slot="card"
+	data-density={density}
 	class={cn(
-		'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+		'group/card flex flex-col rounded-xl border bg-card text-card-foreground shadow-sm',
+		'gap-6 py-6',
+		'data-[density=compact]:gap-3 data-[density=compact]:py-4',
 		className
 	)}
 	{...restProps}

--- a/src/routes/bcrypt-generator/+page.svelte
+++ b/src/routes/bcrypt-generator/+page.svelte
@@ -345,7 +345,7 @@
 			{#if activeTab === 'generate'}
 				{#if hashResult}
 					<div class="space-y-4">
-						<Card.Root>
+						<Card.Root density="compact">
 							<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 								<Card.Title class="text-sm font-medium">BCrypt Hash</Card.Title>
 								<CopyButton
@@ -363,7 +363,7 @@
 							</Card.Content>
 						</Card.Root>
 
-						<Card.Root>
+						<Card.Root density="compact">
 							<Card.Header class="pb-3">
 								<Card.Title class="text-sm font-medium">Hash Details</Card.Title>
 							</Card.Header>

--- a/src/routes/cron-expression-builder/tabs/build-tab.svelte
+++ b/src/routes/cron-expression-builder/tabs/build-tab.svelte
@@ -75,7 +75,7 @@
 
 	<div class="flex-1 overflow-auto p-4">
 		<div class="mx-auto flex max-w-5xl flex-col gap-4">
-			<Card.Root>
+			<Card.Root density="compact">
 				<Card.Header class="pb-3">
 					<Card.Title class="text-sm font-medium">Fields</Card.Title>
 					<Card.Description class="text-xs">
@@ -114,7 +114,7 @@
 			</Card.Root>
 
 			<div class="grid gap-4 lg:grid-cols-2">
-				<Card.Root>
+				<Card.Root density="compact">
 					<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 						<div class="flex items-center gap-2">
 							<Clock class="h-4 w-4 text-muted-foreground" />
@@ -129,7 +129,7 @@
 					</Card.Content>
 				</Card.Root>
 
-				<Card.Root>
+				<Card.Root density="compact">
 					<Card.Header class="pb-3">
 						<div class="flex items-center gap-2">
 							<Sparkles class="h-4 w-4 text-muted-foreground" />
@@ -146,7 +146,7 @@
 				</Card.Root>
 			</div>
 
-			<Card.Root>
+			<Card.Root density="compact">
 				<Card.Header class="pb-3">
 					<div class="flex items-center gap-2">
 						<Calendar class="h-4 w-4 text-muted-foreground" />
@@ -183,7 +183,7 @@
 				</Card.Content>
 			</Card.Root>
 
-			<Card.Root>
+			<Card.Root density="compact">
 				<Card.Header class="pb-3">
 					<Card.Title class="text-sm font-medium">Presets</Card.Title>
 					<Card.Description class="text-xs">

--- a/src/routes/cron-expression-builder/tabs/parse-tab.svelte
+++ b/src/routes/cron-expression-builder/tabs/parse-tab.svelte
@@ -56,7 +56,7 @@
 
 	<div class="flex-1 overflow-auto p-4">
 		<div class="mx-auto flex max-w-5xl flex-col gap-4">
-			<Card.Root>
+			<Card.Root density="compact">
 				<Card.Header class="flex flex-row items-start justify-between space-y-0 pb-3">
 					<div class="space-y-1.5">
 						<Card.Title class="text-sm font-medium">Expression</Card.Title>
@@ -75,7 +75,7 @@
 			</Card.Root>
 
 			{#if expression.trim().length === 0}
-				<Card.Root>
+				<Card.Root density="compact">
 					<Card.Content class="py-10">
 						<EmbeddedEmptyState
 							icon={Clock}
@@ -85,7 +85,7 @@
 					</Card.Content>
 				</Card.Root>
 			{:else}
-				<Card.Root>
+				<Card.Root density="compact">
 					<Card.Header class="pb-3">
 						<div class="flex items-center gap-2">
 							<Clock class="h-4 w-4 text-muted-foreground" />
@@ -118,7 +118,7 @@
 					</Card.Content>
 				</Card.Root>
 
-				<Card.Root>
+				<Card.Root density="compact">
 					<Card.Header class="pb-3">
 						<div class="flex items-center gap-2">
 							<Sparkles class="h-4 w-4 text-muted-foreground" />
@@ -134,7 +134,7 @@
 					</Card.Content>
 				</Card.Root>
 
-				<Card.Root>
+				<Card.Root density="compact">
 					<Card.Header class="pb-3">
 						<div class="flex items-center gap-2">
 							<Calendar class="h-4 w-4 text-muted-foreground" />
@@ -172,7 +172,7 @@
 				</Card.Root>
 			{/if}
 
-			<Card.Root>
+			<Card.Root density="compact">
 				<Card.Header class="pb-3">
 					<Card.Title class="text-sm font-medium">Presets</Card.Title>
 					<Card.Description class="text-xs">

--- a/src/routes/curl-builder/tabs/build-tab.svelte
+++ b/src/routes/curl-builder/tabs/build-tab.svelte
@@ -103,7 +103,7 @@
 	<div class="flex-1 overflow-auto p-4">
 		<div class="mx-auto flex max-w-5xl flex-col gap-4">
 			<!-- Request line -->
-			<Card.Root>
+			<Card.Root density="compact">
 				<Card.Header class="pb-3">
 					<div class="flex items-center gap-2">
 						<Globe class="h-4 w-4 text-muted-foreground" />
@@ -127,7 +127,7 @@
 			</Card.Root>
 
 			<!-- Authentication -->
-			<Card.Root>
+			<Card.Root density="compact">
 				<Card.Header class="pb-3">
 					<div class="flex items-center gap-2">
 						<Lock class="h-4 w-4 text-muted-foreground" />
@@ -202,7 +202,7 @@
 			</Card.Root>
 
 			<!-- Headers -->
-			<Card.Root>
+			<Card.Root density="compact">
 				<Card.Header class="pb-3">
 					<Card.Title class="text-sm font-medium">Headers</Card.Title>
 					<Card.Description class="text-xs">
@@ -222,7 +222,7 @@
 			</Card.Root>
 
 			<!-- Body -->
-			<Card.Root>
+			<Card.Root density="compact">
 				<Card.Header class="pb-3">
 					<Card.Title class="text-sm font-medium">Body</Card.Title>
 					<Card.Description class="text-xs">
@@ -267,7 +267,7 @@
 			</Card.Root>
 
 			<!-- Options -->
-			<Card.Root>
+			<Card.Root density="compact">
 				<Card.Header class="pb-3">
 					<div class="flex items-center gap-2">
 						<Settings2 class="h-4 w-4 text-muted-foreground" />
@@ -311,7 +311,7 @@
 			</Card.Root>
 
 			<!-- Output -->
-			<Card.Root>
+			<Card.Root density="compact">
 				<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 					<div class="flex items-center gap-2">
 						<Terminal class="h-4 w-4 text-muted-foreground" />

--- a/src/routes/curl-builder/tabs/code-tab.svelte
+++ b/src/routes/curl-builder/tabs/code-tab.svelte
@@ -56,7 +56,7 @@
 
 	<div class="flex-1 overflow-auto p-4">
 		<div class="mx-auto flex max-w-5xl flex-col gap-4">
-			<Card.Root>
+			<Card.Root density="compact">
 				<Card.Header class="pb-3">
 					<div class="flex items-center gap-2">
 						<Code2 class="h-4 w-4 text-muted-foreground" />
@@ -84,7 +84,7 @@
 				</Card.Content>
 			</Card.Root>
 
-			<Card.Root>
+			<Card.Root density="compact">
 				<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 					<div class="flex items-center gap-2">
 						<FileCode class="h-4 w-4 text-muted-foreground" />

--- a/src/routes/curl-builder/tabs/parse-tab.svelte
+++ b/src/routes/curl-builder/tabs/parse-tab.svelte
@@ -37,7 +37,7 @@
 
 	<div class="flex-1 overflow-auto p-4">
 		<div class="mx-auto flex max-w-5xl flex-col gap-4">
-			<Card.Root>
+			<Card.Root density="compact">
 				<Card.Header class="flex flex-row items-start justify-between space-y-0 pb-3">
 					<div class="space-y-1.5">
 						<Card.Title class="text-sm font-medium">cURL command</Card.Title>
@@ -72,7 +72,7 @@
 			</Card.Root>
 
 			{#if command.trim().length === 0}
-				<Card.Root>
+				<Card.Root density="compact">
 					<Card.Content class="py-10">
 						<EmbeddedEmptyState
 							icon={Terminal}
@@ -83,7 +83,7 @@
 				</Card.Root>
 			{:else if parsed.ok}
 				<div class="grid gap-4 lg:grid-cols-3">
-					<Card.Root>
+					<Card.Root density="compact">
 						<Card.Header class="pb-3">
 							<div class="flex items-center gap-2">
 								<Globe class="h-4 w-4 text-muted-foreground" />
@@ -95,7 +95,7 @@
 						</Card.Content>
 					</Card.Root>
 
-					<Card.Root class="lg:col-span-2">
+					<Card.Root density="compact" class="lg:col-span-2">
 						<Card.Header class="pb-3">
 							<div class="flex items-center gap-2">
 								<Globe class="h-4 w-4 text-muted-foreground" />
@@ -108,7 +108,7 @@
 					</Card.Root>
 				</div>
 
-				<Card.Root>
+				<Card.Root density="compact">
 					<Card.Header class="pb-3">
 						<Card.Title class="text-sm font-medium">
 							Headers <span class="text-muted-foreground">({parsed.value.headers.length})</span>
@@ -136,7 +136,7 @@
 					</Card.Content>
 				</Card.Root>
 
-				<Card.Root>
+				<Card.Root density="compact">
 					<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 						<Card.Title class="text-sm font-medium">Body</Card.Title>
 						{#if parsed.value.body.length > 0}
@@ -153,7 +153,7 @@
 					</Card.Content>
 				</Card.Root>
 
-				<Card.Root>
+				<Card.Root density="compact">
 					<Card.Header class="pb-3">
 						<div class="flex items-center gap-2">
 							<Settings2 class="h-4 w-4 text-muted-foreground" />
@@ -176,7 +176,7 @@
 					</Card.Content>
 				</Card.Root>
 			{:else}
-				<Card.Root class="border-destructive/40 bg-destructive/5">
+				<Card.Root density="compact" class="border-destructive/40 bg-destructive/5">
 					<Card.Header class="pb-3">
 						<div class="flex items-center gap-2">
 							<Terminal class="h-4 w-4 text-destructive" />

--- a/src/routes/gpg-key-generator/+page.svelte
+++ b/src/routes/gpg-key-generator/+page.svelte
@@ -167,7 +167,7 @@
 
 		{#if name || email}
 			<FormSection title="User ID Preview">
-				<Card.Root class="bg-muted/30">
+				<Card.Root density="compact" class="bg-muted/30">
 					<Card.Content class="p-3">
 						<div class="mb-1 flex items-center gap-1.5 text-xs text-muted-foreground">
 							<User class="h-3 w-3" />
@@ -301,7 +301,7 @@
 			{#if keyResult}
 				<div class="space-y-4">
 					{#if showKeyInfo}
-						<Card.Root>
+						<Card.Root density="compact">
 							<Card.Header class="pb-3">
 								<div class="flex items-center gap-2">
 									<User class="h-4 w-4" />
@@ -331,7 +331,7 @@
 						</Card.Root>
 					{/if}
 
-					<Card.Root>
+					<Card.Root density="compact">
 						<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 							<div class="flex items-center gap-2">
 								<Unlock class="h-4 w-4 text-success" />
@@ -378,7 +378,7 @@
 					</div>
 
 					{#if showGpgCommands}
-						<Card.Root>
+						<Card.Root density="compact">
 							<Card.Header class="pb-3">
 								<div class="flex items-center gap-2">
 									<Terminal class="h-4 w-4" />

--- a/src/routes/hash-generator/+page.svelte
+++ b/src/routes/hash-generator/+page.svelte
@@ -128,7 +128,7 @@
 				{#if textHashes.length > 0}
 					<div class="space-y-3">
 						{#each textHashes as result}
-							<Card.Root>
+							<Card.Root density="compact">
 								<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 									<div class="flex items-center gap-2">
 										<Card.Title class="font-mono text-sm">{result.algorithm}</Card.Title>

--- a/src/routes/jwt-decoder/+page.svelte
+++ b/src/routes/jwt-decoder/+page.svelte
@@ -199,7 +199,7 @@
 						</div>
 					{/if}
 
-					<Card.Root>
+					<Card.Root density="compact">
 						<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 							<Card.Title class="text-sm font-medium text-destructive">Header</Card.Title>
 							<CopyButton
@@ -217,7 +217,7 @@
 						</Card.Content>
 					</Card.Root>
 
-					<Card.Root>
+					<Card.Root density="compact">
 						<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 							<Card.Title class="text-sm font-medium text-primary">Payload</Card.Title>
 							<CopyButton
@@ -236,7 +236,7 @@
 					</Card.Root>
 
 					{#if Object.keys(decoded.payload).some( (k) => JWT_STANDARD_CLAIMS.some((c) => c.claim === k) )}
-						<Card.Root>
+						<Card.Root density="compact">
 							<Card.Header class="pb-3">
 								<Card.Title class="text-sm font-medium">Standard Claims</Card.Title>
 							</Card.Header>
@@ -261,7 +261,7 @@
 						</Card.Root>
 					{/if}
 
-					<Card.Root>
+					<Card.Root density="compact">
 						<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 							<Card.Title class="text-sm font-medium text-info">Signature</Card.Title>
 							<CopyButton

--- a/src/routes/network-scanner/+page.svelte
+++ b/src/routes/network-scanner/+page.svelte
@@ -793,7 +793,7 @@
 				</div>
 			{/if}
 			{#if discoveryResults.length > 0}
-				<Card.Root class="mt-2">
+				<Card.Root density="compact" class="mt-2">
 					<Card.Content class="p-2">
 						<p class="text-xs font-medium text-muted-foreground">Results:</p>
 						<div class="mt-1 max-h-20 space-y-0.5 overflow-y-auto">

--- a/src/routes/qr-code-generator/+page.svelte
+++ b/src/routes/qr-code-generator/+page.svelte
@@ -611,14 +611,14 @@
 
 		<div class="flex-1 overflow-auto p-6">
 			<div class="mx-auto flex max-w-3xl flex-col gap-6">
-				<Card.Root class="overflow-hidden">
+				<Card.Root density="compact" class="overflow-hidden">
 					<Card.Content class="flex items-center justify-center p-8">
 						<div bind:this={previewEl} class="flex items-center justify-center"></div>
 					</Card.Content>
 				</Card.Root>
 
 				{#if !valid}
-					<Card.Root class="border-warning/40 bg-warning/5">
+					<Card.Root density="compact" class="border-warning/40 bg-warning/5">
 						<Card.Content class="flex items-start gap-3 py-4">
 							<ImageIcon class="mt-0.5 h-4 w-4 text-warning" />
 							<div class="text-sm text-muted-foreground">
@@ -628,7 +628,7 @@
 					</Card.Root>
 				{/if}
 
-				<Card.Root>
+				<Card.Root density="compact">
 					<Card.Header class="flex flex-row items-center justify-between space-y-0 py-4">
 						<div class="flex items-center gap-2">
 							<ActiveKindIcon class="h-4 w-4 text-muted-foreground" />

--- a/src/routes/regex-tester/+page.svelte
+++ b/src/routes/regex-tester/+page.svelte
@@ -308,7 +308,7 @@
 		<!-- Hero Railroad -->
 		<div class="shrink-0 border-b bg-background px-4 py-3">
 			<div class="mx-auto max-w-6xl">
-				<Card.Root>
+				<Card.Root density="compact">
 					<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-2 pt-3">
 						<div class="flex items-center gap-2">
 							<Workflow class="h-4 w-4 text-muted-foreground" />
@@ -320,7 +320,7 @@
 							{/if}
 						</div>
 					</Card.Header>
-					<Card.Content class="max-h-80 overflow-auto p-3">
+					<Card.Content class="max-h-80 overflow-auto">
 						{#if pattern.length === 0}
 							<EmbeddedEmptyState
 								icon={Workflow}
@@ -341,7 +341,7 @@
 		<div class="flex flex-1 overflow-hidden">
 			<!-- Left column -->
 			<div class="flex flex-1 flex-col gap-4 overflow-auto p-4">
-				<Card.Root>
+				<Card.Root density="compact">
 					<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 						<div class="flex items-center gap-2">
 							<Eye class="h-4 w-4 text-muted-foreground" />
@@ -377,7 +377,7 @@
 					</Card.Content>
 				</Card.Root>
 
-				<Card.Root>
+				<Card.Root density="compact">
 					<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 						<div class="flex items-center gap-2">
 							<Sparkles class="h-4 w-4 text-muted-foreground" />

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -138,7 +138,7 @@
 			</div>
 
 			<!-- Appearance Card -->
-			<Card.Root id="appearance">
+			<Card.Root density="compact" id="appearance">
 				<Card.Header>
 					<Card.Title>Appearance</Card.Title>
 					<Card.Description>Customize fonts used throughout the application</Card.Description>
@@ -367,7 +367,7 @@
 			</Card.Root>
 
 			<!-- Data Card -->
-			<Card.Root id="data">
+			<Card.Root density="compact" id="data">
 				<Card.Header>
 					<Card.Title>Data</Card.Title>
 					<Card.Description>Settings file location and reset options</Card.Description>

--- a/src/routes/ssh-key-generator/+page.svelte
+++ b/src/routes/ssh-key-generator/+page.svelte
@@ -287,7 +287,7 @@
 			{#if keyResult}
 				<div class="space-y-4">
 					{#if showFingerprint}
-						<Card.Root>
+						<Card.Root density="compact">
 							<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 								<Card.Title class="text-sm font-medium">Fingerprint (SHA-256)</Card.Title>
 								<CopyButton
@@ -306,7 +306,7 @@
 						</Card.Root>
 					{/if}
 
-					<Card.Root>
+					<Card.Root density="compact">
 						<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 							<div class="flex items-center gap-2">
 								<Unlock class="h-4 w-4 text-success" />
@@ -359,7 +359,7 @@
 					</div>
 
 					{#if showEquivalentCommand}
-						<Card.Root>
+						<Card.Root density="compact">
 							<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 								<div class="flex items-center gap-2">
 									<Terminal class="h-4 w-4" />

--- a/src/routes/string-case-converter/+page.svelte
+++ b/src/routes/string-case-converter/+page.svelte
@@ -179,7 +179,7 @@
 				{#if caseResults.length > 0}
 					<div class="space-y-2">
 						{#each caseResults as result}
-							<Card.Root>
+							<Card.Root density="compact">
 								<Card.Content class="flex items-start gap-3 px-3 py-2">
 									<span class="w-32 shrink-0 pt-0.5 font-mono text-xs font-medium">
 										{result.label}

--- a/src/routes/url-encoder/+page.svelte
+++ b/src/routes/url-encoder/+page.svelte
@@ -439,7 +439,7 @@
 
 				{#if parsedUrl}
 					<div class="flex-1 space-y-4 overflow-auto">
-						<Card.Root>
+						<Card.Root density="compact">
 							<Card.Header class="pb-3">
 								<Card.Title class="text-sm font-medium">URL Components</Card.Title>
 							</Card.Header>
@@ -462,7 +462,7 @@
 						</Card.Root>
 
 						{#if parsedUrl.params.length > 0}
-							<Card.Root>
+							<Card.Root density="compact">
 								<Card.Header class="pb-3">
 									<Card.Title class="text-sm font-medium">
 										Query Parameters
@@ -553,7 +553,7 @@
 					</div>
 				</div>
 
-				<Card.Root>
+				<Card.Root density="compact">
 					<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 						<Card.Title class="text-sm font-medium">Generated URL</Card.Title>
 						<div class="flex gap-1">
@@ -571,7 +571,7 @@
 			</div>
 		{:else if tab === 'reference'}
 			<div class="flex-1 overflow-auto p-4">
-				<Card.Root>
+				<Card.Root density="compact">
 					<Card.Header class="pb-3">
 						<Card.Title class="text-sm font-medium">Common URL Encoded Characters</Card.Title>
 					</Card.Header>


### PR DESCRIPTION
## Summary

- The shadcn-svelte `Card` primitive defaults to `py-6 + gap-6 + px-6` on each slot — marketing-style chrome of ~24px in every direction. On tool pages where cards house dense, small content (matches list, inline preview, capture-group rows), this generous whitespace makes surfaces feel sparse / 間延びした.
- Add a `density?: 'default' | 'compact'` prop to `Card.Root` and apply `density="compact"` to every Card.Root on tool pages (56 instances across 17 files). The home page keeps the default density for its marketing-style tile grid.

## How it works

`Card.Root` propagates `density` to its descendants via `data-density` on the root + a named Tailwind group (`group/card`), so child slots react without prop drilling or context wiring:

```html
<div data-slot="card" data-density="compact" class="group/card ... py-6 gap-6 data-[density=compact]:py-4 data-[density=compact]:gap-3">
  <div data-slot="card-header" class="... px-6 group-data-[density=compact]/card:px-4">…</div>
  <div data-slot="card-content" class="px-6 group-data-[density=compact]/card:px-4">…</div>
</div>
```

| Slot | `default` | `compact` |
| --- | --- | --- |
| `Card.Root` | `py-6 gap-6` | `py-4 gap-3` |
| `Card.Header` | `px-6`, `[.border-b]:pb-6` | `px-4`, `[.border-b]:pb-4` |
| `Card.Content` | `px-6` | `px-4` |
| `Card.Footer` | `px-6`, `[.border-t]:pt-6` | `px-4`, `[.border-t]:pt-4` |

## Why a variant instead of overriding the defaults

Pre-PR, individual call sites worked around the default with one-off `class="p-3"` / `class="py-4"` / `class="p-2"` overrides on Card.Content. These produced inconsistent vertical rhythm across pages and made it impossible to read "is this card compact on purpose?" from the call site. The `density` prop:

- Is **explicit** at the call site (no need to grep child padding classes to know the density).
- Is **discoverable** via TS prop completion.
- Lets the existing `p-2` / `py-10` / `p-0` / `p-8` overrides converge or stay as documented specialised cases.

## Migration

| Action | Files |
| --- | --- |
| Add `density="compact"` to every Card.Root | 17 tool files, 56 instances |
| Remove redundant `Card.Content class="p-3"` (now covered by compact) | regex-tester Railroad |
| Leave specialised overrides (`py-10`, `p-2`, `px-3 py-2`, `p-0`, `p-8`) | empty states, list rows, editor wrappers, QR preview |
| Document the convention | `.claude/rules/svelte/components.md` |

## Changes

### Added

- `density` prop on `Card.Root` (`'default' | 'compact'`).
- `.claude/rules/svelte/components.md`: new "density compact for Tool UI" subsection with the decision matrix.

### Changed

- 4 Card primitives (`card.svelte`, `card-header.svelte`, `card-content.svelte`, `card-footer.svelte`) — propagate / react to density via `data-density` + `group/card`.
- 17 tool-page files / 1 panel component — every Card.Root now declares `density="compact"`.
- regex-tester Railroad Card.Content — drop `p-3` (now redundant under `compact`).

## Test Plan

- [x] `bun run check` (svelte-check + validate-pages + audit-design).
- [x] Visual: Regex Tester cards (Test text, Replace, Railroad, Matches) now sit tighter, no longer feel 間延びした.
- [x] Visual: QR Generator — compact cards around the preview, but the preview surface (`Card.Content class="p-8"`) keeps its generous frame.
- [x] Visual: home page (`+page.svelte`) tiles unchanged (no density change).
- [x] No regression on specialised cards: jwt-decoder editor wrapper (`p-0`), network-scanner list rows (`p-2`), QR warning card (`py-4`), empty states (`py-10`).