### PR TITLE
feat(form): extend FormSelect with icon + description per option

### DIFF
--- a/src/lib/components/form/form-select.svelte
+++ b/src/lib/components/form/form-select.svelte
@@ -1,17 +1,22 @@
 <script lang="ts">
+	import type { Component } from 'svelte';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import * as Select from '$lib/components/ui/select/index.js';
 	import { cn } from '$lib/utils.js';
 
 	interface SelectOption {
-		value: string;
-		label: string;
+		readonly value: string;
+		readonly label: string;
+		readonly icon?: Component;
+		readonly description?: string;
+		readonly disabled?: boolean;
 	}
 
 	interface Props {
 		label?: string;
 		value?: string;
-		options: SelectOption[] | string[];
+		options: readonly SelectOption[] | readonly string[];
+		placeholder?: string;
 		displayValue?: string;
 		size?: 'default' | 'compact';
 		onchange?: (value: string) => void;
@@ -21,20 +26,18 @@
 		label,
 		value = $bindable(''),
 		options,
+		placeholder,
 		displayValue,
 		size = 'default',
 		onchange,
 	}: Props = $props();
 
-	// Normalize options to SelectOption format
-	const normalizedOptions = $derived(
+	const normalizedOptions = $derived<readonly SelectOption[]>(
 		options.map((opt) => (typeof opt === 'string' ? { value: opt, label: opt } : opt))
 	);
 
-	// Get display value
-	const display = $derived(
-		displayValue ?? normalizedOptions.find((opt) => opt.value === value)?.label ?? value
-	);
+	const selected = $derived(normalizedOptions.find((opt) => opt.value === value));
+	const display = $derived(displayValue ?? selected?.label ?? value);
 
 	const handleChange = (newValue: string | undefined) => {
 		if (newValue !== undefined) {
@@ -59,10 +62,35 @@
 		<Label class={labelClass}>{label}</Label>
 	{/if}
 	<Select.Root type="single" {value} onValueChange={handleChange}>
-		<Select.Trigger class={triggerClass}>{display}</Select.Trigger>
+		<Select.Trigger class={triggerClass}>
+			{#if selected?.icon}
+				{@const TriggerIcon = selected.icon}
+				<TriggerIcon class="size-4 shrink-0" />
+			{/if}
+			{#if display}
+				<span class="min-w-0 flex-1 truncate text-left">{display}</span>
+			{:else if placeholder}
+				<span class="min-w-0 flex-1 truncate text-left text-muted-foreground">{placeholder}</span>
+			{/if}
+		</Select.Trigger>
 		<Select.Content>
-			{#each normalizedOptions as opt}
-				<Select.Item value={opt.value}>{opt.label}</Select.Item>
+			{#each normalizedOptions as opt (opt.value)}
+				<Select.Item value={opt.value} disabled={opt.disabled}>
+					{#snippet children()}
+						{#if opt.icon}
+							{@const ItemIcon = opt.icon}
+							<ItemIcon class="size-4 shrink-0" />
+						{/if}
+						{#if opt.description}
+							<div class="flex min-w-0 flex-1 flex-col gap-0.5">
+								<span class="truncate text-sm">{opt.label}</span>
+								<span class="truncate text-xs text-muted-foreground">{opt.description}</span>
+							</div>
+						{:else}
+							<span class="min-w-0 flex-1 truncate">{opt.label}</span>
+						{/if}
+					{/snippet}
+				</Select.Item>
 			{/each}
 		</Select.Content>
 	</Select.Root>

--- a/src/lib/services/formatters/constants.ts
+++ b/src/lib/services/formatters/constants.ts
@@ -177,14 +177,14 @@ export const SQL_KEYWORD_CASE_OPTIONS = [
 ] as const;
 
 export const SQL_INDENT_STYLE_OPTIONS = [
-	{ value: 'standard', label: 'Standard' },
-	{ value: 'tabularLeft', label: 'Tabular Left' },
-	{ value: 'tabularRight', label: 'Tabular Right' },
+	{ value: 'standard', label: 'Standard', description: 'Conventional indentation' },
+	{ value: 'tabularLeft', label: 'Tabular Left', description: 'Right-align keywords' },
+	{ value: 'tabularRight', label: 'Tabular Right', description: 'Left-align keywords' },
 ] as const;
 
 export const SQL_LOGICAL_OPERATOR_OPTIONS = [
-	{ value: 'before', label: 'Before' },
-	{ value: 'after', label: 'After' },
+	{ value: 'before', label: 'Before', description: 'Newline before AND / OR' },
+	{ value: 'after', label: 'After', description: 'Newline after AND / OR' },
 ] as const;
 
 // ============================================================================

--- a/src/lib/services/generators.ts
+++ b/src/lib/services/generators.ts
@@ -56,12 +56,42 @@ export interface SshKeyResult {
 }
 
 export const SSH_ALGORITHMS = [
-	{ value: 'ed25519' as const, label: 'Ed25519', recommended: true },
-	{ value: 'ecdsa_p256' as const, label: 'ECDSA P-256', recommended: false },
-	{ value: 'ecdsa_p384' as const, label: 'ECDSA P-384', recommended: false },
-	{ value: 'rsa2048' as const, label: 'RSA 2048', recommended: false },
-	{ value: 'rsa3072' as const, label: 'RSA 3072', recommended: false },
-	{ value: 'rsa4096' as const, label: 'RSA 4096', recommended: false },
+	{
+		value: 'ed25519' as const,
+		label: 'Ed25519',
+		description: 'Modern, fast, small keys',
+		recommended: true,
+	},
+	{
+		value: 'ecdsa_p256' as const,
+		label: 'ECDSA P-256',
+		description: 'NIST curve, widely supported',
+		recommended: false,
+	},
+	{
+		value: 'ecdsa_p384' as const,
+		label: 'ECDSA P-384',
+		description: 'NIST curve, higher security',
+		recommended: false,
+	},
+	{
+		value: 'rsa2048' as const,
+		label: 'RSA 2048',
+		description: 'Legacy compatible',
+		recommended: false,
+	},
+	{
+		value: 'rsa3072' as const,
+		label: 'RSA 3072',
+		description: 'Stronger than 2048',
+		recommended: false,
+	},
+	{
+		value: 'rsa4096' as const,
+		label: 'RSA 4096',
+		description: 'Maximum strength, large keys',
+		recommended: false,
+	},
 ] as const;
 
 // =============================================================================
@@ -91,11 +121,36 @@ export interface GpgKeyResult {
 }
 
 export const GPG_ALGORITHMS = [
-	{ value: 'ecdsa_p256' as const, label: 'ECDSA P-256', recommended: true },
-	{ value: 'ecdsa_p384' as const, label: 'ECDSA P-384', recommended: false },
-	{ value: 'rsa4096' as const, label: 'RSA 4096', recommended: false },
-	{ value: 'rsa3072' as const, label: 'RSA 3072', recommended: false },
-	{ value: 'rsa2048' as const, label: 'RSA 2048', recommended: false },
+	{
+		value: 'ecdsa_p256' as const,
+		label: 'ECDSA P-256',
+		description: 'NIST curve, recommended',
+		recommended: true,
+	},
+	{
+		value: 'ecdsa_p384' as const,
+		label: 'ECDSA P-384',
+		description: 'Higher security NIST curve',
+		recommended: false,
+	},
+	{
+		value: 'rsa4096' as const,
+		label: 'RSA 4096',
+		description: 'Maximum compatibility, large keys',
+		recommended: false,
+	},
+	{
+		value: 'rsa3072' as const,
+		label: 'RSA 3072',
+		description: 'Stronger than 2048',
+		recommended: false,
+	},
+	{
+		value: 'rsa2048' as const,
+		label: 'RSA 2048',
+		description: 'Legacy compatible',
+		recommended: false,
+	},
 ] as const;
 
 // =============================================================================

--- a/src/routes/base64-encoder/+page.svelte
+++ b/src/routes/base64-encoder/+page.svelte
@@ -169,17 +169,25 @@
 					label="Variant"
 					bind:value={variant}
 					options={[
-						{ value: 'standard', label: 'Standard (+/)' },
-						{ value: 'url-safe', label: 'URL-safe (-_)' },
+						{
+							value: 'standard',
+							label: 'Standard',
+							description: 'Uses + and / (RFC 4648 §4)',
+						},
+						{
+							value: 'url-safe',
+							label: 'URL-safe',
+							description: 'Uses - and _ (RFC 4648 §5)',
+						},
 					]}
 				/>
 				<FormSelect
 					label="Line Break"
 					bind:value={lineBreak}
 					options={[
-						{ value: 'none', label: 'None' },
-						{ value: '64', label: '64 chars (PEM)' },
-						{ value: '76', label: '76 chars (MIME)' },
+						{ value: 'none', label: 'None', description: 'Single continuous line' },
+						{ value: '64', label: '64 chars', description: 'PEM convention' },
+						{ value: '76', label: '76 chars', description: 'MIME / RFC 2045' },
 					]}
 				/>
 				<div class="pt-1">

--- a/src/routes/curl-builder/tabs/build-tab.svelte
+++ b/src/routes/curl-builder/tabs/build-tab.svelte
@@ -65,8 +65,16 @@
 	const isValid = $derived(request.url.length > 0);
 
 	const methodOptions = HTTP_METHODS.map((m) => ({ value: m, label: m }));
-	const authOptions = AUTH_SCHEMES.map((info) => ({ value: info.id, label: info.label }));
-	const bodyOptions = BODY_MODES.map((info) => ({ value: info.id, label: info.label }));
+	const authOptions = AUTH_SCHEMES.map((info) => ({
+		value: info.id,
+		label: info.label,
+		description: info.description,
+	}));
+	const bodyOptions = BODY_MODES.map((info) => ({
+		value: info.id,
+		label: info.label,
+		description: info.description,
+	}));
 
 	const handleMethodChange = (value: string) => {
 		if (isHttpMethod(value)) request = { ...request, method: value };

--- a/src/routes/curl-builder/tabs/build-tab.svelte
+++ b/src/routes/curl-builder/tabs/build-tab.svelte
@@ -64,7 +64,20 @@
 	const command = $derived(buildCurl(fullRequest, { multiline }));
 	const isValid = $derived(request.url.length > 0);
 
-	const methodOptions = HTTP_METHODS.map((m) => ({ value: m, label: m }));
+	const METHOD_DESCRIPTIONS: Record<HttpMethod, string> = {
+		GET: 'Retrieve a resource',
+		POST: 'Create a resource or submit form',
+		PUT: 'Replace a resource',
+		PATCH: 'Partially update a resource',
+		DELETE: 'Remove a resource',
+		HEAD: 'Retrieve headers only',
+		OPTIONS: 'List allowed methods (CORS preflight)',
+	};
+	const methodOptions = HTTP_METHODS.map((m) => ({
+		value: m,
+		label: m,
+		description: METHOD_DESCRIPTIONS[m],
+	}));
 	const authOptions = AUTH_SCHEMES.map((info) => ({
 		value: info.id,
 		label: info.label,

--- a/src/routes/gpg-key-generator/+page.svelte
+++ b/src/routes/gpg-key-generator/+page.svelte
@@ -207,8 +207,17 @@
 				label="Method"
 				bind:value={method}
 				options={[
-					{ value: 'library', label: 'Library (pgp)' },
-					{ value: 'cli', label: gpgAvailable ? 'CLI (gpg)' : 'CLI (not available)' },
+					{
+						value: 'library',
+						label: 'Library',
+						description: 'Bundled openpgp.js — no system install needed',
+					},
+					{
+						value: 'cli',
+						label: 'CLI',
+						description: gpgAvailable ? 'Uses local gpg binary' : 'gpg not detected on PATH',
+						disabled: !gpgAvailable,
+					},
 				]}
 			/>
 			{#if cliAvailability?.gpg_version}

--- a/src/routes/gpg-key-generator/+page.svelte
+++ b/src/routes/gpg-key-generator/+page.svelte
@@ -183,7 +183,11 @@
 			<FormSelect
 				label="Type"
 				bind:value={algorithm}
-				options={GPG_ALGORITHMS.map((a) => ({ value: a.value, label: a.label }))}
+				options={GPG_ALGORITHMS.map((a) => ({
+					value: a.value,
+					label: a.recommended ? `${a.label} (Recommended)` : a.label,
+					description: a.description,
+				}))}
 			/>
 		</FormSection>
 

--- a/src/routes/json-formatter/tabs/convert-tab.svelte
+++ b/src/routes/json-formatter/tabs/convert-tab.svelte
@@ -234,9 +234,9 @@
 					label="Collection Style"
 					bind:value={yamlCollectionStyle}
 					options={[
-						{ value: 'block', label: 'Block' },
-						{ value: 'flow', label: 'Flow ({...})' },
-						{ value: 'any', label: 'Auto' },
+						{ value: 'block', label: 'Block', description: 'Indented, readable' },
+						{ value: 'flow', label: 'Flow', description: 'Inline {key: value} / [1, 2]' },
+						{ value: 'any', label: 'Auto', description: 'Engine chooses per value' },
 					]}
 				/>
 				<FormCheckboxGroup class="pt-1">

--- a/src/routes/qr-code-generator/+page.svelte
+++ b/src/routes/qr-code-generator/+page.svelte
@@ -120,13 +120,16 @@
 	const kindOptions = CONTENT_KINDS.map((info) => ({
 		value: info.kind,
 		label: info.label,
+		description: info.description,
+		icon: KIND_ICONS[info.kind],
 	}));
 
 	const ActiveKindIcon = $derived(KIND_ICONS[activeKind]);
 
 	const errorCorrectionOptions = ERROR_CORRECTION_LEVELS.map((info) => ({
 		value: info.level,
-		label: `${info.label} (${info.recovery})`,
+		label: `${info.label} ${info.recovery}`,
+		description: info.description,
 	}));
 
 	const dotOptions = DOT_TYPES.map((opt) => ({ value: opt.value, label: opt.label }));

--- a/src/routes/sql-formatter/+page.svelte
+++ b/src/routes/sql-formatter/+page.svelte
@@ -181,6 +181,7 @@
 					options={SQL_INDENT_STYLE_OPTIONS.map((opt) => ({
 						value: opt.value,
 						label: opt.label,
+						description: opt.description,
 					}))}
 				/>
 			</div>
@@ -207,6 +208,7 @@
 				options={SQL_LOGICAL_OPERATOR_OPTIONS.map((opt) => ({
 					value: opt.value,
 					label: opt.label,
+					description: opt.description,
 				}))}
 			/>
 			<FormSelect

--- a/src/routes/ssh-key-generator/+page.svelte
+++ b/src/routes/ssh-key-generator/+page.svelte
@@ -196,10 +196,18 @@
 				label="Method"
 				bind:value={method}
 				options={[
-					{ value: 'library', label: 'Library (ssh-key)' },
+					{
+						value: 'library',
+						label: 'Library',
+						description: 'Bundled sshpk — no system install needed',
+					},
 					{
 						value: 'cli',
-						label: sshKeygenAvailable ? 'CLI (ssh-keygen)' : 'CLI (not available)',
+						label: 'CLI',
+						description: sshKeygenAvailable
+							? 'Uses local ssh-keygen binary'
+							: 'ssh-keygen not detected on PATH',
+						disabled: !sshKeygenAvailable,
 					},
 				]}
 			/>

--- a/src/routes/ssh-key-generator/+page.svelte
+++ b/src/routes/ssh-key-generator/+page.svelte
@@ -167,6 +167,7 @@
 				options={SSH_ALGORITHMS.map((a) => ({
 					value: a.value,
 					label: a.recommended ? `${a.label} (Recommended)` : a.label,
+					description: a.description,
 				}))}
 			/>
 		</FormSection>

--- a/src/routes/url-encoder/+page.svelte
+++ b/src/routes/url-encoder/+page.svelte
@@ -268,9 +268,21 @@
 								label="Mode"
 								bind:value={encodeMode}
 								options={[
-									{ value: 'component', label: 'Component (strict)' },
-									{ value: 'uri', label: 'URI (preserve structure)' },
-									{ value: 'form', label: 'Form (x-www-form-urlencoded)' },
+									{
+										value: 'component',
+										label: 'Component',
+										description: 'Strict: encodes reserved chars',
+									},
+									{
+										value: 'uri',
+										label: 'URI',
+										description: 'Preserves URI structure characters',
+									},
+									{
+										value: 'form',
+										label: 'Form',
+										description: 'application/x-www-form-urlencoded',
+									},
 									{ value: 'path', label: 'Path segment' },
 									{ value: 'custom', label: 'Custom' },
 								]}
@@ -279,8 +291,12 @@
 								label="Space Encoding"
 								bind:value={spaceEncoding}
 								options={[
-									{ value: 'percent', label: '%20 (standard)' },
-									{ value: 'plus', label: '+ (form data)' },
+									{ value: 'percent', label: '%20', description: 'RFC 3986 standard' },
+									{
+										value: 'plus',
+										label: '+',
+										description: 'Form data (application/x-www-form-urlencoded)',
+									},
 								]}
 							/>
 							<FormSelect

--- a/src/routes/uuid-generator/+page.svelte
+++ b/src/routes/uuid-generator/+page.svelte
@@ -45,7 +45,8 @@
 
 	const versionOptions = UUID_VERSIONS.map((info) => ({
 		value: info.version,
-		label: `${info.label} - ${info.description}`,
+		label: info.label,
+		description: info.description,
 	}));
 
 	const namespaceOptions = NAMESPACE_PRESETS.map((preset) => ({

--- a/src/routes/uuid-generator/+page.svelte
+++ b/src/routes/uuid-generator/+page.svelte
@@ -51,7 +51,8 @@
 
 	const namespaceOptions = NAMESPACE_PRESETS.map((preset) => ({
 		value: preset.value,
-		label: `${preset.label} (${preset.value})`,
+		label: preset.label,
+		description: preset.value,
 	}));
 
 	// Handlers


### PR DESCRIPTION
## Summary

- shadcn-svelte's `Select` supports rich option content (icon + multi-line label), but `FormSelect` only accepted a flat `{ value, label }` pair. Consumers were either concatenating description text into the label (\`v7 - Time-ordered (sortable)\`, \`Library (pgp)\`, \`Standard (+/)\`) or losing the description entirely.
- Extend `SelectOption` to optionally carry `icon`, `description`, and `disabled`. Migrate every selector that was carrying hint text inside its label to the rich form. Plain `{ value, label }` and `string[]` inputs continue to work unchanged.

## API change

```typescript
interface SelectOption {
  readonly value: string;
  readonly label: string;
  readonly icon?: Component;        // rendered inline on trigger + option
  readonly description?: string;    // muted secondary line in option list
  readonly disabled?: boolean;
}
```

Trigger renders \`icon\` + \`label\` only (no description) to stay compact. Option rows render \`icon\` + a column of \`label\` + \`description\`. Selecting an option still shows just the label in the trigger.

## Migrations

| Page | Selector | Enrichment |
| --- | --- | --- |
| UUID Generator | UUID version | Description from `UUID_VERSIONS[*].description` |
| UUID Generator | Namespace preset | Split "DNS (uuid)" → label + UUID description |
| QR Code Generator | Content type | Icon from `KIND_ICONS` + description from `CONTENT_KINDS[*].description` |
| QR Code Generator | Error correction | Description from `ERROR_CORRECTION_LEVELS[*].description` |
| SSH Key Generator | Algorithm | New description on `SSH_ALGORITHMS` (Modern fast small keys, etc.) |
| SSH Key Generator | Method | Library / CLI with description; CLI auto-disables when ssh-keygen missing |
| GPG Key Generator | Algorithm | New description on `GPG_ALGORITHMS` |
| GPG Key Generator | Method | Library / CLI with description; CLI auto-disables when gpg missing |
| Base64 Encoder | Variant | Split "Standard (+/)" → label + RFC description |
| Base64 Encoder | Line break | Split "64 chars (PEM)" → label + format description |
| URL Encoder | Encode mode | Split "Component (strict)" → label + RFC description |
| URL Encoder | Space encoding | Split "%20 (standard)" → label + RFC description |
| JSON → YAML convert | Collection style | Split "Flow ({...})" → label + description |
| cURL Builder Build | HTTP method | New per-method description ("Retrieve a resource", "Create or update", etc.) |
| cURL Builder Build | Auth scheme | Description from `AUTH_SCHEMES[*].description` |
| cURL Builder Build | Body type | Description from `BODY_MODES[*].description` |
| SQL Formatter | Indent style | New description on `SQL_INDENT_STYLE_OPTIONS` (Right-align keywords, etc.) |
| SQL Formatter | Logical operators | New description on `SQL_LOGICAL_OPERATOR_OPTIONS` (Newline before AND / OR, etc.) |

Plain selectors (indent size, spaces vs tabs, sort A→Z, JSON quote style, SQL dialect / keyword case) intentionally stay on the simple form — descriptions on those would be noise.

## Changes

### Added

- `description` fields on `SSH_ALGORITHMS`, `GPG_ALGORITHMS`, `SQL_INDENT_STYLE_OPTIONS`, `SQL_LOGICAL_OPERATOR_OPTIONS` constants.

### Changed

- `src/lib/components/form/form-select.svelte` — extended `SelectOption` type, trigger renders icon, options render icon + (label / description).
- 10 consumer pages — pass `description` (and `icon` for QR content type) through to FormSelect.

## Test Plan

- [x] `bun run check` (svelte-check + validate-pages + audit-design)
- [x] UUID Generator: version + namespace dropdowns show each option with description; selected check mark renders correctly
- [x] QR Code Generator: content type trigger shows Globe icon + "Text / URL"; dropdown options show icon + label + description
- [x] cURL Builder Build: method / auth / body dropdowns show descriptions; method descriptions explain semantics
- [x] Base64 / URL Encoder / SSH / GPG / SQL: all enriched selectors render correctly
- [x] Plain selectors (JSON formatter indent size, sort lines, etc.) unchanged