### PR TITLE
refactor(ui): microinteractions and motion token consolidation

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -252,10 +252,28 @@
 	--color-border-subtle: var(--border-subtle);
 	--color-border-strong: var(--border-strong);
 	--color-accent-brand: var(--accent-brand);
-	--animate-fade-in: fade-in 150ms ease-out;
-	--animate-slide-in: slide-in 150ms ease-out;
-	--animate-slide-up: slide-up 180ms var(--ease-standard);
-	--animate-scale-in: scale-in 150ms var(--ease-standard);
+	--animate-fade-in: fade-in var(--duration-base) ease-out;
+	--animate-slide-in: slide-in var(--duration-base) ease-out;
+	--animate-slide-up: slide-up var(--duration-slow) var(--ease-standard);
+	--animate-scale-in: scale-in var(--duration-base) var(--ease-standard);
+	/*
+	 * Motion duration tokens exposed as Tailwind utilities (`duration-fast`,
+	 * `duration-base`, `duration-slow`). Tailwind v4 reads from the
+	 * `--transition-duration-*` namespace when resolving the `duration-<name>`
+	 * utility, so the project tokens on `:root` are forwarded here. The
+	 * underlying `--duration-*` variables remain the source of truth and can be
+	 * overridden at runtime.
+	 */
+	--transition-duration-fast: var(--duration-fast);
+	--transition-duration-base: var(--duration-base);
+	--transition-duration-slow: var(--duration-slow);
+	/*
+	 * Accordion height animations. `tw-animate-css` ships these keyframes at a
+	 * fixed 200ms, but we want the project motion token to drive the duration
+	 * so accordion expand/collapse stays consistent with other transitions.
+	 */
+	--animate-accordion-down: accordion-down var(--duration-base) ease-out;
+	--animate-accordion-up: accordion-up var(--duration-base) ease-out;
 }
 
 /*
@@ -372,11 +390,36 @@
 	}
 }
 
+/*
+ * Accordion height keyframes. The CSS variable on the `to`/`from` side is
+ * populated by bits-ui at runtime (`--bits-accordion-content-height`), which
+ * is what allows the height animation to animate to the natural content size.
+ */
+@keyframes accordion-down {
+	from {
+		height: 0;
+	}
+	to {
+		height: var(--bits-accordion-content-height);
+	}
+}
+
+@keyframes accordion-up {
+	from {
+		height: var(--bits-accordion-content-height);
+	}
+	to {
+		height: 0;
+	}
+}
+
 @media (prefers-reduced-motion: reduce) {
 	.animate-fade-in,
 	.animate-slide-in,
 	.animate-slide-up,
-	.animate-scale-in {
+	.animate-scale-in,
+	[data-state='open'].animate-accordion-down,
+	[data-state='closed'].animate-accordion-up {
 		animation: none;
 	}
 }
@@ -407,6 +450,12 @@
 
 .animate-highlight-new {
 	animation: highlight-new 1.5s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.animate-highlight-new {
+		animation: none;
+	}
 }
 
 /* Subtle flash applied to a result block on a discrete generation event. */

--- a/src/lib/components/layout/app-sidebar.svelte
+++ b/src/lib/components/layout/app-sidebar.svelte
@@ -56,7 +56,7 @@
 								>{category.label}</span
 							>
 							<ChevronRight
-								class="size-4 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90"
+								class="size-4 transition-transform duration-base group-data-[state=open]/collapsible:rotate-90"
 							/>
 						</Collapsible.Trigger>
 					</Sidebar.GroupLabel>
@@ -116,7 +116,7 @@
 			<Sidebar.MenuItem>
 				<Sidebar.MenuButton onclick={sidebar.toggle} tooltipContent="Toggle sidebar">
 					<ChevronLeft
-						class="size-4 transition-transform duration-200 group-data-[state=collapsed]:rotate-180"
+						class="size-4 transition-transform duration-base group-data-[state=collapsed]:rotate-180"
 					/>
 					<span>Collapse</span>
 				</Sidebar.MenuButton>

--- a/src/lib/components/shell/tool-shell.svelte
+++ b/src/lib/components/shell/tool-shell.svelte
@@ -132,7 +132,7 @@
 								{@const TabIcon = tab.icon}
 								<Tabs.Trigger
 									value={tab.id}
-									class="data-[state=active]:bg-surface-0 data-[state=active]:text-foreground data-[state=active]:shadow-sm text-muted-foreground hover:bg-interactive-hover hover:text-foreground inline-flex flex-none items-center gap-1.5 rounded-md border-0 px-3.5 py-2 text-sm font-medium transition-all duration-150"
+									class="data-[state=active]:bg-surface-0 data-[state=active]:text-foreground data-[state=active]:shadow-sm text-muted-foreground hover:bg-interactive-hover hover:text-foreground inline-flex flex-none items-center gap-1.5 rounded-md border-0 px-3.5 py-2 text-sm font-medium transition-all duration-base"
 								>
 									<TabIcon class="h-4 w-4" />
 									{tab.label}

--- a/src/lib/components/ui/accordion/accordion-trigger.svelte
+++ b/src/lib/components/ui/accordion/accordion-trigger.svelte
@@ -26,7 +26,7 @@
 	>
 		{@render children?.()}
 		<ChevronDownIcon
-			class="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200"
+			class="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-base"
 		/>
 	</AccordionPrimitive.Trigger>
 </AccordionPrimitive.Header>

--- a/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/src/lib/components/ui/dialog/dialog-content.svelte
@@ -27,7 +27,7 @@
 		bind:ref
 		data-slot="dialog-content"
 		class={cn(
-			'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed start-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+			'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed start-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-base sm:max-w-lg',
 			className
 		)}
 		{...restProps}

--- a/src/lib/components/ui/list-item-button/list-item-button.svelte
+++ b/src/lib/components/ui/list-item-button/list-item-button.svelte
@@ -16,8 +16,11 @@
 				option:
 					'border-b border-border border-l-2 border-l-transparent px-3 py-2.5 last:border-b-0 hover:bg-interactive-hover data-[selected=true]:border-l-primary data-[selected=true]:bg-primary/10',
 				card: 'border-input bg-background rounded border px-2 py-1 hover:bg-interactive-hover data-[selected=true]:border-primary data-[selected=true]:bg-primary/10',
+				// `tree-node` selection uses bg + a thin border-l accent (consistent with
+				// `default` / `option`). Rings are reserved for keyboard focus state and
+				// are emitted by the `focus-visible:` rules on the shared base.
 				'tree-node':
-					'gap-1 rounded-md px-1 py-0.5 hover:bg-muted/60 data-[selected=true]:bg-primary/10 data-[selected=true]:ring-1 data-[selected=true]:ring-primary/30',
+					'gap-1 rounded-md border-l-2 border-l-transparent px-1 py-0.5 hover:bg-muted/60 data-[selected=true]:border-l-primary data-[selected=true]:bg-primary/10',
 				toc: 'rounded-sm px-1 hover:text-primary hover:underline',
 			},
 			size: {

--- a/src/lib/components/ui/resizable/resizable-handle.svelte
+++ b/src/lib/components/ui/resizable/resizable-handle.svelte
@@ -17,14 +17,14 @@
 	bind:ref
 	data-slot="resizable-handle"
 	class={cn(
-		'group/handle bg-border/50 hover:bg-primary/20 focus-visible:ring-ring focus-visible:outline-hidden relative flex w-px items-center justify-center transition-colors duration-200 after:absolute after:inset-y-0 after:start-1/2 after:w-2 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 data-[direction=vertical]:h-px data-[direction=vertical]:w-full data-[direction=vertical]:after:start-0 data-[direction=vertical]:after:h-2 data-[direction=vertical]:after:w-full data-[direction=vertical]:after:-translate-y-1/2 data-[direction=vertical]:after:translate-x-0 [&[data-direction=vertical]>div]:rotate-90',
+		'group/handle bg-border/50 hover:bg-primary/20 focus-visible:ring-ring focus-visible:outline-hidden relative flex w-px items-center justify-center transition-colors duration-base after:absolute after:inset-y-0 after:start-1/2 after:w-2 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 data-[direction=vertical]:h-px data-[direction=vertical]:w-full data-[direction=vertical]:after:start-0 data-[direction=vertical]:after:h-2 data-[direction=vertical]:after:w-full data-[direction=vertical]:after:-translate-y-1/2 data-[direction=vertical]:after:translate-x-0 [&[data-direction=vertical]>div]:rotate-90',
 		className
 	)}
 	{...restProps}
 >
 	{#if withHandle}
 		<div
-			class="z-10 flex h-6 w-4 items-center justify-center rounded-sm border border-border/60 bg-background shadow-sm transition-all duration-200 group-hover/handle:border-primary/40 group-hover/handle:bg-accent group-hover/handle:shadow-md group-active/handle:scale-95"
+			class="z-10 flex h-6 w-4 items-center justify-center rounded-sm border border-border/60 bg-background shadow-sm transition-all duration-base group-hover/handle:border-primary/40 group-hover/handle:bg-accent group-hover/handle:shadow-md group-active/handle:scale-95"
 		>
 			<GripVerticalIcon
 				class="size-3 text-muted-foreground/60 transition-colors group-hover/handle:text-primary/80"

--- a/src/lib/components/ui/sidebar/sidebar-group-label.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-group-label.svelte
@@ -15,7 +15,7 @@
 
 	const mergedProps = $derived({
 		class: cn(
-			'text-sidebar-foreground/70 ring-sidebar-ring outline-hidden flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+			'text-sidebar-foreground/70 ring-sidebar-ring outline-hidden flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-base ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
 			'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
 			className
 		),

--- a/src/lib/components/ui/sidebar/sidebar.svelte
+++ b/src/lib/components/ui/sidebar/sidebar.svelte
@@ -66,7 +66,7 @@
 		<div
 			data-slot="sidebar-gap"
 			class={cn(
-				'w-(--sidebar-width) relative bg-transparent transition-[width] duration-200 ease-linear',
+				'w-(--sidebar-width) relative bg-transparent transition-[width] duration-base ease-linear',
 				'group-data-[collapsible=offcanvas]:w-0',
 				'group-data-[side=right]:rotate-180',
 				variant === 'floating' || variant === 'inset'
@@ -77,7 +77,7 @@
 		<div
 			data-slot="sidebar-container"
 			class={cn(
-				'w-(--sidebar-width) fixed inset-y-0 z-10 hidden h-svh transition-[left,right,width] duration-200 ease-linear md:flex',
+				'w-(--sidebar-width) fixed inset-y-0 z-10 hidden h-svh transition-[left,right,width] duration-base ease-linear md:flex',
 				side === 'left'
 					? 'start-0 group-data-[collapsible=offcanvas]:start-[calc(var(--sidebar-width)*-1)]'
 					: 'end-0 group-data-[collapsible=offcanvas]:end-[calc(var(--sidebar-width)*-1)]',


### PR DESCRIPTION
## Summary

Five refinements that give the app a cohesive sense of motion and consistent state affordances. Third PR of the **production-ready polish** track (after #243 rail parity, #244 visual baseline, #245 feedback consistency).

- **Expose motion tokens** as Tailwind utilities (`duration-fast/-base/-slow`).
- **Bind animation keyframes** (`fade-in`, `slide-in`, `slide-up`, `scale-in`) to the same tokens.
- **Add explicit accordion keyframes** instead of relying on fallback defaults.
- **Replace 10 hardcoded `duration-150` / `duration-200`** across primitives with `duration-base`.
- **Standardize tree-node selection** to match other list variants (border-l accent + bg, not ring).

## Why

`src/app.css` already defined `--duration-fast`, `--duration-base`, `--duration-slow` but they were unreachable via Tailwind utility classes. As a result, every primitive hand-picked a duration: `duration-150` here, `duration-200` there, `duration-300` for sheets — no shared rhythm.

Tailwind v4 resolves the `duration-*` utility from the `--transition-duration-*` namespace specifically. The fix is to expose the project tokens via `@theme inline` under that namespace, while the `--duration-*` variables stay on `:root` as the single source of truth.

## Changes

### `src/app.css`

- New `@theme inline` block exposing `--transition-duration-fast/-base/-slow`, plus retuned `--animate-fade-in/slide-in/slide-up/scale-in` to use `var(--duration-base)`.
- Added explicit `@keyframes accordion-down` / `accordion-up` (targeting `var(--bits-accordion-content-height)`), bound via `--animate-accordion-down/-up` in the same `@theme inline` block.
- Added `prefers-reduced-motion` guard for `animate-highlight-new`.

### 10 duration swaps across primitives

`duration-150` / `duration-200` → `duration-base` in:

- `src/lib/components/ui/sidebar/sidebar.svelte`
- `src/lib/components/ui/sidebar/sidebar-group-label.svelte`
- `src/lib/components/ui/accordion/accordion-trigger.svelte`
- `src/lib/components/ui/dialog/dialog-content.svelte`
- `src/lib/components/ui/resizable/resizable-handle.svelte`
- `src/lib/components/shell/tool-shell.svelte`
- `src/lib/components/layout/app-sidebar.svelte`

The sheet-content's deliberate asymmetric `300/500` pair is preserved as intentional emphasis.

### `tree-node` selection consistency

`listItemButtonVariants.tree-node` previously used `ring-1 ring-primary/30` for selected state — conflating selection with focus. Other variants (`default`, `option`, `card`) all use `background + left-border` (`data-[selected=true]:bg-primary/10 data-[selected=true]:border-l-primary`). Migrate `tree-node` to the same pattern.

## Test Plan

- [x] `cargo check` — passes.
- [x] `bun run check` — svelte-check 0 errors, page validation OK, design audit OK.
- [x] `bunx vitest run` — 140 / 140 pass.
- [x] `bun run build` — succeeds; compiled CSS contains `.duration-base { transition-duration: var(--duration-base); ... }` and `@keyframes accordion-down`.
- [ ] Manual: open and close an Accordion item — confirm smooth height animation at `--duration-base` (160ms).
- [ ] Manual: switch a tab — confirm fade-in at the same duration.
- [ ] Manual: hover sidebar entries — confirm hover transition runs at `--duration-base`.
- [ ] Manual: select a row in the JSON tree view — confirm bg + border-l accent (no ring conflation).

## Implementation note

Tailwind v4's `duration-*` utility resolves names from the `--transition-duration-*` namespace specifically, **not** the bare `--duration-*` namespace. So even though we keep `--duration-fast/-base/-slow` on `:root` as the source of truth, the utility-bridging mapping must use the longer key:

```css
@theme inline {
	--transition-duration-fast: var(--duration-fast);
	--transition-duration-base: var(--duration-base);
	--transition-duration-slow: var(--duration-slow);
}
```

Verified by grepping the compiled production CSS for `.duration-base { ... transition-duration: var(--duration-base) }`.

## Follow-ups

PR D (loading skeletons) → PR E (tooltips + inline help) → … → PR H (a11y).
