### PR TITLE
refactor(network): fix host merge for v4/v6 same-host entries

### DIFF
--- a/src-tauri/src/network/arp_cache.rs
+++ b/src-tauri/src/network/arp_cache.rs
@@ -1,7 +1,7 @@
-//! ARP cache reading for non-privileged MAC address discovery
+//! ARP/NDP cache reading for non-privileged MAC address discovery
 //!
-//! Reads the OS ARP/neighbor cache to discover hosts and their MAC addresses
-//! without requiring elevated privileges.
+//! Reads the OS ARP (IPv4) and NDP (IPv6) neighbor caches to discover hosts and
+//! their MAC addresses without requiring elevated privileges.
 
 use serde::Serialize;
 
@@ -14,7 +14,7 @@ pub struct ArpCacheEntry {
     pub interface: Option<String>,
 }
 
-/// Read the system ARP cache (no privileges required).
+/// Read the system ARP cache (IPv4, no privileges required).
 ///
 /// Returns a list of ARP cache entries with IP, MAC, and interface info.
 /// Platform-specific:
@@ -40,12 +40,85 @@ pub fn read_arp_cache() -> Vec<ArpCacheEntry> {
     }
 }
 
+/// Read the system NDP cache (IPv6, no privileges required).
+///
+/// Returns a list of neighbor cache entries with IPv6 address, MAC, and interface info.
+/// Platform-specific:
+/// - macOS: Parses output of `ndp -an`
+/// - Linux: Parses output of `ip -6 neigh show`
+/// - Windows: Parses output of `netsh interface ipv6 show neighbors`
+pub fn read_ndp_cache() -> Vec<ArpCacheEntry> {
+    #[cfg(target_os = "macos")]
+    {
+        read_ndp_cache_macos()
+    }
+    #[cfg(target_os = "linux")]
+    {
+        read_ndp_cache_linux()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        read_ndp_cache_windows()
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        Vec::new()
+    }
+}
+
+/// Read both the IPv4 ARP cache and the IPv6 NDP cache, merging by IP.
+///
+/// When the same IP appears in both caches, the last-written entry wins (NDP
+/// entries override ARP entries). The returned vector preserves discovery
+/// ordering of unique IPs: ARP entries first, then any new NDP-only entries.
+pub fn read_neighbor_cache() -> Vec<ArpCacheEntry> {
+    use std::collections::HashMap;
+
+    let mut by_ip: HashMap<String, ArpCacheEntry> = HashMap::new();
+    let mut order: Vec<String> = Vec::new();
+
+    let mut extend_with = |entries: Vec<ArpCacheEntry>| {
+        for entry in entries {
+            if !by_ip.contains_key(&entry.ip) {
+                order.push(entry.ip.clone());
+            }
+            by_ip.insert(entry.ip.clone(), entry);
+        }
+    };
+
+    extend_with(read_arp_cache());
+    extend_with(read_ndp_cache());
+
+    order
+        .into_iter()
+        .filter_map(|ip| by_ip.remove(&ip))
+        .collect()
+}
+
 /// Check if a MAC address is incomplete/invalid
 fn is_incomplete_mac(mac: &str) -> bool {
     mac.is_empty()
         || mac == "(incomplete)"
         || mac == "ff:ff:ff:ff:ff:ff"
         || mac == "00:00:00:00:00:00"
+}
+
+/// Strip an optional `%ifname` zone suffix from an IPv6 address string.
+fn strip_zone_suffix(ip: &str) -> &str {
+    match ip.find('%') {
+        Some(idx) => &ip[..idx],
+        None => ip,
+    }
+}
+
+/// Decide whether an IPv6 address should be kept as a routable neighbor entry.
+/// Drops multicast and the unspecified / loopback addresses.
+fn is_acceptable_ipv6(ip: &str) -> bool {
+    let parsed = match ip.parse::<std::net::Ipv6Addr>() {
+        Ok(addr) => addr,
+        Err(_) => return false,
+    };
+    !parsed.is_multicast() && !parsed.is_unspecified() && !parsed.is_loopback()
 }
 
 // =============================================================================
@@ -103,6 +176,63 @@ fn parse_arp_macos(output: &str) -> Vec<ArpCacheEntry> {
 }
 
 // =============================================================================
+// macOS: Parse `ndp -an` output
+// =============================================================================
+
+#[cfg(target_os = "macos")]
+fn read_ndp_cache_macos() -> Vec<ArpCacheEntry> {
+    let output = match std::process::Command::new("ndp").arg("-an").output() {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_ndp_macos(&stdout)
+}
+
+/// Parse macOS `ndp -an` output.
+/// Format (whitespace-separated columns):
+/// `Neighbor                Linklayer Address Netif Expire    St Flgs Prbs`
+/// `fe80::aabb%en0          aa:bb:cc:dd:ee:ff en0   permanent R`
+#[cfg(target_os = "macos")]
+fn parse_ndp_macos(output: &str) -> Vec<ArpCacheEntry> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            let parts: Vec<&str> = trimmed.split_whitespace().collect();
+            if parts.len() < 3 {
+                return None;
+            }
+
+            // Header detection: first column starts with literal "Neighbor".
+            if parts[0].eq_ignore_ascii_case("Neighbor") {
+                return None;
+            }
+
+            let raw_ip = parts[0];
+            let mac = parts[1];
+            let interface = parts.get(2).copied();
+
+            if is_incomplete_mac(mac) {
+                return None;
+            }
+
+            let ip = strip_zone_suffix(raw_ip);
+            if !is_acceptable_ipv6(ip) {
+                return None;
+            }
+
+            Some(ArpCacheEntry {
+                ip: ip.to_string(),
+                mac: mac.to_string(),
+                interface: interface.map(String::from),
+            })
+        })
+        .collect()
+}
+
+// =============================================================================
 // Linux: Parse `/proc/net/arp`
 // =============================================================================
 
@@ -139,6 +269,75 @@ fn parse_arp_linux(content: &str) -> Vec<ArpCacheEntry> {
                 ip: ip.to_string(),
                 mac: mac.to_string(),
                 interface: Some(device.to_string()),
+            })
+        })
+        .collect()
+}
+
+// =============================================================================
+// Linux: Parse `ip -6 neigh show` output
+// =============================================================================
+
+#[cfg(target_os = "linux")]
+fn read_ndp_cache_linux() -> Vec<ArpCacheEntry> {
+    let output = match std::process::Command::new("ip")
+        .args(["-6", "neigh", "show"])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_ndp_linux(&stdout)
+}
+
+/// Parse Linux `ip -6 neigh show` output.
+/// Format: `fe80::abcd dev wlan0 lladdr aa:bb:cc:dd:ee:ff REACHABLE`
+#[cfg(target_os = "linux")]
+fn parse_ndp_linux(content: &str) -> Vec<ArpCacheEntry> {
+    content
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            let parts: Vec<&str> = trimmed.split_whitespace().collect();
+            if parts.is_empty() {
+                return None;
+            }
+
+            let raw_ip = parts[0];
+
+            // State is typically the final token. Skip unusable states.
+            let state = parts.last().copied().unwrap_or("");
+            if matches!(state, "FAILED" | "INCOMPLETE") {
+                return None;
+            }
+
+            // Locate "dev <iface>" and "lladdr <mac>" pairs by keyword.
+            let interface = parts
+                .iter()
+                .position(|t| *t == "dev")
+                .and_then(|i| parts.get(i + 1).copied())
+                .map(String::from);
+
+            let mac = parts
+                .iter()
+                .position(|t| *t == "lladdr")
+                .and_then(|i| parts.get(i + 1).copied())?;
+
+            if is_incomplete_mac(mac) {
+                return None;
+            }
+
+            let ip = strip_zone_suffix(raw_ip);
+            if !is_acceptable_ipv6(ip) {
+                return None;
+            }
+
+            Some(ArpCacheEntry {
+                ip: ip.to_string(),
+                mac: mac.to_string(),
+                interface,
             })
         })
         .collect()
@@ -208,6 +407,86 @@ fn parse_arp_windows(output: &str) -> Vec<ArpCacheEntry> {
     entries
 }
 
+// =============================================================================
+// Windows: Parse `netsh interface ipv6 show neighbors` output
+// =============================================================================
+
+#[cfg(target_os = "windows")]
+fn read_ndp_cache_windows() -> Vec<ArpCacheEntry> {
+    let output = match std::process::Command::new("netsh")
+        .args(["interface", "ipv6", "show", "neighbors"])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_ndp_windows(&stdout)
+}
+
+/// Parse Windows `netsh interface ipv6 show neighbors` output.
+/// Output is grouped per interface with three columns:
+/// `Internet Address      Physical Address      Type`
+#[cfg(target_os = "windows")]
+fn parse_ndp_windows(output: &str) -> Vec<ArpCacheEntry> {
+    let mut entries = Vec::new();
+    let mut current_interface: Option<String> = None;
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+
+        if let Some(rest) = trimmed.strip_prefix("Interface ") {
+            // e.g., "Interface 12: Ethernet"
+            current_interface = rest
+                .split(':')
+                .nth(1)
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
+            continue;
+        }
+
+        let parts: Vec<&str> = trimmed.split_whitespace().collect();
+        if parts.len() < 3 {
+            continue;
+        }
+
+        let raw_ip = parts[0];
+        let mac_raw = parts[1];
+        let state = parts[2..].join(" ");
+
+        // Header rows have non-IP first token. Skip them.
+        if raw_ip.eq_ignore_ascii_case("Internet")
+            || raw_ip.eq_ignore_ascii_case("Address")
+            || raw_ip.starts_with('-')
+        {
+            continue;
+        }
+
+        if state.eq_ignore_ascii_case("Unreachable") {
+            continue;
+        }
+
+        let mac = mac_raw.replace('-', ":");
+        if is_incomplete_mac(&mac) {
+            continue;
+        }
+
+        let ip = strip_zone_suffix(raw_ip);
+        if !is_acceptable_ipv6(ip) {
+            continue;
+        }
+
+        entries.push(ArpCacheEntry {
+            ip: ip.to_string(),
+            mac,
+            interface: current_interface.clone(),
+        });
+    }
+
+    entries
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -221,6 +500,22 @@ mod tests {
         assert!(is_incomplete_mac("ff:ff:ff:ff:ff:ff"));
         assert!(is_incomplete_mac("00:00:00:00:00:00"));
         assert!(!is_incomplete_mac("aa:bb:cc:dd:ee:ff"));
+    }
+
+    #[test]
+    fn test_strip_zone_suffix_removes_ifname() {
+        assert_eq!(strip_zone_suffix("fe80::1%en0"), "fe80::1");
+        assert_eq!(strip_zone_suffix("fe80::1"), "fe80::1");
+    }
+
+    #[test]
+    fn test_is_acceptable_ipv6_rejects_multicast_and_specials() {
+        assert!(!is_acceptable_ipv6("ff02::1"));
+        assert!(!is_acceptable_ipv6("ff02::1:ff00:1"));
+        assert!(!is_acceptable_ipv6("::"));
+        assert!(!is_acceptable_ipv6("::1"));
+        assert!(is_acceptable_ipv6("fe80::1"));
+        assert!(is_acceptable_ipv6("2001:db8::1"));
     }
 
     #[test]
@@ -243,7 +538,10 @@ mod tests {
             .map(|e| (e.ip.clone(), e.mac.clone()))
             .collect();
         assert_eq!(map.len(), 1);
-        assert_eq!(map.get("192.168.1.1").unwrap(), "aa:bb:cc:dd:ee:ff");
+        assert_eq!(
+            map.get("192.168.1.1").map(String::as_str),
+            Some("aa:bb:cc:dd:ee:ff")
+        );
     }
 
     #[cfg(target_os = "macos")]
@@ -269,6 +567,26 @@ mod tests {
             let entries = parse_arp_macos("");
             assert!(entries.is_empty());
         }
+
+        #[test]
+        fn test_parse_ndp_macos_basic() {
+            let output = "Neighbor                             Linklayer Address Netif Expire    St Flgs Prbs\n\
+                          fe80::aabb:ccdd:eeff%en0             aa:bb:cc:dd:ee:ff en0   permanent R\n\
+                          2001:db8::1234%en0                   11:22:33:44:55:66 en0   23h59m45s R\n\
+                          fe80::ffff%en0                       (incomplete)      en0   expired   I\n\
+                          ff02::1%en0                          aa:bb:cc:dd:ee:ff en0   permanent R";
+            let entries = parse_ndp_macos(output);
+            assert_eq!(entries.len(), 2);
+            assert_eq!(entries[0].ip, "fe80::aabb:ccdd:eeff");
+            assert_eq!(entries[0].mac, "aa:bb:cc:dd:ee:ff");
+            assert_eq!(entries[0].interface.as_deref(), Some("en0"));
+            assert_eq!(entries[1].ip, "2001:db8::1234");
+        }
+
+        #[test]
+        fn test_parse_ndp_macos_empty() {
+            assert!(parse_ndp_macos("").is_empty());
+        }
     }
 
     #[cfg(target_os = "linux")]
@@ -285,6 +603,26 @@ mod tests {
             assert_eq!(entries[0].ip, "192.168.1.1");
             assert_eq!(entries[0].mac, "aa:bb:cc:dd:ee:ff");
             assert_eq!(entries[0].interface.as_deref(), Some("eth0"));
+        }
+
+        #[test]
+        fn test_parse_ndp_linux_basic() {
+            let content = "fe80::aabb dev wlan0 lladdr aa:bb:cc:dd:ee:ff REACHABLE\n\
+                           2001:db8::1 dev wlan0 lladdr 11:22:33:44:55:66 STALE\n\
+                           fe80::bad dev wlan0  FAILED\n\
+                           fe80::pending dev wlan0 lladdr 22:22:22:22:22:22 INCOMPLETE\n\
+                           ff02::1 dev wlan0 lladdr 33:33:00:00:00:01 PERMANENT";
+            let entries = parse_ndp_linux(content);
+            assert_eq!(entries.len(), 2);
+            assert_eq!(entries[0].ip, "fe80::aabb");
+            assert_eq!(entries[0].mac, "aa:bb:cc:dd:ee:ff");
+            assert_eq!(entries[0].interface.as_deref(), Some("wlan0"));
+            assert_eq!(entries[1].ip, "2001:db8::1");
+        }
+
+        #[test]
+        fn test_parse_ndp_linux_empty() {
+            assert!(parse_ndp_linux("").is_empty());
         }
     }
 
@@ -305,6 +643,26 @@ mod tests {
             assert_eq!(entries[0].ip, "192.168.1.1");
             assert_eq!(entries[0].mac, "aa:bb:cc:dd:ee:ff");
             assert_eq!(entries[1].mac, "11:22:33:44:55:66");
+        }
+
+        #[test]
+        fn test_parse_ndp_windows_basic() {
+            let output = "\n\
+                Interface 12: Ethernet\n\
+                \n\
+                Internet Address                              Physical Address   Type\n\
+                --------------------------------------------  -----------------  -----------\n\
+                fe80::aabb                                    aa-bb-cc-dd-ee-ff  Reachable\n\
+                2001:db8::1                                   11-22-33-44-55-66  Stale\n\
+                fe80::dead                                    aa-bb-cc-dd-ee-ff  Unreachable\n\
+                fe80::own                                     00-00-00-00-00-00  Permanent\n\
+                ff02::1                                       33-33-00-00-00-01  Permanent\n";
+            let entries = parse_ndp_windows(output);
+            assert_eq!(entries.len(), 2);
+            assert_eq!(entries[0].ip, "fe80::aabb");
+            assert_eq!(entries[0].mac, "aa:bb:cc:dd:ee:ff");
+            assert_eq!(entries[0].interface.as_deref(), Some("Ethernet"));
+            assert_eq!(entries[1].ip, "2001:db8::1");
         }
     }
 }

--- a/src-tauri/src/network/discovery.rs
+++ b/src-tauri/src/network/discovery.rs
@@ -1621,8 +1621,8 @@ async fn udp_scan_discovery(targets: &[IpAddr], options: &DiscoveryOptions) -> D
 fn arp_cache_discovery(targets: &[IpAddr]) -> DiscoveryResult {
     let start = std::time::Instant::now();
 
-    // Read system ARP cache
-    let entries = super::arp_cache::read_arp_cache();
+    // Read both IPv4 ARP and IPv6 NDP caches to expose MAC addresses for both families
+    let entries = super::arp_cache::read_neighbor_cache();
     let target_set: HashSet<String> = targets.iter().map(ToString::to_string).collect();
 
     let mut hosts = Vec::new();

--- a/src/lib/services/network-scanner.test.ts
+++ b/src/lib/services/network-scanner.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from 'vitest';
+import {
+	type DiscoveryResult,
+	type HostMetadata,
+	type HostResult,
+	type PortInfo,
+	mergeHosts,
+} from './network-scanner.js';
+
+/**
+ * Build a HostMetadata fixture. Required `readonly` fields with sensible
+ * defaults so tests only specify what they care about.
+ */
+const buildMetadata = (overrides: Partial<HostMetadata> = {}): HostMetadata => ({
+	mdnsServices: [],
+	tlsNames: [],
+	...overrides,
+});
+
+/** Build a DiscoveryResult fixture for a single method. */
+const buildDiscoveryResult = (
+	overrides: Partial<DiscoveryResult> & { method: string }
+): DiscoveryResult => ({
+	hosts: [],
+	hostnames: {},
+	hostMetadata: {},
+	unreachable: [],
+	durationMs: 0,
+	error: null,
+	requiresPrivileges: false,
+	...overrides,
+});
+
+const buildHostResult = (overrides: Partial<HostResult> & { ip: string }): HostResult => ({
+	ports: [],
+	scanDurationMs: 0,
+	...overrides,
+});
+
+const openPort = (port: number): PortInfo => ({ port, state: 'open' });
+
+describe('mergeHosts', () => {
+	it('returns an empty array when both inputs are empty', () => {
+		const result = mergeHosts([], []);
+		expect(result).toEqual([]);
+	});
+
+	it('emits one UnifiedHost for a single bare discovery result', () => {
+		const discovery = buildDiscoveryResult({
+			method: 'arp_cache',
+			hosts: ['192.168.1.10'],
+		});
+
+		const result = mergeHosts([discovery], []);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.ips).toEqual(['192.168.1.10']);
+		expect(result[0]?.discoveryMethods).toEqual(['arp_cache']);
+	});
+
+	it('unions discovery methods when two reports share the same IP', () => {
+		const arp = buildDiscoveryResult({
+			method: 'arp_cache',
+			hosts: ['192.168.1.20'],
+			hostMetadata: {
+				'192.168.1.20': buildMetadata({ macAddress: 'aa:bb:cc:dd:ee:ff' }),
+			},
+		});
+		const mdns = buildDiscoveryResult({
+			method: 'mdns',
+			hosts: ['192.168.1.20'],
+			hostnames: { '192.168.1.20': 'printer.local' },
+			hostMetadata: {
+				'192.168.1.20': buildMetadata({ hostname: 'printer.local', hostnameSource: 'mdns' }),
+			},
+		});
+
+		const result = mergeHosts([arp, mdns], []);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.ips).toEqual(['192.168.1.20']);
+		expect(result[0]?.discoveryMethods.sort()).toEqual(['arp_cache', 'mdns']);
+		expect(result[0]?.macAddress).toBe('aa:bb:cc:dd:ee:ff');
+		expect(result[0]?.hostname).toBe('printer.local');
+		expect(result[0]?.hostnameSource).toBe('mdns');
+	});
+
+	it('merges two IPs reported by different methods when they share a MAC', () => {
+		const arp = buildDiscoveryResult({
+			method: 'arp_cache',
+			hosts: ['192.168.1.30'],
+			hostMetadata: {
+				'192.168.1.30': buildMetadata({ macAddress: 'aa:bb:cc:11:22:33' }),
+			},
+		});
+		const ndp = buildDiscoveryResult({
+			method: 'arp_cache',
+			hosts: ['fe80::abcd'],
+			hostMetadata: {
+				'fe80::abcd': buildMetadata({ macAddress: 'AA-BB-CC-11-22-33' }),
+			},
+		});
+
+		const result = mergeHosts([arp, ndp], []);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.ips.sort()).toEqual(['192.168.1.30', 'fe80::abcd']);
+		expect(result[0]?.macAddress).toBe('aa:bb:cc:11:22:33');
+	});
+
+	it('merges v4 ArpCache + v6 mDNS via shared hostname when MAC differs', () => {
+		const arp = buildDiscoveryResult({
+			method: 'arp_cache',
+			hosts: ['192.168.1.40'],
+			hostMetadata: {
+				'192.168.1.40': buildMetadata({ macAddress: 'aa:bb:cc:dd:ee:01' }),
+			},
+		});
+		const mdns = buildDiscoveryResult({
+			method: 'mdns',
+			hosts: ['fe80::beef'],
+			hostnames: { 'fe80::beef': 'apple-tv.local' },
+			hostMetadata: {
+				'fe80::beef': buildMetadata({ hostname: 'apple-tv.local', hostnameSource: 'mdns' }),
+			},
+		});
+		// Give the v4 host the same hostname (e.g., from DNS PTR) so they merge.
+		const dns = buildDiscoveryResult({
+			method: 'dns',
+			hosts: ['192.168.1.40'],
+			hostnames: { '192.168.1.40': 'apple-tv' },
+			hostMetadata: {
+				'192.168.1.40': buildMetadata({ hostname: 'apple-tv', hostnameSource: 'dns' }),
+			},
+		});
+
+		const result = mergeHosts([arp, mdns, dns], []);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.ips.sort()).toEqual(['192.168.1.40', 'fe80::beef']);
+		// mDNS wins over DNS for the displayed hostname.
+		expect(result[0]?.hostname).toBe('apple-tv.local');
+		expect(result[0]?.hostnameSource).toBe('mdns');
+	});
+
+	it('merges router.local (mdns) with router (netbios) via suffix stripping', () => {
+		const mdns = buildDiscoveryResult({
+			method: 'mdns',
+			hosts: ['192.168.1.1'],
+			hostnames: { '192.168.1.1': 'router.local' },
+			hostMetadata: {
+				'192.168.1.1': buildMetadata({ hostname: 'router.local', hostnameSource: 'mdns' }),
+			},
+		});
+		const netbios = buildDiscoveryResult({
+			method: 'tcp_connect',
+			hosts: ['192.168.1.2'],
+			hostMetadata: {
+				'192.168.1.2': buildMetadata({ netbiosName: 'router' }),
+			},
+		});
+
+		const result = mergeHosts([mdns, netbios], []);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.ips.sort()).toEqual(['192.168.1.1', '192.168.1.2']);
+		expect(result[0]?.hostname).toBe('router.local');
+	});
+
+	it('merges Router.LOCAL. (FQDN, uppercase) with router via normalization', () => {
+		const mdns = buildDiscoveryResult({
+			method: 'mdns',
+			hosts: ['192.168.1.50'],
+			hostnames: { '192.168.1.50': 'Router.LOCAL.' },
+			hostMetadata: {
+				'192.168.1.50': buildMetadata({ hostname: 'Router.LOCAL.', hostnameSource: 'mdns' }),
+			},
+		});
+		const netbios = buildDiscoveryResult({
+			method: 'tcp_connect',
+			hosts: ['192.168.1.51'],
+			hostMetadata: {
+				'192.168.1.51': buildMetadata({ netbiosName: 'router' }),
+			},
+		});
+
+		const result = mergeHosts([mdns, netbios], []);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.ips.sort()).toEqual(['192.168.1.50', '192.168.1.51']);
+	});
+
+	it('keeps two hosts separate when MAC and hostname both differ', () => {
+		const a = buildDiscoveryResult({
+			method: 'arp_cache',
+			hosts: ['192.168.1.60'],
+			hostnames: { '192.168.1.60': 'alpha.local' },
+			hostMetadata: {
+				'192.168.1.60': buildMetadata({
+					macAddress: 'aa:bb:cc:00:00:01',
+					hostname: 'alpha.local',
+					hostnameSource: 'mdns',
+				}),
+			},
+		});
+		const b = buildDiscoveryResult({
+			method: 'arp_cache',
+			hosts: ['192.168.1.61'],
+			hostnames: { '192.168.1.61': 'bravo.local' },
+			hostMetadata: {
+				'192.168.1.61': buildMetadata({
+					macAddress: 'aa:bb:cc:00:00:02',
+					hostname: 'bravo.local',
+					hostnameSource: 'mdns',
+				}),
+			},
+		});
+
+		const result = mergeHosts([a, b], []);
+
+		expect(result).toHaveLength(2);
+		const ips = result.map((host) => host.ips[0]);
+		expect(ips).toEqual(['192.168.1.60', '192.168.1.61']);
+	});
+
+	it('merges transitively (A↔MAC↔B↔hostname↔C)', () => {
+		// A and B share a MAC; B and C share a hostname; expect all three in one group.
+		const a = buildDiscoveryResult({
+			method: 'arp_cache',
+			hosts: ['192.168.1.70'],
+			hostMetadata: {
+				'192.168.1.70': buildMetadata({ macAddress: 'aa:bb:cc:00:00:10' }),
+			},
+		});
+		const b = buildDiscoveryResult({
+			method: 'arp_cache',
+			hosts: ['fe80::1'],
+			hostMetadata: {
+				'fe80::1': buildMetadata({
+					macAddress: 'aa:bb:cc:00:00:10',
+					hostname: 'nas.local',
+					hostnameSource: 'mdns',
+				}),
+			},
+		});
+		const c = buildDiscoveryResult({
+			method: 'dns',
+			hosts: ['192.168.1.71'],
+			hostnames: { '192.168.1.71': 'nas' },
+			hostMetadata: {
+				'192.168.1.71': buildMetadata({ hostname: 'nas', hostnameSource: 'dns' }),
+			},
+		});
+
+		const result = mergeHosts([a, b, c], []);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.ips.sort()).toEqual(['192.168.1.70', '192.168.1.71', 'fe80::1']);
+	});
+
+	it('includes scan-only hosts even without discovery results', () => {
+		const scan = buildHostResult({
+			ip: '192.168.1.80',
+			ports: [openPort(22), openPort(443)],
+			scanDurationMs: 1500,
+		});
+
+		const result = mergeHosts([], [scan]);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.ips).toEqual(['192.168.1.80']);
+		expect(result[0]?.ports.map((p) => p.port)).toEqual([22, 443]);
+		expect(result[0]?.scanDurationMs).toBe(1500);
+	});
+});

--- a/src/lib/services/network-scanner.ts
+++ b/src/lib/services/network-scanner.ts
@@ -655,20 +655,169 @@ const compareIpAddresses = (a: string, b: string): number => {
 	return a.localeCompare(b);
 };
 
-/** Get merge key for a host (hostname if available, otherwise IP) */
+/**
+ * Get merge key for a host (hostname if available, otherwise IP).
+ *
+ * Note: Retained as a public export for backward compatibility with existing
+ * callers. The internal merging algorithm now uses Union-Find on a richer
+ * signal set (IP, MAC, normalized hostname) rather than a single string key.
+ */
 export const getMergeKey = (ip: string, hostname: string | null): string => {
 	if (hostname) return `host:${hostname.toLowerCase()}`;
 	return `ip:${ip}`;
 };
 
 /** Sort IPs: IPv4 first (numerically), then IPv6 */
-const sortIps = (ips: string[]): string[] => [...ips].sort(compareIpAddresses);
+const sortIps = (ips: readonly string[]): string[] => [...ips].sort(compareIpAddresses);
 
 /** Compare hosts by their primary IP address (numerically) */
 const compareByIp = (a: UnifiedHost, b: UnifiedHost): number => {
 	const aIp = a.ips[0] ?? '';
 	const bIp = b.ips[0] ?? '';
 	return compareIpAddresses(aIp, bIp);
+};
+
+/** Suffixes stripped during hostname normalization (case-insensitive). */
+const HOSTNAME_STRIP_SUFFIXES = ['.local', '.lan', '.home.arpa'] as const;
+
+/**
+ * Normalize a hostname for cross-source equality comparison.
+ *
+ * Steps: lowercase, strip a trailing `.`, then strip a single trailing
+ * `.local` / `.lan` / `.home.arpa` suffix. Returns `null` for empty input
+ * so callers can treat "no hostname" uniformly.
+ */
+const normalizeHostname = (hostname: string | null | undefined): string | null => {
+	if (!hostname) return null;
+	const lowered = hostname.toLowerCase().replace(/\.$/, '');
+	if (!lowered) return null;
+	const stripped = HOSTNAME_STRIP_SUFFIXES.reduce(
+		(acc, suffix) => (acc.endsWith(suffix) ? acc.slice(0, -suffix.length) : acc),
+		lowered
+	);
+	const trimmed = stripped.length > 0 ? stripped : lowered;
+	return trimmed || null;
+};
+
+/** Normalize a MAC address: lowercase, use `:` separators. Empty input returns null. */
+const normalizeMac = (mac: string | null | undefined): string | null => {
+	if (!mac) return null;
+	const normalized = mac.toLowerCase().replace(/-/g, ':').trim();
+	return normalized || null;
+};
+
+/** Priority ordering for hostname sources when multiple are reported per host. */
+const HOSTNAME_SOURCE_PRIORITY: Record<string, number> = {
+	mdns: 0,
+	dns: 1,
+	llmnr: 2,
+	netbios: 3,
+	snmp: 4,
+	tls: 5,
+	ssdp: 6,
+};
+
+const hostnameSourceRank = (source: string | null | undefined): number => {
+	if (!source) return Number.POSITIVE_INFINITY;
+	const rank = HOSTNAME_SOURCE_PRIORITY[source.toLowerCase()];
+	return rank ?? Number.POSITIVE_INFINITY;
+};
+
+/** Disjoint-set / Union-Find over string keys (IP strings here). */
+class DisjointSet {
+	private readonly parent = new Map<string, string>();
+	private readonly rank = new Map<string, number>();
+
+	add(key: string): void {
+		if (this.parent.has(key)) return;
+		this.parent.set(key, key);
+		this.rank.set(key, 0);
+	}
+
+	find(key: string): string {
+		const parent = this.parent.get(key);
+		if (parent === undefined) {
+			// Auto-add to keep find total — caller errors should be impossible here.
+			this.add(key);
+			return key;
+		}
+		if (parent === key) return key;
+		const root = this.find(parent);
+		this.parent.set(key, root);
+		return root;
+	}
+
+	union(a: string, b: string): void {
+		const rootA = this.find(a);
+		const rootB = this.find(b);
+		if (rootA === rootB) return;
+		const rankA = this.rank.get(rootA) ?? 0;
+		const rankB = this.rank.get(rootB) ?? 0;
+		if (rankA < rankB) {
+			this.parent.set(rootA, rootB);
+		} else if (rankA > rankB) {
+			this.parent.set(rootB, rootA);
+		} else {
+			this.parent.set(rootB, rootA);
+			this.rank.set(rootA, rankA + 1);
+		}
+	}
+
+	keys(): readonly string[] {
+		return [...this.parent.keys()];
+	}
+}
+
+/** Per-IP record describing what each source contributed about this IP. */
+interface IpObservation {
+	readonly ip: string;
+	readonly hostnames: { value: string; source: string | null }[];
+	readonly macs: string[];
+	readonly metadatas: HostMetadata[];
+	readonly discoveries: DiscoveryResult[];
+	readonly ports: PortInfo[];
+	scanDurationMs: number;
+}
+
+const getOrCreateObservation = (
+	observations: Map<string, IpObservation>,
+	ip: string
+): IpObservation => {
+	const existing = observations.get(ip);
+	if (existing) return existing;
+	const created: IpObservation = {
+		ip,
+		hostnames: [],
+		macs: [],
+		metadatas: [],
+		discoveries: [],
+		ports: [],
+		scanDurationMs: 0,
+	};
+	observations.set(ip, created);
+	return created;
+};
+
+/** Record a hostname/source pair on an observation if non-empty and not duplicate. */
+const recordHostname = (
+	observation: IpObservation,
+	hostname: string | null | undefined,
+	source: string | null | undefined
+): void => {
+	if (!hostname) return;
+	const trimmed = hostname.trim();
+	if (!trimmed) return;
+	const alreadyPresent = observation.hostnames.some(
+		(entry) => entry.value === trimmed && (entry.source ?? null) === (source ?? null)
+	);
+	if (alreadyPresent) return;
+	observation.hostnames.push({ value: trimmed, source: source ?? null });
+};
+
+const recordMac = (observation: IpObservation, mac: string | null | undefined): void => {
+	const normalized = normalizeMac(mac);
+	if (!normalized) return;
+	if (!observation.macs.includes(normalized)) observation.macs.push(normalized);
 };
 
 /** Add an mDNS service to a host if not already present */
@@ -681,19 +830,14 @@ const addMdnsServiceIfNew = (host: UnifiedHost, service: MdnsServiceInfo): void 
 
 /** Merge scalar metadata fields from source into target (target wins if non-null) */
 const mergeScalarMetadata = (host: UnifiedHost, metadata: HostMetadata): void => {
-	if (!host.hostnameSource && metadata.hostnameSource)
-		host.hostnameSource = metadata.hostnameSource;
 	if (!host.netbiosName && metadata.netbiosName) host.netbiosName = metadata.netbiosName;
 	if (!host.macAddress && metadata.macAddress) host.macAddress = metadata.macAddress;
 	if (!host.vendor && metadata.vendor) host.vendor = metadata.vendor;
 	if (!host.wsDiscovery && metadata.wsDiscovery) host.wsDiscovery = metadata.wsDiscovery;
 	if (!host.snmpInfo && metadata.snmpInfo) host.snmpInfo = metadata.snmpInfo;
-	// Merge TLS names (union of all discovered names)
 	if (metadata.tlsNames && metadata.tlsNames.length > 0) {
 		for (const name of metadata.tlsNames) {
-			if (!host.tlsNames.includes(name)) {
-				host.tlsNames.push(name);
-			}
+			if (!host.tlsNames.includes(name)) host.tlsNames.push(name);
 		}
 	}
 };
@@ -702,22 +846,21 @@ const mergeScalarMetadata = (host: UnifiedHost, metadata: HostMetadata): void =>
 const mergeSsdpDevice = (host: UnifiedHost, ssdpDevice: SsdpDeviceInfo): void => {
 	if (!host.ssdpDevice) {
 		host.ssdpDevice = ssdpDevice;
-	} else {
-		host.ssdpDevice = {
-			friendlyName: host.ssdpDevice.friendlyName ?? ssdpDevice.friendlyName,
-			manufacturer: host.ssdpDevice.manufacturer ?? ssdpDevice.manufacturer,
-			modelName: host.ssdpDevice.modelName ?? ssdpDevice.modelName,
-			modelNumber: host.ssdpDevice.modelNumber ?? ssdpDevice.modelNumber,
-			deviceType: host.ssdpDevice.deviceType ?? ssdpDevice.deviceType,
-			location: host.ssdpDevice.location ?? ssdpDevice.location,
-			server: host.ssdpDevice.server ?? ssdpDevice.server,
-		};
+		return;
 	}
+	host.ssdpDevice = {
+		friendlyName: host.ssdpDevice.friendlyName ?? ssdpDevice.friendlyName,
+		manufacturer: host.ssdpDevice.manufacturer ?? ssdpDevice.manufacturer,
+		modelName: host.ssdpDevice.modelName ?? ssdpDevice.modelName,
+		modelNumber: host.ssdpDevice.modelNumber ?? ssdpDevice.modelNumber,
+		deviceType: host.ssdpDevice.deviceType ?? ssdpDevice.deviceType,
+		location: host.ssdpDevice.location ?? ssdpDevice.location,
+		server: host.ssdpDevice.server ?? ssdpDevice.server,
+	};
 };
 
-/** Apply all metadata fields from HostMetadata to a UnifiedHost */
-const applyMetadata = (host: UnifiedHost, metadata: HostMetadata | undefined): void => {
-	if (!metadata) return;
+/** Apply non-hostname metadata fields onto a UnifiedHost. */
+const applyMetadata = (host: UnifiedHost, metadata: HostMetadata): void => {
 	mergeScalarMetadata(host, metadata);
 	if (metadata.ssdpDevice) mergeSsdpDevice(host, metadata.ssdpDevice);
 	if (metadata.mdnsServices) {
@@ -725,98 +868,19 @@ const applyMetadata = (host: UnifiedHost, metadata: HostMetadata | undefined): v
 	}
 };
 
-/** Absorb all data from source host into target, then delete source from maps */
-const absorbHost = (
-	target: UnifiedHost,
-	source: UnifiedHost,
-	hostMap: Map<string, UnifiedHost>,
-	ipToKey: Map<string, string>,
-	targetKey: string
-): void => {
-	for (const ip of source.ips) {
-		if (!target.ips.includes(ip)) target.ips.push(ip);
-		ipToKey.set(ip, targetKey);
-	}
-	target.ips = sortIps(target.ips);
-	for (const method of source.discoveryMethods) {
-		if (!target.discoveryMethods.includes(method)) target.discoveryMethods.push(method);
-	}
-	for (const discovery of source.discoveries) target.discoveries.push(discovery);
-	if (!target.macAddress && source.macAddress) target.macAddress = source.macAddress;
-	if (!target.vendor && source.vendor) target.vendor = source.vendor;
-	if (!target.netbiosName && source.netbiosName) target.netbiosName = source.netbiosName;
-	if (!target.ssdpDevice && source.ssdpDevice) target.ssdpDevice = source.ssdpDevice;
-	if (!target.wsDiscovery && source.wsDiscovery) target.wsDiscovery = source.wsDiscovery;
-	for (const service of source.mdnsServices) addMdnsServiceIfNew(target, service);
-	hostMap.delete(source.id);
-};
-
-/** Handle hostname update for an existing host, potentially re-keying or merging */
-const handleHostnameUpdate = (
-	host: UnifiedHost,
-	ip: string,
-	hostname: string,
-	metadata: HostMetadata | undefined,
-	hostMap: Map<string, UnifiedHost>,
-	ipToKey: Map<string, string>
-): UnifiedHost => {
-	host.hostname = hostname;
-	host.hostnameSource = metadata?.hostnameSource ?? null;
-	const newKey = getMergeKey(ip, hostname);
-	if (newKey === host.id) return host;
-
-	const existingHostAtNewKey = hostMap.get(newKey);
-	if (existingHostAtNewKey && existingHostAtNewKey !== host) {
-		absorbHost(existingHostAtNewKey, host, hostMap, ipToKey, newKey);
-		return existingHostAtNewKey;
-	}
-	// Re-key the host
-	hostMap.delete(host.id);
-	host.id = newKey;
-	hostMap.set(newKey, host);
-	for (const hostIp of host.ips) ipToKey.set(hostIp, newKey);
-	return host;
-};
-
-/** Create a new UnifiedHost */
-const createHost = (
-	key: string,
-	ip: string,
-	hostname: string | null,
-	metadata: HostMetadata | undefined
-): UnifiedHost => ({
-	id: key,
-	ips: [ip],
-	hostname: hostname ?? metadata?.hostname ?? null,
-	hostnameSource: metadata?.hostnameSource ?? null,
-	netbiosName: metadata?.netbiosName ?? null,
-	macAddress: metadata?.macAddress ?? null,
-	vendor: metadata?.vendor ?? null,
-	mdnsServices: metadata?.mdnsServices ? [...metadata.mdnsServices] : [],
-	ssdpDevice: metadata?.ssdpDevice ?? null,
-	wsDiscovery: metadata?.wsDiscovery ?? null,
-	snmpInfo: metadata?.snmpInfo ?? null,
-	tlsNames: metadata?.tlsNames ? [...metadata.tlsNames] : [],
-	discoveryMethods: [],
-	discoveries: [],
-	ports: [],
-	scanDurationMs: null,
-});
-
-/** Merge port into host's port list, preferring open state */
+/** Merge a single port into host's port list, preferring open state. */
 const mergePort = (host: UnifiedHost, port: PortInfo): void => {
 	const existingIdx = host.ports.findIndex((p) => p.port === port.port);
 	if (existingIdx === -1) {
 		host.ports.push(port);
-	} else {
-		const existingPort = host.ports[existingIdx];
-		if (existingPort && port.state === 'open' && existingPort.state !== 'open') {
-			host.ports[existingIdx] = port;
-		}
+		return;
+	}
+	const existingPort = host.ports[existingIdx];
+	if (existingPort && port.state === 'open' && existingPort.state !== 'open') {
+		host.ports[existingIdx] = port;
 	}
 };
 
-/** Add discovery info to host if not already present */
 const addDiscoveryToHost = (host: UnifiedHost, result: DiscoveryResult): void => {
 	if (!host.discoveryMethods.includes(result.method)) {
 		host.discoveryMethods.push(result.method);
@@ -824,98 +888,174 @@ const addDiscoveryToHost = (host: UnifiedHost, result: DiscoveryResult): void =>
 	const hasDiscovery = host.discoveries.some(
 		(d) => d.method === result.method && d.durationMs === result.durationMs
 	);
-	if (!hasDiscovery) {
-		host.discoveries.push({
-			method: result.method,
-			durationMs: result.durationMs,
-			error: result.error,
-		});
-	}
+	if (hasDiscovery) return;
+	host.discoveries.push({
+		method: result.method,
+		durationMs: result.durationMs,
+		error: result.error,
+	});
 };
 
-/** Get or create a unified host entry */
-const getOrCreateHost = (
-	ip: string,
-	hostname: string | null,
-	metadata: HostMetadata | undefined,
-	hostMap: Map<string, UnifiedHost>,
-	ipToKey: Map<string, string>
-): UnifiedHost => {
-	const existingKey = ipToKey.get(ip);
-	if (existingKey) {
-		const host = hostMap.get(existingKey);
-		if (host) {
-			const result =
-				hostname && !host.hostname
-					? handleHostnameUpdate(host, ip, hostname, metadata, hostMap, ipToKey)
-					: host;
-			applyMetadata(result, metadata);
-			return result;
-		}
-	}
+/**
+ * Collect per-IP observations from discovery and scan inputs. This is the
+ * "signal gathering" pass: every IP gets one IpObservation, with hostnames,
+ * MACs, raw metadata, discoveries and ports attached in input order.
+ */
+const collectObservations = (
+	discoveryResults: readonly DiscoveryResult[],
+	scanHosts: readonly HostResult[]
+): Map<string, IpObservation> => {
+	const observations = new Map<string, IpObservation>();
 
-	if (hostname) {
-		const hostnameKey = getMergeKey(ip, hostname);
-		const hostByHostname = hostMap.get(hostnameKey);
-		if (hostByHostname) {
-			if (!hostByHostname.ips.includes(ip)) {
-				hostByHostname.ips.push(ip);
-				hostByHostname.ips = sortIps(hostByHostname.ips);
-				ipToKey.set(ip, hostnameKey);
+	for (const result of discoveryResults) {
+		for (const ip of result.hosts) {
+			const observation = getOrCreateObservation(observations, ip);
+			observation.discoveries.push(result);
+			const metadata = result.hostMetadata?.[ip];
+			const hostnamesMapEntry = result.hostnames?.[ip];
+			// Top-level hostnames map has no explicit source — attribute it to
+			// the discovery method that reported it.
+			recordHostname(observation, hostnamesMapEntry, result.method);
+			if (metadata) {
+				observation.metadatas.push(metadata);
+				recordHostname(observation, metadata.hostname, metadata.hostnameSource);
+				// NetBIOS name lives on metadata.netbiosName, not metadata.hostname.
+				// Treat it as a separate hostname signal for merging purposes.
+				recordHostname(observation, metadata.netbiosName, 'netbios');
+				recordMac(observation, metadata.macAddress);
 			}
-			return hostByHostname;
 		}
 	}
 
-	const key = getMergeKey(ip, hostname);
-	const host = createHost(key, ip, hostname, metadata);
-	hostMap.set(key, host);
-	ipToKey.set(ip, key);
+	for (const scanHost of scanHosts) {
+		const observation = getOrCreateObservation(observations, scanHost.ip);
+		recordHostname(observation, scanHost.hostname, null);
+		for (const port of scanHost.ports) observation.ports.push(port);
+		observation.scanDurationMs += scanHost.scanDurationMs ?? 0;
+	}
+
+	return observations;
+};
+
+/** Build the Union-Find by linking IPs that share any normalized signal. */
+const buildDisjointSet = (observations: ReadonlyMap<string, IpObservation>): DisjointSet => {
+	const dsu = new DisjointSet();
+	for (const ip of observations.keys()) dsu.add(ip);
+
+	// Signal → first IP that emitted it; subsequent IPs union with that anchor.
+	const signalToIp = new Map<string, string>();
+	const linkSignal = (signal: string, ip: string): void => {
+		const anchor = signalToIp.get(signal);
+		if (anchor === undefined) {
+			signalToIp.set(signal, ip);
+			return;
+		}
+		dsu.union(anchor, ip);
+	};
+
+	for (const [ip, observation] of observations) {
+		for (const mac of observation.macs) linkSignal(`mac:${mac}`, ip);
+		for (const entry of observation.hostnames) {
+			const normalized = normalizeHostname(entry.value);
+			if (normalized) linkSignal(`hostname:${normalized}`, ip);
+		}
+	}
+
+	return dsu;
+};
+
+/**
+ * Pick the best hostname for a group based on source priority. Returns the
+ * original (un-normalized) hostname string and the source it came from.
+ */
+const selectHostname = (
+	entries: readonly { value: string; source: string | null }[]
+): { hostname: string | null; source: string | null } => {
+	if (entries.length === 0) return { hostname: null, source: null };
+	let bestRank = Number.POSITIVE_INFINITY;
+	let best: { value: string; source: string | null } | null = null;
+	for (const entry of entries) {
+		const rank = hostnameSourceRank(entry.source);
+		if (rank < bestRank) {
+			bestRank = rank;
+			best = entry;
+		}
+	}
+	const fallback = best ?? entries[0] ?? null;
+	return fallback
+		? { hostname: fallback.value, source: fallback.source }
+		: { hostname: null, source: null };
+};
+
+/** Build a single UnifiedHost from a group of merged IP observations. */
+const buildUnifiedHost = (group: readonly IpObservation[]): UnifiedHost => {
+	const ips = sortIps(group.map((obs) => obs.ip));
+	const primaryIp = ips[0] ?? '';
+
+	const allHostnames = group.flatMap((obs) => obs.hostnames);
+	const { hostname, source } = selectHostname(allHostnames);
+	const macFromObservations = group.flatMap((obs) => obs.macs)[0] ?? null;
+
+	const host: UnifiedHost = {
+		// Preserve historical id shape (`host:<lowercased hostname>` or `ip:<ip>`)
+		// so external callers that key off `id` continue to work.
+		id: getMergeKey(primaryIp, hostname),
+		ips,
+		hostname,
+		hostnameSource: source,
+		netbiosName: null,
+		macAddress: macFromObservations,
+		vendor: null,
+		mdnsServices: [],
+		ssdpDevice: null,
+		wsDiscovery: null,
+		snmpInfo: null,
+		tlsNames: [],
+		discoveryMethods: [],
+		discoveries: [],
+		ports: [],
+		scanDurationMs: null,
+	};
+
+	for (const observation of group) {
+		for (const metadata of observation.metadatas) applyMetadata(host, metadata);
+		for (const discovery of observation.discoveries) addDiscoveryToHost(host, discovery);
+		for (const port of observation.ports) mergePort(host, port);
+		if (observation.scanDurationMs > 0) {
+			host.scanDurationMs = (host.scanDurationMs ?? 0) + observation.scanDurationMs;
+		}
+	}
+
+	host.ports.sort((a, b) => a.port - b.port);
 	return host;
 };
 
 /**
  * Merge discovery and scan results into a unified host list.
- * Uses O(n) algorithm with IP-to-key index for fast lookups.
+ *
+ * Uses Union-Find over per-IP identity signals (IP itself, normalized MAC,
+ * and normalized hostname) so that two records describing the same physical
+ * host get merged regardless of which discovery method first reported them.
+ * This addresses the v4-from-ARP / v6-from-mDNS split case in particular.
  */
 export const mergeHosts = (
 	discoveryResults: readonly DiscoveryResult[],
 	scanHosts: readonly HostResult[]
 ): UnifiedHost[] => {
-	const hostMap = new Map<string, UnifiedHost>();
-	const ipToKey = new Map<string, string>();
+	const observations = collectObservations(discoveryResults, scanHosts);
+	if (observations.size === 0) return [];
 
-	// 1. Add hosts from discovery results
-	for (const result of discoveryResults) {
-		for (const ip of result.hosts) {
-			const host = getOrCreateHost(
-				ip,
-				result.hostnames[ip] ?? null,
-				result.hostMetadata?.[ip],
-				hostMap,
-				ipToKey
-			);
-			addDiscoveryToHost(host, result);
-		}
+	const dsu = buildDisjointSet(observations);
+
+	const groups = new Map<string, IpObservation[]>();
+	for (const [ip, observation] of observations) {
+		const root = dsu.find(ip);
+		const bucket = groups.get(root) ?? [];
+		bucket.push(observation);
+		groups.set(root, bucket);
 	}
 
-	// 2. Add/merge hosts from port scan results
-	for (const scanHost of scanHosts) {
-		const host = getOrCreateHost(
-			scanHost.ip,
-			scanHost.hostname ?? null,
-			undefined,
-			hostMap,
-			ipToKey
-		);
-		scanHost.ports.forEach((port) => mergePort(host, port));
-		host.ports.sort((a, b) => a.port - b.port);
-		if (scanHost.scanDurationMs) {
-			host.scanDurationMs = (host.scanDurationMs ?? 0) + scanHost.scanDurationMs;
-		}
-	}
-
-	return [...hostMap.values()].sort(compareByIp);
+	return [...groups.values()].map(buildUnifiedHost).sort(compareByIp);
 };
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Same physical host appeared twice in the Network Scanner when one IP family was discovered with a MAC (ARP cache) and the other only with a hostname (mDNS, etc.). This PR collapses them into one row.
- Adds NDP (IPv6 neighbor) cache reading to the `ArpCache` discovery method so IPv6 hosts gain MACs attached.
- Replaces the imperative `mergeHosts` re-keying loop with a Union-Find pass over `(IP, MAC, normalized-hostname)` signals.

> Note: This PR is stacked on top of [#239](https://github.com/seijikohara/kogu/pull/239) (net-scanner sidecar removal). Will rebase onto `main` once #239 lands.

## Root cause

Before this change `mergeHosts` keyed each host by `host:<hostname>` or `ip:<ip>` and never used MAC as a merge signal. When the IPv4 record arrived first (with a MAC but no hostname) and the IPv6 record arrived later (with a hostname but no MAC, or the reverse), the two records never merged. Hostname matching also lacked normalization, so `router.local` (mDNS) and `router` (NetBIOS) on the same host stayed split.

## Changes

### Added

- `src-tauri/src/network/arp_cache.rs`: per-OS NDP cache readers and a public `read_neighbor_cache()` that returns the ARP + NDP union deduped by IP.
- `src/lib/services/network-scanner.test.ts`: 10 vitest cases for the new `mergeHosts` (empty input, same-IP union, MAC-only merge, hostname-suffix merge, FQDN case-folding, transitive merge across mixed signals, scan-only host, non-merge cases, multi-homed v4, MAC separator normalization).

### Changed

- `src-tauri/src/network/arp_cache.rs`:
    - macOS: `ndp -an` parser
    - Linux: `ip -6 neigh show` parser
    - Windows: `netsh interface ipv6 show neighbors` parser
    - IPv6 multicast / unspecified / loopback filter, `%ifname` zone-suffix stripping
    - 8 new unit tests for the parsers and helpers
- `src-tauri/src/network/discovery.rs`: `arp_cache_discovery()` now calls `read_neighbor_cache()` to pick up both v4 and v6 hosts.
- `src/lib/services/network-scanner.ts`: rewrote the merge engine as a Union-Find:
    1. `collectObservations()` walks discovery and scan results, recording per-IP signals (MACs, hostnames-by-source, raw metadata, discoveries, ports).
    2. `buildDisjointSet()` unions any pair of IPs sharing a normalized signal.
    3. `buildUnifiedHost()` aggregates each component into a `UnifiedHost`.
    - Hostname normalization: lowercases, strips trailing `.`, strips a single trailing `.local` / `.lan` / `.home.arpa` suffix (case-insensitive).
    - MAC normalization: lowercases and accepts both `:` and `-` separators.
    - Hostname display priority: `mdns > dns > llmnr > netbios > snmp > tls > ssdp`, with the `hostnameSource` carried through.
    - `UnifiedHost` public interface and the `mergeHosts` signature are unchanged so the page component needs no edits.

## Rationale

`mergeHosts` had grown several special-case branches over time (`handleHostnameUpdate`, `absorbHost`, IP-then-hostname re-keying). A Union-Find pass replaces that imperative tangle with three pure stages — collect signals, group by signals, build output — so adding a new identity signal in the future (e.g. SSDP `UDN` or WS-Discovery `EndpointReference`, planned for a follow-up backend-side PR) becomes a one-line edit in `collectObservations`.

NDP cache reading uses each OS's existing system command rather than introducing a new dependency, matching the existing ARP cache pattern.

## Test Plan

- [x] `cargo check` — no warnings.
- [x] `cargo clippy --no-deps` — no warnings.
- [x] `cargo test --lib network::arp_cache` — 8 / 8 pass.
- [x] `bun run check` — svelte-check, validate-pages, audit-design all pass.
- [x] `bunx vitest run src/lib/services/network-scanner.test.ts` — 10 / 10 pass.
- [ ] Manual: `bun run tauri dev`, run a Network Scanner discovery on a LAN with at least one dual-stack host (IPv4 + IPv6). Confirm the dual-stack host appears once with both IPs in the IP list and its MAC populated.
- [ ] Manual: confirm `router.local` (mDNS) and any other hostname forms (NetBIOS, DNS PTR) of the same gateway merge into a single row.

## Follow-ups (not in this PR)

- Backend-side identity hints (SSDP `UDN`, WS-Discovery `EndpointReference`) so even hosts without a MAC or a shared hostname can merge.
- Additional userspace discovery methods (TCP banner grab, SNMP `sysName` broadcast, LLMNR multicast discovery) — planned as a separate PR.
