### PR TITLE
refactor(ui): user feedback consistency

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -409,6 +409,26 @@
 	animation: highlight-new 1.5s ease-out;
 }
 
+/* Subtle flash applied to a result block on a discrete generation event. */
+@keyframes flash-success {
+	0% {
+		background-color: oklch(from var(--success) l c h / 15%);
+	}
+	100% {
+		background-color: transparent;
+	}
+}
+
+.animate-flash-success {
+	animation: flash-success 600ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.animate-flash-success {
+		animation: none;
+	}
+}
+
 /* Unified focus ring utility */
 .focus-ring {
 	outline: none;

--- a/src/lib/components/form/form-error.svelte
+++ b/src/lib/components/form/form-error.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { AlertCircle } from '@lucide/svelte';
+	import type { Snippet } from 'svelte';
+	import { cn } from '$lib/utils.js';
+
+	interface Props {
+		readonly message?: string | null;
+		readonly icon?: boolean;
+		readonly class?: string;
+		readonly children?: Snippet;
+	}
+
+	let { message, icon = true, class: className, children }: Props = $props();
+</script>
+
+{#if message || children}
+	<p
+		role="alert"
+		class={cn('flex items-start gap-1.5 text-xs leading-snug text-destructive', className)}
+	>
+		{#if icon}
+			<AlertCircle class="mt-px h-3.5 w-3.5 shrink-0" />
+		{/if}
+		<span>
+			{#if children}
+				{@render children()}
+			{:else}
+				{message}
+			{/if}
+		</span>
+	</p>
+{/if}

--- a/src/lib/components/form/index.ts
+++ b/src/lib/components/form/index.ts
@@ -1,5 +1,6 @@
 export { default as FormCheckbox } from './form-checkbox.svelte';
 export { default as FormCheckboxGroup } from './form-checkbox-group.svelte';
+export { default as FormError } from './form-error.svelte';
 export { default as FormInfo } from './form-info.svelte';
 export { default as FormInput } from './form-input.svelte';
 export { default as FormMode } from './form-mode.svelte';

--- a/src/lib/components/ui/button/button.svelte
+++ b/src/lib/components/ui/button/button.svelte
@@ -6,8 +6,11 @@
 	// Divergence from registry: cursor-pointer / cursor-not-allowed are added on the base so
 	// every Button on the desktop app shows a proper click affordance (Tailwind v4 Preflight
 	// resets the native <button> cursor to default).
+	// Divergence from registry: active:scale-[0.98] adds a subtle 2% press-down for tactile
+	// feedback across all buttons (5% feels glitchy at tool-UI sizes); transition-all already
+	// animates the transform so no extra utility is needed.
 	export const buttonVariants = tv({
-		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium outline-none transition-all focus-visible:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium outline-none transition-all focus-visible:ring-[3px] active:scale-[0.98] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		variants: {
 			variant: {
 				default: 'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',

--- a/src/routes/base64-encoder/+page.svelte
+++ b/src/routes/base64-encoder/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Code2 } from '@lucide/svelte';
+	import { toast } from 'svelte-sonner';
 	import { CodeEditor } from '$lib/components/editor';
 	import {
 		FormCheckbox,
@@ -124,8 +125,9 @@
 	const handleCopy = async () => {
 		try {
 			await navigator.clipboard.writeText(output);
+			toast.success('Copied to clipboard');
 		} catch {
-			// Clipboard access denied
+			toast.error('Failed to copy to clipboard');
 		}
 	};
 

--- a/src/routes/bcrypt-generator/+page.svelte
+++ b/src/routes/bcrypt-generator/+page.svelte
@@ -40,6 +40,9 @@
 	let showOptions = $state(true);
 	let costInfo = $state<BcryptCostInfo | null>(null);
 	let activeTab = $state<'generate' | 'verify'>('generate');
+	// Increments on each successful hash so the result block can re-mount and
+	// replay the flash-success animation.
+	let flashCounter = $state(0);
 
 	// Elapsed time tracking
 	let elapsedMs = $state(0);
@@ -102,6 +105,7 @@
 			const result = await generateBcryptHash(password, cost);
 			if (!generateCancelled) {
 				hashResult = result;
+				flashCounter += 1;
 				toast.success('BCrypt hash generated successfully');
 			}
 		} catch (e) {
@@ -344,51 +348,53 @@
 		<div class="flex-1 overflow-auto p-4">
 			{#if activeTab === 'generate'}
 				{#if hashResult}
-					<div class="space-y-4">
-						<Card.Root density="compact">
-							<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
-								<Card.Title class="text-sm font-medium">BCrypt Hash</Card.Title>
-								<CopyButton
-									text={hashResult.hash}
-									toastLabel="Hash"
-									size="sm"
-									showLabel
-									class="h-7"
-								/>
-							</Card.Header>
-							<Card.Content>
-								<code class="block break-all rounded bg-muted p-3 font-mono text-sm">
-									{hashResult.hash}
-								</code>
-							</Card.Content>
-						</Card.Root>
+					{#key flashCounter}
+						<div class="space-y-4 rounded-md animate-flash-success">
+							<Card.Root density="compact">
+								<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
+									<Card.Title class="text-sm font-medium">BCrypt Hash</Card.Title>
+									<CopyButton
+										text={hashResult.hash}
+										toastLabel="Hash"
+										size="sm"
+										showLabel
+										class="h-7"
+									/>
+								</Card.Header>
+								<Card.Content>
+									<code class="block break-all rounded bg-muted p-3 font-mono text-sm">
+										{hashResult.hash}
+									</code>
+								</Card.Content>
+							</Card.Root>
 
-						<Card.Root density="compact">
-							<Card.Header class="pb-3">
-								<Card.Title class="text-sm font-medium">Hash Details</Card.Title>
-							</Card.Header>
-							<Card.Content>
-								<div class="space-y-2 text-sm">
-									<div class="flex justify-between">
-										<span class="text-muted-foreground">Algorithm</span>
-										<span class="font-mono">${hashResult.algorithm}$</span>
+							<Card.Root density="compact">
+								<Card.Header class="pb-3">
+									<Card.Title class="text-sm font-medium">Hash Details</Card.Title>
+								</Card.Header>
+								<Card.Content>
+									<div class="space-y-2 text-sm">
+										<div class="flex justify-between">
+											<span class="text-muted-foreground">Algorithm</span>
+											<span class="font-mono">${hashResult.algorithm}$</span>
+										</div>
+										<div class="flex justify-between">
+											<span class="text-muted-foreground">Cost Factor</span>
+											<span class="font-mono">{hashResult.cost}</span>
+										</div>
+										<div class="flex justify-between">
+											<span class="text-muted-foreground">Security Level</span>
+											<span>{costInfo?.security_level ?? 'Unknown'}</span>
+										</div>
+										<div class="flex justify-between">
+											<span class="text-muted-foreground">Hash Length</span>
+											<span class="font-mono">{hashResult.hash.length} chars</span>
+										</div>
 									</div>
-									<div class="flex justify-between">
-										<span class="text-muted-foreground">Cost Factor</span>
-										<span class="font-mono">{hashResult.cost}</span>
-									</div>
-									<div class="flex justify-between">
-										<span class="text-muted-foreground">Security Level</span>
-										<span>{costInfo?.security_level ?? 'Unknown'}</span>
-									</div>
-									<div class="flex justify-between">
-										<span class="text-muted-foreground">Hash Length</span>
-										<span class="font-mono">{hashResult.hash.length} chars</span>
-									</div>
-								</div>
-							</Card.Content>
-						</Card.Root>
-					</div>
+								</Card.Content>
+							</Card.Root>
+						</div>
+					{/key}
 				{:else if generateError}
 					<ErrorDisplay variant="centered" message={generateError} />
 				{:else}

--- a/src/routes/cron-expression-builder/tabs/build-tab.svelte
+++ b/src/routes/cron-expression-builder/tabs/build-tab.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Calendar, Check, Clock, Sparkles, X } from '@lucide/svelte';
 	import { CopyButton } from '$lib/components/action';
-	import { FormInput } from '$lib/components/form';
+	import { FormError, FormInput } from '$lib/components/form';
 	import { SectionHeader } from '$lib/components/layout';
 	import { EmbeddedEmptyState } from '$lib/components/status';
 	import { Badge } from '$lib/components/ui/badge';
@@ -141,7 +141,7 @@
 						{#if description.ok}
 							<p class="text-sm">{description.value}</p>
 						{:else}
-							<p class="text-sm text-destructive">{description.error}</p>
+							<FormError message={description.error} class="text-sm" />
 						{/if}
 					</Card.Content>
 				</Card.Root>

--- a/src/routes/cron-expression-builder/tabs/parse-tab.svelte
+++ b/src/routes/cron-expression-builder/tabs/parse-tab.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Calendar, Clock, FlaskConical, Sparkles } from '@lucide/svelte';
 	import { CopyButton } from '$lib/components/action';
-	import { FormInput } from '$lib/components/form';
+	import { FormError, FormInput } from '$lib/components/form';
 	import { SectionHeader } from '$lib/components/layout';
 	import { EmbeddedEmptyState } from '$lib/components/status';
 	import { Badge } from '$lib/components/ui/badge';
@@ -113,7 +113,7 @@
 								{/each}
 							</div>
 						{:else}
-							<p class="text-sm text-destructive">{parsed.error}</p>
+							<FormError message={parsed.error} class="text-sm" />
 						{/if}
 					</Card.Content>
 				</Card.Root>

--- a/src/routes/gpg-key-generator/+page.svelte
+++ b/src/routes/gpg-key-generator/+page.svelte
@@ -5,6 +5,7 @@
 	import {
 		FormCheckbox,
 		FormCheckboxGroup,
+		FormError,
 		FormInfo,
 		FormInput,
 		FormSection,
@@ -38,6 +39,9 @@
 	let keyResult = $state<GpgKeyResult | null>(null);
 	let isGenerating = $state(false);
 	let isCancelled = $state(false);
+	// Increments on each successful key pair so the result block can re-mount and
+	// replay the flash-success animation.
+	let flashCounter = $state(0);
 	let error = $state<string | null>(null);
 
 	let cliAvailability = $state<CliAvailability | null>(null);
@@ -109,6 +113,7 @@
 			});
 			if (!isCancelled) {
 				keyResult = result;
+				flashCounter += 1;
 				toast.success('GPG key pair generated successfully');
 			}
 		} catch (e) {
@@ -159,7 +164,7 @@
 				/>
 				<FormInput label="Email *" type="email" bind:value={email} placeholder="john@example.com" />
 				{#if email && !isValidEmail(email)}
-					<p class="text-xs text-destructive">Please enter a valid email address</p>
+					<FormError message="Please enter a valid email address" />
 				{/if}
 				<FormInput label="Comment (optional)" bind:value={comment} placeholder="Work key" />
 			</div>
@@ -312,127 +317,129 @@
 
 		<div class="flex-1 overflow-auto p-4">
 			{#if keyResult}
-				<div class="space-y-4">
-					{#if showKeyInfo}
-						<Card.Root density="compact">
-							<Card.Header class="pb-3">
-								<div class="flex items-center gap-2">
-									<User class="h-4 w-4" />
-									<Card.Title class="text-sm font-medium">Key Information</Card.Title>
-								</div>
-							</Card.Header>
-							<Card.Content>
-								<div class="space-y-2">
-									<div class="flex items-start justify-between">
-										<span class="text-xs text-muted-foreground">User ID</span>
-										<code class="text-xs">{keyResult.user_id}</code>
+				{#key flashCounter}
+					<div class="space-y-4 rounded-md animate-flash-success">
+						{#if showKeyInfo}
+							<Card.Root density="compact">
+								<Card.Header class="pb-3">
+									<div class="flex items-center gap-2">
+										<User class="h-4 w-4" />
+										<Card.Title class="text-sm font-medium">Key Information</Card.Title>
 									</div>
-									<div class="flex items-start justify-between">
-										<span class="text-xs text-muted-foreground">Fingerprint</span>
-										<div class="flex items-center gap-2">
-											<code class="text-xs">{keyResult.fingerprint}</code>
-											<CopyButton
-												text={keyResult.fingerprint}
-												toastLabel="Fingerprint"
-												size="icon"
-												class="h-6 w-6"
-											/>
+								</Card.Header>
+								<Card.Content>
+									<div class="space-y-2">
+										<div class="flex items-start justify-between">
+											<span class="text-xs text-muted-foreground">User ID</span>
+											<code class="text-xs">{keyResult.user_id}</code>
+										</div>
+										<div class="flex items-start justify-between">
+											<span class="text-xs text-muted-foreground">Fingerprint</span>
+											<div class="flex items-center gap-2">
+												<code class="text-xs">{keyResult.fingerprint}</code>
+												<CopyButton
+													text={keyResult.fingerprint}
+													toastLabel="Fingerprint"
+													size="icon"
+													class="h-6 w-6"
+												/>
+											</div>
 										</div>
 									</div>
+								</Card.Content>
+							</Card.Root>
+						{/if}
+
+						<Card.Root density="compact">
+							<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
+								<div class="flex items-center gap-2">
+									<Unlock class="h-4 w-4 text-success" />
+									<Card.Title class="text-sm font-medium">Public Key (PGP Armor)</Card.Title>
 								</div>
+								<CopyButton
+									text={keyResult.public_key}
+									toastLabel="Public key"
+									size="sm"
+									showLabel
+									class="h-7"
+								/>
+							</Card.Header>
+							<Card.Content>
+								<pre
+									class="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs">{keyResult.public_key}</pre>
+								<p class="mt-2 text-xs text-muted-foreground">
+									Share this key with others so they can encrypt messages to you
+								</p>
 							</Card.Content>
 						</Card.Root>
-					{/if}
 
-					<Card.Root density="compact">
-						<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
-							<div class="flex items-center gap-2">
-								<Unlock class="h-4 w-4 text-success" />
-								<Card.Title class="text-sm font-medium">Public Key (PGP Armor)</Card.Title>
+						<!-- Private Key -->
+						<div class="rounded-lg border border-warning/30 bg-warning/5 p-4">
+							<div class="mb-2 flex items-center justify-between">
+								<div class="flex items-center gap-2">
+									<Lock class="h-4 w-4 text-warning" />
+									<span class="text-sm font-medium">Private Key (PGP Armor)</span>
+									<span class="text-xs text-warning">(Keep Secret!)</span>
+								</div>
+								<CopyButton
+									text={keyResult.private_key}
+									toastLabel="Private key"
+									size="sm"
+									showLabel
+									class="h-7"
+								/>
 							</div>
-							<CopyButton
-								text={keyResult.public_key}
-								toastLabel="Public key"
-								size="sm"
-								showLabel
-								class="h-7"
-							/>
-						</Card.Header>
-						<Card.Content>
 							<pre
-								class="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs">{keyResult.public_key}</pre>
-							<p class="mt-2 text-xs text-muted-foreground">
-								Share this key with others so they can encrypt messages to you
+								class="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs">{keyResult.private_key}</pre>
+							<p class="mt-2 text-xs text-warning">
+								Never share this key. Import with: <code>gpg --import private-key.asc</code>
 							</p>
-						</Card.Content>
-					</Card.Root>
-
-					<!-- Private Key -->
-					<div class="rounded-lg border border-warning/30 bg-warning/5 p-4">
-						<div class="mb-2 flex items-center justify-between">
-							<div class="flex items-center gap-2">
-								<Lock class="h-4 w-4 text-warning" />
-								<span class="text-sm font-medium">Private Key (PGP Armor)</span>
-								<span class="text-xs text-warning">(Keep Secret!)</span>
-							</div>
-							<CopyButton
-								text={keyResult.private_key}
-								toastLabel="Private key"
-								size="sm"
-								showLabel
-								class="h-7"
-							/>
 						</div>
-						<pre
-							class="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs">{keyResult.private_key}</pre>
-						<p class="mt-2 text-xs text-warning">
-							Never share this key. Import with: <code>gpg --import private-key.asc</code>
-						</p>
+
+						{#if showGpgCommands}
+							<Card.Root density="compact">
+								<Card.Header class="pb-3">
+									<div class="flex items-center gap-2">
+										<Terminal class="h-4 w-4" />
+										<Card.Title class="text-sm font-medium">Equivalent GPG Commands</Card.Title>
+									</div>
+								</Card.Header>
+								<Card.Content>
+									<div class="space-y-3">
+										<div>
+											<div class="mb-1 flex items-center justify-between">
+												<span class="text-xs text-muted-foreground">Interactive</span>
+												<CopyButton
+													text={keyResult.gpg_command_interactive}
+													toastLabel="Command"
+													size="icon"
+													class="h-6 w-6"
+												/>
+											</div>
+											<code class="block rounded bg-muted p-2 font-mono text-xs">
+												{keyResult.gpg_command_interactive}
+											</code>
+										</div>
+
+										<div>
+											<div class="mb-1 flex items-center justify-between">
+												<span class="text-xs text-muted-foreground">Batch Mode</span>
+												<CopyButton
+													text={keyResult.gpg_command_batch}
+													toastLabel="Command"
+													size="icon"
+													class="h-6 w-6"
+												/>
+											</div>
+											<pre
+												class="max-h-32 overflow-auto whitespace-pre-wrap rounded bg-muted p-2 font-mono text-xs">{keyResult.gpg_command_batch}</pre>
+										</div>
+									</div>
+								</Card.Content>
+							</Card.Root>
+						{/if}
 					</div>
-
-					{#if showGpgCommands}
-						<Card.Root density="compact">
-							<Card.Header class="pb-3">
-								<div class="flex items-center gap-2">
-									<Terminal class="h-4 w-4" />
-									<Card.Title class="text-sm font-medium">Equivalent GPG Commands</Card.Title>
-								</div>
-							</Card.Header>
-							<Card.Content>
-								<div class="space-y-3">
-									<div>
-										<div class="mb-1 flex items-center justify-between">
-											<span class="text-xs text-muted-foreground">Interactive</span>
-											<CopyButton
-												text={keyResult.gpg_command_interactive}
-												toastLabel="Command"
-												size="icon"
-												class="h-6 w-6"
-											/>
-										</div>
-										<code class="block rounded bg-muted p-2 font-mono text-xs">
-											{keyResult.gpg_command_interactive}
-										</code>
-									</div>
-
-									<div>
-										<div class="mb-1 flex items-center justify-between">
-											<span class="text-xs text-muted-foreground">Batch Mode</span>
-											<CopyButton
-												text={keyResult.gpg_command_batch}
-												toastLabel="Command"
-												size="icon"
-												class="h-6 w-6"
-											/>
-										</div>
-										<pre
-											class="max-h-32 overflow-auto whitespace-pre-wrap rounded bg-muted p-2 font-mono text-xs">{keyResult.gpg_command_batch}</pre>
-									</div>
-								</div>
-							</Card.Content>
-						</Card.Root>
-					{/if}
-				</div>
+				{/key}
 			{:else if error}
 				<ErrorDisplay variant="centered" message={error} />
 			{:else}

--- a/src/routes/json-formatter/tabs/format-tab.svelte
+++ b/src/routes/json-formatter/tabs/format-tab.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import { toast } from 'svelte-sonner';
 	import type { ContextMenuItem } from '$lib/components/editor';
 	import { CodeEditor } from '$lib/components/editor';
 	import {
@@ -175,8 +176,9 @@
 	const handleCopy = async () => {
 		try {
 			await navigator.clipboard.writeText(output);
+			toast.success('Copied to clipboard');
 		} catch {
-			// Clipboard access denied
+			toast.error('Failed to copy to clipboard');
 		}
 	};
 

--- a/src/routes/network-scanner/+page.svelte
+++ b/src/routes/network-scanner/+page.svelte
@@ -19,6 +19,7 @@
 	import {
 		FormCheckbox,
 		FormCheckboxGroup,
+		FormError,
 		FormInfo,
 		FormInput,
 		FormMode,
@@ -640,7 +641,7 @@
 					placeholder="192.168.1.1 or 192.168.1.0/24"
 				/>
 				{#if target && !isValidTarget(target)}
-					<p class="text-xs text-destructive">Invalid target format</p>
+					<FormError message="Invalid target format" />
 				{/if}
 				<ActionButton
 					label="Detect Local Network"
@@ -882,7 +883,7 @@
 								onblur={() => (portRangeTouched = true)}
 							/>
 							{#if portRangeTouched && portRange && !isValidPortRange(portRange)}
-								<p class="mt-1 text-xs text-destructive">Invalid port range format</p>
+								<FormError class="mt-1" message="Invalid port range format" />
 							{:else}
 								<p class="mt-1 text-xs text-muted-foreground">
 									Examples: 80,443,8080 or 1-1024 or 22,80-100,443

--- a/src/routes/password-generator/+page.svelte
+++ b/src/routes/password-generator/+page.svelte
@@ -32,6 +32,9 @@
 	let results = $state<readonly string[]>([]);
 	let error = $state<string | null>(null);
 	let showOptions = $state(true);
+	// Increments on each successful generation so the result wrapper can re-mount
+	// and replay the flash-success animation.
+	let flashCounter = $state(0);
 
 	// Derived
 	const pool = $derived(buildCharacterPool(options));
@@ -61,6 +64,7 @@
 		error = null;
 		try {
 			results = generatePasswords(options, count);
+			flashCounter += 1;
 			toast.success(`Generated ${results.length} password${results.length > 1 ? 's' : ''}`);
 		} catch (e) {
 			const message = e instanceof Error ? e.message : String(e);
@@ -214,14 +218,16 @@
 
 		<div class="flex-1 overflow-auto p-4">
 			{#if results.length > 0}
-				<div class="space-y-2">
-					{#each results as password, idx (`${idx}-${password}`)}
-						<div class="flex items-center gap-2 rounded-lg border bg-card p-3">
-							<code class="flex-1 break-all font-mono text-sm">{password}</code>
-							<CopyButton text={password} toastLabel="Password" size="sm" showLabel={false} />
-						</div>
-					{/each}
-				</div>
+				{#key flashCounter}
+					<div class="space-y-2 rounded-md animate-flash-success">
+						{#each results as password, idx (`${idx}-${password}`)}
+							<div class="flex items-center gap-2 rounded-lg border bg-card p-3">
+								<code class="flex-1 break-all font-mono text-sm">{password}</code>
+								<CopyButton text={password} toastLabel="Password" size="sm" showLabel={false} />
+							</div>
+						{/each}
+					</div>
+				{/key}
 			{:else}
 				<EmbeddedEmptyState
 					icon={Lock}

--- a/src/routes/regex-tester/+page.svelte
+++ b/src/routes/regex-tester/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Eye, FlaskConical, GitBranch, Info, Search, Sparkles, Workflow } from '@lucide/svelte';
 	import { CopyButton } from '$lib/components/action';
-	import { FormInfo, FormSection, FormTextarea } from '$lib/components/form';
+	import { FormError, FormInfo, FormSection, FormTextarea } from '$lib/components/form';
 	import { PatternEditor, RailroadView } from '$lib/components/regex';
 	import { ToolShell } from '$lib/components/shell';
 	import { EmbeddedEmptyState, StatItem } from '$lib/components/status';
@@ -330,7 +330,7 @@
 						{:else if visualization.ok}
 							<RailroadView node={visualization.value} />
 						{:else}
-							<p class="text-sm text-destructive">{visualization.error}</p>
+							<FormError message={visualization.error} class="text-sm" />
 						{/if}
 					</Card.Content>
 				</Card.Root>

--- a/src/routes/sql-formatter/+page.svelte
+++ b/src/routes/sql-formatter/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Database } from '@lucide/svelte';
 	import type { SqlLanguage } from 'sql-formatter';
+	import { toast } from 'svelte-sonner';
 	import { CodeEditor } from '$lib/components/editor';
 	import {
 		FormCheckbox,
@@ -120,8 +121,9 @@
 	const handleCopy = async () => {
 		try {
 			await navigator.clipboard.writeText(output);
+			toast.success('Copied to clipboard');
 		} catch {
-			// Clipboard access denied
+			toast.error('Failed to copy to clipboard');
 		}
 	};
 

--- a/src/routes/ssh-key-generator/+page.svelte
+++ b/src/routes/ssh-key-generator/+page.svelte
@@ -35,6 +35,9 @@
 	let isGenerating = $state(false);
 	let isCancelled = $state(false);
 	let error = $state<string | null>(null);
+	// Increments on each successful key pair so the result block can re-mount and
+	// replay the flash-success animation.
+	let flashCounter = $state(0);
 
 	let cliAvailability = $state<CliAvailability | null>(null);
 
@@ -120,6 +123,7 @@
 			});
 			if (!isCancelled) {
 				keyResult = result;
+				flashCounter += 1;
 				toast.success('SSH key pair generated successfully');
 			}
 		} catch (e) {
@@ -294,102 +298,106 @@
 
 		<div class="flex-1 overflow-auto p-4">
 			{#if keyResult}
-				<div class="space-y-4">
-					{#if showFingerprint}
-						<Card.Root density="compact">
-							<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
-								<Card.Title class="text-sm font-medium">Fingerprint (SHA-256)</Card.Title>
-								<CopyButton
-									text={keyResult.fingerprint}
-									toastLabel="Fingerprint"
-									size="sm"
-									showLabel
-									class="h-7"
-								/>
-							</Card.Header>
-							<Card.Content>
-								<code class="block rounded bg-muted p-2 font-mono text-sm">
-									{keyResult.fingerprint}
-								</code>
-							</Card.Content>
-						</Card.Root>
-					{/if}
+				{#key flashCounter}
+					<div class="space-y-4 rounded-md animate-flash-success">
+						{#if showFingerprint}
+							<Card.Root density="compact">
+								<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
+									<Card.Title class="text-sm font-medium">Fingerprint (SHA-256)</Card.Title>
+									<CopyButton
+										text={keyResult.fingerprint}
+										toastLabel="Fingerprint"
+										size="sm"
+										showLabel
+										class="h-7"
+									/>
+								</Card.Header>
+								<Card.Content>
+									<code class="block rounded bg-muted p-2 font-mono text-sm">
+										{keyResult.fingerprint}
+									</code>
+								</Card.Content>
+							</Card.Root>
+						{/if}
 
-					<Card.Root density="compact">
-						<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
-							<div class="flex items-center gap-2">
-								<Unlock class="h-4 w-4 text-success" />
-								<Card.Title class="text-sm font-medium">Public Key</Card.Title>
-							</div>
-							<CopyButton
-								text={keyResult.public_key}
-								toastLabel="Public key"
-								size="sm"
-								showLabel
-								class="h-7"
-							/>
-						</Card.Header>
-						<Card.Content>
-							<pre
-								class="max-h-32 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs">{keyResult.public_key}</pre>
-							<p class="mt-2 text-xs text-muted-foreground">
-								Add this to <code>~/.ssh/authorized_keys</code> on remote servers
-							</p>
-						</Card.Content>
-					</Card.Root>
-
-					<!-- Private Key -->
-					<div class="rounded-lg border border-warning/30 bg-warning/5 p-4">
-						<div class="mb-2 flex items-center justify-between">
-							<div class="flex items-center gap-2">
-								<Lock class="h-4 w-4 text-warning" />
-								<span class="text-sm font-medium">Private Key</span>
-								<span class="text-xs text-warning">(Keep Secret!)</span>
-							</div>
-							<CopyButton
-								text={keyResult.private_key}
-								toastLabel="Private key"
-								size="sm"
-								showLabel
-								class="h-7"
-							/>
-						</div>
-						<pre
-							class="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs">{keyResult.private_key}</pre>
-						<p class="mt-2 text-xs text-warning">
-							Save this to <code
-								>~/.ssh/{algorithm === 'ed25519'
-									? 'id_ed25519'
-									: algorithm.startsWith('ecdsa')
-										? 'id_ecdsa'
-										: 'id_rsa'}</code
-							> with permissions 600
-						</p>
-					</div>
-
-					{#if showEquivalentCommand}
 						<Card.Root density="compact">
 							<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
 								<div class="flex items-center gap-2">
-									<Terminal class="h-4 w-4" />
-									<Card.Title class="text-sm font-medium">Equivalent ssh-keygen Command</Card.Title>
+									<Unlock class="h-4 w-4 text-success" />
+									<Card.Title class="text-sm font-medium">Public Key</Card.Title>
 								</div>
 								<CopyButton
-									text={keyResult.ssh_keygen_command}
-									toastLabel="Command"
+									text={keyResult.public_key}
+									toastLabel="Public key"
 									size="sm"
 									showLabel
 									class="h-7"
 								/>
 							</Card.Header>
 							<Card.Content>
-								<code class="block rounded bg-muted p-2 font-mono text-xs">
-									{keyResult.ssh_keygen_command}
-								</code>
+								<pre
+									class="max-h-32 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs">{keyResult.public_key}</pre>
+								<p class="mt-2 text-xs text-muted-foreground">
+									Add this to <code>~/.ssh/authorized_keys</code> on remote servers
+								</p>
 							</Card.Content>
 						</Card.Root>
-					{/if}
-				</div>
+
+						<!-- Private Key -->
+						<div class="rounded-lg border border-warning/30 bg-warning/5 p-4">
+							<div class="mb-2 flex items-center justify-between">
+								<div class="flex items-center gap-2">
+									<Lock class="h-4 w-4 text-warning" />
+									<span class="text-sm font-medium">Private Key</span>
+									<span class="text-xs text-warning">(Keep Secret!)</span>
+								</div>
+								<CopyButton
+									text={keyResult.private_key}
+									toastLabel="Private key"
+									size="sm"
+									showLabel
+									class="h-7"
+								/>
+							</div>
+							<pre
+								class="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs">{keyResult.private_key}</pre>
+							<p class="mt-2 text-xs text-warning">
+								Save this to <code
+									>~/.ssh/{algorithm === 'ed25519'
+										? 'id_ed25519'
+										: algorithm.startsWith('ecdsa')
+											? 'id_ecdsa'
+											: 'id_rsa'}</code
+								> with permissions 600
+							</p>
+						</div>
+
+						{#if showEquivalentCommand}
+							<Card.Root density="compact">
+								<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-3">
+									<div class="flex items-center gap-2">
+										<Terminal class="h-4 w-4" />
+										<Card.Title class="text-sm font-medium"
+											>Equivalent ssh-keygen Command</Card.Title
+										>
+									</div>
+									<CopyButton
+										text={keyResult.ssh_keygen_command}
+										toastLabel="Command"
+										size="sm"
+										showLabel
+										class="h-7"
+									/>
+								</Card.Header>
+								<Card.Content>
+									<code class="block rounded bg-muted p-2 font-mono text-xs">
+										{keyResult.ssh_keygen_command}
+									</code>
+								</Card.Content>
+							</Card.Root>
+						{/if}
+					</div>
+				{/key}
 			{:else if error}
 				<ErrorDisplay variant="centered" message={error} />
 			{:else}

--- a/src/routes/url-encoder/+page.svelte
+++ b/src/routes/url-encoder/+page.svelte
@@ -8,6 +8,7 @@
 		Plus,
 		Trash2,
 	} from '@lucide/svelte';
+	import { toast } from 'svelte-sonner';
 	import { CopyButton } from '$lib/components/action';
 	import { CodeEditor } from '$lib/components/editor';
 	import {
@@ -185,8 +186,9 @@
 	const handleCopy = async () => {
 		try {
 			await navigator.clipboard.writeText(output);
+			toast.success('Copied to clipboard');
 		} catch {
-			// Clipboard access denied
+			toast.error('Failed to copy to clipboard');
 		}
 	};
 

--- a/src/routes/uuid-generator/+page.svelte
+++ b/src/routes/uuid-generator/+page.svelte
@@ -38,6 +38,9 @@
 	let results = $state<readonly string[]>([]);
 	let error = $state<string | null>(null);
 	let showOptions = $state(true);
+	// Increments on each successful generation so the result wrapper can re-mount
+	// and replay the flash-success animation.
+	let flashCounter = $state(0);
 
 	// Derived
 	const needsNamespace = $derived(requiresNamespace(version));
@@ -74,6 +77,7 @@
 				name: needsNamespace ? nameInput : undefined,
 				format,
 			});
+			flashCounter += 1;
 			toast.success(`Generated ${results.length} UUID${results.length > 1 ? 's' : ''}`);
 		} catch (e) {
 			const message = e instanceof Error ? e.message : String(e);
@@ -208,14 +212,16 @@
 
 		<div class="flex-1 overflow-auto p-4">
 			{#if results.length > 0}
-				<div class="space-y-2">
-					{#each results as uuid, idx (`${idx}-${uuid}`)}
-						<div class="flex items-center gap-2 rounded-lg border bg-card p-3">
-							<code class="flex-1 break-all font-mono text-sm">{uuid}</code>
-							<CopyButton text={uuid} toastLabel="UUID" size="sm" showLabel={false} />
-						</div>
-					{/each}
-				</div>
+				{#key flashCounter}
+					<div class="space-y-2 rounded-md animate-flash-success">
+						{#each results as uuid, idx (`${idx}-${uuid}`)}
+							<div class="flex items-center gap-2 rounded-lg border bg-card p-3">
+								<code class="flex-1 break-all font-mono text-sm">{uuid}</code>
+								<CopyButton text={uuid} toastLabel="UUID" size="sm" showLabel={false} />
+							</div>
+						{/each}
+					</div>
+				{/key}
 			{:else}
 				<EmbeddedEmptyState
 					icon={Fingerprint}

--- a/src/routes/xml-formatter/tabs/format-tab.svelte
+++ b/src/routes/xml-formatter/tabs/format-tab.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { toast } from 'svelte-sonner';
 	import type { ContextMenuItem } from '$lib/components/editor';
 	import { CodeEditor } from '$lib/components/editor';
 	import {
@@ -116,8 +117,9 @@
 	const handleCopy = async () => {
 		try {
 			await navigator.clipboard.writeText(output);
+			toast.success('Copied to clipboard');
 		} catch {
-			// Clipboard access denied
+			toast.error('Failed to copy to clipboard');
 		}
 	};
 

--- a/src/routes/yaml-formatter/tabs/format-tab.svelte
+++ b/src/routes/yaml-formatter/tabs/format-tab.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { FileText } from '@lucide/svelte';
+	import { toast } from 'svelte-sonner';
 	import * as yaml from 'yaml';
 	import type { ContextMenuItem } from '$lib/components/editor';
 	import { CodeEditor } from '$lib/components/editor';
@@ -149,8 +150,9 @@
 	const handleCopy = async () => {
 		try {
 			await navigator.clipboard.writeText(output);
+			toast.success('Copied to clipboard');
 		} catch {
-			// Clipboard access denied
+			toast.error('Failed to copy to clipboard');
 		}
 	};
 


### PR DESCRIPTION
## Summary

Four refinements that lift the responsiveness floor of the app. Second PR of the **production-ready polish** track (after #243 rail parity and #244 visual baseline).

- **Button press feedback** — `active:scale-[0.98]` on the Button primitive.
- **`FormError` wrapper** — 7 hand-rolled inline error patterns now use a consistent component.
- **`flash-success` animation** — 5 generator pages briefly tint their result block on new generation.
- **Toast audit** — copy/generate flows verified to consistently fire toasts.

## Changes

### Added

- `src/lib/components/form/form-error.svelte` — exports `FormError`. `<FormError message={...} />` (or with snippet children) renders a `role="alert"` paragraph with `AlertCircle` icon and `text-destructive` typography.
- `@keyframes flash-success` + `.animate-flash-success` class in `src/app.css`. 600ms ease-out, fading from `success/15` background to transparent. `prefers-reduced-motion` aware.

### Changed

- `src/lib/components/ui/button/button.svelte` — added `active:scale-[0.98]` to `buttonVariants.base`. Smaller than registry-default `scale-95` (5%) because tool-UI buttons are small enough that a 5% scale-down reads as a glitch. Documented as deliberate registry divergence.

### Migrated to `FormError`

- `src/routes/regex-tester/+page.svelte` (1 site)
- `src/routes/cron-expression-builder/tabs/build-tab.svelte` (1 site)
- `src/routes/cron-expression-builder/tabs/parse-tab.svelte` (1 site)
- `src/routes/gpg-key-generator/+page.svelte` (1 site)
- `src/routes/network-scanner/+page.svelte` (2 sites)

### Got `flash-success` on result block

- `src/routes/uuid-generator/+page.svelte`
- `src/routes/password-generator/+page.svelte`
- `src/routes/bcrypt-generator/+page.svelte`
- `src/routes/ssh-key-generator/+page.svelte`
- `src/routes/gpg-key-generator/+page.svelte`

Not applied to real-time previews (regex match highlight, JSON format) — only to discrete generation events where a brief success cue clarifies "the action completed".

## Rationale

- **`active:scale-[0.98]`** — a tactile press-down on click is one of the cheapest microinteractions and one of the most universally-appreciated. Even a 2% scale gives the user's eye+motor system confirmation that the click registered.
- **`FormError`** — the 7 hand-rolled `<p class="text-sm text-destructive">` patterns had subtly different typography, spacing, and icons. Consolidating into one component locks in consistency and adds `role="alert"` for screen readers.
- **`flash-success`** — generators produce results that look identical to previous results (UUID v4 looks like a previous UUID v4). Without a visual cue, users wonder "did anything change?". The flash answers that without being intrusive.

## Test Plan

- [x] `cargo check` — passes.
- [x] `bun run check` — svelte-check 0 errors, page validation OK, design audit OK.
- [x] `bunx vitest run` — 140 / 140 pass.
- [ ] Manual: click any button — confirm tactile press-down.
- [ ] Manual: invalid input on regex-tester / cron parse — confirm new `FormError` rendering with icon.
- [ ] Manual: trigger a UUID/password generation — confirm subtle success flash on the result block.

## Follow-ups

PR C (microinteractions) → PR D (loading skeletons) → … → PR H (a11y).
