### PR TITLE
fix(ci): force ~/.cargo/bin onto PATH in build-sidecar action

### DIFF
--- a/.github/actions/build-sidecar/action.yml
+++ b/.github/actions/build-sidecar/action.yml
@@ -19,6 +19,22 @@ runs:
       shell: bash
       working-directory: src-tauri
       run: |
+        # actions-rust-lang/setup-rust-toolchain skips prepending
+        # ~/.cargo/bin to $GITHUB_PATH when an existing rustup-init is
+        # detected on the runner image. On macOS-latest this means
+        # subsequent composite actions can see /opt/homebrew/bin/rustup-init
+        # before the real cargo proxy, causing `cargo build` to be
+        # interpreted as `rustup-init build` and exit with
+        # "unexpected argument 'build' found". Explicitly source the
+        # cargo env file (and/or prepend the cargo bin dir) to guarantee
+        # the proxy wins regardless of $GITHUB_PATH state.
+        if [ -f "$HOME/.cargo/env" ]; then
+          . "$HOME/.cargo/env"
+        fi
+        if [ -d "$HOME/.cargo/bin" ]; then
+          export PATH="$HOME/.cargo/bin:$PATH"
+        fi
+
         TARGET="${{ inputs.target }}"
         PROFILE="${{ inputs.profile }}"
 


### PR DESCRIPTION
## Summary

**Hotfix for the Release workflow's intermittent `macos-x64` failures.**

The Release workflow has been failing on `main` with an intermittent `~50%` rate. Symptom:

```
error: error: unexpected argument 'build' found
Usage: rustup-init[EXE] [OPTIONS]
##[error]Process completed with exit code 1.
```

Only the `macos-x64` matrix entry fails — `macos-arm64`, `linux-x64`, `windows-x64` all succeed. Same commit produces success ~50% of runs.

## Root cause

`actions-rust-lang/setup-rust-toolchain@v1` only prepends `~/.cargo/bin` to `$GITHUB_PATH` when `rustup` is **not already** in `PATH` at action start:

```bash
if ! command -v rustup &> /dev/null ; then
  curl --proto '=https' --tlsv1.2 ... | sh -s -- --default-toolchain none -y
  echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
fi
```

The `macos-latest` runner image ships with `rustup-init` preinstalled at `/opt/homebrew/bin/rustup-init`. When `command -v rustup` finds it, the action skips the `$GITHUB_PATH` write — assuming the runner-image-installed rustup is fully wired.

But the runner-image's rustup install **doesn't include a `cargo` proxy at `/opt/homebrew/bin/cargo`** (only `rustup-init`). Inside the `Setup Rust` step the action's own shell-level handling installs the toolchain inline, so `cargo --version` works at that point. But later **composite-action** steps (like `build-sidecar`) run in their own shell that inherits the runner's `$PATH` only — and `$GITHUB_PATH` wasn't updated, so `~/.cargo/bin/cargo` isn't visible. The next-best `cargo` on PATH is `/opt/homebrew/bin/rustup-init` (because some Homebrew shim aliases rustup to rustup-init when no toolchain is fully bootstrapped), which then receives `build --bin worker ...` and exits with "unexpected argument 'build' found".

**Why intermittent**: runner image cache state can flip on whether `/opt/homebrew/bin/rustup-init` is present at action start.

## Fix

In `.github/actions/build-sidecar/action.yml`, prepend `~/.cargo/bin` to `PATH` explicitly at the start of the script and source `~/.cargo/env` if present. This guarantees the cargo proxy wins regardless of `$GITHUB_PATH` state set by upstream Rust-setup actions.

```bash
if [ -f "$HOME/.cargo/env" ]; then
  . "$HOME/.cargo/env"
fi
if [ -d "$HOME/.cargo/bin" ]; then
  export PATH="$HOME/.cargo/bin:$PATH"
fi
```

No-op on runners where the PATH was already correct.

## Changes

- `.github/actions/build-sidecar/action.yml` — +16 lines at the start of the Unix branch.

The Windows branch is unaffected — the runner image doesn't have the `/opt/homebrew/bin/rustup-init` issue.

## Test Plan

- [ ] Merge this PR. The Release workflow runs automatically on push to `main` (nightly).
- [ ] Observe at least 2 consecutive successful Release runs on `main` after merge.
- [ ] If the issue recurs, escalate to either:
    - Pinning the macos runner image to `macos-13` for the `macos-x64` matrix entry (Intel, native build), or
    - Switching the toolchain action to `dtolnay/rust-toolchain@stable`.

## Note

This is a CI infrastructure fix; it does not change any application code.
