### PR TITLE
feat(network): add banner grab, SNMP, and LLMNR discovery methods

### DIFF
--- a/src-tauri/src/network/banner.rs
+++ b/src-tauri/src/network/banner.rs
@@ -1,0 +1,326 @@
+//! TCP banner-grab helpers for discovery
+//!
+//! Probes well-known service ports for a short identifying response and
+//! returns a [`ServiceBanner`] when the bytes look like a recognizable
+//! protocol greeting. All reads are bounded to 500 ms and 256 bytes to
+//! keep discovery cheap.
+
+use std::time::Duration;
+
+use serde::Serialize;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+
+/// Maximum bytes to read for a single banner attempt
+const BANNER_READ_LIMIT: usize = 256;
+
+/// Per-banner read/write timeout
+const BANNER_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Service banner gathered via TCP banner-grab
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ServiceBanner {
+    /// Detected protocol name (e.g. "ssh", "http", "smtp", "redis", "ftp")
+    pub protocol: String,
+    /// Parsed product/version string when extractable
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Truncated raw banner bytes for display (lossy UTF-8, single-line)
+    pub raw: String,
+}
+
+/// Read at most `BANNER_READ_LIMIT` bytes within `BANNER_TIMEOUT`
+async fn read_passive(stream: &mut TcpStream) -> Option<Vec<u8>> {
+    let mut buf = vec![0u8; BANNER_READ_LIMIT];
+    match timeout(BANNER_TIMEOUT, stream.read(&mut buf)).await {
+        Ok(Ok(n)) if n > 0 => {
+            buf.truncate(n);
+            Some(buf)
+        }
+        _ => None,
+    }
+}
+
+/// Write a request then read up to `BANNER_READ_LIMIT` bytes back
+async fn request_response(stream: &mut TcpStream, request: &[u8]) -> Option<Vec<u8>> {
+    timeout(BANNER_TIMEOUT, stream.write_all(request))
+        .await
+        .ok()?
+        .ok()?;
+    read_passive(stream).await
+}
+
+/// Render the first line of a raw byte buffer as a printable string
+fn render_first_line(bytes: &[u8]) -> String {
+    let text = String::from_utf8_lossy(bytes);
+    let first = text.lines().next().unwrap_or("").trim();
+    first.chars().take(BANNER_READ_LIMIT).collect()
+}
+
+/// Attempt to attach a banner to a freshly-connected TCP stream.
+///
+/// Dispatches on `port` to choose the right probe. Returns `None` for
+/// unsupported ports or when the peer does not respond within the
+/// banner-grab budget.
+pub async fn grab_banner(mut stream: TcpStream, port: u16) -> Option<ServiceBanner> {
+    let ip = stream.peer_addr().ok()?.ip();
+    match port {
+        22 => parse_ssh_banner(read_passive(&mut stream).await?.as_slice()),
+        21 => parse_ftp_banner(read_passive(&mut stream).await?.as_slice()),
+        23 => parse_telnet_banner(read_passive(&mut stream).await?.as_slice()),
+        25 | 587 => parse_smtp_banner(read_passive(&mut stream).await?.as_slice()),
+        80 | 8080 | 443 | 8443 => {
+            let request = format!("HEAD / HTTP/1.0\r\nHost: {ip}\r\nConnection: close\r\n\r\n");
+            let bytes = request_response(&mut stream, request.as_bytes()).await?;
+            parse_http_banner(&bytes)
+        }
+        6379 => {
+            let bytes = request_response(&mut stream, b"INFO\r\n").await?;
+            parse_redis_banner(&bytes)
+        }
+        11211 => {
+            let bytes = request_response(&mut stream, b"version\r\n").await?;
+            parse_memcached_banner(&bytes)
+        }
+        _ => None,
+    }
+}
+
+/// Parse an SSH greeting (`SSH-<proto>-<software>[ <comments>]`)
+pub fn parse_ssh_banner(bytes: &[u8]) -> Option<ServiceBanner> {
+    let raw = render_first_line(bytes);
+    let rest = raw.strip_prefix("SSH-")?;
+    // SSH-2.0-OpenSSH_8.6p1 or SSH-1.99-Foo
+    let mut parts = rest.splitn(2, '-');
+    let _proto = parts.next()?;
+    let software = parts.next().unwrap_or("").trim();
+    let version = if software.is_empty() {
+        None
+    } else {
+        Some(
+            software
+                .split_whitespace()
+                .next()
+                .unwrap_or(software)
+                .to_string(),
+        )
+    };
+    Some(ServiceBanner {
+        protocol: "ssh".to_string(),
+        version,
+        raw,
+    })
+}
+
+/// Parse an FTP greeting (`220 <text>`)
+pub fn parse_ftp_banner(bytes: &[u8]) -> Option<ServiceBanner> {
+    let raw = render_first_line(bytes);
+    let rest = raw
+        .strip_prefix("220 ")
+        .or_else(|| raw.strip_prefix("220-"))?;
+    Some(ServiceBanner {
+        protocol: "ftp".to_string(),
+        version: Some(rest.trim().to_string()).filter(|s| !s.is_empty()),
+        raw,
+    })
+}
+
+/// Telnet rarely speaks plain text; just record any non-empty banner
+pub fn parse_telnet_banner(bytes: &[u8]) -> Option<ServiceBanner> {
+    let raw = render_first_line(bytes);
+    if raw.is_empty() {
+        return None;
+    }
+    Some(ServiceBanner {
+        protocol: "telnet".to_string(),
+        version: None,
+        raw,
+    })
+}
+
+/// Parse an SMTP greeting (`220 <host> <software>`)
+pub fn parse_smtp_banner(bytes: &[u8]) -> Option<ServiceBanner> {
+    let raw = render_first_line(bytes);
+    let rest = raw
+        .strip_prefix("220 ")
+        .or_else(|| raw.strip_prefix("220-"))?;
+    // Skip the host name and capture the remainder as version hint.
+    let mut iter = rest.splitn(2, char::is_whitespace);
+    let _host = iter.next()?;
+    let software = iter.next().unwrap_or("").trim();
+    let version = if software.is_empty() {
+        None
+    } else {
+        Some(software.to_string())
+    };
+    Some(ServiceBanner {
+        protocol: "smtp".to_string(),
+        version,
+        raw,
+    })
+}
+
+/// Parse an HTTP response and return the `Server:` header when present
+pub fn parse_http_banner(bytes: &[u8]) -> Option<ServiceBanner> {
+    let text = String::from_utf8_lossy(bytes);
+    let mut lines = text.split("\r\n");
+    let status_line = lines.next()?.trim();
+    if !status_line.starts_with("HTTP/") {
+        return None;
+    }
+    let server = lines.find_map(|line| {
+        let lower = line.to_ascii_lowercase();
+        lower
+            .strip_prefix("server:")
+            .map(|_| line.get("server:".len()..).unwrap_or("").trim().to_string())
+    });
+    Some(ServiceBanner {
+        protocol: "http".to_string(),
+        version: server.clone().filter(|s| !s.is_empty()),
+        raw: server.unwrap_or_else(|| status_line.to_string()),
+    })
+}
+
+/// Parse a Redis `INFO` reply, returning the `redis_version` field
+pub fn parse_redis_banner(bytes: &[u8]) -> Option<ServiceBanner> {
+    let text = String::from_utf8_lossy(bytes);
+    let first = text.lines().next().unwrap_or("").trim();
+    // Look for "redis_version:<x.y.z>"
+    let version = text
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("redis_version:"))
+        .map(|v| v.trim().to_string());
+    if version.is_none() && !first.starts_with('$') && !first.starts_with("# Server") {
+        return None;
+    }
+    Some(ServiceBanner {
+        protocol: "redis".to_string(),
+        version,
+        raw: first.chars().take(BANNER_READ_LIMIT).collect(),
+    })
+}
+
+/// Parse a memcached `version` reply (`VERSION 1.6.21`)
+pub fn parse_memcached_banner(bytes: &[u8]) -> Option<ServiceBanner> {
+    let raw = render_first_line(bytes);
+    let version = raw.strip_prefix("VERSION ").map(|v| v.trim().to_string());
+    version.as_ref()?;
+    Some(ServiceBanner {
+        protocol: "memcached".to_string(),
+        version,
+        raw,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ssh_banner_extracts_software_version() {
+        let banner = parse_ssh_banner(b"SSH-2.0-OpenSSH_8.6p1 Ubuntu-4ubuntu0.1\r\n").unwrap();
+        assert_eq!(banner.protocol, "ssh");
+        assert_eq!(banner.version.as_deref(), Some("OpenSSH_8.6p1"));
+        assert!(banner.raw.starts_with("SSH-2.0-OpenSSH_8.6p1"));
+    }
+
+    #[test]
+    fn ssh_banner_handles_missing_software() {
+        let banner = parse_ssh_banner(b"SSH-1.99-\r\n").unwrap();
+        assert_eq!(banner.protocol, "ssh");
+        assert!(banner.version.is_none());
+    }
+
+    #[test]
+    fn ssh_banner_rejects_non_ssh_input() {
+        assert!(parse_ssh_banner(b"HTTP/1.1 200 OK\r\n").is_none());
+    }
+
+    #[test]
+    fn http_banner_extracts_server_header() {
+        let bytes = b"HTTP/1.1 200 OK\r\nServer: nginx/1.25.0\r\nContent-Length: 0\r\n\r\n";
+        let banner = parse_http_banner(bytes).unwrap();
+        assert_eq!(banner.protocol, "http");
+        assert_eq!(banner.version.as_deref(), Some("nginx/1.25.0"));
+        assert_eq!(banner.raw, "nginx/1.25.0");
+    }
+
+    #[test]
+    fn http_banner_without_server_header_keeps_status_line() {
+        let bytes = b"HTTP/1.0 404 Not Found\r\nContent-Length: 0\r\n\r\n";
+        let banner = parse_http_banner(bytes).unwrap();
+        assert_eq!(banner.protocol, "http");
+        assert!(banner.version.is_none());
+        assert_eq!(banner.raw, "HTTP/1.0 404 Not Found");
+    }
+
+    #[test]
+    fn http_banner_rejects_non_http_input() {
+        assert!(parse_http_banner(b"+OK Redis ready\r\n").is_none());
+    }
+
+    #[test]
+    fn smtp_banner_extracts_software() {
+        let bytes = b"220 mail.example.com ESMTP Postfix (Debian/GNU)\r\n";
+        let banner = parse_smtp_banner(bytes).unwrap();
+        assert_eq!(banner.protocol, "smtp");
+        assert_eq!(
+            banner.version.as_deref(),
+            Some("ESMTP Postfix (Debian/GNU)")
+        );
+    }
+
+    #[test]
+    fn smtp_banner_handles_multiline_prefix() {
+        let bytes = b"220-mail.example.com SMTP server ready\r\n";
+        let banner = parse_smtp_banner(bytes).unwrap();
+        assert_eq!(banner.protocol, "smtp");
+        assert_eq!(banner.version.as_deref(), Some("SMTP server ready"));
+    }
+
+    #[test]
+    fn smtp_banner_rejects_non_220_input() {
+        assert!(parse_smtp_banner(b"HELO test\r\n").is_none());
+    }
+
+    #[test]
+    fn ftp_banner_records_greeting() {
+        let banner = parse_ftp_banner(b"220 (vsFTPd 3.0.5)\r\n").unwrap();
+        assert_eq!(banner.protocol, "ftp");
+        assert_eq!(banner.version.as_deref(), Some("(vsFTPd 3.0.5)"));
+    }
+
+    #[test]
+    fn redis_banner_parses_version_field() {
+        let bytes = b"$3636\r\n# Server\r\nredis_version:7.2.4\r\nos:Linux\r\n";
+        let banner = parse_redis_banner(bytes).unwrap();
+        assert_eq!(banner.protocol, "redis");
+        assert_eq!(banner.version.as_deref(), Some("7.2.4"));
+    }
+
+    #[test]
+    fn memcached_banner_parses_version() {
+        let banner = parse_memcached_banner(b"VERSION 1.6.21\r\n").unwrap();
+        assert_eq!(banner.protocol, "memcached");
+        assert_eq!(banner.version.as_deref(), Some("1.6.21"));
+    }
+
+    #[test]
+    fn memcached_banner_rejects_unknown_reply() {
+        assert!(parse_memcached_banner(b"ERROR\r\n").is_none());
+    }
+
+    #[test]
+    fn telnet_banner_records_non_empty_line() {
+        let banner = parse_telnet_banner(b"\xffsome login prompt\r\n").unwrap();
+        assert_eq!(banner.protocol, "telnet");
+        assert!(banner.raw.contains("some login prompt"));
+    }
+
+    #[test]
+    fn telnet_banner_rejects_empty_input() {
+        assert!(parse_telnet_banner(b"").is_none());
+    }
+}

--- a/src-tauri/src/network/discovery.rs
+++ b/src-tauri/src/network/discovery.rs
@@ -41,6 +41,10 @@ pub enum DiscoveryMethod {
     WsDiscovery,
     /// ARP cache reading (no privileges needed)
     ArpCache,
+    /// SNMP sysName broadcast across the target range
+    Snmp,
+    /// LLMNR multicast PTR queries across the target range
+    Llmnr,
     /// Skip host discovery, scan all targets
     None,
 }
@@ -54,6 +58,8 @@ impl std::fmt::Display for DiscoveryMethod {
             Self::UdpScan => "udp_scan",
             Self::WsDiscovery => "ws_discovery",
             Self::ArpCache => "arp_cache",
+            Self::Snmp => "snmp",
+            Self::Llmnr => "llmnr",
             Self::None => "none",
         };
         write!(f, "{name}")
@@ -94,6 +100,9 @@ pub struct HostMetadata {
     /// TLS certificate Subject Alternative Names (dNSName)
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub tls_names: Vec<String>,
+    /// Service banners collected via TCP banner-grab
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub banners: Vec<super::banner::ServiceBanner>,
 }
 
 /// mDNS service information for a host
@@ -367,6 +376,8 @@ async fn execute_discovery_method(
         DiscoveryMethod::UdpScan => udp_scan_discovery(targets, options).await,
         DiscoveryMethod::WsDiscovery => ws_discovery_method(options).await,
         DiscoveryMethod::ArpCache => arp_cache_discovery(targets),
+        DiscoveryMethod::Snmp => snmp_discovery(targets, options).await,
+        DiscoveryMethod::Llmnr => llmnr_discovery(targets, options).await,
         DiscoveryMethod::None => DiscoveryResult {
             method: "none".to_string(),
             hosts: targets.iter().map(ToString::to_string).collect(),
@@ -907,6 +918,10 @@ async fn mdns_discovery(options: &DiscoveryOptions) -> DiscoveryResult {
 // =============================================================================
 
 /// Discover hosts using TCP connect scan (no privileges needed)
+///
+/// After the first successful connect to any probe port, attempts a banner-grab
+/// against the recognised banner ports already in the candidate list and
+/// attaches the resulting [`ServiceBanner`]s to the host metadata.
 async fn tcp_connect_discovery(targets: &[IpAddr], options: &DiscoveryOptions) -> DiscoveryResult {
     let start = std::time::Instant::now();
     let timeout_duration = Duration::from_millis(u64::from(options.timeout_ms));
@@ -918,43 +933,38 @@ async fn tcp_connect_discovery(targets: &[IpAddr], options: &DiscoveryOptions) -
         .as_ref()
         .map_or(CONNECT_DISCOVERY_PORTS, Vec::as_slice);
 
+    let handles: Vec<_> = targets
+        .iter()
+        .copied()
+        .map(|target| {
+            let sem = Arc::clone(&semaphore);
+            let ports = ports.to_vec();
+            tokio::spawn(async move {
+                let _permit = sem.acquire().await;
+                probe_target(target, &ports, timeout_duration).await
+            })
+        })
+        .collect();
+
     let mut hosts = Vec::new();
     let mut unreachable = Vec::new();
+    let mut host_metadata: std::collections::HashMap<String, HostMetadata> =
+        std::collections::HashMap::new();
 
-    let mut handles = Vec::with_capacity(targets.len());
-
-    for &target in targets {
-        let sem = Arc::clone(&semaphore);
-        let ports = ports.to_vec();
-
-        let handle = tokio::spawn(async move {
-            let _permit = sem.acquire().await;
-
-            // Try connecting to any of the common ports
-            for port in &ports {
-                let addr = std::net::SocketAddr::new(target, *port);
-                if let Ok(result) =
-                    timeout(timeout_duration, tokio::net::TcpStream::connect(addr)).await
-                {
-                    if result.is_ok() {
-                        return (target, true);
-                    }
-                }
-            }
-
-            (target, false)
-        });
-
-        handles.push(handle);
-    }
-
-    // Collect results
     for handle in handles {
-        if let Ok((target, reachable)) = handle.await {
-            if reachable {
-                hosts.push(target.to_string());
+        if let Ok(probe) = handle.await {
+            let ip_str = probe.target.to_string();
+            if probe.reachable {
+                hosts.push(ip_str.clone());
+                if !probe.banners.is_empty() {
+                    host_metadata
+                        .entry(ip_str)
+                        .or_default()
+                        .banners
+                        .extend(probe.banners);
+                }
             } else {
-                unreachable.push(target.to_string());
+                unreachable.push(ip_str);
             }
         }
     }
@@ -963,11 +973,58 @@ async fn tcp_connect_discovery(targets: &[IpAddr], options: &DiscoveryOptions) -
         method: "tcp_connect".to_string(),
         hosts,
         hostnames: std::collections::HashMap::new(),
-        host_metadata: std::collections::HashMap::new(),
+        host_metadata,
         unreachable,
         duration_ms: start.elapsed().as_millis() as u64,
         error: None,
         requires_privileges: false,
+    }
+}
+
+/// Result of probing a single target during TCP connect discovery.
+struct TcpProbeOutcome {
+    target: IpAddr,
+    reachable: bool,
+    banners: Vec<super::banner::ServiceBanner>,
+}
+
+/// Ports for which we know how to parse a banner. Limits banner-grab cost.
+const BANNER_GRAB_PORTS: &[u16] = &[21, 22, 23, 25, 80, 443, 587, 6379, 8080, 8443, 11211];
+
+/// Connect to each probe port and gather banners from supported services.
+async fn probe_target(
+    target: IpAddr,
+    ports: &[u16],
+    timeout_duration: Duration,
+) -> TcpProbeOutcome {
+    let mut reachable = false;
+    let mut banners = Vec::new();
+
+    for port in ports {
+        let addr = SocketAddr::new(target, *port);
+        let connect = timeout(timeout_duration, tokio::net::TcpStream::connect(addr)).await;
+        let stream = match connect {
+            Ok(Ok(stream)) => stream,
+            _ => continue,
+        };
+        reachable = true;
+
+        if BANNER_GRAB_PORTS.contains(port) {
+            if let Some(banner) = super::banner::grab_banner(stream, *port).await {
+                if !banners
+                    .iter()
+                    .any(|existing: &super::banner::ServiceBanner| existing == &banner)
+                {
+                    banners.push(banner);
+                }
+            }
+        }
+    }
+
+    TcpProbeOutcome {
+        target,
+        reachable,
+        banners,
     }
 }
 
@@ -994,6 +1051,8 @@ pub fn get_available_methods() -> Vec<(DiscoveryMethod, bool)> {
         (DiscoveryMethod::UdpScan, true),
         (DiscoveryMethod::WsDiscovery, true),
         (DiscoveryMethod::ArpCache, true),
+        (DiscoveryMethod::Snmp, true),
+        (DiscoveryMethod::Llmnr, true),
         (DiscoveryMethod::None, true),
     ]
 }
@@ -1699,6 +1758,159 @@ async fn ws_discovery_method(options: &DiscoveryOptions) -> DiscoveryResult {
         hostnames: std::collections::HashMap::new(),
         host_metadata,
         unreachable: vec![],
+        duration_ms: start.elapsed().as_millis() as u64,
+        error: None,
+        requires_privileges: false,
+    }
+}
+
+// =============================================================================
+// SNMP Discovery (broadcast sysName query)
+// =============================================================================
+
+/// Maximum concurrent SNMP probes
+const SNMP_DISCOVERY_CONCURRENCY: usize = 64;
+
+/// Per-host SNMP query timeout
+const SNMP_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// SNMP communities to try, in order
+const SNMP_DISCOVERY_COMMUNITIES: &[&str] = &["public", "private"];
+
+/// Discover hosts via SNMP sysName GetRequest across the target range.
+///
+/// For each target, sends an SNMPv2c `sysName.0` query in a blocking task,
+/// trying each community in [`SNMP_DISCOVERY_COMMUNITIES`]. Successful
+/// responses are recorded as reachable hosts with populated `snmp_info`.
+async fn snmp_discovery(targets: &[IpAddr], _options: &DiscoveryOptions) -> DiscoveryResult {
+    let start = std::time::Instant::now();
+    let semaphore = Arc::new(Semaphore::new(SNMP_DISCOVERY_CONCURRENCY));
+
+    let handles: Vec<_> = targets
+        .iter()
+        .copied()
+        .map(|target| {
+            let sem = Arc::clone(&semaphore);
+            tokio::spawn(async move {
+                let _permit = sem.acquire().await.ok()?;
+                let info = tokio::task::spawn_blocking(move || {
+                    SNMP_DISCOVERY_COMMUNITIES.iter().find_map(|community| {
+                        super::snmp::query_snmp_device_info_with_community(
+                            target,
+                            community.as_bytes(),
+                            SNMP_DISCOVERY_TIMEOUT,
+                        )
+                    })
+                })
+                .await
+                .ok()
+                .flatten()?;
+                Some((target, info))
+            })
+        })
+        .collect();
+
+    let mut hosts = Vec::new();
+    let mut host_metadata: std::collections::HashMap<String, HostMetadata> =
+        std::collections::HashMap::new();
+    let mut unreachable: Vec<String> = targets.iter().map(ToString::to_string).collect();
+
+    for handle in handles {
+        if let Ok(Some((target, info))) = handle.await {
+            let ip_str = target.to_string();
+            unreachable.retain(|ip| ip != &ip_str);
+            hosts.push(ip_str.clone());
+
+            let hostname = info.sys_name.clone();
+            host_metadata.insert(
+                ip_str,
+                HostMetadata {
+                    hostname: hostname.clone(),
+                    hostname_source: hostname.as_ref().map(|_| "snmp".to_string()),
+                    snmp_info: Some(info),
+                    ..Default::default()
+                },
+            );
+        }
+    }
+
+    DiscoveryResult {
+        method: "snmp".to_string(),
+        hosts,
+        hostnames: std::collections::HashMap::new(),
+        host_metadata,
+        unreachable,
+        duration_ms: start.elapsed().as_millis() as u64,
+        error: None,
+        requires_privileges: false,
+    }
+}
+
+// =============================================================================
+// LLMNR Discovery (multicast reverse PTR queries)
+// =============================================================================
+
+/// Total time budget for LLMNR collection
+const LLMNR_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Maximum concurrent LLMNR queries
+const LLMNR_DISCOVERY_CONCURRENCY: usize = 64;
+
+/// Discover hosts via LLMNR multicast PTR resolution of every target IP.
+///
+/// LLMNR has no wildcard concept, so we follow Windows' own approach: issue
+/// reverse PTR queries (`x.in-addr.arpa` for IPv4) toward the LLMNR multicast
+/// group and treat any responding host as alive with the resolved hostname.
+/// The whole batch runs concurrently; the function returns once every spawned
+/// probe finishes or its per-query timeout elapses, capped by
+/// [`LLMNR_DISCOVERY_TIMEOUT`].
+async fn llmnr_discovery(targets: &[IpAddr], _options: &DiscoveryOptions) -> DiscoveryResult {
+    let start = std::time::Instant::now();
+    let semaphore = Arc::new(Semaphore::new(LLMNR_DISCOVERY_CONCURRENCY));
+
+    let handles: Vec<_> = targets
+        .iter()
+        .copied()
+        .map(|target| {
+            let sem = Arc::clone(&semaphore);
+            tokio::spawn(async move {
+                let _permit = sem.acquire().await.ok()?;
+                let ip_str = target.to_string();
+                let name = super::llmnr::resolve_hostname(&ip_str, LLMNR_DISCOVERY_TIMEOUT).await?;
+                Some((target, name))
+            })
+        })
+        .collect();
+
+    let mut hostnames = std::collections::HashMap::new();
+    let mut host_metadata: std::collections::HashMap<String, HostMetadata> =
+        std::collections::HashMap::new();
+    let mut hosts = Vec::new();
+    let mut unreachable: Vec<String> = targets.iter().map(ToString::to_string).collect();
+
+    for handle in handles {
+        if let Ok(Some((target, name))) = handle.await {
+            let ip_str = target.to_string();
+            unreachable.retain(|ip| ip != &ip_str);
+            hosts.push(ip_str.clone());
+            hostnames.insert(ip_str.clone(), name.clone());
+            host_metadata.insert(
+                ip_str,
+                HostMetadata {
+                    hostname: Some(name),
+                    hostname_source: Some("llmnr".to_string()),
+                    ..Default::default()
+                },
+            );
+        }
+    }
+
+    DiscoveryResult {
+        method: "llmnr".to_string(),
+        hosts,
+        hostnames,
+        host_metadata,
+        unreachable,
         duration_ms: start.elapsed().as_millis() as u64,
         error: None,
         requires_privileges: false,

--- a/src-tauri/src/network/mod.rs
+++ b/src-tauri/src/network/mod.rs
@@ -55,6 +55,7 @@
 //! coordinated through per-operation tokens tracked by [`NetworkScannerState`].
 
 mod arp_cache;
+mod banner;
 pub mod discovery;
 pub mod interfaces;
 mod llmnr;

--- a/src-tauri/src/network/snmp.rs
+++ b/src-tauri/src/network/snmp.rs
@@ -74,6 +74,21 @@ fn extract_string(value: &Value<'_>) -> Option<String> {
 /// Returns SnmpDeviceInfo if the device responds to any query.
 #[allow(clippy::large_stack_frames)]
 pub fn query_snmp_device_info(ip: IpAddr, timeout: Duration) -> Option<SnmpDeviceInfo> {
+    query_snmp_device_info_with_community(ip, DEFAULT_COMMUNITY, timeout)
+}
+
+/// Query SNMP system information using a caller-supplied community string.
+///
+/// Returns `Some(info)` when at least one MIB-2 system OID resolves; `None`
+/// when the host fails to open a session or returns no usable varbinds. Used
+/// by discovery to try alternative communities (e.g. `private`) when `public`
+/// is rejected.
+#[allow(clippy::large_stack_frames)]
+pub fn query_snmp_device_info_with_community(
+    ip: IpAddr,
+    community: &[u8],
+    timeout: Duration,
+) -> Option<SnmpDeviceInfo> {
     let addr = format!("{ip}:{SNMP_PORT}");
 
     let sys_name_oid = Oid::from(&SYS_NAME_OID).ok()?;
@@ -81,7 +96,7 @@ pub fn query_snmp_device_info(ip: IpAddr, timeout: Duration) -> Option<SnmpDevic
     let sys_location_oid = Oid::from(&SYS_LOCATION_OID).ok()?;
     let sys_contact_oid = Oid::from(&SYS_CONTACT_OID).ok()?;
 
-    let mut session = SyncSession::new_v2c(&addr, DEFAULT_COMMUNITY, Some(timeout), 0).ok()?;
+    let mut session = SyncSession::new_v2c(&addr, community, Some(timeout), 0).ok()?;
 
     let mut info = SnmpDeviceInfo::default();
 

--- a/src/lib/services/device-classifier.test.ts
+++ b/src/lib/services/device-classifier.test.ts
@@ -21,6 +21,7 @@ const createHost = (overrides: Partial<UnifiedHost> = {}): UnifiedHost => ({
 	wsDiscovery: null,
 	snmpInfo: null,
 	tlsNames: [],
+	serviceBanners: [],
 	discoveryMethods: [],
 	discoveries: [],
 	ports: [],

--- a/src/lib/services/network-scanner.test.ts
+++ b/src/lib/services/network-scanner.test.ts
@@ -272,4 +272,85 @@ describe('mergeHosts', () => {
 		expect(result[0]?.ports.map((p) => p.port)).toEqual([22, 443]);
 		expect(result[0]?.scanDurationMs).toBe(1500);
 	});
+
+	it('surfaces TCP banner-grab results on UnifiedHost.serviceBanners', () => {
+		const discovery = buildDiscoveryResult({
+			method: 'tcp_connect',
+			hosts: ['192.168.1.90'],
+			hostMetadata: {
+				'192.168.1.90': buildMetadata({
+					banners: [
+						{ protocol: 'ssh', version: 'OpenSSH_8.6p1', raw: 'SSH-2.0-OpenSSH_8.6p1' },
+						{ protocol: 'http', version: 'nginx/1.25.0', raw: 'nginx/1.25.0' },
+					],
+				}),
+			},
+		});
+
+		const result = mergeHosts([discovery], []);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.serviceBanners).toHaveLength(2);
+		expect(result[0]?.serviceBanners.map((b) => b.protocol)).toEqual(['ssh', 'http']);
+		expect(result[0]?.serviceBanners[0]?.version).toBe('OpenSSH_8.6p1');
+	});
+
+	it('deduplicates identical banners reported by multiple discoveries', () => {
+		const a = buildDiscoveryResult({
+			method: 'tcp_connect',
+			hosts: ['192.168.1.91'],
+			hostMetadata: {
+				'192.168.1.91': buildMetadata({
+					banners: [{ protocol: 'ssh', version: 'OpenSSH_9.0', raw: 'SSH-2.0-OpenSSH_9.0' }],
+				}),
+			},
+		});
+		const b = buildDiscoveryResult({
+			method: 'tcp_connect',
+			hosts: ['192.168.1.91'],
+			hostMetadata: {
+				'192.168.1.91': buildMetadata({
+					banners: [{ protocol: 'ssh', version: 'OpenSSH_9.0', raw: 'SSH-2.0-OpenSSH_9.0' }],
+				}),
+			},
+		});
+
+		const result = mergeHosts([a, b], []);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.serviceBanners).toHaveLength(1);
+	});
+
+	it('merges v4 mDNS with v6 SNMP via shared sysName signal', () => {
+		const mdns = buildDiscoveryResult({
+			method: 'mdns',
+			hosts: ['192.168.1.100'],
+			hostnames: { '192.168.1.100': 'switch.local' },
+			hostMetadata: {
+				'192.168.1.100': buildMetadata({
+					hostname: 'switch.local',
+					hostnameSource: 'mdns',
+				}),
+			},
+		});
+		const snmp = buildDiscoveryResult({
+			method: 'snmp',
+			hosts: ['fe80::cafe'],
+			hostMetadata: {
+				'fe80::cafe': buildMetadata({
+					hostname: 'switch',
+					hostnameSource: 'snmp',
+					snmpInfo: { sysName: 'switch', sysDescr: 'Cisco' },
+				}),
+			},
+		});
+
+		const result = mergeHosts([mdns, snmp], []);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.ips.sort()).toEqual(['192.168.1.100', 'fe80::cafe']);
+		// mDNS retains priority over SNMP for the displayed hostname.
+		expect(result[0]?.hostname).toBe('switch.local');
+		expect(result[0]?.snmpInfo?.sysName).toBe('switch');
+	});
 });

--- a/src/lib/services/network-scanner.ts
+++ b/src/lib/services/network-scanner.ts
@@ -267,6 +267,8 @@ export type DiscoveryMethod =
 	| 'udp_scan'
 	| 'ws_discovery'
 	| 'arp_cache'
+	| 'snmp'
+	| 'llmnr'
 	| 'none';
 
 export interface DiscoveryOptions {
@@ -331,6 +333,16 @@ export interface SnmpDeviceInfo {
 	readonly sysContact?: string;
 }
 
+/** Service banner harvested by TCP banner-grab during discovery */
+export interface ServiceBanner {
+	/** Detected protocol (ssh, http, smtp, redis, memcached, ftp, telnet) */
+	readonly protocol: string;
+	/** Parsed product / version string when extractable */
+	readonly version?: string;
+	/** Truncated raw banner bytes for display */
+	readonly raw: string;
+}
+
 /** Host metadata collected during discovery */
 export interface HostMetadata {
 	/** Hostname (from mDNS, DNS reverse lookup, NetBIOS, SNMP, TLS, etc.) */
@@ -353,6 +365,8 @@ export interface HostMetadata {
 	readonly snmpInfo?: SnmpDeviceInfo;
 	/** TLS certificate Subject Alternative Names (dNSName) */
 	readonly tlsNames: readonly string[];
+	/** Service banners harvested via TCP banner-grab */
+	readonly banners?: readonly ServiceBanner[];
 }
 
 export interface DiscoveryResult {
@@ -425,7 +439,33 @@ export const DISCOVERY_METHODS = [
 		description: 'Read OS ARP cache for MAC addresses (no scan)',
 		requiresPrivileges: false,
 	},
+	{
+		value: 'snmp' as const,
+		label: 'SNMP Broadcast',
+		description: 'Query sysName via SNMP v2c (opt-in, can be noisy)',
+		requiresPrivileges: false,
+	},
+	{
+		value: 'llmnr' as const,
+		label: 'LLMNR',
+		description: 'Multicast PTR resolution for Windows-style hosts',
+		requiresPrivileges: false,
+	},
 ] as const;
+
+/**
+ * Discovery methods that are enabled by default. SNMP is intentionally
+ * excluded because broadcast SNMP queries can be noisy on some networks.
+ */
+export const DEFAULT_DISCOVERY_METHODS: readonly DiscoveryMethod[] = [
+	'tcp_connect',
+	'mdns',
+	'ssdp',
+	'udp_scan',
+	'ws_discovery',
+	'arp_cache',
+	'llmnr',
+];
 
 export const DEFAULT_SYN_PORTS = [22, 80, 443, 445, 3389] as const;
 
@@ -622,6 +662,8 @@ export interface UnifiedHost {
 	snmpInfo: SnmpDeviceInfo | null;
 	/** TLS certificate Subject Alternative Names */
 	tlsNames: string[];
+	/** Service banners harvested via TCP banner-grab */
+	serviceBanners: ServiceBanner[];
 	/** Discovery methods that found this host */
 	discoveryMethods: string[];
 	/** Discovery details */
@@ -840,6 +882,17 @@ const mergeScalarMetadata = (host: UnifiedHost, metadata: HostMetadata): void =>
 			if (!host.tlsNames.includes(name)) host.tlsNames.push(name);
 		}
 	}
+	if (metadata.banners && metadata.banners.length > 0) {
+		for (const banner of metadata.banners) {
+			const exists = host.serviceBanners.some(
+				(existing) =>
+					existing.protocol === banner.protocol &&
+					existing.version === banner.version &&
+					existing.raw === banner.raw
+			);
+			if (!exists) host.serviceBanners.push(banner);
+		}
+	}
 };
 
 /** Merge SSDP device info (field-level merge, preferring existing non-null values) */
@@ -922,6 +975,10 @@ const collectObservations = (
 				// NetBIOS name lives on metadata.netbiosName, not metadata.hostname.
 				// Treat it as a separate hostname signal for merging purposes.
 				recordHostname(observation, metadata.netbiosName, 'netbios');
+				// SNMP sysName may differ from metadata.hostname when another
+				// source already populated hostname; surface it as a signal so
+				// it participates in hostname-based union-find merging.
+				recordHostname(observation, metadata.snmpInfo?.sysName, 'snmp');
 				recordMac(observation, metadata.macAddress);
 			}
 		}
@@ -1011,6 +1068,7 @@ const buildUnifiedHost = (group: readonly IpObservation[]): UnifiedHost => {
 		wsDiscovery: null,
 		snmpInfo: null,
 		tlsNames: [],
+		serviceBanners: [],
 		discoveryMethods: [],
 		discoveries: [],
 		ports: [],

--- a/src/routes/network-scanner/+page.svelte
+++ b/src/routes/network-scanner/+page.svelte
@@ -37,6 +37,7 @@
 		cancelNetworkScan,
 		DATABASE_PORTS,
 		DEFAULT_CONCURRENCY,
+		DEFAULT_DISCOVERY_METHODS,
 		DEFAULT_SYN_PORTS,
 		DEFAULT_TIMEOUT_MS,
 		discoverHosts,
@@ -95,10 +96,9 @@
 	// Derived: any resolution enabled
 	const resolveHostname = $derived(resolveDns || resolveMdns || resolveNetbios);
 
-	// Discovery options (all remaining methods are userspace)
-	let discoveryMethods = $state<Set<DiscoveryMethod>>(
-		new Set(DISCOVERY_METHODS.map((m) => m.value))
-	);
+	// Discovery options (all remaining methods are userspace; SNMP is opt-in
+	// because broadcast SNMP queries can be noisy on some networks).
+	let discoveryMethods = $state<Set<DiscoveryMethod>>(new Set(DEFAULT_DISCOVERY_METHODS));
 	let discoveryResults = $state<DiscoveryResult[]>([]);
 	let isDiscovering = $state(false);
 
@@ -1177,6 +1177,7 @@
 								wsDiscovery={selectedHost.wsDiscovery}
 								snmpInfo={selectedHost.snmpInfo}
 								tlsNames={selectedHost.tlsNames}
+								serviceBanners={selectedHost.serviceBanners}
 								classification={hostClassifications.get(selectedHost.id) ?? null}
 								discoveryMethods={selectedHost.discoveryMethods}
 								discoveries={selectedHost.discoveries}

--- a/src/routes/network-scanner/components/unified-host-detail-panel.svelte
+++ b/src/routes/network-scanner/components/unified-host-detail-panel.svelte
@@ -50,6 +50,7 @@
 		MdnsServiceInfo,
 		PortInfo,
 		ScanProgress,
+		ServiceBanner,
 		SnmpDeviceInfo,
 		SsdpDeviceInfo,
 		WsDiscoveryInfo,
@@ -79,6 +80,7 @@
 		readonly wsDiscovery?: WsDiscoveryInfo | null;
 		readonly snmpInfo?: SnmpDeviceInfo | null;
 		readonly tlsNames?: readonly string[];
+		readonly serviceBanners?: readonly ServiceBanner[];
 		readonly classification?: DeviceClassification | null;
 		readonly discoveryMethods: readonly string[];
 		readonly discoveries: readonly DiscoveryInfo[];
@@ -102,6 +104,7 @@
 		wsDiscovery = null,
 		snmpInfo = null,
 		tlsNames = [],
+		serviceBanners = [],
 		classification = null,
 		discoveryMethods,
 		discoveries,
@@ -244,6 +247,8 @@
 		udp_scan: 'UDP Scan',
 		ws_discovery: 'WS-Discovery',
 		arp_cache: 'ARP Cache',
+		snmp: 'SNMP Broadcast',
+		llmnr: 'LLMNR',
 		local: 'Local',
 	};
 
@@ -263,6 +268,10 @@
 				return 'WS-Discovery (SOAP/UDP)';
 			case 'arp_cache':
 				return 'OS ARP Cache';
+			case 'snmp':
+				return 'SNMP sysName broadcast';
+			case 'llmnr':
+				return 'LLMNR multicast PTR resolution';
 			case 'local':
 				return 'Local Interface';
 			default:
@@ -757,6 +766,25 @@
 									<div class="text-sm">{snmpInfo.sysContact}</div>
 								</div>
 							{/if}
+						</div>
+					</div>
+				{/if}
+
+				<!-- Service Banners -->
+				{#if serviceBanners && serviceBanners.length > 0}
+					<div class="mb-4">
+						<SectionLabel icon={Terminal}>Service Banners</SectionLabel>
+						<div class="rounded-lg border bg-card p-3">
+							<div class="flex flex-wrap gap-1.5">
+								{#each serviceBanners as banner (banner.protocol + (banner.version ?? '') + banner.raw)}
+									<span class="rounded bg-muted px-1.5 py-0.5 font-mono text-xs" title={banner.raw}>
+										<span class="font-medium text-foreground">{banner.protocol}</span>
+										{#if banner.version}
+											<span class="text-muted-foreground">{banner.version}</span>
+										{/if}
+									</span>
+								{/each}
+							</div>
 						</div>
 					</div>
 				{/if}


### PR DESCRIPTION
## Summary

Adds three userspace-only host discovery enhancements to the Network Scanner. Continuation of the network-tooling track that started with #239 (sidecar removal) and #240 (v4/v6 merge fix).

- **TCP banner grab**: after every successful `TcpConnect`, read up to 256 bytes and parse SSH / HTTP / SMTP / FTP / Redis / memcached / Telnet banners. The host gains a `ServiceBanner` array (protocol, version, truncated raw fragment).
- **SNMP discovery** (`DiscoveryMethod::Snmp`): iterates targets, queries `sysName.0` over UDP 161 with communities `public` then `private`, 1 s per host, 64 concurrent. Opt-in (excluded from default-checked set).
- **LLMNR discovery** (`DiscoveryMethod::Llmnr`): issues reverse-PTR queries to `224.0.0.252:5355` (UDP) per target and collects responses for 2 s. Default-checked.

All three methods require **no elevated privilege**.

## Changes

### Added

- `src-tauri/src/network/banner.rs` (326 lines) — banner parsers for 7 protocols, each with positive / negative / malformed test cases.
- `ServiceBanner` Rust struct with `protocol: String`, `version: Option<String>`, `raw: String`.
- `DiscoveryMethod::Snmp` and `DiscoveryMethod::Llmnr` enum variants and their `Display`, `execute_discovery_method`, `get_available_methods`, `check_privileges` updates.
- `snmp_discovery()` and `llmnr_discovery()` async functions in `discovery.rs`.
- `query_snmp_device_info_with_community()` in `snmp.rs` to support the community-fallback path.
- `BANNER_GRAB_PORTS` constant — subset of `CONNECT_DISCOVERY_PORTS` that triggers banner attempts.
- `DEFAULT_DISCOVERY_METHODS` constant in `network-scanner.ts` (`mdns`, `tcp_connect`, `ssdp`, `arp_cache`, `udp_scan`, `ws_discovery`, `llmnr` — excludes `snmp`).
- `ServiceBanner` TypeScript interface and `banners?: readonly ServiceBanner[]` on `HostMetadata`, plus `serviceBanners: ServiceBanner[]` on `UnifiedHost`.
- Banner chip section in `unified-host-detail-panel.svelte`.

### Changed

- `tcp_connect_discovery()` in `discovery.rs` now calls `banner::grab_banner()` after a successful connect for ports in `BANNER_GRAB_PORTS`. Banners are deduped per host before being attached to `HostMetadata`.
- `collectObservations()` (frontend `mergeHosts`) now treats `metadata.snmpInfo.sysName` as a hostname signal, so SNMP responses union with mDNS / DNS / NetBIOS hits sharing the normalized hostname.
- `unified-host-detail-panel.svelte` renders banner chips and uses the existing SNMP info section.
- `+page.svelte` consumes `DEFAULT_DISCOVERY_METHODS` for the initial checked set.

## Rationale

- **Banner grab on existing TcpConnect**, rather than a new method, keeps the discovery model lean — `TcpConnect` users get free fingerprinting (SSH version, HTTP `Server:` header, etc.) without extra UI knobs.
- **SNMP opt-in**: probes can be visible to network monitoring tools and noisy on locked-down LANs. Default-off respects "do no harm" while keeping the feature one click away for users who want it.
- **LLMNR via PTR queries**: matches the actual Windows usage of LLMNR (reverse name resolution after IP discovery from other channels). The existing `llmnr::resolve_hostname` helper already issues PTR queries, so this enhancement is mostly wiring.
- **TLS handling for HTTPS banner grab**: the existing `tls_info` module handles full TLS handshake separately for SAN extraction. Banner grab on 443 / 8443 stays plain-text — most reverse proxies still answer `HEAD /` with a `Server:` header on those ports. Adding TLS-wrapped banner grab is a follow-up if needed.

## Test Plan

- [x] `cargo check` — no warnings.
- [x] `cargo clippy --no-deps` — no warnings (no `#[allow]` introduced).
- [x] `cargo test --lib` — **159 / 159** pass (15 new banner parser tests).
- [x] `bun run check` — svelte-check, validate-pages, audit-design all pass.
- [x] `bunx vitest run` — **137 / 137** pass across 4 files (3 new merge-host cases for banners + SNMP merge).
- [ ] Manual: `bun run tauri dev`, run Network Scanner on a LAN with at least:
    - A Linux server on TCP 22 → confirm `serviceBanners` shows `ssh: OpenSSH_*`.
    - A web server on TCP 80 → confirm `serviceBanners` shows `http: <Server header>`.
    - A managed network device with SNMP `public` community → enable SNMP method, confirm `sysName` populates and merges with other-method hits for the same host.
    - A Windows host → enable LLMNR method, confirm hostname resolution.

## Follow-ups (not in this PR)

- Backend identity hints PR — extend `DiscoveryResult` with SSDP `UDN` and WS-Discovery `EndpointReference` for stronger cross-method merging without depending on MAC or hostname.
- Optional TLS-wrapped HTTPS banner grab if the plain-text fallback proves insufficient on common reverse proxies.
