### PR TITLE
refactor(ui): add loading skeletons for in-place async work

### DIFF
--- a/src/lib/components/ui/skeleton/index.ts
+++ b/src/lib/components/ui/skeleton/index.ts
@@ -1,7 +1,11 @@
 import Root from './skeleton.svelte';
+import SkeletonRow from './skeleton-row.svelte';
+import SkeletonCard from './skeleton-card.svelte';
 
 export {
 	Root,
 	//
 	Root as Skeleton,
+	SkeletonRow,
+	SkeletonCard,
 };

--- a/src/lib/components/ui/skeleton/skeleton-card.svelte
+++ b/src/lib/components/ui/skeleton/skeleton-card.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Skeleton } from '.';
+
+	interface Props {
+		readonly lines?: number;
+		readonly delay?: number;
+	}
+
+	let { lines = 3, delay = 0 }: Props = $props();
+</script>
+
+<div class="rounded-xl border bg-card p-4 space-y-3" style:animation-delay="{delay}ms">
+	<Skeleton class="h-4 w-2/3" />
+	{#each Array(lines) as _, i (i)}
+		<Skeleton class="h-3 w-full" />
+	{/each}
+</div>

--- a/src/lib/components/ui/skeleton/skeleton-row.svelte
+++ b/src/lib/components/ui/skeleton/skeleton-row.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { Skeleton } from '.';
+
+	interface Props {
+		/** Animation delay in ms for staggered list reveals. */
+		readonly delay?: number;
+		/** Show a leading icon skeleton (square). */
+		readonly leading?: boolean;
+		/** Show a trailing badge skeleton (small pill). */
+		readonly trailing?: boolean;
+		/** Width of the main label skeleton, as a Tailwind class. */
+		readonly labelWidth?: string;
+	}
+
+	let { delay = 0, leading = true, trailing = false, labelWidth = 'w-32' }: Props = $props();
+</script>
+
+<div
+	class="flex items-center gap-3 rounded-md border bg-card px-3 py-2"
+	style:animation-delay="{delay}ms"
+>
+	{#if leading}
+		<Skeleton class="h-4 w-4 shrink-0 rounded" />
+	{/if}
+	<div class="flex flex-1 flex-col gap-1.5">
+		<Skeleton class="h-3 {labelWidth}" />
+		<Skeleton class="h-2.5 w-20" />
+	</div>
+	{#if trailing}
+		<Skeleton class="h-4 w-10 rounded-full" />
+	{/if}
+</div>

--- a/src/routes/network-interfaces/+page.svelte
+++ b/src/routes/network-interfaces/+page.svelte
@@ -23,6 +23,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { ListItemButton } from '$lib/components/ui/list-item-button';
 	import * as Resizable from '$lib/components/ui/resizable';
+	import { SkeletonRow } from '$lib/components/ui/skeleton';
 	import { cn } from '$lib/utils';
 	import {
 		type DetailedNetworkInterface,
@@ -641,7 +642,15 @@
 					</Resizable.Pane>
 				</Resizable.PaneGroup>
 			{:else if loading}
-				<EmptyState icon={RefreshCw} title="Loading network interfaces..." />
+				<!--
+					Initial fetch of interfaces is async (Tauri command).
+					Render skeleton rows in place of a single loading label.
+				-->
+				<div class="space-y-1.5 p-2" aria-busy="true" aria-label="Loading network interfaces">
+					{#each Array(5) as _, i (i)}
+						<SkeletonRow delay={i * 30} labelWidth="w-28" trailing />
+					{/each}
+				</div>
 			{:else if error}
 				<EmptyState icon={Circle} title="Failed to load interfaces" description={error} />
 			{:else}

--- a/src/routes/network-scanner/+page.svelte
+++ b/src/routes/network-scanner/+page.svelte
@@ -32,6 +32,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { ListItemButton } from '$lib/components/ui/list-item-button';
 	import * as Resizable from '$lib/components/ui/resizable';
+	import { SkeletonRow } from '$lib/components/ui/skeleton';
 	import { Channel } from '@tauri-apps/api/core';
 	import {
 		cancelDiscovery,
@@ -1101,7 +1102,17 @@
 
 		<!-- Main Content -->
 		<div class="flex-1 overflow-hidden">
-			{#if unifiedHosts.length > 0}
+			{#if (isDiscovering || isScanning) && unifiedHosts.length === 0 && !error}
+				<!--
+					Discovery / scan is running but the first host has not arrived yet.
+					Render a stack of skeleton rows so the panel does not look frozen.
+				-->
+				<div class="space-y-1.5 p-2" aria-busy="true" aria-label="Loading hosts">
+					{#each Array(6) as _, i (i)}
+						<SkeletonRow delay={i * 30} labelWidth="w-32" trailing />
+					{/each}
+				</div>
+			{:else if unifiedHosts.length > 0}
 				<!-- Unified 2-Pane Layout: Host List + Detail -->
 				<Resizable.PaneGroup direction="horizontal" class="h-full">
 					<!-- Left Pane: Host List -->

--- a/src/routes/network-scanner/components/unified-host-detail-panel.svelte
+++ b/src/routes/network-scanner/components/unified-host-detail-panel.svelte
@@ -40,6 +40,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
 	import * as Select from '$lib/components/ui/select';
+	import { SkeletonRow } from '$lib/components/ui/skeleton';
 	import * as Tabs from '$lib/components/ui/tabs';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import {
@@ -882,7 +883,17 @@
 					</div>
 				{/if}
 
-				{#if ports.length === 0}
+				{#if ports.length === 0 && scanDisabled && scanProgress}
+					<!--
+						Scan is running but the first port result has not arrived yet.
+						Render skeleton rows so the tab does not look empty.
+					-->
+					<div class="space-y-1.5" aria-busy="true" aria-label="Loading ports">
+						{#each Array(5) as _, i (i)}
+							<SkeletonRow delay={i * 30} labelWidth="w-24" trailing />
+						{/each}
+					</div>
+				{:else if ports.length === 0}
 					<EmbeddedEmptyState
 						icon={Network}
 						title="No Port Scan Data"


### PR DESCRIPTION
## Summary

Add in-place loading skeleton feedback for incremental async work. Fourth PR of the **production-ready polish** track (after #243 / #244 / #245 / #246).

- **Two new composed skeleton primitives** on top of the existing `Skeleton` building block.
- **3 application sites** where the app previously showed a blank panel during incremental async operations.

## Why

The existing `Skeleton` primitive lives at `src/lib/components/ui/skeleton/skeleton.svelte` but was only used by `SidebarMenuSkeleton`. The audit identified concrete sites where the panel sits empty during a scan or discovery, with no feedback that work is in progress and results are coming.

`LoadingOverlay` already covers full-screen async work (BCrypt, SSH, GPG generation). What was missing is the **list-arrival case** — when results trickle in over time, the panel should show structured placeholders rather than a blank rectangle.

## Changes

### Added

- `src/lib/components/ui/skeleton/skeleton-row.svelte` — list-row placeholder with optional leading icon and trailing badge. Accepts `delay` for staggered reveals. Two stacked muted bars represent the label + sub-label.
- `src/lib/components/ui/skeleton/skeleton-card.svelte` — card-shaped placeholder with configurable `lines`.
- Both exported from `src/lib/components/ui/skeleton/index.ts`.

### Applied at

| Site | Condition | Pattern |
| --- | --- | --- |
| Network scanner host list | `(isDiscovering \|\| isScanning) && unifiedHosts.length === 0 && !error` | 6 `SkeletonRow` with 30 ms stagger |
| Network scanner Ports tab (host detail) | `ports.length === 0 && scanDisabled && scanProgress` | 5 `SkeletonRow` with 30 ms stagger |
| Network interfaces page | `loading` branch (replaces former `EmptyState "Loading…"`) | 5 `SkeletonRow` |

All skeleton wrappers set `aria-busy="true"` and a descriptive `aria-label` so assistive technologies announce the load state.

## Design choices

- **Stagger via `style:animation-delay`** instead of CSS `:nth-child` — keeps the stagger value at the call site, so consumers can pick 30 ms, 50 ms, etc. without editing component CSS.
- **Composed on top of `Skeleton`**, not built from scratch — preserves the registry-aligned `bg-accent animate-pulse` baseline and inherits Tailwind's `prefers-reduced-motion` handling automatically.
- **Not applied to instant operations** — the audit confirmed BCrypt / SSH / GPG already use `LoadingOverlay` (right tool for full-screen waits), and pure-computation tools (regex, JSON format, password generate) don't need skeletons.

## Test Plan

- [x] `cargo check` — passes.
- [x] `bun run check` — svelte-check 0 errors, page validation OK, design audit OK.
- [x] `bunx vitest run` — 140 / 140 pass.
- [ ] Manual: start a network scan on a /24 — confirm the host list shows skeleton rows with the staggered pulse during discovery, then those skeletons are replaced by real host rows as they arrive.
- [ ] Manual: open a host detail panel and trigger a port scan — confirm the Ports tab shows skeleton rows while the scan is running.
- [ ] Manual: navigate to Network Interfaces — confirm the initial loading state shows skeleton rows.

## Follow-ups

PR E (tooltips + inline help) → PR F (platform native) → PR G (persistence) → PR H (a11y).
