### PR TITLE
refactor(ui): visual baseline polish across all tool pages

### DIFF
--- a/src/lib/components/ui/button/button.svelte
+++ b/src/lib/components/ui/button/button.svelte
@@ -3,8 +3,11 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 	import { cn, type WithElementRef } from '$lib/utils.js';
 
+	// Divergence from registry: cursor-pointer / cursor-not-allowed are added on the base so
+	// every Button on the desktop app shows a proper click affordance (Tailwind v4 Preflight
+	// resets the native <button> cursor to default).
 	export const buttonVariants = tv({
-		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium outline-none transition-all focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium outline-none transition-all focus-visible:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		variants: {
 			variant: {
 				default: 'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',

--- a/src/lib/components/ui/list-item-button/list-item-button.svelte
+++ b/src/lib/components/ui/list-item-button/list-item-button.svelte
@@ -4,8 +4,11 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 	import { cn, type WithElementRef } from '$lib/utils.js';
 
+	// Divergence from registry: cursor-pointer / cursor-not-allowed are added on the base so
+	// every list row shows a proper click affordance (Tailwind v4 Preflight resets the native
+	// <button> cursor to default).
 	export const listItemButtonVariants = tv({
-		base: "focus-visible:border-ring focus-visible:ring-ring/50 inline-flex w-full shrink-0 items-center gap-2 text-left outline-none transition-colors focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		base: "focus-visible:border-ring focus-visible:ring-ring/50 inline-flex w-full shrink-0 cursor-pointer items-center gap-2 text-left outline-none transition-colors focus-visible:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		variants: {
 			variant: {
 				default:

--- a/src/routes/base64-encoder/+page.svelte
+++ b/src/routes/base64-encoder/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { Code2 } from '@lucide/svelte';
 	import { CodeEditor } from '$lib/components/editor';
 	import {
 		FormCheckbox,
@@ -8,9 +9,9 @@
 		FormSection,
 		FormSelect,
 	} from '$lib/components/form';
-	import { SplitPane } from '$lib/components/layout';
+	import { SectionHeader, SplitPane } from '$lib/components/layout';
 	import { ToolShell } from '$lib/components/shell';
-	import { StatItem } from '$lib/components/status';
+	import { EmbeddedEmptyState, StatItem } from '$lib/components/status';
 	import {
 		BASE64_MIME_TYPES,
 		type Base64DecodeOptions,
@@ -259,15 +260,31 @@
 			/>
 		{/snippet}
 		{#snippet right()}
-			<CodeEditor
-				title={mode === 'encode' ? 'Base64 Output' : 'Decoded Text'}
-				value={output}
-				mode="readonly"
-				editorMode="plain"
-				placeholder={mode === 'encode' ? 'Encoded output...' : 'Decoded output...'}
-				oncopy={handleCopy}
-				showViewToggle={false}
-			/>
+			{#if !input.trim()}
+				<div class="flex h-full flex-col overflow-hidden">
+					<SectionHeader title={mode === 'encode' ? 'Base64 Output' : 'Decoded Text'} />
+					<div class="flex-1">
+						<EmbeddedEmptyState
+							icon={Code2}
+							title={mode === 'encode' ? 'Enter text to encode' : 'Paste Base64 to decode'}
+							description={mode === 'encode'
+								? 'The Base64-encoded result will appear here.'
+								: 'The decoded plain text will appear here.'}
+							fillHeight
+						/>
+					</div>
+				</div>
+			{:else}
+				<CodeEditor
+					title={mode === 'encode' ? 'Base64 Output' : 'Decoded Text'}
+					value={output}
+					mode="readonly"
+					editorMode="plain"
+					placeholder={mode === 'encode' ? 'Encoded output...' : 'Decoded output...'}
+					oncopy={handleCopy}
+					showViewToggle={false}
+				/>
+			{/if}
 		{/snippet}
 	</SplitPane>
 </ToolShell>

--- a/src/routes/cron-expression-builder/tabs/build-tab.svelte
+++ b/src/routes/cron-expression-builder/tabs/build-tab.svelte
@@ -3,6 +3,7 @@
 	import { CopyButton } from '$lib/components/action';
 	import { FormInput } from '$lib/components/form';
 	import { SectionHeader } from '$lib/components/layout';
+	import { EmbeddedEmptyState } from '$lib/components/status';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
@@ -175,7 +176,11 @@
 								{/each}
 							</ul>
 						{:else}
-							<p class="text-sm text-muted-foreground">No upcoming executions.</p>
+							<EmbeddedEmptyState
+								icon={Calendar}
+								title="No upcoming executions"
+								description="The current expression does not match any future time within the lookahead window."
+							/>
 						{/if}
 					{:else}
 						<p class="text-sm text-destructive">{nextRuns.error}</p>

--- a/src/routes/curl-builder/tabs/build-tab.svelte
+++ b/src/routes/curl-builder/tabs/build-tab.svelte
@@ -9,6 +9,7 @@
 		FormTextarea,
 	} from '$lib/components/form';
 	import { SectionHeader } from '$lib/components/layout';
+	import { EmbeddedEmptyState } from '$lib/components/status';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
@@ -338,10 +339,20 @@
 						<Terminal class="h-4 w-4 text-muted-foreground" />
 						<Card.Title class="text-sm font-medium">Generated command</Card.Title>
 					</div>
-					<CopyButton text={command} toastLabel="Command" size="sm" />
+					{#if isValid}
+						<CopyButton text={command} toastLabel="Command" size="sm" />
+					{/if}
 				</Card.Header>
 				<Card.Content>
-					<pre class="overflow-auto rounded-md bg-muted p-3 font-mono text-sm">{command}</pre>
+					{#if isValid}
+						<pre class="overflow-auto rounded-md bg-muted p-3 font-mono text-sm">{command}</pre>
+					{:else}
+						<EmbeddedEmptyState
+							icon={Terminal}
+							title="Enter a URL to build the command"
+							description="The generated cURL command will appear here once a request URL is set."
+						/>
+					{/if}
 				</Card.Content>
 			</Card.Root>
 		</div>

--- a/src/routes/hash-generator/+page.svelte
+++ b/src/routes/hash-generator/+page.svelte
@@ -5,7 +5,7 @@
 	import { FormInfo, FormSection } from '$lib/components/form';
 	import { SectionHeader } from '$lib/components/layout';
 	import { ToolShell } from '$lib/components/shell';
-	import { EmptyState, StatItem } from '$lib/components/status';
+	import { EmbeddedEmptyState, StatItem } from '$lib/components/status';
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';
 	import {
@@ -132,7 +132,9 @@
 								<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 									<div class="flex items-center gap-2">
 										<Card.Title class="font-mono text-sm">{result.algorithm}</Card.Title>
-										<span class="text-xs text-muted-foreground">({result.bits} bits)</span>
+										<span class="text-xs tabular-nums text-muted-foreground"
+											>({result.bits} bits)</span
+										>
 										{#if getSecurityBadge(result.algorithm)}
 											<Badge variant="outline" class="gap-1 bg-success/10 text-success">
 												<ShieldCheck class="h-3 w-3" />
@@ -162,7 +164,12 @@
 						{/each}
 					</div>
 				{:else}
-					<EmptyState icon={Hash} title="Enter text to generate hashes" />
+					<EmbeddedEmptyState
+						icon={Hash}
+						title="Enter text to hash"
+						description="Type or paste content above to compute MD5, SHA-1, SHA-256, and more."
+						fillHeight
+					/>
 				{/if}
 			</div>
 		</div>

--- a/src/routes/network-scanner/+page.svelte
+++ b/src/routes/network-scanner/+page.svelte
@@ -795,7 +795,7 @@
 									class="flex items-center justify-between bg-background px-2 py-1"
 									title={WELL_KNOWN_SERVICES[port] ?? `Port ${port}`}
 								>
-									<span class="font-mono text-xs font-medium">{port}</span>
+									<span class="font-mono text-xs font-medium tabular-nums">{port}</span>
 									<span class="truncate text-xs text-muted-foreground">
 										{WELL_KNOWN_SERVICES[port] ?? ''}
 									</span>
@@ -840,7 +840,7 @@
 											class="flex items-center justify-between bg-background px-2 py-1"
 											title={WELL_KNOWN_SERVICES[port] ?? `Port ${port}`}
 										>
-											<span class="font-mono text-xs font-medium">{port}</span>
+											<span class="font-mono text-xs font-medium tabular-nums">{port}</span>
 											<span class="truncate text-xs text-muted-foreground">
 												{WELL_KNOWN_SERVICES[port] ?? ''}
 											</span>
@@ -864,7 +864,7 @@
 											class="flex items-center justify-between bg-background px-2 py-1"
 											title={WELL_KNOWN_SERVICES[port] ?? `Port ${port}`}
 										>
-											<span class="font-mono text-xs font-medium">{port}</span>
+											<span class="font-mono text-xs font-medium tabular-nums">{port}</span>
 											<span class="truncate text-xs text-muted-foreground">
 												{WELL_KNOWN_SERVICES[port] ?? ''}
 											</span>
@@ -1021,7 +1021,9 @@
 											: 0}%"
 								></div>
 							</div>
-							<div class="flex items-center justify-between text-xs text-muted-foreground">
+							<div
+								class="flex items-center justify-between text-xs tabular-nums text-muted-foreground"
+							>
 								{#if progress?.hostsFound !== undefined && progress.hostsFound > 0}
 									<span class="text-success">{progress.hostsFound} hosts</span>
 								{:else}
@@ -1045,7 +1047,9 @@
 						<span class="text-xs text-muted-foreground">{progressText}</span>
 					</div>
 					<div class="flex items-center gap-3">
-						<span class="text-sm font-medium text-primary">{progressPercentage.toFixed(0)}%</span>
+						<span class="text-sm font-medium tabular-nums text-primary"
+							>{progressPercentage.toFixed(0)}%</span
+						>
 						<ActionButton
 							label="Cancel"
 							variant="ghost"
@@ -1209,7 +1213,7 @@
 		<!-- Summary Footer -->
 		{#if results}
 			<div class="shrink-0 border-t bg-surface-3 px-4 py-2">
-				<div class="flex items-center justify-between text-xs text-muted-foreground">
+				<div class="flex items-center justify-between text-xs tabular-nums text-muted-foreground">
 					<div class="flex items-center gap-4">
 						<span class="flex items-center gap-1">
 							<Server class="h-3 w-3" />

--- a/src/routes/network-scanner/components/unified-host-detail-panel.svelte
+++ b/src/routes/network-scanner/components/unified-host-detail-panel.svelte
@@ -364,7 +364,7 @@
 							</Button>
 						</div>
 						<div class="flex items-center gap-2">
-							<span class="font-mono text-sm text-muted-foreground">{primaryIp}</span>
+							<span class="font-mono text-sm tabular-nums text-muted-foreground">{primaryIp}</span>
 							<Button
 								variant="ghost"
 								size="icon-sm"
@@ -378,7 +378,7 @@
 						</div>
 					{:else}
 						<div class="flex items-center gap-2">
-							<h2 class="font-mono text-lg font-semibold">{primaryIp}</h2>
+							<h2 class="font-mono text-lg font-semibold tabular-nums">{primaryIp}</h2>
 							<Button
 								variant="ghost"
 								size="icon-sm"
@@ -468,7 +468,7 @@
 					<TabIcon />
 					{tab.label}
 					{#if tab.count !== null}
-						<Badge variant="outline" class="font-mono text-2xs">{tab.count}</Badge>
+						<Badge variant="outline" class="font-mono text-2xs tabular-nums">{tab.count}</Badge>
 					{/if}
 				</Tabs.Trigger>
 			{/each}
@@ -951,7 +951,9 @@
 												</div>
 												<div class="min-w-0 flex-1">
 													<div class="flex items-center gap-2">
-														<span class="font-mono text-base font-semibold">{port.port}</span>
+														<span class="font-mono text-base font-semibold tabular-nums"
+															>{port.port}</span
+														>
 														{#if serviceName}
 															<span class="rounded bg-muted px-1.5 py-0.5 text-xs font-medium">
 																{serviceName}

--- a/src/routes/network-scanner/components/unified-host-list-item.svelte
+++ b/src/routes/network-scanner/components/unified-host-list-item.svelte
@@ -103,7 +103,7 @@
 	<div class="min-w-0 flex-1">
 		<!-- Primary IP + IPv6 badge + status dot + badges -->
 		<div class="flex items-center gap-2">
-			<span class="font-mono text-sm font-medium">{primaryIp}</span>
+			<span class="font-mono text-sm font-medium tabular-nums">{primaryIp}</span>
 			{#if ipv6Count > 0}
 				<span
 					class="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground"
@@ -124,7 +124,7 @@
 			<div class="flex items-center gap-1">
 				{#if openPortCount > 0}
 					<span
-						class="flex items-center gap-0.5 rounded bg-success/10 px-1.5 py-0.5 text-xs font-medium text-success"
+						class="flex items-center gap-0.5 rounded bg-success/10 px-1.5 py-0.5 text-xs font-medium tabular-nums text-success"
 						title="{openPortCount} open ports"
 					>
 						<CheckCircle2 class="h-2.5 w-2.5" />
@@ -133,7 +133,7 @@
 				{/if}
 				{#if discoveryMethodCount > 1}
 					<span
-						class="flex items-center gap-0.5 rounded bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary"
+						class="flex items-center gap-0.5 rounded bg-primary/10 px-1.5 py-0.5 text-xs font-medium tabular-nums text-primary"
 						title="{discoveryMethodCount} discovery methods"
 					>
 						<Radar class="h-2.5 w-2.5" />
@@ -142,7 +142,7 @@
 				{/if}
 				{#if mdnsServiceCount > 0}
 					<span
-						class="flex items-center gap-0.5 rounded bg-info/10 px-1.5 py-0.5 text-xs font-medium text-info"
+						class="flex items-center gap-0.5 rounded bg-info/10 px-1.5 py-0.5 text-xs font-medium tabular-nums text-info"
 						title="{mdnsServiceCount} mDNS services"
 					>
 						<Radio class="h-2.5 w-2.5" />
@@ -183,7 +183,7 @@
 			<div class="mt-0.5 flex flex-wrap gap-1">
 				{#each additionalIpv4s as ip (ip)}
 					<span
-						class="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground"
+						class="rounded bg-muted px-1.5 py-0.5 font-mono text-xs tabular-nums text-muted-foreground"
 						title={ip}
 					>
 						{ip}

--- a/src/routes/password-generator/+page.svelte
+++ b/src/routes/password-generator/+page.svelte
@@ -11,7 +11,7 @@
 	} from '$lib/components/form';
 	import { SectionHeader } from '$lib/components/layout';
 	import { ToolShell } from '$lib/components/shell';
-	import { EmptyState, StatItem } from '$lib/components/status';
+	import { EmbeddedEmptyState, StatItem } from '$lib/components/status';
 	import {
 		buildCharacterPool,
 		calculateEntropy,
@@ -223,7 +223,12 @@
 					{/each}
 				</div>
 			{:else}
-				<EmptyState icon={Lock} title="Click Generate to create passwords" />
+				<EmbeddedEmptyState
+					icon={Lock}
+					title="Generate passwords"
+					description="Adjust the options on the left and click Generate to create secure passwords."
+					fillHeight
+				/>
 			{/if}
 		</div>
 	</div>

--- a/src/routes/qr-code-generator/+page.svelte
+++ b/src/routes/qr-code-generator/+page.svelte
@@ -5,7 +5,6 @@
 		Contact,
 		Download,
 		Globe,
-		Image as ImageIcon,
 		Mail,
 		MapPin,
 		MessageSquare,
@@ -31,7 +30,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { SectionHeader } from '$lib/components/layout';
 	import { ToolShell } from '$lib/components/shell';
-	import { StatItem } from '$lib/components/status';
+	import { EmbeddedEmptyState, StatItem } from '$lib/components/status';
 	import {
 		CONTENT_KINDS,
 		CORNER_DOT_TYPES,
@@ -622,11 +621,12 @@
 
 				{#if !valid}
 					<Card.Root density="compact" class="border-warning/40 bg-warning/5">
-						<Card.Content class="flex items-start gap-3 py-4">
-							<ImageIcon class="mt-0.5 h-4 w-4 text-warning" />
-							<div class="text-sm text-muted-foreground">
-								Fill in the required fields above to render the QR code.
-							</div>
+						<Card.Content class="py-6">
+							<EmbeddedEmptyState
+								icon={QrCode}
+								title="Fill in content to render"
+								description="Complete the required fields on the left to generate the QR code."
+							/>
 						</Card.Content>
 					</Card.Root>
 				{/if}

--- a/src/routes/sql-formatter/+page.svelte
+++ b/src/routes/sql-formatter/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { Database } from '@lucide/svelte';
 	import type { SqlLanguage } from 'sql-formatter';
 	import { CodeEditor } from '$lib/components/editor';
 	import {
@@ -8,9 +9,9 @@
 		FormSection,
 		FormSelect,
 	} from '$lib/components/form';
-	import { SplitPane } from '$lib/components/layout';
+	import { SectionHeader, SplitPane } from '$lib/components/layout';
 	import { ToolShell } from '$lib/components/shell';
-	import { StatItem } from '$lib/components/status';
+	import { EmbeddedEmptyState, StatItem } from '$lib/components/status';
 	import {
 		calculateSqlStats,
 		defaultSqlFormatOptions,
@@ -248,14 +249,28 @@
 			/>
 		{/snippet}
 		{#snippet right()}
-			<CodeEditor
-				title="Output"
-				value={output}
-				mode="readonly"
-				editorMode="sql"
-				placeholder="Formatted output..."
-				oncopy={handleCopy}
-			/>
+			{#if !input.trim()}
+				<div class="flex h-full flex-col overflow-hidden">
+					<SectionHeader title="Output" />
+					<div class="flex-1">
+						<EmbeddedEmptyState
+							icon={Database}
+							title="Enter SQL to format"
+							description="The formatted (or minified) statement will appear here."
+							fillHeight
+						/>
+					</div>
+				</div>
+			{:else}
+				<CodeEditor
+					title="Output"
+					value={output}
+					mode="readonly"
+					editorMode="sql"
+					placeholder="Formatted output..."
+					oncopy={handleCopy}
+				/>
+			{/if}
 		{/snippet}
 	</SplitPane>
 </ToolShell>

--- a/src/routes/string-case-converter/+page.svelte
+++ b/src/routes/string-case-converter/+page.svelte
@@ -12,7 +12,7 @@
 	} from '$lib/components/form';
 	import { SectionHeader } from '$lib/components/layout';
 	import { ToolShell } from '$lib/components/shell';
-	import { EmptyState, StatItem } from '$lib/components/status';
+	import { EmbeddedEmptyState, StatItem } from '$lib/components/status';
 	import * as Card from '$lib/components/ui/card';
 	import {
 		CASE_DEFINITIONS,
@@ -200,7 +200,12 @@
 						{/each}
 					</div>
 				{:else}
-					<EmptyState icon={CaseSensitive} title="Enter text to see case conversions" />
+					<EmbeddedEmptyState
+						icon={CaseSensitive}
+						title="Enter text to convert"
+						description="Type or paste text above to see all case format conversions."
+						fillHeight
+					/>
 				{/if}
 			</div>
 		</div>

--- a/src/routes/uuid-generator/+page.svelte
+++ b/src/routes/uuid-generator/+page.svelte
@@ -13,7 +13,7 @@
 	} from '$lib/components/form';
 	import { SectionHeader } from '$lib/components/layout';
 	import { ToolShell } from '$lib/components/shell';
-	import { EmptyState, StatItem } from '$lib/components/status';
+	import { EmbeddedEmptyState, StatItem } from '$lib/components/status';
 	import {
 		DEFAULT_COUNT,
 		DEFAULT_FORMAT_OPTIONS,
@@ -217,7 +217,12 @@
 					{/each}
 				</div>
 			{:else}
-				<EmptyState icon={Fingerprint} title="Click Generate to create UUIDs" />
+				<EmbeddedEmptyState
+					icon={Fingerprint}
+					title="Generate UUIDs"
+					description="Pick a version on the left and click Generate to create unique identifiers."
+					fillHeight
+				/>
 			{/if}
 		</div>
 	</div>

--- a/src/routes/yaml-formatter/tabs/format-tab.svelte
+++ b/src/routes/yaml-formatter/tabs/format-tab.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { FileText } from '@lucide/svelte';
 	import * as yaml from 'yaml';
 	import type { ContextMenuItem } from '$lib/components/editor';
 	import { CodeEditor } from '$lib/components/editor';
@@ -10,9 +11,10 @@
 		FormSection,
 		FormSelect,
 	} from '$lib/components/form';
-	import { SplitPane } from '$lib/components/layout';
+	import { SectionHeader, SplitPane } from '$lib/components/layout';
 	import { OptionsPanel } from '$lib/components/panel';
 	import { SAMPLE_YAML, sortKeysDeep, validateYaml } from '$lib/services/formatters';
+	import { EmbeddedEmptyState } from '$lib/components/status';
 
 	interface Props {
 		input: string;
@@ -319,14 +321,28 @@
 			/>
 		{/snippet}
 		{#snippet right()}
-			<CodeEditor
-				title="Output"
-				value={output}
-				mode="readonly"
-				editorMode="yaml"
-				placeholder="Formatted output..."
-				oncopy={handleCopy}
-			/>
+			{#if !input.trim()}
+				<div class="flex h-full flex-col overflow-hidden">
+					<SectionHeader title="Output" />
+					<div class="flex-1">
+						<EmbeddedEmptyState
+							icon={FileText}
+							title="Enter YAML to format"
+							description="The formatted (or minified) document will appear here."
+							fillHeight
+						/>
+					</div>
+				</div>
+			{:else}
+				<CodeEditor
+					title="Output"
+					value={output}
+					mode="readonly"
+					editorMode="yaml"
+					placeholder="Formatted output..."
+					oncopy={handleCopy}
+				/>
+			{/if}
 		{/snippet}
 	</SplitPane>
 </div>


### PR DESCRIPTION
## Summary

Four mechanical refinements that lift the visual baseline of the app:

1. `EmbeddedEmptyState` on 10 tool pages that previously rendered a blank panel.
2. `tabular-nums` on numeric grids so columns align between rows.
3. `cursor-pointer` at the `Button` / `ListItemButton` primitive level (propagates to ~50 sites).
4. `Card.Root density="compact"` audit (no-op — already migrated in an earlier PR).

First PR of the **production-ready polish** track. PR I (rail + sidebar parity) already merged as #243.

## Changes

### Empty states (10 tool pages)

| Page | Icon | Title |
| --- | --- | --- |
| `base64-encoder` | `Code2` | "Enter text to encode" / "Paste Base64 to decode" |
| `string-case-converter` | `CaseSensitive` | "Enter text to convert" |
| `password-generator` | `Lock` | "Generate passwords" |
| `uuid-generator` | `Fingerprint` | "Generate UUIDs" |
| `qr-code-generator` | `QrCode` | "Fill in content to render" |
| `curl-builder` build tab | `Terminal` | "Enter a URL to build the command" |
| `cron-expression-builder` build tab | `Calendar` | "No upcoming executions" |
| `hash-generator` | `Hash` | "Enter text to hash" |
| `yaml-formatter` format tab | `FileText` | "Enter YAML to format" |
| `sql-formatter` | `Database` | "Enter SQL to format" |

Base64 / SQL / YAML: the right (output) `CodeEditor` is now only mounted when input is non-empty; the empty branch swaps in `SectionHeader` + `EmbeddedEmptyState`.

### `tabular-nums` additions (12 locations)

Network scanner port lists, progress percent, host/port stats footer, per-method progress row. Host list-item primary IP + 3 count badges + IPv4 pills. Host detail panel IP, tab counts, port numbers. Hash generator bits annotation.

`StatItem` and `FormSlider` already had `tabular-nums` baked in.

### `cursor-pointer` at primitive level

Tailwind v4's Preflight resets the native `<button>` cursor to default — so without an explicit class, buttons across the app showed an arrow cursor. Adding `cursor-pointer` + `disabled:cursor-not-allowed` / `aria-disabled:cursor-not-allowed` to:

- `src/lib/components/ui/button/button.svelte`
- `src/lib/components/ui/list-item-button/list-item-button.svelte`

propagates the fix to ~50 consumer sites (ActionButton, CopyButton, tool tiles, host list rows, tree-view rows, etc.). This is a deliberate divergence from the shadcn-svelte registry baseline; documented with an inline comment in each file.

## Test Plan

- [x] `cargo check` — passes.
- [x] `bun run check` — svelte-check 0 errors, page validation OK, design audit OK.
- [x] `bunx vitest run` — 140 / 140 pass.
- [x] `bun run format:check` — clean.
- [x] Audit grep: 0 `<Card.Root>` without `density="compact"` outside home.
- [ ] Manual: visit each of the 10 pages and confirm the new empty states render with input cleared.
- [ ] Manual: hover any button in the app — confirm pointer cursor (not arrow).
- [ ] Manual: view the network scanner port list with multi-digit ports — confirm columns align.

## Follow-ups

PR B (toast / feedback / `FormError`) → PR C (microinteractions) → … → PR H (a11y).
