### PR TITLE
chore(deps): bump cargo deps to majors and swap snmp2 for csnmp

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"deps:check": "bunx taze",
 		"deps:check:backend": "cargo install cargo-edit -q && cd src-tauri && cargo upgrade --dry-run",
 		"deps:update": "bunx taze major -r -w && bun install",
-		"deps:update:backend": "cargo install cargo-edit -q && cd src-tauri && cargo upgrade --incompatible --exclude ipnetwork --exclude rand --exclude snmp2 && cargo update",
+		"deps:update:backend": "cargo install cargo-edit -q && cd src-tauri && cargo upgrade --incompatible && cargo update",
 		"deps:update:all": "bun run deps:update && bun run deps:update:backend"
 	},
 	"license": "MIT",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -149,26 +149,11 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
-dependencies = [
- "asn1-rs-derive 0.5.1",
- "asn1-rs-impl",
- "displaydoc",
- "nom 7.1.3",
- "num-traits",
- "rusticata-macros",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
 dependencies = [
- "asn1-rs-derive 0.6.0",
+ "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
  "nom 7.1.3",
@@ -176,18 +161,6 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
 ]
 
 [[package]]
@@ -1177,6 +1150,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "csnmp"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30da8dba8a9eccc31290275c3803f1a730044029e026bfda5db3538a79d3a4e6"
+dependencies = [
+ "derivative",
+ "from-to-repr",
+ "simple_asn1",
+ "tokio",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,7 +1365,7 @@ version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs",
  "displaydoc",
  "nom 7.1.3",
  "num-bigint",
@@ -1396,6 +1381,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2071,6 +2067,17 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "from-to-repr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c07b2fb0864fc59a417a61ef5bc41d935a3045bba84c50a1a45b8fb4f6917a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3271,6 +3278,7 @@ name = "kogu"
 version = "0.0.6"
 dependencies = [
  "bcrypt",
+ "csnmp",
  "dns-lookup",
  "font-kit",
  "futures",
@@ -3280,15 +3288,15 @@ dependencies = [
  "mdns-sd",
  "netdev",
  "pgp",
- "quick-xml",
- "rand 0.8.6",
+ "quick-xml 0.40.1",
+ "rand 0.10.1",
+ "rand_core 0.6.4",
  "reqwest",
  "roxmltree",
  "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
- "snmp2",
  "sqlparser",
  "ssh-key",
  "tauri",
@@ -4333,7 +4341,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs",
 ]
 
 [[package]]
@@ -4765,7 +4773,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.39.4",
  "serde",
  "time",
 ]
@@ -4988,6 +4996,15 @@ name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
 ]
@@ -5978,6 +5995,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6014,15 +6043,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "snmp2"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49dc4ff9dc6c2b03d818a4c2abb8ffcef9e16357113ddc7ce1631c03195fde64"
-dependencies = [
- "asn1-rs 0.6.2",
 ]
 
 [[package]]
@@ -6115,9 +6135,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
 dependencies = [
  "log",
  "recursive",
@@ -6247,6 +6267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -7645,7 +7666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.39.4",
  "quote",
 ]
 
@@ -8582,7 +8603,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs",
  "data-encoding",
  "der-parser",
  "lazy_static",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,15 +39,15 @@ thiserror = "2"
 roxmltree = "0.21"
 serde_yaml = "0.9"
 yaml-rust2 = "0.11"
-sqlparser = "0.61"
-tauri-plugin-mcp-bridge = "0.11.0"
-tauri-plugin-dialog = "2.7.0"
-tauri-plugin-fs = "2.5.0"
+sqlparser = "0.62"
+tauri-plugin-mcp-bridge = "0.11.1"
+tauri-plugin-dialog = "2.7.1"
+tauri-plugin-fs = "2.5.1"
 tauri-plugin-shell = "2"
 tauri-plugin-window-state = "2"
 
 # Settings
-toml = "1.0"
+toml = "1.1"
 font-kit = "0.14"
 
 # Async Runtime (for cancellable operations and network)
@@ -58,7 +58,7 @@ tokio-util = { version = "0.7", default-features = false }
 bcrypt = "0.19"
 ssh-key = { version = "0.6", features = ["ed25519", "p256", "p384", "rsa", "encryption", "rand_core"] }
 pgp = "0.19"
-rand = "0.8"
+rand = "0.10"
 
 # Network Scanning
 futures = "0.3"
@@ -73,7 +73,7 @@ netdev = { version = "0.43", features = ["gateway"] }
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 
 # XML Parsing (for SSDP/WS-Discovery device descriptions)
-quick-xml = "0.39"
+quick-xml = "0.40"
 
 # TLS Certificate Inspection
 rustls = { version = "0.23", features = ["ring"] }
@@ -82,7 +82,6 @@ x509-parser = "0.18"
 
 # DNS PTR Reverse Lookup
 hickory-resolver = { version = "0.26", features = ["tokio", "system-config"] }
-
-# SNMP sysName Query
-snmp2 = "0.4"
+csnmp = "0.6.0"
+rand_core = { version = "0.6", features = ["getrandom"] }
 

--- a/src-tauri/src/ast/sql.rs
+++ b/src-tauri/src/ast/sql.rs
@@ -167,16 +167,16 @@ fn insert_to_ast(insert: &sqlparser::ast::Insert, path: &str) -> AstNode {
     .with_children(children)
 }
 
-fn columns_to_ast(columns: &[sqlparser::ast::Ident], path: &str) -> AstNode {
+fn columns_to_ast(columns: &[sqlparser::ast::ObjectName], path: &str) -> AstNode {
     let children: Vec<_> = columns
         .iter()
         .enumerate()
         .map(|(i, col)| {
-            let col_range = span_to_range(col.span);
+            let col_range = span_to_range(col.span());
             AstNode::new(
                 AstNodeType::Identifier,
                 format!("{path}.columns[{i}]"),
-                col.value.clone(),
+                col.to_string(),
                 col_range,
             )
         })
@@ -185,8 +185,8 @@ fn columns_to_ast(columns: &[sqlparser::ast::Ident], path: &str) -> AstNode {
     // Use span of first and last column for the columns clause
     let range = if let (Some(first), Some(last)) = (columns.first(), columns.last()) {
         AstRange::new(
-            span_to_range(first.span).start,
-            span_to_range(last.span).end,
+            span_to_range(first.span()).start,
+            span_to_range(last.span()).end,
         )
     } else {
         AstRange::new(AstPosition::new(1, 1, 0), AstPosition::new(1, 1, 0))
@@ -404,6 +404,7 @@ const fn object_type_label(object_type: sqlparser::ast::ObjectType) -> &'static 
         ObjectType::Role => "ROLE",
         ObjectType::User => "USER",
         ObjectType::Stream => "STREAM",
+        ObjectType::Collation => "COLLATION",
     }
 }
 
@@ -649,6 +650,14 @@ fn projection_to_ast(projection: &[SelectItem], path: &str) -> AstNode {
             let label = match item {
                 SelectItem::UnnamedExpr(expr) => expr.to_string(),
                 SelectItem::ExprWithAlias { expr, alias } => format!("{expr} AS {alias}"),
+                SelectItem::ExprWithAliases { expr, aliases } => {
+                    let alias_str = aliases
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!("{expr} AS ({alias_str})")
+                }
                 SelectItem::QualifiedWildcard(name, _) => format!("{name}.*"),
                 SelectItem::Wildcard(_) => "*".to_string(),
             };
@@ -806,6 +815,9 @@ const fn join_operator_label(op: &sqlparser::ast::JoinOperator) -> &'static str 
         JoinOperator::OuterApply => "OUTER APPLY",
         JoinOperator::AsOf { .. } => "AS OF JOIN",
         JoinOperator::StraightJoin(_) => "STRAIGHT_JOIN",
+        JoinOperator::ArrayJoin => "ARRAY JOIN",
+        JoinOperator::LeftArrayJoin => "LEFT ARRAY JOIN",
+        JoinOperator::InnerArrayJoin => "INNER ARRAY JOIN",
     }
 }
 

--- a/src-tauri/src/bin/worker.rs
+++ b/src-tauri/src/bin/worker.rs
@@ -445,7 +445,7 @@ fn handle_gpg_keygen(req: GpgRequest) -> String {
         _ => format!("{} <{}>", req.name, req.email),
     };
 
-    let rng = rand::rngs::OsRng;
+    let rng = rand_core::OsRng;
 
     let key_type = match req.algorithm {
         GpgKeyAlgorithm::Rsa2048 => KeyType::Rsa(2048),

--- a/src-tauri/src/generators/gpg.rs
+++ b/src-tauri/src/generators/gpg.rs
@@ -231,7 +231,7 @@ fn generate_with_library(options: GpgKeyOptions) -> Result<GpgKeyResult, Generat
     // Build user_id string
     let user_id = build_user_id(&name, &email, comment.as_deref());
 
-    let rng = rand::rngs::OsRng;
+    let rng = rand_core::OsRng;
 
     let key_type = match algorithm {
         GpgKeyAlgorithm::Rsa2048 => KeyType::Rsa(2048),

--- a/src-tauri/src/generators/ssh.rs
+++ b/src-tauri/src/generators/ssh.rs
@@ -7,8 +7,6 @@ use super::worker::{self, SshKeyRequest, SshKeyResponse, WorkerProcessState};
 use super::{GenerationMethod, GeneratorError};
 
 #[cfg(test)]
-use rand::rngs::OsRng;
-#[cfg(test)]
 use ssh_key::{
     private::{EcdsaKeypair, Ed25519Keypair, RsaKeypair},
     HashAlg, LineEnding, PrivateKey,
@@ -224,7 +222,7 @@ fn generate_with_library(options: SshKeyOptions) -> Result<SshKeyResult, Generat
         method: _,
     } = options;
 
-    let mut rng = OsRng;
+    let mut rng = rand_core::OsRng;
     let comment_str = comment.as_deref().unwrap_or("");
 
     let private_key: PrivateKey = match algorithm {

--- a/src-tauri/src/network/discovery.rs
+++ b/src-tauri/src/network/discovery.rs
@@ -499,16 +499,8 @@ async fn resolve_hostnames_for_results(
 
         snmp_handles.push(tokio::spawn(async move {
             let _permit = sem.acquire().await.ok()?;
-
-            // SNMP is blocking, run in a blocking task
-            let result = tokio::task::spawn_blocking(move || {
-                super::snmp::query_snmp_device_info(ip, timeout)
-            })
-            .await
-            .ok()
-            .flatten();
-
-            result.map(|info| (ip.to_string(), info))
+            let info = super::snmp::query_snmp_device_info(ip, timeout).await?;
+            Some((ip.to_string(), info))
         }));
     }
 
@@ -1494,7 +1486,11 @@ fn parse_upnp_device_xml(xml: &str, location: &str) -> Option<super::types::Ssdp
             }
             Ok(Event::Text(ref e)) => {
                 if device_depth == 1 {
-                    let text = e.xml_content().unwrap_or_default().trim().to_string();
+                    let text = e
+                        .xml_content(quick_xml::XmlVersion::Implicit1_0)
+                        .unwrap_or_default()
+                        .trim()
+                        .to_string();
                     if !text.is_empty() {
                         assign_field(&current_tag, text);
                     }
@@ -1797,19 +1793,20 @@ async fn snmp_discovery(targets: &[IpAddr], _options: &DiscoveryOptions) -> Disc
             let sem = Arc::clone(&semaphore);
             tokio::spawn(async move {
                 let _permit = sem.acquire().await.ok()?;
-                let info = tokio::task::spawn_blocking(move || {
-                    SNMP_DISCOVERY_COMMUNITIES.iter().find_map(|community| {
-                        super::snmp::query_snmp_device_info_with_community(
-                            target,
-                            community.as_bytes(),
-                            SNMP_DISCOVERY_TIMEOUT,
-                        )
-                    })
-                })
-                .await
-                .ok()
-                .flatten()?;
-                Some((target, info))
+                let mut found = None;
+                for community in SNMP_DISCOVERY_COMMUNITIES {
+                    if let Some(info) = super::snmp::query_snmp_device_info_with_community(
+                        target,
+                        community.as_bytes(),
+                        SNMP_DISCOVERY_TIMEOUT,
+                    )
+                    .await
+                    {
+                        found = Some(info);
+                        break;
+                    }
+                }
+                found.map(|info| (target, info))
             })
         })
         .collect();

--- a/src-tauri/src/network/snmp.rs
+++ b/src-tauri/src/network/snmp.rs
@@ -3,22 +3,18 @@
 //! Queries network devices for their SNMPv2c sysName using the public community string.
 //! This is effective for routers, switches, NAS devices, and other SNMP-enabled equipment.
 
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
 
+use csnmp::{ObjectIdentifier, ObjectValue, Snmp2cClient};
 use serde::Serialize;
-use snmp2::{Oid, SyncSession, Value};
 
-/// SNMP MIB-2 system group OIDs
-const SYS_NAME_OID: [u64; 9] = [1, 3, 6, 1, 2, 1, 1, 5, 0];
-const SYS_DESCR_OID: [u64; 9] = [1, 3, 6, 1, 2, 1, 1, 1, 0];
-const SYS_LOCATION_OID: [u64; 9] = [1, 3, 6, 1, 2, 1, 1, 6, 0];
-const SYS_CONTACT_OID: [u64; 9] = [1, 3, 6, 1, 2, 1, 1, 4, 0];
+const SYS_NAME_OID: [u32; 9] = [1, 3, 6, 1, 2, 1, 1, 5, 0];
+const SYS_DESCR_OID: [u32; 9] = [1, 3, 6, 1, 2, 1, 1, 1, 0];
+const SYS_LOCATION_OID: [u32; 9] = [1, 3, 6, 1, 2, 1, 1, 6, 0];
+const SYS_CONTACT_OID: [u32; 9] = [1, 3, 6, 1, 2, 1, 1, 4, 0];
 
-/// Default SNMP community string
 const DEFAULT_COMMUNITY: &[u8] = b"public";
-
-/// Default SNMP port
 const SNMP_PORT: u16 = 161;
 
 /// SNMP device information
@@ -52,29 +48,25 @@ impl SnmpDeviceInfo {
     }
 }
 
-/// Extract string value from SNMP Value
-fn extract_string(value: &Value<'_>) -> Option<String> {
+/// Extract a UTF-8 string from an SNMP `OctetString` value, trimming whitespace.
+/// Returns `None` for empty values or non-string variants.
+fn extract_string(value: &ObjectValue) -> Option<String> {
     match value {
-        Value::OctetString(bytes) => {
-            // Try to parse as UTF-8, fall back to lossy conversion
-            let s = String::from_utf8_lossy(bytes).to_string();
+        ObjectValue::String(bytes) => {
+            let s = String::from_utf8_lossy(bytes).trim().to_string();
             if s.is_empty() {
                 None
             } else {
-                Some(s.trim().to_string())
+                Some(s)
             }
         }
         _ => None,
     }
 }
 
-/// Query SNMP system information for a single IP address
-///
-/// Queries sysName, sysDescr, sysLocation, and sysContact.
-/// Returns SnmpDeviceInfo if the device responds to any query.
-#[allow(clippy::large_stack_frames)]
-pub fn query_snmp_device_info(ip: IpAddr, timeout: Duration) -> Option<SnmpDeviceInfo> {
-    query_snmp_device_info_with_community(ip, DEFAULT_COMMUNITY, timeout)
+/// Query SNMP system information for a single IP address using the default community.
+pub async fn query_snmp_device_info(ip: IpAddr, timeout: Duration) -> Option<SnmpDeviceInfo> {
+    query_snmp_device_info_with_community(ip, DEFAULT_COMMUNITY, timeout).await
 }
 
 /// Query SNMP system information using a caller-supplied community string.
@@ -83,46 +75,35 @@ pub fn query_snmp_device_info(ip: IpAddr, timeout: Duration) -> Option<SnmpDevic
 /// when the host fails to open a session or returns no usable varbinds. Used
 /// by discovery to try alternative communities (e.g. `private`) when `public`
 /// is rejected.
-#[allow(clippy::large_stack_frames)]
-pub fn query_snmp_device_info_with_community(
+pub async fn query_snmp_device_info_with_community(
     ip: IpAddr,
     community: &[u8],
     timeout: Duration,
 ) -> Option<SnmpDeviceInfo> {
-    let addr = format!("{ip}:{SNMP_PORT}");
+    let target = SocketAddr::new(ip, SNMP_PORT);
 
-    let sys_name_oid = Oid::from(&SYS_NAME_OID).ok()?;
-    let sys_descr_oid = Oid::from(&SYS_DESCR_OID).ok()?;
-    let sys_location_oid = Oid::from(&SYS_LOCATION_OID).ok()?;
-    let sys_contact_oid = Oid::from(&SYS_CONTACT_OID).ok()?;
+    let sys_name_oid = ObjectIdentifier::try_from(SYS_NAME_OID.as_slice()).ok()?;
+    let sys_descr_oid = ObjectIdentifier::try_from(SYS_DESCR_OID.as_slice()).ok()?;
+    let sys_location_oid = ObjectIdentifier::try_from(SYS_LOCATION_OID.as_slice()).ok()?;
+    let sys_contact_oid = ObjectIdentifier::try_from(SYS_CONTACT_OID.as_slice()).ok()?;
 
-    let mut session = SyncSession::new_v2c(&addr, community, Some(timeout), 0).ok()?;
+    let client = Snmp2cClient::new(target, community.to_vec(), None, Some(timeout), 0)
+        .await
+        .ok()?;
 
     let mut info = SnmpDeviceInfo::default();
 
-    // Query each OID individually (some devices may not support all OIDs)
-    if let Ok(response) = session.get(&sys_name_oid) {
-        for (_oid, value) in response.varbinds {
-            info.sys_name = extract_string(&value);
-        }
+    if let Ok(value) = client.get(sys_name_oid).await {
+        info.sys_name = extract_string(&value);
     }
-
-    if let Ok(response) = session.get(&sys_descr_oid) {
-        for (_oid, value) in response.varbinds {
-            info.sys_descr = extract_string(&value);
-        }
+    if let Ok(value) = client.get(sys_descr_oid).await {
+        info.sys_descr = extract_string(&value);
     }
-
-    if let Ok(response) = session.get(&sys_location_oid) {
-        for (_oid, value) in response.varbinds {
-            info.sys_location = extract_string(&value);
-        }
+    if let Ok(value) = client.get(sys_location_oid).await {
+        info.sys_location = extract_string(&value);
     }
-
-    if let Ok(response) = session.get(&sys_contact_oid) {
-        for (_oid, value) in response.varbinds {
-            info.sys_contact = extract_string(&value);
-        }
+    if let Ok(value) = client.get(sys_contact_oid).await {
+        info.sys_contact = extract_string(&value);
     }
 
     if info.is_populated() {
@@ -163,32 +144,31 @@ mod tests {
         assert!(json.contains("sysName"));
         assert!(json.contains("router1"));
         assert!(json.contains("sysDescr"));
-        // sys_location and sys_contact should be skipped
         assert!(!json.contains("sysLocation"));
         assert!(!json.contains("sysContact"));
     }
 
     #[test]
     fn test_extract_string_octet_string() {
-        let value = Value::OctetString(b"test");
+        let value = ObjectValue::String(b"test".to_vec());
         assert_eq!(extract_string(&value), Some("test".to_string()));
     }
 
     #[test]
     fn test_extract_string_empty() {
-        let value = Value::OctetString(b"");
+        let value = ObjectValue::String(Vec::new());
         assert_eq!(extract_string(&value), None);
     }
 
     #[test]
     fn test_extract_string_with_whitespace() {
-        let value = Value::OctetString(b"  router1  ");
+        let value = ObjectValue::String(b"  router1  ".to_vec());
         assert_eq!(extract_string(&value), Some("router1".to_string()));
     }
 
     #[test]
     fn test_extract_string_non_string_value() {
-        let value = Value::Integer(42);
+        let value = ObjectValue::Integer(42);
         assert_eq!(extract_string(&value), None);
     }
 }

--- a/src-tauri/src/network/ws_discovery.rs
+++ b/src-tauri/src/network/ws_discovery.rs
@@ -147,7 +147,11 @@ fn parse_probe_match(xml: &str) -> Option<WsDiscoveryInfo> {
             }
             Ok(Event::Text(ref e)) => {
                 if in_probe_match {
-                    let text = e.xml_content().unwrap_or_default().trim().to_string();
+                    let text = e
+                        .xml_content(quick_xml::XmlVersion::Implicit1_0)
+                        .unwrap_or_default()
+                        .trim()
+                        .to_string();
                     if !text.is_empty() {
                         match current_tag.as_str() {
                             "Types" => {


### PR DESCRIPTION
## Summary

Bring backend crates to their latest, removing the workaround
exclusions in `deps:update:backend` that were avoiding breaking
changes. This consolidates the three stale Renovate-driven bumps
(#167 `rand`, #168 `snmp2`, #198 `sqlparser`) into a single PR
that also addresses the code-level breakage they each triggered.

This PR **supersedes Renovate PRs #167, #168, #198**, which will be
closed after this lands.

## Manifest changes (`src-tauri/Cargo.toml`)

| Crate | Old | New | Notes |
|---|---|---|---|
| `rand` | 0.8 | 0.10 | `OsRng` removed from `rand::rngs`; introduces `rand_core = "0.6"` direct dep for ssh-key/pgp compatibility |
| `sqlparser` | 0.61 | 0.62 | New AST variants + `Insert::columns` type change |
| `quick-xml` | 0.39 | 0.40 | `xml_content()` now takes `XmlVersion` argument |
| `toml` | 1.0 | 1.1 | |
| `snmp2` | 0.4 | — (removed) | Replaced by `csnmp` 0.6 (see below) |
| `csnmp` | — | 0.6 | New, SNMPv2c-only crate |
| `rand_core` | — | 0.6 | New direct dep; bridges `ssh-key`/`pgp` (rand_core 0.6) and `rand` 0.10 (rand_core 0.9) coexistence |
| `tauri-plugin-{mcp-bridge,dialog,fs}` | 0.11.0 / 2.7.0 / 2.5.0 | 0.11.1 / 2.7.1 / 2.5.1 | Already at these versions in `Cargo.lock` via #256; this update aligns the manifest |

## Code changes

### `snmp2` → `csnmp` (network/snmp.rs)

`snmp2 0.5` has an unresolved upstream bug
([roboplc/snmp2#27](https://github.com/roboplc/snmp2/issues/27))
that triggers when `crypto-common` gets the `rand_core` feature via
`ssh-key` in our workspace. The fix PR
([#28](https://github.com/roboplc/snmp2/pull/28)) was closed
unmerged and the crate has been silent since 2026-03-01. Our
SNMPv2c-only usage does not touch the HMAC code path that triggers
the conflict, so we are blocked by an upstream lib that fails to
compile in our build.

`csnmp 0.6` is SNMPv2c-only (no SNMPv3 / HMAC stack) and
**structurally cannot reproduce the bug**. Its API is async
(Tokio), so `query_snmp_device_info` / `query_snmp_device_info_with_community`
became `async fn`. Both call sites in `network/discovery.rs` were
already inside `tokio::spawn(async move { ... })` blocks, so the
migration just drops the `spawn_blocking` wrapper.

### `rand` 0.10 + `rand_core` 0.6 coexistence

`rand 0.10` removed `rand::rngs::OsRng`, but `ssh-key 0.6` and
`pgp 0.19` still require `rand_core 0.6` traits (`ssh-key`'s
`CryptoRng`, `pgp`'s `Rng + CryptoRng` from `rand 0.8`). The
`ThreadRng` returned by `rand::rng()` does not implement either.

Resolution: add `rand_core = "0.6"` as a direct dep and use
`rand_core::OsRng` for crypto-quality randomness (SSH/GPG key
generation in `generators/{ssh,gpg}.rs` and `bin/worker.rs`).
Casual `rand::random::<u16>()` for LLMNR/NetBIOS transaction IDs
continues to use `rand 0.10`. Cargo carries both rand_core majors
in the lockfile, which is the standard behavior for ecosystem
transitions.

### sqlparser 0.62 (ast/sql.rs)

- `Insert::columns` type changed from `Vec<Ident>` to
  `Vec<ObjectName>`. `columns_to_ast` now accepts `&[ObjectName]`
  and uses `Spanned::span()` + `ObjectName::to_string()`.
- Added match arms for new variants:
  - `ObjectType::Collation` → `"COLLATION"`
  - `SelectItem::ExprWithAliases { expr, aliases }` → renders
    `expr AS (a1, a2, ...)`
  - `JoinOperator::ArrayJoin` / `LeftArrayJoin` / `InnerArrayJoin`
    (ClickHouse array-join operators, unit variants)

### quick-xml 0.40 (network/discovery.rs, network/ws_discovery.rs)

`e.xml_content()` now requires an `XmlVersion` argument. Both call
sites pass `quick_xml::XmlVersion::Implicit1_0`, which preserves
the prior assumption of XML 1.0 parsing.

### Script cleanup (package.json)

Dropped `--exclude ipnetwork --exclude rand --exclude snmp2` from
`deps:update:backend`. The exclusion list was a workaround for
breaking-change cost; now that the code-level breakage is handled,
the script can drive a clean `cargo upgrade --incompatible` on
future runs.

## Test plan

- [x] `cargo check --all-targets` passes locally
- [x] `cargo test --lib` passes locally (165/165)
- [x] `cargo clippy --all-targets -- -D warnings` passes locally
- [ ] CI: full Rust matrix (lint + test) on PR workflow
- [ ] CI: Release workflow on merge (all four platforms)
- [ ] Manual smoke test: SSH key generation, GPG key generation,
  network scanner with SNMP discovery
