### PR TITLE
fix(ci): disable cache-bin to keep cargo rustup proxies intact on macos-latest

### DIFF
--- a/.github/actions/build-sidecar/action.yml
+++ b/.github/actions/build-sidecar/action.yml
@@ -19,22 +19,6 @@ runs:
       shell: bash
       working-directory: src-tauri
       run: |
-        # actions-rust-lang/setup-rust-toolchain skips prepending
-        # ~/.cargo/bin to $GITHUB_PATH when an existing rustup-init is
-        # detected on the runner image. On macOS-latest this means
-        # subsequent composite actions can see /opt/homebrew/bin/rustup-init
-        # before the real cargo proxy, causing `cargo build` to be
-        # interpreted as `rustup-init build` and exit with
-        # "unexpected argument 'build' found". Explicitly source the
-        # cargo env file (and/or prepend the cargo bin dir) to guarantee
-        # the proxy wins regardless of $GITHUB_PATH state.
-        if [ -f "$HOME/.cargo/env" ]; then
-          . "$HOME/.cargo/env"
-        fi
-        if [ -d "$HOME/.cargo/bin" ]; then
-          export PATH="$HOME/.cargo/bin:$PATH"
-        fi
-
         TARGET="${{ inputs.target }}"
         PROFILE="${{ inputs.profile }}"
 

--- a/.github/actions/setup-rust-tauri/action.yml
+++ b/.github/actions/setup-rust-tauri/action.yml
@@ -24,3 +24,10 @@ runs:
       with:
         components: ${{ inputs.components }}
         cache-workspaces: src-tauri -> src-tauri/target
+        # Swatinem/rust-cache#341: on the macos-latest runner image rolled out
+        # 2026-05-13, restoring `~/.cargo/bin/` with cache-bin enabled clobbers
+        # the cargo/rustc rustup proxies (they become broken links to
+        # rustup-init), causing later `cargo build` invocations to be dispatched
+        # to rustup-init and fail with "unexpected argument 'build' found".
+        # Disabling cache-bin keeps the rustup-installed proxies intact.
+        cache-bin: 'false'


### PR DESCRIPTION
## Summary

- Set `cache-bin: 'false'` on the setup-rust-tauri composite action so the macos-latest `cargo`/`rustc` rustup proxies are not clobbered by rust-cache.
- Remove the PR #253 PATH-prepend workaround from `build-sidecar`: it did not address the broken symlinks and is no longer needed.

## Root Cause

[Swatinem/rust-cache#341](https://github.com/Swatinem/rust-cache/issues/341): on the macos-latest runner image rolled out 2026-05-13, restoring `~/.cargo/bin/` with `cache-bin: true` (rust-cache default since PR #325) leaves the cargo and rustc proxy symlinks pointing at `rustup-init`. Subsequent composite-action `cargo build` calls then dispatch to `rustup-init`, which rejects the subcommand:

```
error: error: unexpected argument 'build' found
Usage: rustup-init[EXE] [OPTIONS]
```

This matches the symptoms observed on five of the six Release runs since 2026-05-15 06:09Z (all macos-x64 only). The earlier hotfix in #253 mis-attributed the failure to `actions-rust-lang/setup-rust-toolchain` GITHUB_PATH handling; PATH order does not help because the proxies themselves are broken.

## Changes

### Changed

- `.github/actions/setup-rust-tauri/action.yml`: pass `cache-bin: 'false'` through to `actions-rust-lang/setup-rust-toolchain@v1`, with a comment referencing rust-cache#341.

### Removed

- `.github/actions/build-sidecar/action.yml`: remove the `~/.cargo/env` source and `$HOME/.cargo/bin` PATH prepend introduced in #253.

## Test Plan

- [ ] Release workflow on this branch completes with macos-x64 succeeding.
- [ ] CI workflow (which also uses setup-rust-tauri) still green for non-macOS targets.
- [ ] Re-evaluate `cache-bin: 'false'` once Swatinem/rust-cache#341 is resolved upstream.
