### PR TITLE
fix(ui/textarea): use bg-background instead of bg-transparent

### DIFF
--- a/src/lib/components/ui/textarea/textarea.svelte
+++ b/src/lib/components/ui/textarea/textarea.svelte
@@ -15,7 +15,7 @@
 	bind:this={ref}
 	data-slot={dataSlot}
 	class={cn(
-		'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 field-sizing-content shadow-xs flex min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+		'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 field-sizing-content shadow-xs flex min-h-16 w-full rounded-md border bg-background px-3 py-2 text-base outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
 		className
 	)}
 	bind:value


### PR DESCRIPTION
## Summary

- The shadcn-svelte registry baseline uses `bg-transparent` on `Textarea`, which made the field blend into any darker surrounding surface and look uneditable. On rail / OptionsPanel backgrounds (`bg-surface-2`, `bg-sidebar`) the textarea appeared as a grey block indistinguishable from the rail — most visibly on the QR Code Generator's "Text or URL" input.
- Switch Textarea to `bg-background`, mirroring the project's `Input` component which already diverged from the registry for the same reason.

## Before / After

| Context | Before | After |
| --- | --- | --- |
| Textarea on `bg-background` (main pane) | OK (transparent → white) | OK |
| Textarea on `bg-surface-2` rail (QR Generator Text/URL) | Grey block, no visible input chrome | Distinct white surface, clearly editable |
| Dark mode | `dark:bg-input/30` (translucent input tone) | Same — preserved |

## Changes

### Changed

- `src/lib/components/ui/textarea/textarea.svelte` — single class swap `bg-transparent` → `bg-background`.

## Test Plan

- [x] `bun run check` (svelte-check + validate-pages + audit-design).
- [x] Visual: QR Code Generator Text/URL textarea now reads as an editable input on the bg-surface-2 rail.
- [x] No regression: textareas in main-pane cards (regex-tester Test text, curl-builder Parse, json-formatter, etc.) keep their normal appearance.
- [x] Dark mode preserves `bg-input/30` tone.