### PR TITLE
refactor(ui): tooltips and inline help for discoverability

### DIFF
--- a/src/lib/components/editor/code/tree-view.svelte
+++ b/src/lib/components/editor/code/tree-view.svelte
@@ -26,6 +26,7 @@
 	import { toast } from 'svelte-sonner';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { ListItemButton } from '$lib/components/ui/list-item-button/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import type { AstNode, AstNodeType } from '$lib/services/ast/index.js';
 	import TreeView from './tree-view.svelte';
 
@@ -412,24 +413,33 @@
 	style:padding-left="calc(var(--tree-depth) * 16px)"
 >
 	{#if hasChildren}
+		{@const chevronLabel = expanded ? 'Collapse' : 'Expand'}
 		<!-- Chevron (absolute-positioned to avoid nesting <button>) -->
-		<Button
-			variant="ghost"
-			size="icon-sm"
-			class="hover:bg-muted-foreground/20 absolute left-[calc(var(--tree-depth)*16px+4px)] top-1/2 z-10 h-5 w-5 -translate-y-1/2 rounded transition-all"
-			aria-label={expanded ? 'Collapse' : 'Expand'}
-			tabindex={-1}
-			onclick={(e) => {
-				e.stopPropagation();
-				expanded = !expanded;
-			}}
-		>
-			<ChevronRight
-				class="h-3.5 w-3.5 text-muted-foreground transition-transform duration-200 {expanded
-					? 'rotate-90'
-					: ''}"
-			/>
-		</Button>
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				{#snippet child({ props })}
+					<Button
+						{...props}
+						variant="ghost"
+						size="icon-sm"
+						class="hover:bg-muted-foreground/20 absolute left-[calc(var(--tree-depth)*16px+4px)] top-1/2 z-10 h-5 w-5 -translate-y-1/2 rounded transition-all"
+						tabindex={-1}
+						onclick={(e) => {
+							e.stopPropagation();
+							expanded = !expanded;
+						}}
+					>
+						<ChevronRight
+							class="h-3.5 w-3.5 text-muted-foreground transition-transform duration-200 {expanded
+								? 'rotate-90'
+								: ''}"
+						/>
+						<span class="sr-only">{chevronLabel}</span>
+					</Button>
+				{/snippet}
+			</Tooltip.Trigger>
+			<Tooltip.Content>{chevronLabel}</Tooltip.Content>
+		</Tooltip.Root>
 	{/if}
 
 	<ListItemButton
@@ -488,32 +498,46 @@
 	<div
 		class="absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity group-hover/tree:opacity-100"
 	>
-		<Button
-			variant="ghost"
-			size="icon-sm"
-			class="hover:bg-muted hover:text-foreground h-5 w-5 text-muted-foreground"
-			aria-label="Copy path"
-			title="Copy path"
-			tabindex={-1}
-			onclick={handleCopyPath}
-		>
-			<span class="text-xs font-mono">$</span>
-		</Button>
-		<Button
-			variant="ghost"
-			size="icon-sm"
-			class="hover:bg-muted hover:text-foreground h-5 w-5 text-muted-foreground"
-			aria-label="Copy value"
-			title="Copy value"
-			tabindex={-1}
-			onclick={handleCopyValue}
-		>
-			{#if justCopied === node.path}
-				<Check class="h-3 w-3 text-success" />
-			{:else}
-				<Copy class="h-3 w-3" />
-			{/if}
-		</Button>
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				{#snippet child({ props })}
+					<Button
+						{...props}
+						variant="ghost"
+						size="icon-sm"
+						class="hover:bg-muted hover:text-foreground h-5 w-5 text-muted-foreground"
+						tabindex={-1}
+						onclick={handleCopyPath}
+					>
+						<span class="text-xs font-mono">$</span>
+						<span class="sr-only">Copy path</span>
+					</Button>
+				{/snippet}
+			</Tooltip.Trigger>
+			<Tooltip.Content>Copy path</Tooltip.Content>
+		</Tooltip.Root>
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				{#snippet child({ props })}
+					<Button
+						{...props}
+						variant="ghost"
+						size="icon-sm"
+						class="hover:bg-muted hover:text-foreground h-5 w-5 text-muted-foreground"
+						tabindex={-1}
+						onclick={handleCopyValue}
+					>
+						{#if justCopied === node.path}
+							<Check class="h-3 w-3 text-success" />
+						{:else}
+							<Copy class="h-3 w-3" />
+						{/if}
+						<span class="sr-only">Copy value</span>
+					</Button>
+				{/snippet}
+			</Tooltip.Trigger>
+			<Tooltip.Content>Copy value</Tooltip.Content>
+		</Tooltip.Root>
 	</div>
 </div>
 

--- a/src/lib/components/form/form-input.svelte
+++ b/src/lib/components/form/form-input.svelte
@@ -3,6 +3,7 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import { cn } from '$lib/utils.js';
 
 	interface Props {
@@ -69,19 +70,28 @@
 			class={inputClass}
 		/>
 		{#if showToggle && type === 'password'}
-			<Button
-				variant="ghost"
-				size="icon-sm"
-				class="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-				aria-label={showValue ? 'Hide password' : 'Show password'}
-				onclick={() => (showValue = !showValue)}
-			>
-				{#if showValue}
-					<EyeOff class="h-3.5 w-3.5" />
-				{:else}
-					<Eye class="h-3.5 w-3.5" />
-				{/if}
-			</Button>
+			{@const toggleLabel = showValue ? 'Hide password' : 'Show password'}
+			<Tooltip.Root>
+				<Tooltip.Trigger>
+					{#snippet child({ props })}
+						<Button
+							{...props}
+							variant="ghost"
+							size="icon-sm"
+							class="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+							onclick={() => (showValue = !showValue)}
+						>
+							{#if showValue}
+								<EyeOff class="h-3.5 w-3.5" />
+							{:else}
+								<Eye class="h-3.5 w-3.5" />
+							{/if}
+							<span class="sr-only">{toggleLabel}</span>
+						</Button>
+					{/snippet}
+				</Tooltip.Trigger>
+				<Tooltip.Content>{toggleLabel}</Tooltip.Content>
+			</Tooltip.Root>
 		{/if}
 	</div>
 	{#if hint}

--- a/src/lib/components/layout/keyboard-shortcuts-dialog.svelte
+++ b/src/lib/components/layout/keyboard-shortcuts-dialog.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+	import { Search } from '@lucide/svelte';
 	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
 	import { modLabel } from '$lib/utils/keyboard.js';
 
 	interface Props {
@@ -60,6 +62,36 @@
 			],
 		},
 	];
+
+	let query = $state('');
+	let searchInput = $state<HTMLInputElement | null>(null);
+
+	const filteredGroups = $derived.by(() => {
+		const trimmed = query.trim().toLowerCase();
+		if (!trimmed) return groups;
+		return groups
+			.map((group) => ({
+				...group,
+				shortcuts: group.shortcuts.filter(
+					(shortcut) =>
+						shortcut.description.toLowerCase().includes(trimmed) ||
+						shortcut.keys.toLowerCase().includes(trimmed)
+				),
+			}))
+			.filter((group) => group.shortcuts.length > 0);
+	});
+
+	// Reset the query and focus the input each time the dialog opens so the
+	// next keystroke filters from a clean state.
+	$effect(() => {
+		if (open) {
+			query = '';
+			// Defer focus until after bits-ui has mounted the dialog content.
+			queueMicrotask(() => {
+				searchInput?.focus();
+			});
+		}
+	});
 </script>
 
 <Dialog.Root bind:open>
@@ -68,18 +100,29 @@
 			<Dialog.Title>Keyboard Shortcuts</Dialog.Title>
 			<Dialog.Description>Available keyboard shortcuts in Kogu.</Dialog.Description>
 		</Dialog.Header>
+		<div class="relative">
+			<Search
+				class="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+			/>
+			<Input
+				bind:ref={searchInput}
+				bind:value={query}
+				placeholder="Search shortcuts..."
+				class="pl-8"
+			/>
+		</div>
 		<div class="max-h-[60vh] space-y-4 overflow-y-auto py-2">
-			{#each groups as group}
+			{#each filteredGroups as group (group.title)}
 				<div>
 					<h3 class="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
 						{group.title}
 					</h3>
 					<div class="space-y-1">
-						{#each group.shortcuts as shortcut}
+						{#each group.shortcuts as shortcut (shortcut.description)}
 							<div class="flex items-center justify-between py-1">
 								<span class="text-sm">{shortcut.description}</span>
 								<div class="flex items-center gap-1">
-									{#each shortcut.keys.split('+') as part}
+									{#each shortcut.keys.split('+') as part (part)}
 										<kbd
 											class="rounded border border-border/40 bg-card px-1.5 py-0.5 font-mono text-2xs text-muted-foreground"
 										>
@@ -92,6 +135,11 @@
 					</div>
 				</div>
 			{/each}
+			{#if filteredGroups.length === 0}
+				<p class="py-6 text-center text-sm text-muted-foreground">
+					No shortcuts match "{query}"
+				</p>
+			{/if}
 		</div>
 	</Dialog.Content>
 </Dialog.Root>

--- a/src/lib/components/layout/nav-buttons.svelte
+++ b/src/lib/components/layout/nav-buttons.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { ChevronLeft, ChevronRight } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import {
 		getCanGoBack,
 		getCanGoForward,
@@ -22,24 +23,40 @@
 </script>
 
 <div class="flex items-center gap-0.5">
-	<Button
-		variant="ghost"
-		size="icon-sm"
-		disabled={!canGoBack}
-		onclick={handleBack}
-		aria-label="Go back"
-		class="h-7 w-7"
-	>
-		<ChevronLeft class="h-4 w-4" />
-	</Button>
-	<Button
-		variant="ghost"
-		size="icon-sm"
-		disabled={!canGoForward}
-		onclick={handleForward}
-		aria-label="Go forward"
-		class="h-7 w-7"
-	>
-		<ChevronRight class="h-4 w-4" />
-	</Button>
+	<Tooltip.Root>
+		<Tooltip.Trigger>
+			{#snippet child({ props })}
+				<Button
+					{...props}
+					variant="ghost"
+					size="icon-sm"
+					disabled={!canGoBack}
+					onclick={handleBack}
+					class="h-7 w-7"
+				>
+					<ChevronLeft class="h-4 w-4" />
+					<span class="sr-only">Go back</span>
+				</Button>
+			{/snippet}
+		</Tooltip.Trigger>
+		<Tooltip.Content>Go back</Tooltip.Content>
+	</Tooltip.Root>
+	<Tooltip.Root>
+		<Tooltip.Trigger>
+			{#snippet child({ props })}
+				<Button
+					{...props}
+					variant="ghost"
+					size="icon-sm"
+					disabled={!canGoForward}
+					onclick={handleForward}
+					class="h-7 w-7"
+				>
+					<ChevronRight class="h-4 w-4" />
+					<span class="sr-only">Go forward</span>
+				</Button>
+			{/snippet}
+		</Tooltip.Trigger>
+		<Tooltip.Content>Go forward</Tooltip.Content>
+	</Tooltip.Root>
 </div>

--- a/src/lib/components/ui/collapsible-aside/collapsible-aside.svelte
+++ b/src/lib/components/ui/collapsible-aside/collapsible-aside.svelte
@@ -3,6 +3,7 @@
 	import type { Snippet } from 'svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as ScrollArea from '$lib/components/ui/scroll-area/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import { cn } from '$lib/utils.js';
 
 	interface Props {
@@ -78,16 +79,23 @@
 			</div>
 		</ScrollArea.Root>
 	{:else}
-		<Button
-			variant="ghost"
-			size="icon"
-			class="m-1.5 h-8 w-8"
-			onclick={handleToggle}
-			aria-label="Show {title}"
-			title="Show {title}"
-		>
-			<Settings2 class="h-4 w-4" />
-		</Button>
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				{#snippet child({ props })}
+					<Button
+						{...props}
+						variant="ghost"
+						size="icon"
+						class="m-1.5 h-8 w-8"
+						onclick={handleToggle}
+					>
+						<Settings2 class="h-4 w-4" />
+						<span class="sr-only">Show {title}</span>
+					</Button>
+				{/snippet}
+			</Tooltip.Trigger>
+			<Tooltip.Content>Show {title}</Tooltip.Content>
+		</Tooltip.Root>
 	{/if}
 
 	<button

--- a/src/lib/components/ui/sidebar/sidebar-trigger.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-trigger.svelte
@@ -2,6 +2,7 @@
 	import PanelLeftIcon from '@lucide/svelte/icons/panel-left';
 	import type { ComponentProps } from 'svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import { cn } from '$lib/utils.js';
 	import { useSidebar } from './context.svelte.js';
 
@@ -17,19 +18,27 @@
 	const sidebar = useSidebar();
 </script>
 
-<Button
-	data-sidebar="trigger"
-	data-slot="sidebar-trigger"
-	variant="ghost"
-	size="icon"
-	class={cn('size-7', className)}
-	type="button"
-	onclick={(e) => {
-		onclick?.(e);
-		sidebar.toggle();
-	}}
-	{...restProps}
->
-	<PanelLeftIcon />
-	<span class="sr-only">Toggle Sidebar</span>
-</Button>
+<Tooltip.Root>
+	<Tooltip.Trigger>
+		{#snippet child({ props })}
+			<Button
+				{...props}
+				data-sidebar="trigger"
+				data-slot="sidebar-trigger"
+				variant="ghost"
+				size="icon"
+				class={cn('size-7', className)}
+				type="button"
+				onclick={(e) => {
+					onclick?.(e);
+					sidebar.toggle();
+				}}
+				{...restProps}
+			>
+				<PanelLeftIcon />
+				<span class="sr-only">Toggle Sidebar</span>
+			</Button>
+		{/snippet}
+	</Tooltip.Trigger>
+	<Tooltip.Content>Toggle Sidebar</Tooltip.Content>
+</Tooltip.Root>

--- a/src/routes/jwt-decoder/+page.svelte
+++ b/src/routes/jwt-decoder/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { AlertTriangle, CheckCircle, Clock, KeyRound } from '@lucide/svelte';
+	import { AlertTriangle, CheckCircle, Clock, Info, KeyRound } from '@lucide/svelte';
 	import { CopyButton } from '$lib/components/action';
 	import { CodeEditor } from '$lib/components/editor';
 	import { FormInfo, FormSection } from '$lib/components/form';
@@ -7,6 +7,7 @@
 	import { ToolShell } from '$lib/components/shell';
 	import { EmptyState } from '$lib/components/status';
 	import * as Card from '$lib/components/ui/card';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 	import {
 		decodeJwt,
 		JWT_STANDARD_CLAIMS,
@@ -99,6 +100,31 @@
 	const getClaimDescription = (claim: string): string | undefined => {
 		return JWT_STANDARD_CLAIMS.find((c) => c.claim === claim)?.name;
 	};
+
+	// JWT signing-algorithm descriptions. Returns null for unknown alg values
+	// so the UI can omit the hint icon rather than display the raw string.
+	const ALG_DESCRIPTIONS: Readonly<Record<string, string>> = {
+		HS256: 'HMAC + SHA-256 (symmetric)',
+		HS384: 'HMAC + SHA-384 (symmetric)',
+		HS512: 'HMAC + SHA-512 (symmetric)',
+		RS256: 'RSA + SHA-256 (asymmetric)',
+		RS384: 'RSA + SHA-384 (asymmetric)',
+		RS512: 'RSA + SHA-512 (asymmetric)',
+		ES256: 'ECDSA + SHA-256 over P-256 (asymmetric)',
+		ES384: 'ECDSA + SHA-384 over P-384 (asymmetric)',
+		ES512: 'ECDSA + SHA-512 over P-521 (asymmetric)',
+		PS256: 'RSASSA-PSS + SHA-256',
+		none: 'No signature — INSECURE',
+	};
+
+	const getAlgDescription = (alg: string): string | null => ALG_DESCRIPTIONS[alg] ?? null;
+
+	const headerAlg = $derived.by((): string | null => {
+		const alg = decoded?.header.alg;
+		return typeof alg === 'string' ? alg : null;
+	});
+
+	const algDescription = $derived(headerAlg ? getAlgDescription(headerAlg) : null);
 </script>
 
 <svelte:head>
@@ -211,6 +237,29 @@
 							/>
 						</Card.Header>
 						<Card.Content>
+							{#if headerAlg}
+								<div class="mb-2 flex items-center gap-2 text-xs">
+									<span class="font-mono font-medium text-muted-foreground">alg:</span>
+									<code class="rounded bg-muted px-1.5 py-0.5 font-mono">{headerAlg}</code>
+									{#if algDescription}
+										<Tooltip.Root>
+											<Tooltip.Trigger>
+												{#snippet child({ props })}
+													<button
+														{...props}
+														type="button"
+														class="inline-flex h-4 w-4 items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+													>
+														<Info class="h-3.5 w-3.5" />
+														<span class="sr-only">Algorithm details</span>
+													</button>
+												{/snippet}
+											</Tooltip.Trigger>
+											<Tooltip.Content>{algDescription}</Tooltip.Content>
+										</Tooltip.Root>
+									{/if}
+								</div>
+							{/if}
 							<pre class="overflow-auto rounded bg-muted p-3 font-mono text-xs">{formatJson(
 									decoded.header
 								)}</pre>

--- a/src/routes/markdown-editor/+page.svelte
+++ b/src/routes/markdown-editor/+page.svelte
@@ -41,6 +41,7 @@
 	import * as ContextMenu from '$lib/components/ui/context-menu';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import { ListItemButton } from '$lib/components/ui/list-item-button';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 	import {
 		applyFormat,
 		exportAsHtml,
@@ -552,15 +553,23 @@ ${tocToMarkdown(toc)}
 		<div class="flex h-9 shrink-0 items-center gap-0.5 border-b bg-surface-3 px-2">
 			<!-- Text Formatting -->
 			{#each textFormatButtons as btn}
-				<Button
-					variant="ghost"
-					size="sm"
-					class="h-7 w-7 p-0"
-					title={btn.label}
-					onclick={() => handleFormat(btn.action)}
-				>
-					<btn.icon class="h-3.5 w-3.5" />
-				</Button>
+				<Tooltip.Root>
+					<Tooltip.Trigger>
+						{#snippet child({ props })}
+							<Button
+								{...props}
+								variant="ghost"
+								size="sm"
+								class="h-7 w-7 p-0"
+								onclick={() => handleFormat(btn.action)}
+							>
+								<btn.icon class="h-3.5 w-3.5" />
+								<span class="sr-only">{btn.label}</span>
+							</Button>
+						{/snippet}
+					</Tooltip.Trigger>
+					<Tooltip.Content>{btn.label}</Tooltip.Content>
+				</Tooltip.Root>
 			{/each}
 
 			<div class="mx-1 h-4 w-px bg-border"></div>
@@ -587,44 +596,68 @@ ${tocToMarkdown(toc)}
 
 			<!-- Lists -->
 			{#each listButtons as btn}
-				<Button
-					variant="ghost"
-					size="sm"
-					class="h-7 w-7 p-0"
-					title={btn.label}
-					onclick={() => handleFormat(btn.action)}
-				>
-					<btn.icon class="h-3.5 w-3.5" />
-				</Button>
+				<Tooltip.Root>
+					<Tooltip.Trigger>
+						{#snippet child({ props })}
+							<Button
+								{...props}
+								variant="ghost"
+								size="sm"
+								class="h-7 w-7 p-0"
+								onclick={() => handleFormat(btn.action)}
+							>
+								<btn.icon class="h-3.5 w-3.5" />
+								<span class="sr-only">{btn.label}</span>
+							</Button>
+						{/snippet}
+					</Tooltip.Trigger>
+					<Tooltip.Content>{btn.label}</Tooltip.Content>
+				</Tooltip.Root>
 			{/each}
 
 			<div class="mx-1 h-4 w-px bg-border"></div>
 
 			<!-- Insert Elements -->
 			{#each insertButtons as btn}
-				<Button
-					variant="ghost"
-					size="sm"
-					class="h-7 w-7 p-0"
-					title={btn.label}
-					onclick={() => handleFormat(btn.action)}
-				>
-					<btn.icon class="h-3.5 w-3.5" />
-				</Button>
+				<Tooltip.Root>
+					<Tooltip.Trigger>
+						{#snippet child({ props })}
+							<Button
+								{...props}
+								variant="ghost"
+								size="sm"
+								class="h-7 w-7 p-0"
+								onclick={() => handleFormat(btn.action)}
+							>
+								<btn.icon class="h-3.5 w-3.5" />
+								<span class="sr-only">{btn.label}</span>
+							</Button>
+						{/snippet}
+					</Tooltip.Trigger>
+					<Tooltip.Content>{btn.label}</Tooltip.Content>
+				</Tooltip.Root>
 			{/each}
 
 			<div class="mx-1 h-4 w-px bg-border"></div>
 
 			<!-- Clear Formatting -->
-			<Button
-				variant="ghost"
-				size="sm"
-				class="h-7 w-7 p-0"
-				title="Clear Formatting"
-				onclick={() => handleFormat('clearFormat')}
-			>
-				<Eraser class="h-3.5 w-3.5" />
-			</Button>
+			<Tooltip.Root>
+				<Tooltip.Trigger>
+					{#snippet child({ props })}
+						<Button
+							{...props}
+							variant="ghost"
+							size="sm"
+							class="h-7 w-7 p-0"
+							onclick={() => handleFormat('clearFormat')}
+						>
+							<Eraser class="h-3.5 w-3.5" />
+							<span class="sr-only">Clear Formatting</span>
+						</Button>
+					{/snippet}
+				</Tooltip.Trigger>
+				<Tooltip.Content>Clear Formatting</Tooltip.Content>
+			</Tooltip.Root>
 		</div>
 
 		<!-- Content Area -->

--- a/src/routes/network-scanner/components/unified-host-detail-panel.svelte
+++ b/src/routes/network-scanner/components/unified-host-detail-panel.svelte
@@ -353,43 +353,64 @@
 									{displaySource.toUpperCase()}
 								</span>
 							{/if}
-							<Button
-								variant="ghost"
-								size="icon-sm"
-								class="hover:bg-muted hover:text-foreground h-7 w-7 text-muted-foreground"
-								aria-label="Copy hostname"
-								title="Copy hostname"
-								onclick={() => copyToClipboard(displayName ?? '', 'Hostname')}
-							>
-								<Copy class="h-3.5 w-3.5" />
-							</Button>
+							<Tooltip.Root>
+								<Tooltip.Trigger>
+									{#snippet child({ props })}
+										<Button
+											{...props}
+											variant="ghost"
+											size="icon-sm"
+											class="hover:bg-muted hover:text-foreground h-7 w-7 text-muted-foreground"
+											onclick={() => copyToClipboard(displayName ?? '', 'Hostname')}
+										>
+											<Copy class="h-3.5 w-3.5" />
+											<span class="sr-only">Copy hostname</span>
+										</Button>
+									{/snippet}
+								</Tooltip.Trigger>
+								<Tooltip.Content>Copy hostname</Tooltip.Content>
+							</Tooltip.Root>
 						</div>
 						<div class="flex items-center gap-2">
 							<span class="font-mono text-sm tabular-nums text-muted-foreground">{primaryIp}</span>
-							<Button
-								variant="ghost"
-								size="icon-sm"
-								class="hover:bg-muted hover:text-foreground h-5 w-5 text-muted-foreground"
-								aria-label="Copy IP"
-								title="Copy IP"
-								onclick={() => copyToClipboard(primaryIp, 'IP address')}
-							>
-								<Copy class="h-3 w-3" />
-							</Button>
+							<Tooltip.Root>
+								<Tooltip.Trigger>
+									{#snippet child({ props })}
+										<Button
+											{...props}
+											variant="ghost"
+											size="icon-sm"
+											class="hover:bg-muted hover:text-foreground h-5 w-5 text-muted-foreground"
+											onclick={() => copyToClipboard(primaryIp, 'IP address')}
+										>
+											<Copy class="h-3 w-3" />
+											<span class="sr-only">Copy IP</span>
+										</Button>
+									{/snippet}
+								</Tooltip.Trigger>
+								<Tooltip.Content>Copy IP</Tooltip.Content>
+							</Tooltip.Root>
 						</div>
 					{:else}
 						<div class="flex items-center gap-2">
 							<h2 class="font-mono text-lg font-semibold tabular-nums">{primaryIp}</h2>
-							<Button
-								variant="ghost"
-								size="icon-sm"
-								class="hover:bg-muted hover:text-foreground h-7 w-7 text-muted-foreground"
-								aria-label="Copy IP"
-								title="Copy IP"
-								onclick={() => copyToClipboard(primaryIp, 'IP address')}
-							>
-								<Copy class="h-3.5 w-3.5" />
-							</Button>
+							<Tooltip.Root>
+								<Tooltip.Trigger>
+									{#snippet child({ props })}
+										<Button
+											{...props}
+											variant="ghost"
+											size="icon-sm"
+											class="hover:bg-muted hover:text-foreground h-7 w-7 text-muted-foreground"
+											onclick={() => copyToClipboard(primaryIp, 'IP address')}
+										>
+											<Copy class="h-3.5 w-3.5" />
+											<span class="sr-only">Copy IP</span>
+										</Button>
+									{/snippet}
+								</Tooltip.Trigger>
+								<Tooltip.Content>Copy IP</Tooltip.Content>
+							</Tooltip.Root>
 						</div>
 						<p class="text-xs text-muted-foreground">Hostname not resolved</p>
 					{/if}
@@ -608,16 +629,23 @@
 									<div class="text-xs text-muted-foreground">NetBIOS Name</div>
 									<div class="mt-0.5 flex items-center gap-1.5 font-mono text-sm font-medium">
 										{netbiosName}
-										<Button
-											variant="ghost"
-											size="icon-sm"
-											class="hover:bg-muted hover:text-foreground h-5 w-5 text-muted-foreground"
-											aria-label="Copy NetBIOS name"
-											title="Copy NetBIOS name"
-											onclick={() => copyToClipboard(netbiosName ?? '', 'NetBIOS name')}
-										>
-											<Copy class="h-3 w-3" />
-										</Button>
+										<Tooltip.Root>
+											<Tooltip.Trigger>
+												{#snippet child({ props })}
+													<Button
+														{...props}
+														variant="ghost"
+														size="icon-sm"
+														class="hover:bg-muted hover:text-foreground h-5 w-5 text-muted-foreground"
+														onclick={() => copyToClipboard(netbiosName ?? '', 'NetBIOS name')}
+													>
+														<Copy class="h-3 w-3" />
+														<span class="sr-only">Copy NetBIOS name</span>
+													</Button>
+												{/snippet}
+											</Tooltip.Trigger>
+											<Tooltip.Content>Copy NetBIOS name</Tooltip.Content>
+										</Tooltip.Root>
 									</div>
 								</div>
 							{/if}
@@ -626,16 +654,23 @@
 									<div class="text-xs text-muted-foreground">MAC Address</div>
 									<div class="mt-0.5 flex items-center gap-1.5 font-mono text-sm font-medium">
 										{macAddress}
-										<Button
-											variant="ghost"
-											size="icon-sm"
-											class="hover:bg-muted hover:text-foreground h-5 w-5 text-muted-foreground"
-											aria-label="Copy MAC address"
-											title="Copy MAC address"
-											onclick={() => copyToClipboard(macAddress ?? '', 'MAC address')}
-										>
-											<Copy class="h-3 w-3" />
-										</Button>
+										<Tooltip.Root>
+											<Tooltip.Trigger>
+												{#snippet child({ props })}
+													<Button
+														{...props}
+														variant="ghost"
+														size="icon-sm"
+														class="hover:bg-muted hover:text-foreground h-5 w-5 text-muted-foreground"
+														onclick={() => copyToClipboard(macAddress ?? '', 'MAC address')}
+													>
+														<Copy class="h-3 w-3" />
+														<span class="sr-only">Copy MAC address</span>
+													</Button>
+												{/snippet}
+											</Tooltip.Trigger>
+											<Tooltip.Content>Copy MAC address</Tooltip.Content>
+										</Tooltip.Root>
 									</div>
 								</div>
 							{/if}
@@ -1044,16 +1079,23 @@
 													{/if}
 												</div>
 											</div>
-											<Button
-												variant="ghost"
-												size="icon-sm"
-												class="hover:bg-muted hover:text-foreground h-6 w-6 text-muted-foreground"
-												aria-label="Copy port"
-												title="Copy port"
-												onclick={() => copyToClipboard(String(port.port), 'Port number')}
-											>
-												<Copy class="h-3 w-3" />
-											</Button>
+											<Tooltip.Root>
+												<Tooltip.Trigger>
+													{#snippet child({ props })}
+														<Button
+															{...props}
+															variant="ghost"
+															size="icon-sm"
+															class="hover:bg-muted hover:text-foreground h-6 w-6 text-muted-foreground"
+															onclick={() => copyToClipboard(String(port.port), 'Port number')}
+														>
+															<Copy class="h-3 w-3" />
+															<span class="sr-only">Copy port</span>
+														</Button>
+													{/snippet}
+												</Tooltip.Trigger>
+												<Tooltip.Content>Copy port</Tooltip.Content>
+											</Tooltip.Root>
 										</div>
 									</div>
 								{/each}
@@ -1209,20 +1251,27 @@
 											</details>
 										{/if}
 									</div>
-									<Button
-										variant="ghost"
-										size="icon-sm"
-										class="hover:bg-muted hover:text-foreground h-6 w-6 shrink-0 text-muted-foreground"
-										aria-label="Copy service info"
-										title="Copy service info"
-										onclick={() =>
-											copyToClipboard(
-												`${service.instanceName} (${service.serviceType}:${service.port})`,
-												'Service info'
-											)}
-									>
-										<Copy class="h-3 w-3" />
-									</Button>
+									<Tooltip.Root>
+										<Tooltip.Trigger>
+											{#snippet child({ props })}
+												<Button
+													{...props}
+													variant="ghost"
+													size="icon-sm"
+													class="hover:bg-muted hover:text-foreground h-6 w-6 shrink-0 text-muted-foreground"
+													onclick={() =>
+														copyToClipboard(
+															`${service.instanceName} (${service.serviceType}:${service.port})`,
+															'Service info'
+														)}
+												>
+													<Copy class="h-3 w-3" />
+													<span class="sr-only">Copy service info</span>
+												</Button>
+											{/snippet}
+										</Tooltip.Trigger>
+										<Tooltip.Content>Copy service info</Tooltip.Content>
+									</Tooltip.Root>
 								</div>
 							</div>
 						{/each}

--- a/src/routes/regex-tester/+page.svelte
+++ b/src/routes/regex-tester/+page.svelte
@@ -10,6 +10,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import * as ToggleGroup from '$lib/components/ui/toggle-group';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { cn } from '$lib/utils';
 	import { groupColor, matchBackdropColor } from '$lib/services/regex-design.js';
 	import {
@@ -157,6 +158,19 @@
 		unknown: { label: 'Unknown', className: 'bg-destructive/10 text-destructive' },
 	};
 
+	// Tooltip copy for each regex flag, keyed by single-letter flag character.
+	// Kept inline rather than in the regex service so the strings stay close to
+	// the only consumer (the flag ToggleGroup) and can be tuned for UX without
+	// rippling through code-generation utilities.
+	const FLAG_TOOLTIPS: Readonly<Record<string, string>> = {
+		g: 'Global: find all matches',
+		i: 'Case insensitive',
+		m: 'Multiline: ^ and $ match line breaks',
+		s: 'Dotall: . matches newlines',
+		u: 'Unicode: enable full Unicode matching',
+		y: 'Sticky: match from lastIndex',
+	};
+
 	const activeFlagIds = $derived(FLAG_INFO.filter((info) => flags[info.id]).map((info) => info.id));
 
 	const handleFlagsChange = (selected: string[]) => {
@@ -267,14 +281,22 @@
 						onValueChange={handleFlagsChange}
 					>
 						{#each FLAG_INFO as info (info.id)}
-							<ToggleGroup.Item
-								value={info.id}
-								aria-label={info.label}
-								title={`${info.label} — ${info.description}`}
-								class="h-9 w-9 font-mono data-[state=on]:border-primary data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
-							>
-								{info.char}
-							</ToggleGroup.Item>
+							{@const flagTooltip = FLAG_TOOLTIPS[info.char] ?? info.label}
+							<Tooltip.Root>
+								<Tooltip.Trigger>
+									{#snippet child({ props })}
+										<ToggleGroup.Item
+											{...props}
+											value={info.id}
+											aria-label={info.label}
+											class="h-9 w-9 font-mono data-[state=on]:border-primary data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
+										>
+											{info.char}
+										</ToggleGroup.Item>
+									{/snippet}
+								</Tooltip.Trigger>
+								<Tooltip.Content>{flagTooltip}</Tooltip.Content>
+							</Tooltip.Root>
 						{/each}
 					</ToggleGroup.Root>
 				</div>

--- a/src/routes/url-encoder/+page.svelte
+++ b/src/routes/url-encoder/+page.svelte
@@ -27,6 +27,7 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as Card from '$lib/components/ui/card';
 	import { Input } from '$lib/components/ui/input/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import {
 		buildUrl,
 		decodeUrlWithOptions,
@@ -563,9 +564,22 @@
 									oninput={(e) => updateQueryParam(index, 'value', e.currentTarget.value)}
 									class="flex-1 font-mono text-sm"
 								/>
-								<Button variant="ghost" size="icon" onclick={() => removeQueryParam(index)}>
-									<Trash2 class="h-4 w-4" />
-								</Button>
+								<Tooltip.Root>
+									<Tooltip.Trigger>
+										{#snippet child({ props })}
+											<Button
+												{...props}
+												variant="ghost"
+												size="icon"
+												onclick={() => removeQueryParam(index)}
+											>
+												<Trash2 class="h-4 w-4" />
+												<span class="sr-only">Remove parameter</span>
+											</Button>
+										{/snippet}
+									</Tooltip.Trigger>
+									<Tooltip.Content>Remove parameter</Tooltip.Content>
+								</Tooltip.Root>
 							</div>
 						{/each}
 					</div>


### PR DESCRIPTION
## Summary

Four discoverability refinements that turn implicit affordances into explicit hover hints. Fifth PR of the **production-ready polish** track (after #243 / #244 / #245 / #246 / #247).

- **21 tooltips** on icon-only buttons across nav, toolbar, sidebar, code editor, host detail panel.
- **Regex flag explainers** — each `g/i/m/s/u/y` toggle now has a tooltip with its meaning.
- **JWT algorithm explainers** — the JWT decoder Header card shows an Info icon with a Tooltip for recognized algorithms (HS / RS / ES / PS / `none`).
- **Keyboard shortcuts search** — the shortcuts dialog gains a leading search input with empty-category hiding and a no-results fallback.

## Why

Icon-only buttons accumulate over time and become a memorability tax: which icon means "expand", which means "copy hostname", which means "open settings"? The audit identified 20+ sites where a Tooltip would replace guessing with hovering. Same principle drives the regex flag and JWT alg explainers — these are well-known to specialists but invisible to casual users.

The keyboard shortcuts dialog had grown to multiple categories; finding a specific shortcut needed eye-scanning. A leading search input collapses that to one keystroke.

## Changes

### Tooltips on icon buttons (21 sites)

- Title bar nav: back / forward (`nav-buttons.svelte`).
- Sidebar trigger (`sidebar-trigger.svelte`).
- CollapsibleAside Settings2 toggle (`collapsible-aside.svelte`).
- FormInput password show/hide toggle.
- Code tree view: chevron expand/collapse, copy path, copy value.
- Network scanner host detail panel: 6 copy buttons (hostname, IP x2, NetBIOS, MAC, port, service info).
- URL encoder: query-parameter delete.
- Markdown editor toolbar: text-format, list, insert, Clear Formatting groups.

All follow the bits-ui `child` snippet pattern documented in `.claude/rules/svelte/components.md` § "bits-ui `child` Snippet Pattern". The accessible name lives in `<span class="sr-only">`, the visible hover label in `Tooltip.Content` — no duplicated `aria-label`.

### Regex flag explainers

Each `g/i/m/s/u/y` ToggleGroup item is wrapped in `Tooltip.Root` using the `child` snippet. Static `FLAG_TOOLTIPS` map carries the canonical descriptions (`g` → "Global: find all matches", etc.).

### JWT algorithm explainers (`jwt-decoder/+page.svelte`)

- New helper `getAlgDescription(alg: string): string | null` keyed by `ALG_DESCRIPTIONS`.
- Header card now renders `alg: <value>` above the raw JSON. When recognized, an `Info` icon appears next to the value with a Tooltip explaining the primitive (e.g., `HS256` → "HMAC + SHA-256 (symmetric)", `none` → "No signature — **INSECURE**").
- Unknown algorithms render verbatim without the hint.

### Keyboard shortcuts search

Leading search `Input` with a `Search` icon at the top of `KeyboardShortcutsDialog`. Case-insensitive substring match on the description + key combo. Empty categories hide during filtering; a "No shortcuts match" empty state appears when all are filtered out. Input auto-focuses on dialog open (deferred via `queueMicrotask` so bits-ui has mounted the content before `.focus()` runs). Query resets each open.

## Test Plan

- [x] `cargo check` — passes.
- [x] `bun run check` — svelte-check 0 errors, page validation OK, design audit OK.
- [x] `bunx vitest run` — 140 / 140 pass.
- [ ] Manual: hover any icon-only button — confirm tooltip with descriptive label.
- [ ] Manual: hover each regex flag — confirm tooltip matches the spec descriptions.
- [ ] Manual: decode a JWT with `alg: HS256` — confirm the Info icon appears with the HMAC tooltip.
- [ ] Manual: open Cmd+? (Keyboard Shortcuts) and type a partial shortcut name — confirm filtering, empty-category hiding, and the no-results message.

## Follow-up note

`CopyButton` does not currently wrap its trigger in a Tooltip. Centralizing tooltip behavior inside that primitive would propagate the affordance everywhere — flagged for a follow-up.

## Continuation

PR F (platform native polish) → PR G (persistence depth) → PR H (a11y polish).
