### PR TITLE
refactor(ui): persist sidebar state, active tabs, and tool options

### DIFF
--- a/src/lib/components/template/tabbed-formatter-page.svelte
+++ b/src/lib/components/template/tabbed-formatter-page.svelte
@@ -44,17 +44,32 @@
 		readonly title: string;
 		/** Function to calculate stats from input */
 		readonly calculateStats: (input: string) => TStats | null;
+		/**
+		 * Optional `persisted` key for the active tab. Pass the tool slug
+		 * (e.g. `xml-formatter`) so each tool tracks its tab independently.
+		 */
+		readonly persistKey?: string;
 		/** Status bar content snippet - receives liveStats */
 		readonly renderStatusContent?: Snippet<[TStats | null]>;
 		/** Tab content snippet - receives tab props */
 		readonly renderTabContent: Snippet<[TabContentProps]>;
 	}
 
-	let { title, calculateStats, renderStatusContent, renderTabContent }: Props<unknown> = $props();
+	let { title, calculateStats, persistKey, renderStatusContent, renderTabContent }: Props<unknown> =
+		$props();
 
-	// Wrap calculateStats to avoid state_referenced_locally warning
+	// Wrap calculateStats to avoid the `state_referenced_locally` warning.
+	// `persistKey` is read through a getter for the same reason: the prop is
+	// treated as immutable by `useTabSync`, but capturing it as a plain local
+	// would trip the lint rule. Returning the current prop on demand keeps the
+	// rule satisfied without changing observable behaviour.
 	const statsCalculator = (input: string) => calculateStats(input);
-	const page = useFormatterPage({ calculateStats: statsCalculator });
+	const page = useFormatterPage({
+		calculateStats: statsCalculator,
+		get persistKey() {
+			return persistKey;
+		},
+	});
 
 	// Type-safe tab change handler for ToolShell
 	const handleTabChange = (tab: string) => {

--- a/src/lib/hooks/use-formatter-page.svelte.ts
+++ b/src/lib/hooks/use-formatter-page.svelte.ts
@@ -29,6 +29,12 @@ export type FormatterTabType = (typeof FORMATTER_TABS)[number];
 export interface UseFormatterPageConfig<TStats> {
 	/** Function to calculate live stats from input */
 	readonly calculateStats: (input: string) => TStats | null;
+	/**
+	 * Optional `persisted` key for the active tab. When provided, the last
+	 * active tab is restored after an app restart if the URL does not specify
+	 * one. Typically the tool slug (`json-formatter`, `xml-formatter`, ...).
+	 */
+	readonly persistKey?: string;
 }
 
 /**
@@ -76,12 +82,13 @@ export interface UseFormatterPageReturn<TStats> {
 export const useFormatterPage = <TStats>(
 	config: UseFormatterPageConfig<TStats>
 ): UseFormatterPageReturn<TStats> => {
-	const { calculateStats } = config;
+	const { calculateStats, persistKey } = config;
 
-	// Tab sync with URL
+	// Tab sync with URL (and optional localStorage fallback for restart survival).
 	const tabSync = useTabSync({
 		tabs: FORMATTER_TABS,
 		defaultTab: 'format',
+		persistKey,
 	});
 
 	// Type-safe tab change handler

--- a/src/lib/services/persisted.svelte.ts
+++ b/src/lib/services/persisted.svelte.ts
@@ -1,0 +1,102 @@
+/**
+ * Persisted reactive state helper.
+ *
+ * Wraps a Svelte 5 `$state` value with localStorage persistence so ephemeral UI
+ * preferences (sidebar collapsed flag, active tabs, per-tool option selections)
+ * survive an app restart. Real settings that need cross-device portability or
+ * structured schema validation should continue to use the Tauri TOML-backed
+ * `settings.ts` service.
+ *
+ * Design notes:
+ * - Returns an object exposing a `current` getter/setter so callers can use
+ *   `state.current` for reads/writes and `bind:value={state.current}` for
+ *   two-way binding on shadcn-svelte primitives.
+ * - SSR-safe: every `localStorage` access is wrapped in `typeof window !==
+ *   'undefined'` plus `try/catch`. The Tauri webview always has a window, but
+ *   `svelte-check` also validates server context.
+ * - 200KB soft cap on serialized JSON guards against accidentally persisting
+ *   large code editor content. Writes above the cap are skipped with a
+ *   `console.warn`; the in-memory value still updates normally.
+ * - Uses `$effect.root` because the helper may be called at module scope
+ *   (outside a component context). The root effect is intentionally never
+ *   cleaned up — these stores live for the lifetime of the app.
+ */
+
+const KEY_PREFIX = 'kogu:';
+const MAX_SERIALIZED_LENGTH = 200_000;
+
+/** Reactive value mirrored to localStorage. */
+export interface Persisted<T> {
+	/** Current value (reactive). */
+	current: T;
+}
+
+/**
+ * Read a JSON-serialised value from localStorage with a typed fallback.
+ *
+ * Returns the fallback when the key is missing, when storage is unavailable
+ * (SSR, privacy mode, quota exceeded reads), or when JSON parsing fails.
+ */
+const readStored = <T>(key: string, fallback: T): T => {
+	if (typeof window === 'undefined') return fallback;
+	try {
+		const raw = window.localStorage.getItem(key);
+		if (raw === null) return fallback;
+		return JSON.parse(raw) as T;
+	} catch {
+		return fallback;
+	}
+};
+
+/**
+ * Write a JSON-serialisable value to localStorage, skipping writes that exceed
+ * the soft size cap or fail (quota, disabled storage, SSR).
+ */
+const writeStored = <T>(key: string, value: T): void => {
+	if (typeof window === 'undefined') return;
+	try {
+		const serialized = JSON.stringify(value);
+		if (serialized.length > MAX_SERIALIZED_LENGTH) {
+			// Avoid filling the 5 MB localStorage quota with one giant entry.
+			console.warn(
+				`[persisted] Skipping write for "${key}": serialized size ${serialized.length} exceeds ${MAX_SERIALIZED_LENGTH} chars.`
+			);
+			return;
+		}
+		window.localStorage.setItem(key, serialized);
+	} catch {
+		// Quota exceeded, storage disabled, or value not serialisable.
+	}
+};
+
+/**
+ * Create a reactive value mirrored to `localStorage` under `kogu:<key>`.
+ *
+ * Reads the stored value on first access (falling back to `initial`) and
+ * registers a root effect that writes future updates back to storage.
+ *
+ * @example
+ * ```ts
+ * const sidebarOpen = persisted('sidebar:open', true);
+ * sidebarOpen.current = false; // persists across restarts
+ * ```
+ */
+export const persisted = <T>(key: string, initial: T): Persisted<T> => {
+	const storageKey = `${KEY_PREFIX}${key}`;
+	let value = $state<T>(readStored(storageKey, initial));
+
+	$effect.root(() => {
+		$effect(() => {
+			writeStored(storageKey, value);
+		});
+	});
+
+	return {
+		get current() {
+			return value;
+		},
+		set current(next: T) {
+			value = next;
+		},
+	};
+};

--- a/src/lib/utils/use-tab-sync.svelte.ts
+++ b/src/lib/utils/use-tab-sync.svelte.ts
@@ -1,5 +1,6 @@
 import { goto } from '$app/navigation';
 import { page } from '$app/state';
+import { persisted } from '$lib/services/persisted.svelte.js';
 
 /**
  * Options for useTabSync hook.
@@ -9,6 +10,13 @@ export interface UseTabSyncOptions<T extends string> {
 	readonly tabs: readonly T[];
 	/** Default tab to use when none specified in URL */
 	readonly defaultTab: T;
+	/**
+	 * Optional `persisted` key. When provided, the last-active tab is mirrored
+	 * to `localStorage` and used as the fallback when the URL has no `?tab=`
+	 * query parameter (e.g. on a fresh app launch). URL parameters still take
+	 * precedence so deep links work as before.
+	 */
+	readonly persistKey?: string;
 }
 
 /**
@@ -45,17 +53,28 @@ export interface UseTabSyncReturn<T extends string> {
 export const useTabSync = <T extends string>(
 	options: UseTabSyncOptions<T>
 ): UseTabSyncReturn<T> => {
-	const { tabs, defaultTab } = options;
+	const { tabs, defaultTab, persistKey } = options;
+
+	// Optional localStorage-backed fallback. When `persistKey` is omitted, this
+	// resolves to `null` and tab state behaves exactly as before (URL only).
+	const persistedTab = persistKey ? persisted<T>(`tab:${persistKey}`, defaultTab) : null;
+
+	const isValidTab = (candidate: string | null | undefined): candidate is T =>
+		candidate !== null && candidate !== undefined && tabs.includes(candidate as T);
+
+	const resolveInitialTab = (): T => {
+		if (persistedTab && isValidTab(persistedTab.current)) return persistedTab.current;
+		return defaultTab;
+	};
 
 	/**
-	 * Get tab from URL or return default.
+	 * Get tab from URL, falling back to the persisted value (if configured) and
+	 * finally to the default.
 	 */
 	const getTabFromUrl = (): T => {
 		const tabParam = page.url.searchParams.get('tab');
-		if (tabParam && tabs.includes(tabParam as T)) {
-			return tabParam as T;
-		}
-		return defaultTab;
+		if (isValidTab(tabParam)) return tabParam;
+		return resolveInitialTab();
 	};
 
 	// Reactive state - initialize from URL
@@ -64,10 +83,10 @@ export const useTabSync = <T extends string>(
 	// Sync from URL changes (browser back/forward)
 	$effect(() => {
 		const tabParam = page.url.searchParams.get('tab');
-		if (tabParam && tabs.includes(tabParam as T)) {
-			_activeTab = tabParam as T;
+		if (isValidTab(tabParam)) {
+			_activeTab = tabParam;
 		} else if (!tabParam) {
-			_activeTab = defaultTab;
+			_activeTab = resolveInitialTab();
 		}
 	});
 
@@ -76,6 +95,7 @@ export const useTabSync = <T extends string>(
 	 */
 	const setActiveTab = (tab: T): void => {
 		_activeTab = tab;
+		if (persistedTab) persistedTab.current = tab;
 		const url = new URL(page.url);
 		if (tab === defaultTab) {
 			url.searchParams.delete('tab');

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
 	import { Sonner } from '$lib/components/ui/sonner/index.js';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import { goBack, goForward } from '$lib/services/navigation-history.svelte.js';
+	import { persisted } from '$lib/services/persisted.svelte.js';
 	import {
 		applyAllSettings,
 		getSettings,
@@ -22,6 +23,9 @@
 
 	let titleBarCommand = $state<{ focusInput: () => void } | null>(null);
 	let shortcutsHelpOpen = $state(false);
+
+	// Sidebar collapse state survives app restarts via localStorage.
+	const sidebarOpen = persisted('sidebar:open', true);
 
 	const handleGlobalKeydown = (e: KeyboardEvent) => {
 		// Cmd+K → focus inline command palette in title bar
@@ -124,6 +128,7 @@
 	<div class="flex h-screen flex-col">
 		<TitleBar bind:commandRef={titleBarCommand} />
 		<Sidebar.Provider
+			bind:open={sidebarOpen.current}
 			class="flex-1 !min-h-0 [&_[data-slot=sidebar-container]]:top-8 [&_[data-slot=sidebar-container]]:h-[calc(100svh-2rem)]"
 		>
 			<div class="flex h-full w-full overflow-hidden">

--- a/src/routes/cron-expression-builder/+page.svelte
+++ b/src/routes/cron-expression-builder/+page.svelte
@@ -3,6 +3,7 @@
 	import { FormInfo, FormSection } from '$lib/components/form';
 	import { ToolShell } from '$lib/components/shell';
 	import { StatItem } from '$lib/components/status';
+	import { persisted } from '$lib/services/persisted.svelte.js';
 	import { BuildTab, ParseTab } from './tabs/index.js';
 
 	type CronTab = 'build' | 'parse';
@@ -12,7 +13,8 @@
 		{ id: 'parse' as const, label: 'Parse', icon: Search },
 	] as const;
 
-	let activeTab = $state<CronTab>('build');
+	// Persist the active tab so restarts open the panel the user last used.
+	const activeTab = persisted<CronTab>('tab:cron-expression-builder', 'build');
 	let buildStats = $state<{ expression: string; valid: boolean }>({
 		expression: '* * * * *',
 		valid: true,
@@ -22,10 +24,10 @@
 		valid: true,
 	});
 
-	const currentStats = $derived(activeTab === 'build' ? buildStats : parseStats);
+	const currentStats = $derived(activeTab.current === 'build' ? buildStats : parseStats);
 
 	const handleTabChange = (tab: string) => {
-		if (tab === 'build' || tab === 'parse') activeTab = tab;
+		if (tab === 'build' || tab === 'parse') activeTab.current = tab;
 	};
 </script>
 
@@ -36,7 +38,7 @@
 <ToolShell
 	layout="tabbed"
 	tabs={TABS}
-	{activeTab}
+	activeTab={activeTab.current}
 	ontabchange={handleTabChange}
 	valid={currentStats.valid}
 >

--- a/src/routes/json-formatter/+page.svelte
+++ b/src/routes/json-formatter/+page.svelte
@@ -38,6 +38,7 @@
 	// Use formatter page hook with JSON-specific stats calculation
 	const page = useFormatterPage<JsonStats>({
 		calculateStats: (input) => calculateJsonStats(input, inputFormat),
+		persistKey: 'json-formatter',
 	});
 
 	// Type-safe tab change handler

--- a/src/routes/network-scanner/+page.svelte
+++ b/src/routes/network-scanner/+page.svelte
@@ -79,11 +79,13 @@
 		type UnifiedHost,
 	} from '$lib/services/network-scanner.js';
 	import { classifyHosts } from '$lib/services/device-classifier.js';
+	import { persisted } from '$lib/services/persisted.svelte.js';
 	import { UnifiedHostDetailPanel, UnifiedHostListItem } from './components/index.js';
 
-	// Form state
-	let target = $state('');
-	let scanMode = $state<ScanMode>('quick');
+	// Form state — preferences that survive an app restart. Scan results,
+	// in-flight progress, and host classifications are kept ephemeral.
+	const targetStore = persisted<string>('network-scanner:target', '');
+	const scanModeStore = persisted<ScanMode>('network-scanner:scanMode', 'quick');
 	let portPreset = $state<PortPreset>('well_known');
 	let portRange = $state('');
 	let concurrency = $state(DEFAULT_CONCURRENCY);
@@ -98,9 +100,22 @@
 	// Derived: any resolution enabled
 	const resolveHostname = $derived(resolveDns || resolveMdns || resolveNetbios);
 
+	// Reactive aliases let the existing template references (`target`,
+	// `scanMode`) keep their shape while the underlying value lives in the
+	// persisted store.
+	const target = $derived(targetStore.current);
+	const scanMode = $derived(scanModeStore.current);
+
 	// Discovery options (all remaining methods are userspace; SNMP is opt-in
 	// because broadcast SNMP queries can be noisy on some networks).
-	let discoveryMethods = $state<Set<DiscoveryMethod>>(new Set(DEFAULT_DISCOVERY_METHODS));
+	// Stored as a sorted array of strings because `Set` does not survive
+	// `JSON.stringify`; the in-memory representation stays a `Set` for fast
+	// membership checks.
+	const discoveryMethodsStore = persisted<readonly DiscoveryMethod[]>(
+		'network-scanner:discoveryMethods',
+		[...DEFAULT_DISCOVERY_METHODS]
+	);
+	const discoveryMethods = $derived(new Set<DiscoveryMethod>(discoveryMethodsStore.current));
 	let discoveryResults = $state<DiscoveryResult[]>([]);
 	let isDiscovering = $state(false);
 
@@ -380,7 +395,7 @@
 			// Auto-fill with primary IPv4 CIDR if available
 			const primary = networkInfo.primaryIpv4;
 			if (primary?.suggestedCidr) {
-				target = primary.suggestedCidr;
+				targetStore.current = primary.suggestedCidr;
 				toast.success('Target auto-filled', {
 					description: `Using ${primary.name} (${primary.ip})`,
 				});
@@ -388,7 +403,7 @@
 				// Find first non-loopback interface with suggested CIDR
 				const usable = networkInfo.interfaces.find((i) => !i.isLoopback && i.suggestedCidr);
 				if (usable?.suggestedCidr) {
-					target = usable.suggestedCidr;
+					targetStore.current = usable.suggestedCidr;
 					toast.success('Target auto-filled', {
 						description: `Using ${usable.name} (${usable.ip})`,
 					});
@@ -407,9 +422,9 @@
 
 	const handleSelectInterface = (iface: NetworkInterface) => {
 		if (iface.suggestedCidr) {
-			target = iface.suggestedCidr;
+			targetStore.current = iface.suggestedCidr;
 		} else {
-			target = iface.ip;
+			targetStore.current = iface.ip;
 		}
 	};
 
@@ -429,7 +444,7 @@
 		} else {
 			newSet.add(method);
 		}
-		discoveryMethods = newSet;
+		discoveryMethodsStore.current = [...newSet];
 	};
 
 	/** Replace discovery results for methods that have been resolved with hostname data */
@@ -609,8 +624,8 @@
 	};
 
 	const handleScanDiscoveredHost = (ip: string, mode: ScanMode) => {
-		target = ip;
-		scanMode = mode;
+		targetStore.current = ip;
+		scanModeStore.current = mode;
 		handleScan();
 	};
 </script>
@@ -638,7 +653,7 @@
 			<div class="space-y-2">
 				<FormInput
 					label="Host / IP / CIDR"
-					bind:value={target}
+					bind:value={targetStore.current}
 					placeholder="192.168.1.1 or 192.168.1.0/24"
 				/>
 				{#if target && !isValidTarget(target)}
@@ -778,7 +793,7 @@
 					label: m.label,
 					description: m.description,
 				}))}
-				onchange={(v) => (scanMode = v as ScanMode)}
+				onchange={(v) => (scanModeStore.current = v as ScanMode)}
 			/>
 
 			<!-- Quick Scan Port Details -->
@@ -1169,7 +1184,7 @@
 										variant="outline"
 										disabled={isScanning}
 										onclick={() => {
-											target = hostsWithoutScans.flatMap((h) => h.ips).join(',');
+											targetStore.current = hostsWithoutScans.flatMap((h) => h.ips).join(',');
 											handleScan();
 										}}
 									/>

--- a/src/routes/password-generator/+page.svelte
+++ b/src/routes/password-generator/+page.svelte
@@ -25,16 +25,27 @@
 		MIN_LENGTH,
 		type PasswordOptions,
 	} from '$lib/services/password.js';
+	import { persisted } from '$lib/services/persisted.svelte.js';
 
-	// State
-	let options = $state<PasswordOptions>({ ...DEFAULT_PASSWORD_OPTIONS });
-	let count = $state<number>(DEFAULT_COUNT);
+	// State — option preferences (character classes, exclusions, length, count)
+	// survive across restarts. Generated passwords are intentionally never
+	// persisted (sensitive content).
+	const optionsStore = persisted<PasswordOptions>('password-generator:options', {
+		...DEFAULT_PASSWORD_OPTIONS,
+	});
+	const countStore = persisted<number>('password-generator:count', DEFAULT_COUNT);
 	let results = $state<readonly string[]>([]);
 	let error = $state<string | null>(null);
 	let showOptions = $state(true);
 	// Increments on each successful generation so the result wrapper can re-mount
 	// and replay the flash-success animation.
 	let flashCounter = $state(0);
+
+	// Reactive aliases keep the template legible. `optionsStore.current` is a
+	// deeply-reactive `$state` proxy so nested mutations via `bind:` propagate
+	// back through the persisted store.
+	const options = $derived(optionsStore.current);
+	const count = $derived(countStore.current);
 
 	// Derived
 	const pool = $derived(buildCharacterPool(options));
@@ -101,7 +112,7 @@
 		<FormSection title="Length">
 			<FormSlider
 				label="Length"
-				bind:value={options.length}
+				bind:value={optionsStore.current.length}
 				min={MIN_LENGTH}
 				max={MAX_LENGTH}
 				step={1}
@@ -111,10 +122,10 @@
 
 		<FormSection title="Character Classes">
 			<FormCheckboxGroup>
-				<FormCheckbox label="Lowercase (a-z)" bind:checked={options.lowercase} />
-				<FormCheckbox label="Uppercase (A-Z)" bind:checked={options.uppercase} />
-				<FormCheckbox label="Numbers (0-9)" bind:checked={options.numbers} />
-				<FormCheckbox label="Symbols (!@#$...)" bind:checked={options.symbols} />
+				<FormCheckbox label="Lowercase (a-z)" bind:checked={optionsStore.current.lowercase} />
+				<FormCheckbox label="Uppercase (A-Z)" bind:checked={optionsStore.current.uppercase} />
+				<FormCheckbox label="Numbers (0-9)" bind:checked={optionsStore.current.numbers} />
+				<FormCheckbox label="Symbols (!@#$...)" bind:checked={optionsStore.current.symbols} />
 			</FormCheckboxGroup>
 		</FormSection>
 
@@ -123,12 +134,12 @@
 				<FormCheckbox
 					label="Exclude similar characters"
 					hint="0/O, 1/l/I, |"
-					bind:checked={options.excludeSimilar}
+					bind:checked={optionsStore.current.excludeSimilar}
 				/>
 				<FormCheckbox
 					label="Exclude ambiguous symbols"
 					hint="Brackets, quotes, slashes"
-					bind:checked={options.excludeAmbiguous}
+					bind:checked={optionsStore.current.excludeAmbiguous}
 				/>
 			</FormCheckboxGroup>
 		</FormSection>
@@ -136,7 +147,7 @@
 		<FormSection title="Quantity">
 			<FormSlider
 				label="Count"
-				bind:value={count}
+				bind:value={countStore.current}
 				min={MIN_COUNT}
 				max={MAX_COUNT}
 				step={1}

--- a/src/routes/regex-tester/+page.svelte
+++ b/src/routes/regex-tester/+page.svelte
@@ -12,6 +12,7 @@
 	import * as ToggleGroup from '$lib/components/ui/toggle-group';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { cn } from '$lib/utils';
+	import { persisted } from '$lib/services/persisted.svelte.js';
 	import { groupColor, matchBackdropColor } from '$lib/services/regex-design.js';
 	import {
 		compileRegex,
@@ -32,11 +33,15 @@
 
 	// State
 	let pattern = $state<string>('');
-	let flags = $state<RegexFlags>({ ...DEFAULT_FLAGS });
+	// Flag set persists between sessions; pattern, test text, and replacement
+	// are intentionally not persisted to keep ephemeral content out of storage.
+	const flagsStore = persisted<RegexFlags>('regex-tester:flags', { ...DEFAULT_FLAGS });
 	let testText = $state<string>('');
 	let replaceEnabled = $state<boolean>(false);
 	let replacement = $state<string>('');
 	let showOptions = $state<boolean>(true);
+
+	const flags = $derived(flagsStore.current);
 
 	const loadSample = () => {
 		pattern = SAMPLE_PATTERN;
@@ -174,7 +179,7 @@
 	const activeFlagIds = $derived(FLAG_INFO.filter((info) => flags[info.id]).map((info) => info.id));
 
 	const handleFlagsChange = (selected: string[]) => {
-		flags = {
+		flagsStore.current = {
 			global: selected.includes('global'),
 			ignoreCase: selected.includes('ignoreCase'),
 			multiline: selected.includes('multiline'),

--- a/src/routes/url-encoder/+page.svelte
+++ b/src/routes/url-encoder/+page.svelte
@@ -63,10 +63,12 @@
 
 	const tabIds = tabs.map((t) => t.id);
 
-	// Tab sync with URL (keep as object reference to preserve reactivity)
+	// Tab sync with URL (keep as object reference to preserve reactivity).
+	// `persistKey` survives the last-active tab across app restarts.
 	const tabSync = useTabSync({
 		tabs: tabIds,
 		defaultTab: 'encode',
+		persistKey: 'url-encoder',
 	});
 
 	// Type-safe tab change handler for ToolShell

--- a/src/routes/uuid-generator/+page.svelte
+++ b/src/routes/uuid-generator/+page.svelte
@@ -14,6 +14,7 @@
 	import { SectionHeader } from '$lib/components/layout';
 	import { ToolShell } from '$lib/components/shell';
 	import { EmbeddedEmptyState, StatItem } from '$lib/components/status';
+	import { persisted } from '$lib/services/persisted.svelte.js';
 	import {
 		DEFAULT_COUNT,
 		DEFAULT_FORMAT_OPTIONS,
@@ -29,15 +30,22 @@
 		type UuidVersion,
 	} from '$lib/services/uuid.js';
 
-	// State
-	let version = $state<UuidVersion>('v7');
-	let count = $state<number>(DEFAULT_COUNT);
+	// State — version, count, and format options persist between sessions.
+	// Generated UUIDs are never persisted (one-shot output).
+	const versionStore = persisted<UuidVersion>('uuid-generator:version', 'v7');
+	const countStore = persisted<number>('uuid-generator:count', DEFAULT_COUNT);
+	const formatStore = persisted<UuidFormatOptions>('uuid-generator:format', {
+		...DEFAULT_FORMAT_OPTIONS,
+	});
 	let namespace = $state<string>(NAMESPACE_DNS);
 	let nameInput = $state<string>('');
-	let format = $state<UuidFormatOptions>({ ...DEFAULT_FORMAT_OPTIONS });
 	let results = $state<readonly string[]>([]);
 	let error = $state<string | null>(null);
 	let showOptions = $state(true);
+
+	const version = $derived(versionStore.current);
+	const count = $derived(countStore.current);
+	const format = $derived(formatStore.current);
 	// Increments on each successful generation so the result wrapper can re-mount
 	// and replay the flash-success animation.
 	let flashCounter = $state(0);
@@ -60,7 +68,7 @@
 
 	// Handlers
 	const handleVersionChange = (value: string) => {
-		if (isUuidVersion(value)) version = value;
+		if (isUuidVersion(value)) versionStore.current = value;
 	};
 
 	const handleNamespaceChange = (value: string) => {
@@ -145,7 +153,7 @@
 		<FormSection title="Quantity">
 			<FormSlider
 				label="Count"
-				bind:value={count}
+				bind:value={countStore.current}
 				min={MIN_COUNT}
 				max={MAX_COUNT}
 				step={1}
@@ -155,9 +163,9 @@
 
 		<FormSection title="Format">
 			<FormCheckboxGroup>
-				<FormCheckbox label="Uppercase" bind:checked={format.uppercase} />
-				<FormCheckbox label="Hyphens" bind:checked={format.hyphens} />
-				<FormCheckbox label="Wrap in braces" bind:checked={format.braces} />
+				<FormCheckbox label="Uppercase" bind:checked={formatStore.current.uppercase} />
+				<FormCheckbox label="Hyphens" bind:checked={formatStore.current.hyphens} />
+				<FormCheckbox label="Wrap in braces" bind:checked={formatStore.current.braces} />
 			</FormCheckboxGroup>
 		</FormSection>
 

--- a/src/routes/xml-formatter/+page.svelte
+++ b/src/routes/xml-formatter/+page.svelte
@@ -13,7 +13,11 @@
 	} from './tabs/index.js';
 </script>
 
-<TabbedFormatterPage title="XML Formatter" calculateStats={calculateXmlStats}>
+<TabbedFormatterPage
+	title="XML Formatter"
+	calculateStats={calculateXmlStats}
+	persistKey="xml-formatter"
+>
 	{#snippet renderStatusContent(stats: unknown)}
 		{@const liveStats = stats as XmlStats | null}
 		{#if liveStats}

--- a/src/routes/yaml-formatter/+page.svelte
+++ b/src/routes/yaml-formatter/+page.svelte
@@ -13,7 +13,11 @@
 	} from './tabs/index.js';
 </script>
 
-<TabbedFormatterPage title="YAML Formatter" calculateStats={calculateYamlStats}>
+<TabbedFormatterPage
+	title="YAML Formatter"
+	calculateStats={calculateYamlStats}
+	persistKey="yaml-formatter"
+>
 	{#snippet renderStatusContent(stats: unknown)}
 		{@const liveStats = stats as YamlStats | null}
 		{#if liveStats}


### PR DESCRIPTION
## Summary

Per-tool UI state persistence so user sessions survive an app restart. Seventh PR of the **production-ready polish** track (after #243 / #244 / #245 / #246 / #247 / #248 / #249 hotfix / #250).

- New `persisted<T>(key, initial)` rune helper backed by `localStorage`.
- Sidebar collapse state persisted.
- Active tab persisted per tabbed tool.
- Per-tool option selections persisted (regex flags, scanner targets, password options, UUID format flags, etc.).

## What persists / what doesn't

| Persists | Doesn't persist |
| --- | --- |
| Sidebar collapsed / expanded | Pattern text, test text |
| Active tab per tool | JSON / YAML / SQL editor content |
| Regex flags `g/i/m/s/u/y` | Generated UUIDs, hashes, passwords |
| Network scanner target / scanMode / discoveryMethods | Scan results / discovered hosts |
| Password generator options + count | Plaintext passwords (sensitive) |
| UUID generator version / count / format flags | Namespace / name input |

Rationale: keep the **preferences** but never persist **content** (too large for localStorage's ~5MB budget) or **sensitive material** (passwords entered for hashing).

## Changes

### `src/lib/services/persisted.svelte.ts` (new)

Returns `{ current: T }` with getter/setter so:

- `state.current = v` reads / writes
- `bind:value={state.current}` works in Svelte 5 (the getter returns the underlying `$state` proxy)

SSR-safe via `typeof window !== 'undefined'` + `try/catch`. Enforces a 200,000-char serialized cap to prevent accidentally persisting large editor content — over-cap writes are skipped with `console.warn`. Uses `$effect.root` for module-scope safety.

### Sidebar persistence

`+layout.svelte`: `Sidebar.Provider` already exposed bindable `open`, so `bind:open={sidebarOpen.current}` was sufficient. No primitive change needed.

### Tab persistence (5 tools)

- `useTabSync` (used by JSON / XML / YAML / URL encoder) extended with `persistKey`. URL `?tab=` query parameter still wins for deep linking; persisted value is the fallback.
- `cron-expression-builder` (doesn't use `useTabSync`) wraps activeTab in a direct `persisted` call.

### Option-selection persistence

- Regex tester: flag set (`regex-tester:flags`).
- Network scanner: `target`, `scanMode`, `discoveryMethods` (array-serialized; rehydrated to `Set` via `$derived`).
- Password generator: full `options` block + `count`.
- UUID generator: `version`, `count`, `format` (uppercase / hyphens / braces).

## Test Plan

- [x] `cargo check` — passes.
- [x] `bun run check` — svelte-check 0 errors, page validation OK, design audit OK.
- [x] `bunx vitest run` — 140 / 140 pass.
- [ ] Manual: open Regex Tester, toggle `i` and `m` flags, close the app, reopen — confirm flags survive.
- [ ] Manual: collapse the sidebar, close the app, reopen — confirm sidebar stays collapsed.
- [ ] Manual: change Password Generator length to 32 and toggle off symbols, restart — confirm preferences survive.
- [ ] Manual: deep link to `/json-formatter?tab=query`, restart with no query param — confirm Query tab is restored.

## Implementation note (worth flagging)

`Set<DiscoveryMethod>` can't survive `JSON.stringify`. The helper guards against non-JSON-safe values silently (try/catch around `JSON.stringify`), but the network scanner specifically stores discovery methods as an array and rehydrates to a `Set` via `$derived`. This pattern is slightly more code in one place but keeps the `persisted` helper agnostic of value type.

## Continuation

PR H (a11y polish) closes the production-ready polish track.
