### PR TITLE
fix(layout): wrap layout in Tooltip.Provider for TitleBar tooltips

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,6 +8,7 @@
 	import { AppSidebar, KeyboardShortcutsDialog, TitleBar } from '$lib/components/layout/index.js';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { Sonner } from '$lib/components/ui/sonner/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import { goBack, goForward } from '$lib/services/navigation-history.svelte.js';
 	import {
 		applyAllSettings,
@@ -119,16 +120,18 @@
 <Sonner richColors />
 <KeyboardShortcutsDialog bind:open={shortcutsHelpOpen} />
 
-<div class="flex h-screen flex-col">
-	<TitleBar bind:commandRef={titleBarCommand} />
-	<Sidebar.Provider
-		class="flex-1 !min-h-0 [&_[data-slot=sidebar-container]]:top-8 [&_[data-slot=sidebar-container]]:h-[calc(100svh-2rem)]"
-	>
-		<div class="flex h-full w-full overflow-hidden">
-			<AppSidebar />
-			<Sidebar.Inset class="flex h-full flex-col overflow-hidden">
-				{@render children()}
-			</Sidebar.Inset>
-		</div>
-	</Sidebar.Provider>
-</div>
+<Tooltip.Provider delayDuration={150}>
+	<div class="flex h-screen flex-col">
+		<TitleBar bind:commandRef={titleBarCommand} />
+		<Sidebar.Provider
+			class="flex-1 !min-h-0 [&_[data-slot=sidebar-container]]:top-8 [&_[data-slot=sidebar-container]]:h-[calc(100svh-2rem)]"
+		>
+			<div class="flex h-full w-full overflow-hidden">
+				<AppSidebar />
+				<Sidebar.Inset class="flex h-full flex-col overflow-hidden">
+					{@render children()}
+				</Sidebar.Inset>
+			</div>
+		</Sidebar.Provider>
+	</div>
+</Tooltip.Provider>


### PR DESCRIPTION
## Summary

**Hotfix for a white-screen rendering failure introduced by #248.**

PR #248 wrapped icon-only buttons in `nav-buttons.svelte` with `Tooltip.Root` + `Tooltip.Trigger`, under the (wrong) assumption that `Sidebar.Provider` transparently established a `Tooltip.Provider` context for the whole app. That assumption was incorrect: `TitleBar` lives **outside** `Sidebar.Provider` in the layout hierarchy, so its tooltips threw:

```
Context "Tooltip.Provider" not found
  in tooltip.svelte
  in nav-buttons.svelte
  in title-bar.svelte
```

at runtime, causing the entire app to render as a blank white window.

## Fix

Wrap the entire layout body (`TitleBar` + `Sidebar.Provider`) in an explicit `<Tooltip.Provider delayDuration={150}>` at the `+layout.svelte` root. This is the canonical pattern recommended by shadcn-svelte / bits-ui — a single Provider at the root ensures every consumer in the tree (including chrome elements outside the sidebar) has the context available.

## Changes

- `src/routes/+layout.svelte`:
    - Added `import * as Tooltip from '$lib/components/ui/tooltip/index.js'`.
    - Wrapped the outer `<div class="flex h-screen flex-col">` with `<Tooltip.Provider delayDuration={150}>`.

## Test Plan

- [x] `bun run check` — svelte-check 0 errors, page validation OK, design audit OK.
- [x] Manual: dev server's HMR picked up the change. White-screen resolved.
- [ ] Manual: hover TitleBar back / forward buttons — confirm tooltips appear.
- [ ] Manual: hover any other icon-only button across the app — confirm tooltips still work via the new root provider.

## Lessons captured for memory

- **Never assume `Sidebar.Provider` establishes a Tooltip context for chrome outside Sidebar.** The `Tooltip.Provider` exists inside `Sidebar.Provider` only for the sidebar tree's own use. App-wide tooltip access requires an explicit root-level `<Tooltip.Provider>`.
- The bug was missed by `bun run check` because Svelte's type system can't catch missing runtime context. Manual rendering verification (literally seeing the app load) is the only reliable check for `Context "X" not found` regressions.
- Adding context-dependent primitives to "shell" components (TitleBar, AppSidebar, layouts) requires verifying the provider hierarchy, not just type-checking.

## Continuation

After this hotfix lands, resume the polish track: PR F (platform native polish) → PR G (persistence depth) → PR H (a11y polish).
