### PR TITLE
refactor(ui): platform-native polish

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
 				"titleBarStyle": "Overlay",
 				"trafficLightPosition": {
 					"x": 12,
-					"y": 10
+					"y": 11
 				},
 				"dragDropEnabled": false
 			}

--- a/src/app.css
+++ b/src/app.css
@@ -486,3 +486,26 @@
 	outline: 2px solid oklch(from var(--primary) l c h / 30%);
 	outline-offset: 2px;
 }
+
+/*
+ * Thin themed scrollbars for a native-app feel.
+ *
+ * Applied to all scrollable elements that fall back to the platform default
+ * (page-level scrolls, dropdown overflow, code-editor scrollbars, etc.).
+ * The shadcn `ScrollArea` component ships its own scrollbar treatment, so
+ * these rules only affect the OS-default scrollbar surfaces.
+ */
+*::-webkit-scrollbar {
+	width: 8px;
+	height: 8px;
+}
+*::-webkit-scrollbar-track {
+	background: transparent;
+}
+*::-webkit-scrollbar-thumb {
+	background: var(--border);
+	border-radius: 9999px;
+}
+*::-webkit-scrollbar-thumb:hover {
+	background: oklch(from var(--muted-foreground) l c h / 40%);
+}

--- a/src/lib/components/ui/dialog/dialog-overlay.svelte
+++ b/src/lib/components/ui/dialog/dialog-overlay.svelte
@@ -13,7 +13,7 @@
 	bind:ref
 	data-slot="dialog-overlay"
 	class={cn(
-		'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+		'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 backdrop-blur-sm',
 		className
 	)}
 	{...restProps}

--- a/src/lib/components/ui/sheet/sheet-overlay.svelte
+++ b/src/lib/components/ui/sheet/sheet-overlay.svelte
@@ -13,7 +13,7 @@
 	bind:ref
 	data-slot="sheet-overlay"
 	class={cn(
-		'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+		'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 backdrop-blur-sm',
 		className
 	)}
 	{...restProps}

--- a/src/lib/utils/keyboard.ts
+++ b/src/lib/utils/keyboard.ts
@@ -1,10 +1,24 @@
 /**
  * Platform-aware keyboard shortcut utilities.
+ *
+ * Detection is synchronous so it can be used inside reactive expressions and
+ * event handlers without awaiting `@tauri-apps/plugin-os`. The Tauri webview
+ * exposes `navigator.platform` / `navigator.userAgent`, both of which reveal
+ * the host OS reliably enough for picking modifier glyphs vs. words.
  */
 
+const detectMac = (): boolean => {
+	if (typeof navigator === 'undefined') return false;
+	// `navigator.platform` is the most stable signal in webviews; fall back to
+	// `userAgent` (which still contains "Mac" / "iPhone" / "iPad" on Apple
+	// platforms) when `platform` is empty or unrecognised.
+	const platform = navigator.platform || '';
+	const ua = navigator.userAgent || '';
+	return /Mac|iPod|iPhone|iPad/i.test(platform) || /Mac|iPhone|iPad/i.test(ua);
+};
+
 /** Whether the current platform is macOS (synchronous detection for event handlers). */
-export const isMac: boolean =
-	typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+export const isMac: boolean = detectMac();
 
 /** Check if the platform modifier key is pressed (Cmd on macOS, Ctrl on others). */
 export const isModKey = (e: KeyboardEvent): boolean => (isMac ? e.metaKey : e.ctrlKey);
@@ -20,11 +34,26 @@ export const isEditableTarget = (e: KeyboardEvent): boolean => {
 	return false;
 };
 
-/** Format a shortcut for display (e.g., "⌘K" on macOS, "Ctrl+K" on others). */
+/** Platform-specific modifier label for display (⌘ on macOS, Ctrl on others). */
+export const modLabel: string = isMac ? '⌘' : 'Ctrl';
+
+/** Platform-specific shift label for display (⇧ on macOS, Shift on others). */
+export const shiftLabel: string = isMac ? '⇧' : 'Shift';
+
+/** Platform-specific alt/option label for display (⌥ on macOS, Alt on others). */
+export const altLabel: string = isMac ? '⌥' : 'Alt';
+
+/** Platform-specific control label for display (⌃ on macOS, Ctrl on others). */
+export const ctrlLabel: string = isMac ? '⌃' : 'Ctrl';
+
+/**
+ * Format a shortcut for display.
+ *
+ * On macOS the modifier glyph is concatenated directly to the key (`⌘K`),
+ * matching the convention seen in native macOS menus. On other platforms the
+ * modifier word is joined with `+` (`Ctrl+K`).
+ */
 export const formatShortcut = (key: string, mod = false): string => {
 	if (!mod) return key;
-	return isMac ? `⌘${key}` : `Ctrl+${key}`;
+	return isMac ? `${modLabel}${key}` : `${modLabel}+${key}`;
 };
-
-/** Platform-specific modifier label for display. */
-export const modLabel: string = isMac ? '⌘' : 'Ctrl';


### PR DESCRIPTION
## Summary

Four refinements that lift the platform-native feel without adding new features. Sixth PR of the **production-ready polish** track (after #243 / #244 / #245 / #246 / #247 / #248 + hotfix #249).

- **Traffic-light alignment** fixed by 1px (10 → 11).
- **OS-aware keyboard shortcuts** — display flips from `⌘K` to `Ctrl+K` on Linux / Windows.
- **Frosted-glass modals** — `backdrop-blur-sm` on Dialog and Sheet overlays.
- **Thin themed scrollbars** — 8px webkit scrollbars with OKLCH-themed thumb.

## Changes

### `src-tauri/tauri.conf.json`

`trafficLightPosition.y`: `10` → `11`. The macOS standard vertical center for the traffic-light buttons in an `h-8` (32px) custom title bar is 11px from the top, not 10px. Visible to designers but easy to miss.

### `src/lib/utils/keyboard.ts`

Hardened the existing sync platform detector with a `navigator.userAgent` fallback (for webviews that ship an empty `navigator.platform`). Exposed three new constants alongside `modLabel`:

- `shiftLabel` → `⇧` on macOS, `Shift` elsewhere
- `altLabel` → `⌥` on macOS, `Alt` elsewhere
- `ctrlLabel` → `⌃` on macOS, `Ctrl` elsewhere

Future shortcuts that need any of these modifiers can pull from one place instead of re-implementing OS detection. `formatShortcut(key, true)` continues to produce `⌘K` on macOS and `Ctrl+K` on Linux / Windows.

### Dialog / Sheet overlays

`dialog-overlay.svelte` and `sheet-overlay.svelte` gain `backdrop-blur-sm` (4px). Kept at `sm` rather than `md` (12px) to preserve modal text legibility — the goal is "content underneath softens when a modal opens" not "content disappears".

### `src/app.css`

Added `::-webkit-scrollbar` rules at the file end:

- 8px width / height
- Transparent track
- Thumb uses `var(--border)` directly (the project's OKLCH-based border token)
- Hover thumb uses `oklch(from var(--muted-foreground) l c h / 40%)`

Comment notes that shadcn `ScrollArea` is unaffected because that component renders its own custom scrollbar inside the slotted content.

## Test Plan

- [x] `cargo check` — passes.
- [x] `bun run check` — svelte-check 0 errors, page validation OK, design audit OK.
- [x] `bunx vitest run` — 140 / 140 pass.
- [ ] Manual: confirm traffic-light buttons align with the vertical center of the title bar (no longer 1px above).
- [ ] Manual: open Cmd+? (or whatever the system key is) — confirm the shortcut display shows the right OS-specific modifier text.
- [ ] Manual: open any modal (Reset Settings confirmation, KeyboardShortcutsDialog) — confirm the underlying page content blurs subtly.
- [ ] Manual: scroll a long list (e.g., the sidebar) — confirm thin themed scrollbar.

## Implementation note

The spec suggested `hsl(var(--border))` for the scrollbar thumb but the project's `--border` is an OKLCH expression. Used `var(--border)` directly and `oklch(from var(--muted-foreground) l c h / 40%)` for hover state, which matches the rest of `app.css` style conventions.

## Continuation

PR G (persistence depth) → PR H (a11y polish).
