### PR TITLE
refactor(shell): unify rail width tokens and add edge-strip toggle

### DIFF
--- a/.claude/rules/svelte/layouts.md
+++ b/.claude/rules/svelte/layouts.md
@@ -22,7 +22,7 @@ Every page uses the `ToolShell` component (CSS Grid based):
 │          │ ├──────────┬─────────────────────────────────┐ │
 │  [Home]  │ │ Options  │                                  │ │
 │  [JSON]  │ │  Rail    │        Main Content Area         │ │
-│  [XML]   │ │ (w-64)   │                                  │ │
+│  [XML]   │ │(rail-w)  │                                  │ │
 │  [YAML]  │ │          │    (varies by pattern below)     │ │
 │  [SQL]   │ │          │                                  │ │
 │  [...]   │ ├──────────┴─────────────────────────────────┤ │
@@ -302,10 +302,24 @@ CSS Grid layout with areas: toolbar, rail, content, status.
 
 ### OptionsRail (`src/lib/components/shell/options-rail.svelte`)
 
-- Width: `w-64` (256px), collapsed: `w-10` (40px)
+- Width: `var(--rail-w)` (288px), collapsed: `var(--rail-w-collapsed)` (44px)
 - Uses `ScrollArea` for content overflow
-- Background: `bg-surface-2`
-- Border: `border-r border-border/60`
+- Background: `bg-sidebar`
+- Border: `border-r border-border/50`
+- Toggle interaction: edge-strip hit zone hugging the aside's right border
+  (mirrors the shadcn `SidebarRail` pattern). Hover surfaces a 2px vertical
+  accent line; `cursor-w-resize` when open, `cursor-e-resize` when collapsed.
+  In the collapsed state a `Settings2` icon button is also rendered as the
+  primary expand affordance because the narrow strip is too small to target
+  the edge-strip reliably.
+
+### Width Tokens
+
+| Token                | Value   | Usage                                                             |
+| -------------------- | ------- | ----------------------------------------------------------------- |
+| `--rail-w`           | 18rem   | Standard options rail width (OptionsRail, OptionsPanel)           |
+| `--rail-w-wide`      | 24rem   | Wide analytical panel (ReactiveSinglePage right accordion column) |
+| `--rail-w-collapsed` | 2.75rem | Collapsed-state width for any rail-like aside                     |
 
 ### StatusBar (`src/lib/components/shell/status-bar.svelte`)
 

--- a/src/app.css
+++ b/src/app.css
@@ -73,6 +73,7 @@
 	/* Layout */
 	--toolbar-h: 3rem;
 	--rail-w: 18rem;
+	--rail-w-wide: 24rem;
 	--rail-w-collapsed: 2.75rem;
 	--status-h: 1.75rem;
 	--editor-header-h: 2rem;

--- a/src/lib/components/panel/options-panel.svelte
+++ b/src/lib/components/panel/options-panel.svelte
@@ -13,7 +13,7 @@
 
 	let {
 		title = 'Options',
-		width = 'w-64',
+		width = 'w-[var(--rail-w)]',
 		show = $bindable(true),
 		onclose,
 		onopen,

--- a/src/lib/components/ui/collapsible-aside/collapsible-aside.svelte
+++ b/src/lib/components/ui/collapsible-aside/collapsible-aside.svelte
@@ -1,17 +1,18 @@
 <script lang="ts">
-	import { ChevronLeft, Settings2 } from '@lucide/svelte';
+	import { Settings2 } from '@lucide/svelte';
 	import type { Snippet } from 'svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as ScrollArea from '$lib/components/ui/scroll-area/index.js';
+	import { cn } from '$lib/utils.js';
 
 	interface Props {
 		/** Whether the aside is expanded. Bindable. */
 		show?: boolean;
-		/** Accessible label, used for collapse-button aria-label/title. */
+		/** Accessible label, used for toggle-button aria-label/title. */
 		readonly title?: string;
 		/** Background tone utility class (e.g., 'bg-sidebar', 'bg-surface-2'). */
 		readonly background?: string;
-		/** Width utility class for the expanded state (e.g., 'w-64'). */
+		/** Width utility class for the expanded state (e.g., 'w-[var(--rail-w)]'). */
 		readonly width?: string;
 		/** Content rendered inside the scrollable expanded body. */
 		readonly children?: Snippet;
@@ -25,62 +26,82 @@
 		show = $bindable(true),
 		title = 'Options',
 		background = 'bg-surface-2',
-		width = 'w-64',
+		width = 'w-[var(--rail-w)]',
 		children,
 		onclose,
 		onopen,
 	}: Props = $props();
 
-	const handleClose = () => {
-		show = false;
-		onclose?.();
-	};
-
-	const handleOpen = () => {
+	const handleToggle = () => {
+		if (show) {
+			show = false;
+			onclose?.();
+			return;
+		}
 		show = true;
 		onopen?.();
 	};
+
+	const toggleLabel = $derived(show ? `Collapse ${title}` : `Expand ${title}`);
 </script>
 
-{#if show}
-	<aside
-		class="flex h-full {width} flex-col overflow-hidden border-r border-border/50 {background}"
-		data-slot="collapsible-aside"
-		data-state="open"
-	>
+<!--
+	Edge-strip toggle mirrors `ui/sidebar/sidebar-rail.svelte`:
+	a thin absolute hit zone hugging the aside's right border. Hover
+	reveals a 2px vertical accent line via `::after`. `tabIndex={-1}`
+	matches SidebarRail (mouse-only affordance; keyboard users rely on
+	the explicit shortcut wired up at the page level).
+
+	The Settings2 button is retained as the primary expand affordance in
+	the collapsed state — the w-11 strip is too narrow to reliably target
+	the edge-strip with a pointer. In the open state the edge-strip is the
+	only toggle, matching how SidebarRail is the sidebar's only toggle.
+
+	The strip is positioned with `end-0` (inside the aside's right border)
+	rather than `-end-4` (overlapping outside, as SidebarRail does) because
+	`tool-shell .tool-rail { overflow: hidden }` would clip any outside
+	overflow in our grid layout.
+-->
+<aside
+	class={cn(
+		'relative flex h-full shrink-0 flex-col border-r border-border/50',
+		show ? cn(width, 'overflow-hidden') : 'w-[var(--rail-w-collapsed)]',
+		background
+	)}
+	data-slot="collapsible-aside"
+	data-state={show ? 'open' : 'closed'}
+>
+	{#if show}
 		<ScrollArea.Root class="min-h-0 flex-1">
 			<div class="py-3">
 				{@render children?.()}
 			</div>
 		</ScrollArea.Root>
-		<div class="flex h-8 shrink-0 items-center justify-end border-t border-border/30 px-2">
-			<Button
-				variant="ghost"
-				size="icon"
-				class="h-6 w-6"
-				onclick={handleClose}
-				aria-label="Collapse {title}"
-				title="Collapse {title}"
-			>
-				<ChevronLeft class="h-3.5 w-3.5" />
-			</Button>
-		</div>
-	</aside>
-{:else}
-	<aside
-		class="flex w-11 shrink-0 flex-col border-r border-border/50 {background}"
-		data-slot="collapsible-aside"
-		data-state="closed"
-	>
+	{:else}
 		<Button
 			variant="ghost"
 			size="icon"
 			class="m-1.5 h-8 w-8"
-			onclick={handleOpen}
+			onclick={handleToggle}
 			aria-label="Show {title}"
 			title="Show {title}"
 		>
 			<Settings2 class="h-4 w-4" />
 		</Button>
-	</aside>
-{/if}
+	{/if}
+
+	<button
+		type="button"
+		data-slot="collapsible-aside-rail"
+		aria-label={toggleLabel}
+		title={toggleLabel}
+		tabIndex={-1}
+		onclick={handleToggle}
+		class={cn(
+			'absolute inset-y-0 end-0 z-20 hidden w-4 transition-all ease-linear sm:flex',
+			'after:absolute after:inset-y-0 after:end-0 after:w-[2px]',
+			'hover:after:bg-border',
+			show ? 'cursor-w-resize' : 'cursor-e-resize'
+		)}
+	></button>
+</aside>

--- a/src/routes/regex-tester/+page.svelte
+++ b/src/routes/regex-tester/+page.svelte
@@ -427,8 +427,14 @@
 				</Card.Root>
 			</div>
 
-			<!-- Right column: accordion -->
-			<div class="w-96 shrink-0 overflow-auto border-l bg-surface-2 p-4">
+			<!--
+				Right column: analytical accordion.
+				Width uses `--rail-w-wide` (24rem) rather than `--rail-w` (18rem) because
+				this panel hosts multiple stacked accordion sections (Matches, Explain,
+				...) whose content density needs more horizontal room than a standard
+				options rail of flat option groups.
+			-->
+			<div class="w-[var(--rail-w-wide)] shrink-0 overflow-auto border-l bg-surface-2 p-4">
 				<Accordion.Root type="multiple" value={['matches', 'explain']} class="w-full">
 					<Accordion.Item value="matches">
 						<Accordion.Trigger>


### PR DESCRIPTION
## Summary

Two layout-shell consistency fixes that address user-reported issues:

- **Rail widths now use named tokens.** `--rail-w` (18rem) for standard rails, `--rail-w-wide` (24rem) for the analytical accordion column in ReactiveSinglePage pages (regex tester), `--rail-w-collapsed` (2.75rem) for the collapsed strip.
- **CollapsibleAside / Sidebar collapse parity.** Replace the bottom-right `ChevronLeft` button on `CollapsibleAside` with an edge-strip toggle that mirrors `SidebarRail`'s interaction pattern. Same hover treatment (2px vertical accent), same resize cursor language.

## Why

The user reported:

1. Rail widths were inconsistent across pages — regex tester's right column was a hardcoded `w-96` while standard tools used `var(--rail-w)`. The `layouts.md` doc still mentioned `w-64 (256px)` which had been stale since the rail was widened.
2. Sidebar and Rail look like the same kind of element (a collapsible vertical panel docked to a side), yet they used different collapse interactions. Sidebar used the elegant edge-strip pattern; Rail used a corner button. Mixing patterns for the same role forces the user to re-learn for each panel.

## Changes

### Added
- `--rail-w-wide` CSS variable in `src/app.css`.
- Edge-strip toggle inside `CollapsibleAside`, available in both open and collapsed states. Class set mirrors `SidebarRail`:
    - `absolute inset-y-0 end-0 z-20 w-4 sm:flex`
    - `after:` overlay for the 2px accent line on hover
    - `cursor-w-resize` / `cursor-e-resize` depending on state
- "Width Tokens" table in `.claude/rules/svelte/layouts.md` documenting the three named width tokens.

### Changed
- `CollapsibleAside` rewritten as a single aside element with `data-state="open|closed"` instead of a fork between open and closed asides. Reduces duplication and lets the edge-strip live in one place.
- `CollapsibleAside` default `width` updated from `w-64` (stale 256px) to `w-[var(--rail-w)]` so consumers that don't override get the standard width.
- `OptionsPanel` default `width` updated identically.
- `regex-tester/+page.svelte` right accordion column changed from `w-96` to `w-[var(--rail-w-wide)]` with a comment explaining the deliberate wider variant.

### Removed
- Bottom-right `ChevronLeft` ghost button from `CollapsibleAside`'s open state (replaced by the edge-strip).

## Deviation from `SidebarRail`

`SidebarRail` positions itself at `-end-4` (half outside the sidebar's border). `CollapsibleAside`'s edge-strip uses `end-0` (flush inside the border) because `ToolShell .tool-rail { overflow: hidden }` would clip an outside overflow in the grid layout. Documented in a comment block at the top of the component. If we ever want a perfect visual match, the `tool-rail` grid cell needs `overflow: visible` (flagged for a future pass).

## Test Plan

- [x] `cargo check` — passes (10.45s).
- [x] `bun run check` — svelte-check 0 errors / 0 warnings, page validation OK, design audit OK.
- [x] `bunx vitest run` — 140 / 140 tests pass.
- [x] `bun run format:check` — clean.
- [x] Audit grep `\b(w-64|w-72|w-80|w-96)\b` across `src/` — zero rail-like hits remain.
- [ ] Manual: `bun run tauri dev`, navigate to any tool with a rail (e.g., base64-encoder). Click the right edge of the rail — confirm it collapses. Click again — confirm it expands. Hover the edge — confirm the 2px accent line appears.
- [ ] Manual: navigate to the regex tester. Confirm the right accordion column is at the wider `--rail-w-wide` (384px) and accordion content is comfortably laid out.

## Follow-ups (out of scope)

- `OptionsPanel` and `OptionsRail` are now functionally near-identical (only `background` differs: `bg-surface-2` vs `bg-sidebar`). Consider merging into a single `OptionsRail` with a `variant` prop.
- `ToolShell .tool-rail { overflow: hidden }` blocks the SidebarRail-style `-end-4` outside-overflow positioning. Lifting this would let CollapsibleAside's edge-strip match SidebarRail pixel-for-pixel.
