### PR TITLE
refactor(react)(ui): ValidityBadge API, SectionLabel cleanup, sub-component extraction

### DIFF
--- a/src/lib/components/formatter-tabs/json/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/format-tab.tsx
@@ -14,6 +14,8 @@ import { OptionsPanel } from '@/lib/components/panel';
 import {
 	defaultJsonFormatOptions,
 	type JsonFormatOptions,
+	type JsonInputFormat,
+	type JsonOutputFormat,
 	parseJson,
 	processJsonWithOptions,
 	SAMPLE_JSON,
@@ -39,6 +41,83 @@ interface FormatTabProps {
 	readonly onInputChange: (value: string) => void;
 	readonly onStatsChange?: (stats: TabStats) => void;
 }
+
+type Transform = (input: string) => string;
+
+const identity: Transform = (input) => input;
+
+const escapeUnicodeTransform: Transform = (input) =>
+	input.replace(
+		/[\u0080-\uffff]/g,
+		(char) => `\\u${`0000${char.charCodeAt(0).toString(16)}`.slice(-4)}`
+	);
+
+const arrayBracketSpacingTransform: Transform = (input) =>
+	input.replace(/\[(?!\s*\n)/g, '[ ').replace(/(?<!\n\s*)\]/g, ' ]');
+
+const objectBracketSpacingTransform: Transform = (input) =>
+	input.replace(/\{(?!\s*\n)/g, '{ ').replace(/(?<!\n\s*)\}/g, ' }');
+
+const stripColonSpacingTransform: Transform = (input) => input.replace(/:\s+/g, ':');
+
+const compactArraysTransform: Transform = (input) =>
+	input.replace(
+		/\[\s*\n(\s*)((?:"[^"]*"|'[^']*'|[\d.eE+-]+|true|false|null)(?:,\s*\n\s*(?:"[^"]*"|'[^']*'|[\d.eE+-]+|true|false|null))*)\s*\n\s*\]/g,
+		(_, _indent, content: string) => {
+			const items = content.split(/,\s*\n\s*/);
+			return `[${items.join(', ')}]`;
+		}
+	);
+
+const buildFormatTransforms = (options: Partial<JsonFormatOptions>): readonly Transform[] => {
+	const compactArraysEnabled = Boolean(options.compactArrays) && (options.indentSize ?? 2) > 0;
+	return [
+		options.escapeUnicode ? escapeUnicodeTransform : identity,
+		options.arrayBracketSpacing ? arrayBracketSpacingTransform : identity,
+		options.objectBracketSpacing ? objectBracketSpacingTransform : identity,
+		options.colonSpacing ? identity : stripColonSpacingTransform,
+		compactArraysEnabled ? compactArraysTransform : identity,
+	];
+};
+
+interface FormattedResult {
+	readonly output: string;
+	readonly error: string;
+}
+
+const computeFormattedOutput = (
+	input: string,
+	inputFormat: JsonInputFormat,
+	outputFormat: JsonOutputFormat,
+	formatMode: FormatMode,
+	formatOptions: Partial<JsonFormatOptions>
+): FormattedResult => {
+	if (!input.trim()) return { output: '', error: '' };
+
+	try {
+		const data = parseJson(input, inputFormat);
+		const processedData = processJsonWithOptions(data, formatOptions);
+
+		if (formatMode === 'minify') {
+			return { output: stringifyJson(processedData, outputFormat, { indent: 0 }), error: '' };
+		}
+
+		const baseResult = stringifyJson(processedData, outputFormat, {
+			indent: formatOptions.indentType === 'tabs' ? '\t' : formatOptions.indentSize,
+			sortKeys: formatOptions.sortKeys,
+			trailingComma: formatOptions.trailingComma,
+			quote: formatOptions.quoteStyle,
+		});
+
+		const transforms = buildFormatTransforms(formatOptions);
+		return {
+			output: transforms.reduce((acc, transform) => transform(acc), baseResult),
+			error: '',
+		};
+	} catch (e) {
+		return { output: '', error: e instanceof Error ? e.message : 'Invalid JSON' };
+	}
+};
 
 export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProps) {
 	const { value: jsonOptions } = useJsonFormatterOptions();
@@ -109,64 +188,13 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 		return { valid: result.valid };
 	}, [input, inputFormat]);
 
-	const { output, error: formatError } = ((): { output: string; error: string } => {
-		if (!input.trim()) return { output: '', error: '' };
-
-		try {
-			const data = parseJson(input, inputFormat);
-
-			// Apply filtering options (removeNulls, removeEmptyStrings, etc.).
-			const processedData = processJsonWithOptions(data, formatOptions);
-
-			if (formatMode === 'minify') {
-				return { output: stringifyJson(processedData, outputFormat, { indent: 0 }), error: '' };
-			}
-
-			const baseResult = stringifyJson(processedData, outputFormat, {
-				indent: formatOptions.indentType === 'tabs' ? '\t' : formatOptions.indentSize,
-				sortKeys: formatOptions.sortKeys,
-				trailingComma: formatOptions.trailingComma,
-				quote: formatOptions.quoteStyle,
-			});
-
-			// Apply additional formatting options as a const pipeline so each
-			// rule reads from / writes to a fresh string.
-			type Transform = (input: string) => string;
-			const transforms: readonly Transform[] = [
-				formatOptions.escapeUnicode
-					? (input) =>
-							input.replace(
-								/[\u0080-\uffff]/g,
-								(char) => `\\u${`0000${char.charCodeAt(0).toString(16)}`.slice(-4)}`
-							)
-					: (input) => input,
-				formatOptions.arrayBracketSpacing
-					? (input) => input.replace(/\[(?!\s*\n)/g, '[ ').replace(/(?<!\n\s*)\]/g, ' ]')
-					: (input) => input,
-				formatOptions.objectBracketSpacing
-					? (input) => input.replace(/\{(?!\s*\n)/g, '{ ').replace(/(?<!\n\s*)\}/g, ' }')
-					: (input) => input,
-				formatOptions.colonSpacing ? (input) => input : (input) => input.replace(/:\s+/g, ':'),
-				formatOptions.compactArrays && (formatOptions.indentSize ?? 2) > 0
-					? (input) =>
-							input.replace(
-								/\[\s*\n(\s*)((?:"[^"]*"|'[^']*'|[\d.eE+-]+|true|false|null)(?:,\s*\n\s*(?:"[^"]*"|'[^']*'|[\d.eE+-]+|true|false|null))*)\s*\n\s*\]/g,
-								(_, _indent, content: string) => {
-									const items = content.split(/,\s*\n\s*/);
-									return `[${items.join(', ')}]`;
-								}
-							)
-					: (input) => input,
-			];
-
-			return {
-				output: transforms.reduce((acc, transform) => transform(acc), baseResult),
-				error: '',
-			};
-		} catch (e) {
-			return { output: '', error: e instanceof Error ? e.message : 'Invalid JSON' };
-		}
-	})();
+	const { output, error: formatError } = computeFormattedOutput(
+		input,
+		inputFormat,
+		outputFormat,
+		formatMode,
+		formatOptions
+	);
 
 	useEffect(() => {
 		onStatsChange?.({

--- a/src/lib/components/layout/section-label.tsx
+++ b/src/lib/components/layout/section-label.tsx
@@ -3,7 +3,6 @@ import type { ComponentType, ReactNode, SVGProps } from 'react';
 import { cn } from '@/lib/utils';
 
 export function SectionLabel({
-	title,
 	icon: Icon,
 	iconClass = 'h-4 w-4 text-muted-foreground',
 	className,
@@ -12,14 +11,12 @@ export function SectionLabel({
 	return (
 		<h3 className={cn('mb-2 flex items-center gap-2 text-sm font-medium', className)}>
 			{Icon ? <Icon className={iconClass} /> : null}
-			{title}
 			{children}
 		</h3>
 	);
 }
 
 export type SectionLabelProps = {
-	readonly title?: string;
 	readonly icon?: ComponentType<SVGProps<SVGSVGElement>>;
 	readonly iconClass?: string;
 	readonly className?: string;

--- a/src/lib/components/network-scanner/unified-host-detail-panel.tsx
+++ b/src/lib/components/network-scanner/unified-host-detail-panel.tsx
@@ -189,6 +189,1397 @@ const copyToClipboard = async (text: string, label: string) => {
 	toast.success(`${label} copied`);
 };
 
+const getConfidenceLabel = (classification: DeviceClassification | null): string | null => {
+	if (!classification || classification.confidence === 0) return null;
+	if (classification.confidence >= 0.7) return 'High';
+	if (classification.confidence >= 0.4) return 'Medium';
+	return 'Low';
+};
+
+const getConfidenceColor = (classification: DeviceClassification | null): string => {
+	if (!classification || classification.confidence === 0) return '';
+	if (classification.confidence >= 0.7) return 'text-success';
+	if (classification.confidence >= 0.4) return 'text-warning';
+	return 'text-muted-foreground';
+};
+
+const getScanStatusText = (scanProgress: ScanProgress | null): string => {
+	if (!scanProgress) return '';
+	if (scanProgress.type === 'started') {
+		return `Scanning ${scanProgress.total_hosts} hosts, ${scanProgress.total_ports} ports each`;
+	}
+	if (scanProgress.type === 'progress') {
+		return `${scanProgress.scanned_hosts} / ${scanProgress.total_hosts} hosts`;
+	}
+	return '';
+};
+
+interface DisplayIdentity {
+	readonly name: string | null;
+	readonly source: string | null;
+}
+
+const resolveDisplayIdentity = (
+	hostname: string | null,
+	hostnameSource: string | null,
+	netbiosName: string | null,
+	ssdpDevice: SsdpDeviceInfo | null
+): DisplayIdentity => {
+	if (isUsefulHostname(hostname)) {
+		return { name: hostname, source: hostnameSource };
+	}
+	if (isUsefulHostname(netbiosName)) {
+		return { name: netbiosName, source: 'netbios' };
+	}
+	if (isUsefulHostname(ssdpDevice?.friendlyName)) {
+		return { name: ssdpDevice?.friendlyName ?? null, source: 'ssdp' };
+	}
+	return { name: null, source: null };
+};
+
+const buildTabs = (
+	discoveries: readonly DiscoveryInfo[],
+	mdnsServices: readonly MdnsServiceInfo[],
+	openPorts: readonly PortInfo[]
+) => [
+	{ id: 'overview' as const, label: 'Overview', icon: Info, count: null as number | null },
+	{
+		id: 'discovery' as const,
+		label: 'Discovery',
+		icon: Radar,
+		count: discoveries.length > 0 ? discoveries.length : null,
+	},
+	{
+		id: 'services' as const,
+		label: 'Services',
+		icon: Radio,
+		count: mdnsServices.length > 0 ? mdnsServices.length : null,
+	},
+	{
+		id: 'ports' as const,
+		label: 'Ports',
+		icon: Network,
+		count: openPorts.length > 0 ? openPorts.length : null,
+	},
+];
+
+const computeSsdpHasInfo = (device: SsdpDeviceInfo | null): boolean =>
+	Boolean(
+		device &&
+		(device.friendlyName ||
+			device.manufacturer ||
+			device.modelName ||
+			device.deviceType ||
+			device.server)
+	);
+
+interface BrowserPort {
+	readonly protocol: 'http' | 'https';
+	readonly port: number;
+}
+
+const findBrowserPort = (ports: readonly PortInfo[]): BrowserPort | null => {
+	const webPort = ports.find((p) => p.state === 'open' && [443, 8443, 80, 8080].includes(p.port));
+	if (!webPort) return null;
+	const protocol: BrowserPort['protocol'] = [443, 8443].includes(webPort.port) ? 'https' : 'http';
+	return { protocol, port: webPort.port };
+};
+
+interface OpenPortCardProps {
+	readonly port: PortInfo;
+}
+
+function OpenPortCard({ port }: OpenPortCardProps) {
+	const PortIcon = getPortIcon(port.port);
+	const serviceName = getServiceName(port);
+	return (
+		<Card key={port.port} density="compact" className="transition-colors hover:border-border/80">
+			<CardContent>
+				<div className="flex items-start justify-between">
+					<div className="flex items-start gap-3">
+						<div className="rounded bg-success/10 p-1.5">
+							<PortIcon className="h-4 w-4 text-success" />
+						</div>
+						<div className="min-w-0 flex-1">
+							<div className="flex items-center gap-2">
+								<span className="font-mono text-base font-semibold tabular-nums">{port.port}</span>
+								{serviceName ? (
+									<span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium">
+										{serviceName}
+									</span>
+								) : null}
+							</div>
+							{port.banner ? <PortBannerDetails banner={port.banner} /> : null}
+							{port.tlsCert ? <PortTlsDetails cert={port.tlsCert} /> : null}
+						</div>
+					</div>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant="ghost"
+								size="icon-sm"
+								className="h-6 w-6 text-muted-foreground hover:bg-muted hover:text-foreground"
+								onClick={() => {
+									copyToClipboard(String(port.port), 'Port number').catch(() => {});
+								}}
+							>
+								<Copy className="h-3 w-3" />
+								<span className="sr-only">Copy port</span>
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Copy port</TooltipContent>
+					</Tooltip>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface PortBannerDetailsProps {
+	readonly banner: string;
+}
+
+function PortBannerDetails({ banner }: PortBannerDetailsProps) {
+	return (
+		<details className="mt-2">
+			<summary className="flex cursor-pointer items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+				<ChevronRight className="h-3 w-3 transition-transform [[open]>&]:rotate-90" />
+				Banner / Version Info
+			</summary>
+			<div className="mt-1.5 rounded bg-muted/50 p-2 font-mono text-xs leading-relaxed text-muted-foreground">
+				{banner}
+			</div>
+		</details>
+	);
+}
+
+interface PortTlsDetailsProps {
+	readonly cert: NonNullable<PortInfo['tlsCert']>;
+}
+
+function PortTlsDetails({ cert }: PortTlsDetailsProps) {
+	return (
+		<details className="mt-2">
+			<summary className="flex cursor-pointer items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+				<ChevronRight className="h-3 w-3 transition-transform [[open]>&]:rotate-90" />
+				<Lock className="h-3 w-3" />
+				TLS Certificate
+				{cert.isSelfSigned ? (
+					<span className="rounded bg-warning/10 px-1.5 py-0.5 text-xs font-medium text-warning">
+						Self-signed
+					</span>
+				) : null}
+			</summary>
+			<div className="mt-1.5 space-y-1.5 rounded bg-muted/50 p-2 text-xs">
+				{cert.commonName ? (
+					<div className="flex gap-1">
+						<span className="shrink-0 font-medium text-muted-foreground">CN:</span>
+						<span className="break-all font-mono">{cert.commonName}</span>
+					</div>
+				) : null}
+				{cert.issuer ? (
+					<div className="flex gap-1">
+						<span className="shrink-0 font-medium text-muted-foreground">Issuer:</span>
+						<span className="break-all font-mono">{cert.issuer}</span>
+					</div>
+				) : null}
+				{cert.subjectAltNames && cert.subjectAltNames.length > 0 ? (
+					<div>
+						<span className="font-medium text-muted-foreground">SAN:</span>
+						<div className="ml-3 mt-0.5 space-y-0.5">
+							{cert.subjectAltNames.map((san) => (
+								<div key={san} className="break-all font-mono">
+									{san}
+								</div>
+							))}
+						</div>
+					</div>
+				) : null}
+			</div>
+		</details>
+	);
+}
+
+interface PortsTabProps {
+	readonly ports: readonly PortInfo[];
+	readonly openPorts: readonly PortInfo[];
+	readonly filteredPorts: readonly PortInfo[];
+	readonly closedPorts: readonly PortInfo[];
+	readonly primaryIp: string;
+	readonly scanDisabled: boolean;
+	readonly scanProgress: ScanProgress | null;
+	readonly scanPercentage: number;
+	readonly scanStatusText: string;
+	readonly scanCurrentIp: string | null;
+	readonly scanDiscoveredHosts: number;
+	readonly scanDiscoveredPorts: number;
+	readonly localScanMode: ScanMode;
+	readonly onLocalScanModeChange: (mode: ScanMode) => void;
+	readonly onScan?: (ip: string, scanMode: ScanMode) => void;
+	readonly onCancel?: () => void;
+}
+
+function PortsTab({
+	ports,
+	openPorts,
+	filteredPorts,
+	closedPorts,
+	primaryIp,
+	scanDisabled,
+	scanProgress,
+	scanPercentage,
+	scanStatusText,
+	scanCurrentIp,
+	scanDiscoveredHosts,
+	scanDiscoveredPorts,
+	localScanMode,
+	onLocalScanModeChange,
+	onScan,
+	onCancel,
+}: PortsTabProps) {
+	return (
+		<>
+			{scanDisabled && scanProgress ? (
+				<PortsScanProgressCard
+					scanPercentage={scanPercentage}
+					scanStatusText={scanStatusText}
+					scanCurrentIp={scanCurrentIp}
+					scanDiscoveredHosts={scanDiscoveredHosts}
+					scanDiscoveredPorts={scanDiscoveredPorts}
+					onCancel={onCancel}
+				/>
+			) : onScan ? (
+				<PortsScanControls
+					primaryIp={primaryIp}
+					hasPorts={ports.length > 0}
+					localScanMode={localScanMode}
+					onLocalScanModeChange={onLocalScanModeChange}
+					scanDisabled={scanDisabled}
+					onScan={onScan}
+				/>
+			) : null}
+
+			{ports.length === 0 && scanDisabled && scanProgress ? (
+				<div className="space-y-1.5" role="status" aria-busy="true" aria-label="Loading ports">
+					{Array.from({ length: 5 }, (_, i) => (
+						// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
+						<div key={i} className="flex items-center gap-2">
+							<Skeleton className="h-4 w-24" />
+							<Skeleton className="ml-auto h-4 w-12" />
+						</div>
+					))}
+				</div>
+			) : ports.length === 0 ? (
+				<EmbeddedEmptyState
+					icon={Network}
+					title="No Port Scan Data"
+					description="Select a scan mode and run a port scan to detect open services."
+				/>
+			) : (
+				<>
+					<PortSummaryCard
+						total={ports.length}
+						openCount={openPorts.length}
+						filteredCount={filteredPorts.length}
+						closedCount={closedPorts.length}
+					/>
+
+					{openPorts.length > 0 ? (
+						<div className="mb-4">
+							<SectionLabel icon={CheckCircle2} iconClass="h-4 w-4 text-success">
+								{`Open Ports (${openPorts.length})`}
+							</SectionLabel>
+							<div className="space-y-2">
+								{openPorts.map((port) => (
+									<OpenPortCard key={port.port} port={port} />
+								))}
+							</div>
+						</div>
+					) : null}
+
+					{filteredPorts.length > 0 ? <FilteredPortsSection ports={filteredPorts} /> : null}
+
+					{closedPorts.length > 0 ? <ClosedPortsSection ports={closedPorts} /> : null}
+				</>
+			)}
+		</>
+	);
+}
+
+interface PortsScanProgressCardProps {
+	readonly scanPercentage: number;
+	readonly scanStatusText: string;
+	readonly scanCurrentIp: string | null;
+	readonly scanDiscoveredHosts: number;
+	readonly scanDiscoveredPorts: number;
+	readonly onCancel?: () => void;
+}
+
+function PortsScanProgressCard({
+	scanPercentage,
+	scanStatusText,
+	scanCurrentIp,
+	scanDiscoveredHosts,
+	scanDiscoveredPorts,
+	onCancel,
+}: PortsScanProgressCardProps) {
+	return (
+		<Card density="compact" className="mb-4">
+			<CardContent>
+				<div className="mb-2 flex items-center justify-between">
+					<div className="flex items-center gap-2">
+						<Loader2 className="h-4 w-4 animate-spin text-primary" />
+						<span className="text-sm font-medium">Scanning Ports...</span>
+					</div>
+					<div className="flex items-center gap-2">
+						<span className="text-sm font-medium text-primary">{scanPercentage.toFixed(0)}%</span>
+						{onCancel ? (
+							<Button
+								variant="ghost"
+								size="sm"
+								className="h-7 gap-1 px-2 text-xs text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+								onClick={onCancel}
+							>
+								<Square className="h-3 w-3" />
+								Cancel
+							</Button>
+						) : null}
+					</div>
+				</div>
+				<div className="mb-2 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+					<div
+						className="h-full bg-primary transition-all duration-300"
+						style={{ width: `${scanPercentage}%` }}
+					/>
+				</div>
+				<div className="flex items-center justify-between text-xs text-muted-foreground">
+					<span>{scanStatusText}</span>
+					<div className="flex items-center gap-3">
+						{scanCurrentIp ? <span className="font-mono">{scanCurrentIp}</span> : null}
+						{scanDiscoveredHosts > 0 ? (
+							<span className="text-success">{scanDiscoveredHosts} hosts</span>
+						) : null}
+						{scanDiscoveredPorts > 0 ? (
+							<span className="text-success">{scanDiscoveredPorts} ports</span>
+						) : null}
+					</div>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface PortsScanControlsProps {
+	readonly primaryIp: string;
+	readonly hasPorts: boolean;
+	readonly localScanMode: ScanMode;
+	readonly onLocalScanModeChange: (mode: ScanMode) => void;
+	readonly scanDisabled: boolean;
+	readonly onScan: (ip: string, scanMode: ScanMode) => void;
+}
+
+function PortsScanControls({
+	primaryIp,
+	hasPorts,
+	localScanMode,
+	onLocalScanModeChange,
+	scanDisabled,
+	onScan,
+}: PortsScanControlsProps) {
+	return (
+		<Card density="compact" className="mb-4">
+			<CardContent>
+				<div className="flex items-center gap-2">
+					<Select value={localScanMode} onValueChange={(v) => onLocalScanModeChange(v as ScanMode)}>
+						<SelectTrigger size="sm" className="flex-1">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{SCAN_MODES.map((mode) => (
+								<SelectItem key={mode.value} value={mode.value}>
+									{mode.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+					<Button
+						variant="default"
+						size="sm"
+						className="h-8 shrink-0 gap-1.5 px-3 text-xs"
+						disabled={scanDisabled}
+						onClick={() => onScan(primaryIp, localScanMode)}
+					>
+						<Play className="h-3.5 w-3.5" />
+						{hasPorts ? 'Re-scan' : 'Scan'}
+					</Button>
+				</div>
+				<p className="mt-1.5 text-xs text-muted-foreground">
+					{SCAN_MODES.find((m) => m.value === localScanMode)?.description ?? ''}
+				</p>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface PortSummaryCardProps {
+	readonly total: number;
+	readonly openCount: number;
+	readonly filteredCount: number;
+	readonly closedCount: number;
+}
+
+function PortSummaryCard({ total, openCount, filteredCount, closedCount }: PortSummaryCardProps) {
+	return (
+		<Card density="compact" className="mb-4">
+			<CardContent>
+				<div className="flex items-center justify-between text-sm">
+					<span className="font-medium">Port Summary</span>
+					<span className="text-xs text-muted-foreground">{total} scanned</span>
+				</div>
+				<div className="mt-2 flex gap-4 text-xs">
+					<span className="flex items-center gap-1.5 text-success">
+						<CheckCircle2 className="h-3 w-3" aria-hidden="true" />
+						{openCount} open
+					</span>
+					<span className="flex items-center gap-1.5 text-warning">
+						<Shield className="h-3 w-3" aria-hidden="true" />
+						{filteredCount} filtered
+					</span>
+					<span className="flex items-center gap-1.5 text-destructive">
+						<XCircle className="h-3 w-3" aria-hidden="true" />
+						{closedCount} closed
+					</span>
+				</div>
+				<div className="mt-2 flex h-1.5 overflow-hidden rounded-full bg-muted">
+					{openCount > 0 ? (
+						<div className="bg-success" style={{ width: `${(openCount / total) * 100}%` }} />
+					) : null}
+					{filteredCount > 0 ? (
+						<div className="bg-warning" style={{ width: `${(filteredCount / total) * 100}%` }} />
+					) : null}
+					{closedCount > 0 ? (
+						<div className="bg-destructive" style={{ width: `${(closedCount / total) * 100}%` }} />
+					) : null}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface FilteredPortsSectionProps {
+	readonly ports: readonly PortInfo[];
+}
+
+function FilteredPortsSection({ ports }: FilteredPortsSectionProps) {
+	return (
+		<div className="mb-4">
+			<SectionLabel icon={Shield} iconClass="h-4 w-4 text-warning">
+				{`Filtered Ports (${ports.length})`}
+			</SectionLabel>
+			<div className="flex flex-wrap gap-2">
+				{ports.map((port) => {
+					const serviceName = getServiceName(port);
+					return (
+						<div
+							key={port.port}
+							className="flex items-center gap-1.5 rounded border bg-warning/5 px-2 py-1 text-xs"
+							title={
+								serviceName
+									? `${port.port}/${serviceName} - Firewall or security software blocking`
+									: `Port ${port.port} - Firewall or security software blocking`
+							}
+						>
+							<span className="font-mono font-medium">{port.port}</span>
+							{serviceName ? <span className="text-muted-foreground">/{serviceName}</span> : null}
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}
+
+interface ClosedPortsSectionProps {
+	readonly ports: readonly PortInfo[];
+}
+
+function ClosedPortsSection({ ports }: ClosedPortsSectionProps) {
+	return (
+		<div className="mb-4">
+			<SectionLabel icon={XCircle} iconClass="h-4 w-4 text-destructive">
+				{`Closed Ports (${ports.length})`}
+			</SectionLabel>
+			<div className="flex flex-wrap gap-2">
+				{ports.map((port) => {
+					const serviceName = getServiceName(port);
+					return (
+						<div
+							key={port.port}
+							className="flex items-center gap-1.5 rounded border bg-destructive/5 px-2 py-1 text-xs"
+							title={
+								serviceName
+									? `${port.port}/${serviceName} - No service listening`
+									: `Port ${port.port} - No service listening`
+							}
+						>
+							<span className="font-mono font-medium">{port.port}</span>
+							{serviceName ? <span className="text-muted-foreground">/{serviceName}</span> : null}
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}
+
+interface DiscoveryTabProps {
+	readonly discoveries: readonly DiscoveryInfo[];
+}
+
+function DiscoveryTab({ discoveries }: DiscoveryTabProps) {
+	if (discoveries.length === 0) {
+		return (
+			<EmbeddedEmptyState
+				icon={Radar}
+				title="No Discovery Data"
+				description="Run host discovery to detect this device using various network protocols."
+				fillHeight
+			/>
+		);
+	}
+	return (
+		<div className="space-y-2">
+			{discoveries.map((discovery) => (
+				<Card
+					key={discovery.method}
+					density="compact"
+					className="transition-colors hover:border-border/80"
+				>
+					<CardContent>
+						<div className="flex items-center justify-between">
+							<div className="flex items-center gap-3">
+								<div
+									className={cn(
+										'rounded p-1.5',
+										discovery.error ? 'bg-destructive/10' : 'bg-success/10'
+									)}
+								>
+									{discovery.error ? (
+										<XCircle className="h-4 w-4 text-destructive" />
+									) : (
+										<CheckCircle2 className="h-4 w-4 text-success" />
+									)}
+								</div>
+								<div>
+									<span className="font-medium">{formatMethodName(discovery.method)}</span>
+									<p className="text-xs text-muted-foreground">
+										{getMethodDescription(discovery.method)}
+									</p>
+									{discovery.error ? (
+										<p className="mt-0.5 text-xs text-destructive">{discovery.error}</p>
+									) : null}
+								</div>
+							</div>
+							<div className="flex items-center gap-1 text-xs text-muted-foreground">
+								<Clock className="h-3 w-3" />
+								<span>{formatDuration(discovery.durationMs)}</span>
+							</div>
+						</div>
+					</CardContent>
+				</Card>
+			))}
+		</div>
+	);
+}
+
+interface ServicesTabProps {
+	readonly mdnsServices: readonly MdnsServiceInfo[];
+}
+
+function ServicesTab({ mdnsServices }: ServicesTabProps) {
+	if (!mdnsServices || mdnsServices.length === 0) {
+		return (
+			<EmbeddedEmptyState
+				icon={Radio}
+				title="No mDNS Services"
+				description="This host is not advertising any services via mDNS/Bonjour."
+				fillHeight
+			/>
+		);
+	}
+	return (
+		<div className="space-y-2">
+			{mdnsServices.map((service) => (
+				<MdnsServiceCard key={`${service.instanceName}-${service.serviceType}`} service={service} />
+			))}
+		</div>
+	);
+}
+
+interface MdnsServiceCardProps {
+	readonly service: MdnsServiceInfo;
+}
+
+function MdnsServiceCard({ service }: MdnsServiceCardProps) {
+	return (
+		<Card density="compact" className="transition-colors hover:border-border/80">
+			<CardContent>
+				<div className="flex items-start justify-between">
+					<div className="min-w-0 flex-1">
+						<div className="flex items-center gap-2">
+							<span className="truncate font-medium">{service.instanceName}</span>
+							<span className="shrink-0 rounded bg-info/10 px-1.5 py-0.5 text-xs font-medium text-info">
+								{service.serviceType.replace(/\._tcp\.local\.$/, '').replace(/^_/, '')}
+							</span>
+						</div>
+						<div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+							<span className="font-mono">Port {service.port}</span>
+						</div>
+						{service.properties.length > 0 ? (
+							<details className="mt-2">
+								<summary className="flex cursor-pointer items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+									<ChevronRight className="h-3 w-3 transition-transform [[open]>&]:rotate-90" />
+									TXT Properties ({service.properties.length})
+								</summary>
+								<div className="mt-1.5 max-h-24 overflow-y-auto rounded bg-muted/50 p-2 text-xs">
+									{service.properties.map(([key, value]) => (
+										<div key={`${key}-${value}`} className="flex gap-2">
+											<span className="font-medium text-muted-foreground">{key}:</span>
+											<span className="break-all font-mono">{value || '(empty)'}</span>
+										</div>
+									))}
+								</div>
+							</details>
+						) : null}
+					</div>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant="ghost"
+								size="icon-sm"
+								className="h-6 w-6 shrink-0 text-muted-foreground hover:bg-muted hover:text-foreground"
+								onClick={() => {
+									copyToClipboard(
+										`${service.instanceName} (${service.serviceType}:${service.port})`,
+										'Service info'
+									).catch(() => {});
+								}}
+							>
+								<Copy className="h-3 w-3" />
+								<span className="sr-only">Copy service info</span>
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Copy service info</TooltipContent>
+					</Tooltip>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface OverviewTabProps {
+	readonly ips: readonly string[];
+	readonly ipv4Addresses: readonly string[];
+	readonly ipv6Addresses: readonly string[];
+	readonly openPorts: readonly PortInfo[];
+	readonly discoveriesCount: number;
+	readonly mdnsServicesCount: number;
+	readonly classification: DeviceClassification | null;
+	readonly HeaderIcon: ComponentType<SVGProps<SVGSVGElement>>;
+	readonly confidenceLabel: string | null;
+	readonly confidenceColor: string;
+	readonly netbiosName: string | null;
+	readonly macAddress: string | null;
+	readonly vendor: string | null;
+	readonly hasSsdpInfo: boolean;
+	readonly ssdpDevice: SsdpDeviceInfo | null;
+	readonly wsDiscovery: WsDiscoveryInfo | null;
+	readonly snmpInfo: SnmpDeviceInfo | null;
+	readonly tlsNames: readonly string[];
+	readonly serviceBanners: readonly ServiceBanner[];
+}
+
+function OverviewTab({
+	ips,
+	ipv4Addresses,
+	ipv6Addresses,
+	openPorts,
+	discoveriesCount,
+	mdnsServicesCount,
+	classification,
+	HeaderIcon,
+	confidenceLabel,
+	confidenceColor,
+	netbiosName,
+	macAddress,
+	vendor,
+	hasSsdpInfo,
+	ssdpDevice,
+	wsDiscovery,
+	snmpInfo,
+	tlsNames,
+	serviceBanners,
+}: OverviewTabProps) {
+	return (
+		<>
+			<div className="mb-4 grid grid-cols-2 gap-2">
+				<OverviewStatCard icon={Hash} label="IPs" value={ips.length} />
+				<OverviewStatCard
+					icon={CheckCircle2}
+					iconClass="h-3 w-3 text-success"
+					label="Open Ports"
+					value={openPorts.length}
+				/>
+				<OverviewStatCard
+					icon={Radar}
+					iconClass="h-3 w-3 text-primary"
+					label="Discovery"
+					value={discoveriesCount}
+				/>
+				<OverviewStatCard
+					icon={Radio}
+					iconClass="h-3 w-3 text-info"
+					label="Services"
+					value={mdnsServicesCount}
+				/>
+			</div>
+
+			{ips.length > 1 || ipv6Addresses.length > 0 ? (
+				<IpAddressesSection ipv4={ipv4Addresses} ipv6={ipv6Addresses} />
+			) : null}
+
+			{classification && classification.category !== 'unknown' ? (
+				<DeviceTypeSection
+					classification={classification}
+					HeaderIcon={HeaderIcon}
+					confidenceLabel={confidenceLabel}
+					confidenceColor={confidenceColor}
+				/>
+			) : null}
+
+			{macAddress || vendor || netbiosName ? (
+				<DeviceInfoSection netbiosName={netbiosName} macAddress={macAddress} vendor={vendor} />
+			) : null}
+
+			{hasSsdpInfo && ssdpDevice ? <SsdpDeviceSection device={ssdpDevice} /> : null}
+
+			{wsDiscovery && (wsDiscovery.deviceTypes.length > 0 || wsDiscovery.scopes.length > 0) ? (
+				<WsDiscoverySection wsDiscovery={wsDiscovery} />
+			) : null}
+
+			{snmpInfo &&
+			(snmpInfo.sysName || snmpInfo.sysDescr || snmpInfo.sysLocation || snmpInfo.sysContact) ? (
+				<SnmpSection snmpInfo={snmpInfo} />
+			) : null}
+
+			{serviceBanners && serviceBanners.length > 0 ? (
+				<ServiceBannersSection banners={serviceBanners} />
+			) : null}
+
+			{tlsNames && tlsNames.length > 0 ? <TlsCertificateSection names={tlsNames} /> : null}
+		</>
+	);
+}
+
+interface OverviewStatCardProps {
+	readonly icon: ComponentType<SVGProps<SVGSVGElement>>;
+	readonly iconClass?: string;
+	readonly label: string;
+	readonly value: number;
+}
+
+function OverviewStatCard({
+	icon: Icon,
+	iconClass = 'h-3 w-3',
+	label,
+	value,
+}: OverviewStatCardProps) {
+	return (
+		<Card density="compact">
+			<CardContent>
+				<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+					<Icon className={iconClass} />
+					{label}
+				</div>
+				<div className="mt-0.5 text-base font-semibold tabular-nums">{value}</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface IpAddressesSectionProps {
+	readonly ipv4: readonly string[];
+	readonly ipv6: readonly string[];
+}
+
+function IpAddressesSection({ ipv4, ipv6 }: IpAddressesSectionProps) {
+	return (
+		<div className="mb-4">
+			<SectionLabel icon={Hash}>IP Addresses</SectionLabel>
+			<div className="space-y-2">
+				{ipv4.length > 0 ? (
+					<Card density="compact">
+						<CardContent>
+							<div className="mb-1.5 text-xs font-medium text-muted-foreground">IPv4</div>
+							<div className="flex flex-wrap gap-2">
+								{ipv4.map((ip) => (
+									<Button
+										key={ip}
+										variant="ghost"
+										size="sm"
+										className="h-auto gap-1.5 rounded bg-muted px-2 py-1 font-mono text-xs hover:bg-muted/80"
+										title={`Copy ${ip}`}
+										onClick={() => {
+											copyToClipboard(ip, 'IP address').catch(() => {});
+										}}
+									>
+										{ip}
+										<Copy className="h-3 w-3 text-muted-foreground" />
+									</Button>
+								))}
+							</div>
+						</CardContent>
+					</Card>
+				) : null}
+				{ipv6.length > 0 ? (
+					<Card density="compact">
+						<CardContent>
+							<div className="mb-1.5 text-xs font-medium text-muted-foreground">IPv6</div>
+							<div className="space-y-1">
+								{ipv6.map((ip) => (
+									<Button
+										key={ip}
+										variant="ghost"
+										size="sm"
+										className="h-auto w-full justify-between gap-2 rounded bg-muted px-2 py-1 font-mono text-xs hover:bg-muted/80"
+										title={`Copy ${ip}`}
+										onClick={() => {
+											copyToClipboard(ip, 'IP address').catch(() => {});
+										}}
+									>
+										<span className="truncate">{ip}</span>
+										<Copy className="h-3 w-3 shrink-0 text-muted-foreground" />
+									</Button>
+								))}
+							</div>
+						</CardContent>
+					</Card>
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+interface DeviceTypeSectionProps {
+	readonly classification: DeviceClassification;
+	readonly HeaderIcon: ComponentType<SVGProps<SVGSVGElement>>;
+	readonly confidenceLabel: string | null;
+	readonly confidenceColor: string;
+}
+
+function DeviceTypeSection({
+	classification,
+	HeaderIcon,
+	confidenceLabel,
+	confidenceColor,
+}: DeviceTypeSectionProps) {
+	return (
+		<div className="mb-4">
+			<SectionLabel icon={HeaderIcon}>Device Type</SectionLabel>
+			<Card density="compact">
+				<CardContent>
+					<div className="flex items-center justify-between">
+						<div className="flex items-center gap-2">
+							<span className="text-sm font-medium">
+								{DEVICE_CATEGORIES[classification.category].label}
+							</span>
+							{confidenceLabel ? (
+								<span
+									className={cn(
+										'rounded bg-muted px-1.5 py-0.5 text-xs font-medium',
+										confidenceColor
+									)}
+								>
+									{confidenceLabel}
+								</span>
+							) : null}
+						</div>
+						<span className="text-xs text-muted-foreground">
+							{(classification.confidence * 100).toFixed(0)}%
+						</span>
+					</div>
+					<p className="mt-1 text-xs text-muted-foreground">
+						{DEVICE_CATEGORIES[classification.category].description}
+					</p>
+					{classification.evidence.length > 0 ? (
+						<div className="mt-2 border-t pt-2">
+							<div className="text-xs text-muted-foreground">
+								{classification.evidence.map((evidence) => (
+									<div key={evidence} className="flex items-center gap-1">
+										<span className="text-[8px]">-</span>
+										<span>{evidence}</span>
+									</div>
+								))}
+							</div>
+						</div>
+					) : null}
+				</CardContent>
+			</Card>
+		</div>
+	);
+}
+
+interface DeviceInfoSectionProps {
+	readonly netbiosName: string | null;
+	readonly macAddress: string | null;
+	readonly vendor: string | null;
+}
+
+function DeviceInfoSection({ netbiosName, macAddress, vendor }: DeviceInfoSectionProps) {
+	return (
+		<div className="mb-4">
+			<SectionLabel icon={Cpu}>Device Info</SectionLabel>
+			<div className="grid grid-cols-2 gap-2">
+				{netbiosName ? <NamedInfoCard label="NetBIOS Name" value={netbiosName} /> : null}
+				{macAddress ? <NamedInfoCard label="MAC Address" value={macAddress} /> : null}
+				{vendor ? (
+					<Card density="compact" className={cn(netbiosName && macAddress && 'col-span-2')}>
+						<CardContent>
+							<div className="text-xs text-muted-foreground">Vendor</div>
+							<div className="mt-0.5 text-sm">{vendor}</div>
+						</CardContent>
+					</Card>
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+interface NamedInfoCardProps {
+	readonly label: string;
+	readonly value: string;
+}
+
+function NamedInfoCard({ label, value }: NamedInfoCardProps) {
+	return (
+		<Card density="compact">
+			<CardContent>
+				<div className="text-xs text-muted-foreground">{label}</div>
+				<div className="mt-0.5 flex items-center gap-1.5 font-mono text-sm font-medium">
+					{value}
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant="ghost"
+								size="icon-sm"
+								className="h-5 w-5 text-muted-foreground hover:bg-muted hover:text-foreground"
+								onClick={() => {
+									copyToClipboard(value, label).catch(() => {});
+								}}
+							>
+								<Copy className="h-3 w-3" />
+								<span className="sr-only">{`Copy ${label}`}</span>
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>{`Copy ${label}`}</TooltipContent>
+					</Tooltip>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface SsdpDeviceSectionProps {
+	readonly device: SsdpDeviceInfo;
+}
+
+function SsdpDeviceSection({ device }: SsdpDeviceSectionProps) {
+	return (
+		<div className="mb-4">
+			<SectionLabel icon={Wifi}>SSDP/UPnP Device</SectionLabel>
+			<Card density="compact">
+				<CardContent>
+					{device.friendlyName ? (
+						<div>
+							<div className="text-xs font-medium text-muted-foreground">Friendly Name</div>
+							<div className="text-sm font-medium">{device.friendlyName}</div>
+						</div>
+					) : null}
+					{device.manufacturer || device.modelName ? (
+						<div className={device.friendlyName ? 'mt-2 border-t pt-2' : ''}>
+							<div className="text-xs font-medium text-muted-foreground">
+								{device.manufacturer && device.modelName
+									? 'Manufacturer / Model'
+									: device.manufacturer
+										? 'Manufacturer'
+										: 'Model'}
+							</div>
+							<div className="text-sm">
+								{[device.manufacturer, device.modelName].filter(Boolean).join(' ')}
+								{device.modelNumber ? (
+									<span className="text-muted-foreground"> ({device.modelNumber})</span>
+								) : null}
+							</div>
+						</div>
+					) : null}
+					{device.deviceType ? (
+						<div
+							className={
+								device.friendlyName || device.manufacturer || device.modelName
+									? 'mt-2 border-t pt-2'
+									: ''
+							}
+						>
+							<div className="text-xs font-medium text-muted-foreground">Device Type</div>
+							<div className="font-mono text-xs text-muted-foreground">{device.deviceType}</div>
+						</div>
+					) : null}
+					{device.server ? (
+						<div className="mt-2 border-t pt-2">
+							<div className="text-xs font-medium text-muted-foreground">Server</div>
+							<div className="font-mono text-xs text-muted-foreground">{device.server}</div>
+						</div>
+					) : null}
+				</CardContent>
+			</Card>
+		</div>
+	);
+}
+
+interface WsDiscoverySectionProps {
+	readonly wsDiscovery: WsDiscoveryInfo;
+}
+
+function WsDiscoverySection({ wsDiscovery }: WsDiscoverySectionProps) {
+	return (
+		<div className="mb-4">
+			<SectionLabel icon={Globe}>WS-Discovery</SectionLabel>
+			<Card density="compact">
+				<CardContent>
+					{wsDiscovery.deviceTypes.length > 0 ? (
+						<div>
+							<div className="text-xs font-medium text-muted-foreground">Device Types</div>
+							<div className="mt-1 space-y-0.5">
+								{wsDiscovery.deviceTypes.map((dtype) => (
+									<div key={dtype} className="font-mono text-xs text-muted-foreground">
+										{dtype}
+									</div>
+								))}
+							</div>
+						</div>
+					) : null}
+					{wsDiscovery.scopes.length > 0 ? (
+						<div className={wsDiscovery.deviceTypes.length > 0 ? 'mt-2 border-t pt-2' : ''}>
+							<div className="text-xs font-medium text-muted-foreground">Scopes</div>
+							<div className="mt-1 max-h-20 space-y-0.5 overflow-y-auto">
+								{wsDiscovery.scopes.map((scope) => (
+									<div key={scope} className="break-all font-mono text-xs text-muted-foreground">
+										{scope}
+									</div>
+								))}
+							</div>
+						</div>
+					) : null}
+				</CardContent>
+			</Card>
+		</div>
+	);
+}
+
+interface SnmpSectionProps {
+	readonly snmpInfo: SnmpDeviceInfo;
+}
+
+function SnmpSection({ snmpInfo }: SnmpSectionProps) {
+	return (
+		<div className="mb-4">
+			<SectionLabel icon={Server}>SNMP</SectionLabel>
+			<Card density="compact">
+				<CardContent className="space-y-2">
+					{snmpInfo.sysName ? (
+						<div>
+							<div className="text-xs font-medium text-muted-foreground">System Name</div>
+							<div className="text-sm">{snmpInfo.sysName}</div>
+						</div>
+					) : null}
+					{snmpInfo.sysDescr ? (
+						<div>
+							<div className="text-xs font-medium text-muted-foreground">Description</div>
+							<div className="break-words text-xs text-muted-foreground">{snmpInfo.sysDescr}</div>
+						</div>
+					) : null}
+					{snmpInfo.sysLocation ? (
+						<div>
+							<div className="text-xs font-medium text-muted-foreground">Location</div>
+							<div className="text-sm">{snmpInfo.sysLocation}</div>
+						</div>
+					) : null}
+					{snmpInfo.sysContact ? (
+						<div>
+							<div className="text-xs font-medium text-muted-foreground">Contact</div>
+							<div className="text-sm">{snmpInfo.sysContact}</div>
+						</div>
+					) : null}
+				</CardContent>
+			</Card>
+		</div>
+	);
+}
+
+interface ServiceBannersSectionProps {
+	readonly banners: readonly ServiceBanner[];
+}
+
+function ServiceBannersSection({ banners }: ServiceBannersSectionProps) {
+	return (
+		<div className="mb-4">
+			<SectionLabel icon={Terminal}>Service Banners</SectionLabel>
+			<Card density="compact">
+				<CardContent>
+					<div className="flex flex-wrap gap-1.5">
+						{banners.map((banner) => (
+							<span
+								key={`${banner.protocol}-${banner.version ?? ''}-${banner.raw}`}
+								className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs"
+								title={banner.raw}
+							>
+								<span className="font-medium text-foreground">{banner.protocol}</span>
+								{banner.version ? (
+									<span className="text-muted-foreground"> {banner.version}</span>
+								) : null}
+							</span>
+						))}
+					</div>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}
+
+interface TlsCertificateSectionProps {
+	readonly names: readonly string[];
+}
+
+function TlsCertificateSection({ names }: TlsCertificateSectionProps) {
+	return (
+		<div className="mb-4">
+			<SectionLabel icon={Shield}>TLS Certificate</SectionLabel>
+			<Card density="compact">
+				<CardContent>
+					<div className="text-xs font-medium text-muted-foreground">Subject Alternative Names</div>
+					<div className="mt-1 space-y-0.5">
+						{names.map((name) => (
+							<div key={name} className="font-mono text-sm">
+								{name}
+							</div>
+						))}
+					</div>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}
+
+interface HostDetailHeaderProps {
+	readonly HeaderIcon: ComponentType<SVGProps<SVGSVGElement>>;
+	readonly displayName: string | null;
+	readonly displaySource: string | null;
+	readonly primaryIp: string;
+	readonly classification: DeviceClassification | null;
+	readonly confidenceLabel: string | null;
+	readonly confidenceColor: string;
+	readonly hasWebPort: boolean;
+	readonly hasSshPort: boolean;
+	readonly scanDurationMs: number | null;
+	readonly onOpenInBrowser: () => void;
+	readonly onCopySshCommand: () => void;
+}
+
+function HostDetailHeader({
+	HeaderIcon,
+	displayName,
+	displaySource,
+	primaryIp,
+	classification,
+	confidenceLabel,
+	confidenceColor,
+	hasWebPort,
+	hasSshPort,
+	scanDurationMs,
+	onOpenInBrowser,
+	onCopySshCommand,
+}: HostDetailHeaderProps) {
+	return (
+		<div className="shrink-0 border-b bg-surface-3 px-4 py-3">
+			<div className="flex items-start justify-between">
+				<div className="flex items-center gap-3">
+					<div className="rounded-lg bg-primary/10 p-2">
+						<HeaderIcon className="h-5 w-5 text-primary" />
+					</div>
+					<div>
+						{displayName ? (
+							<HeaderTitleWithName
+								displayName={displayName}
+								displaySource={displaySource}
+								primaryIp={primaryIp}
+							/>
+						) : (
+							<HeaderTitleIpOnly primaryIp={primaryIp} />
+						)}
+						{classification && classification.category !== 'unknown' ? (
+							<div className="mt-1 flex items-center gap-2">
+								<span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium">
+									{DEVICE_CATEGORIES[classification.category].label}
+								</span>
+								{confidenceLabel ? (
+									<span className={cn('text-xs', confidenceColor)}>
+										{confidenceLabel} confidence
+									</span>
+								) : null}
+							</div>
+						) : null}
+					</div>
+				</div>
+				<div className="flex items-center gap-1">
+					{hasWebPort ? (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon-sm"
+									className="h-7 w-7 text-muted-foreground hover:bg-muted hover:text-foreground"
+									onClick={onOpenInBrowser}
+								>
+									<Globe className="h-3.5 w-3.5" />
+									<span className="sr-only">Open in browser</span>
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>Open in browser</TooltipContent>
+						</Tooltip>
+					) : null}
+					{hasSshPort ? (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon-sm"
+									className="h-7 w-7 text-muted-foreground hover:bg-muted hover:text-foreground"
+									onClick={onCopySshCommand}
+								>
+									<Terminal className="h-3.5 w-3.5" />
+									<span className="sr-only">Copy SSH command</span>
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>Copy SSH command</TooltipContent>
+						</Tooltip>
+					) : null}
+					{scanDurationMs ? (
+						<div className="ml-1 flex items-center gap-1 text-xs text-muted-foreground">
+							<Clock className="h-3 w-3" />
+							<span>{formatDuration(scanDurationMs)}</span>
+						</div>
+					) : null}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+interface HeaderTitleWithNameProps {
+	readonly displayName: string;
+	readonly displaySource: string | null;
+	readonly primaryIp: string;
+}
+
+function HeaderTitleWithName({ displayName, displaySource, primaryIp }: HeaderTitleWithNameProps) {
+	return (
+		<>
+			<div className="flex items-center gap-2">
+				<h2 className="text-lg font-semibold">{displayName}</h2>
+				{displaySource ? (
+					<span
+						className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground"
+						title={`Resolved via ${displaySource.toUpperCase()}`}
+					>
+						{displaySource.toUpperCase()}
+					</span>
+				) : null}
+				<CopyIconButton
+					label="Copy hostname"
+					iconClass="h-3.5 w-3.5"
+					onClick={() => {
+						copyToClipboard(displayName, 'Hostname').catch(() => {});
+					}}
+				/>
+			</div>
+			<div className="flex items-center gap-2">
+				<span className="font-mono text-sm tabular-nums text-muted-foreground">{primaryIp}</span>
+				<CopyIconButton
+					label="Copy IP"
+					iconClass="h-3 w-3"
+					buttonClass="h-5 w-5"
+					onClick={() => {
+						copyToClipboard(primaryIp, 'IP address').catch(() => {});
+					}}
+				/>
+			</div>
+		</>
+	);
+}
+
+interface HeaderTitleIpOnlyProps {
+	readonly primaryIp: string;
+}
+
+function HeaderTitleIpOnly({ primaryIp }: HeaderTitleIpOnlyProps) {
+	return (
+		<>
+			<div className="flex items-center gap-2">
+				<h2 className="font-mono text-lg font-semibold tabular-nums">{primaryIp}</h2>
+				<CopyIconButton
+					label="Copy IP"
+					iconClass="h-3.5 w-3.5"
+					onClick={() => {
+						copyToClipboard(primaryIp, 'IP address').catch(() => {});
+					}}
+				/>
+			</div>
+			<p className="text-xs text-muted-foreground">Hostname not resolved</p>
+		</>
+	);
+}
+
+interface CopyIconButtonProps {
+	readonly label: string;
+	readonly iconClass: string;
+	readonly buttonClass?: string;
+	readonly onClick: () => void;
+}
+
+function CopyIconButton({
+	label,
+	iconClass,
+	buttonClass = 'h-7 w-7',
+	onClick,
+}: CopyIconButtonProps) {
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<Button
+					variant="ghost"
+					size="icon-sm"
+					className={cn(buttonClass, 'text-muted-foreground hover:bg-muted hover:text-foreground')}
+					onClick={onClick}
+				>
+					<Copy className={iconClass} />
+					<span className="sr-only">{label}</span>
+				</Button>
+			</TooltipTrigger>
+			<TooltipContent>{label}</TooltipContent>
+		</Tooltip>
+	);
+}
+
 export function UnifiedHostDetailPanel({
 	ips,
 	hostname,
@@ -217,19 +1608,8 @@ export function UnifiedHostDetailPanel({
 	const deviceCategory: DeviceCategory = classification?.category ?? 'unknown';
 	const HeaderIcon = DEVICE_ICONS[deviceCategory] ?? CircleDot;
 
-	const confidenceLabel = ((): string | null => {
-		if (!classification || classification.confidence === 0) return null;
-		if (classification.confidence >= 0.7) return 'High';
-		if (classification.confidence >= 0.4) return 'Medium';
-		return 'Low';
-	})();
-
-	const confidenceColor = ((): string => {
-		if (!classification || classification.confidence === 0) return '';
-		if (classification.confidence >= 0.7) return 'text-success';
-		if (classification.confidence >= 0.4) return 'text-warning';
-		return 'text-muted-foreground';
-	})();
+	const confidenceLabel = getConfidenceLabel(classification);
+	const confidenceColor = getConfidenceColor(classification);
 
 	const primaryIp = ips[0] ?? '';
 	const ipv4Addresses = ips.filter((ip) => !isIPv6(ip));
@@ -241,16 +1621,7 @@ export function UnifiedHostDetailPanel({
 
 	// Scan progress derived values
 	const scanPercentage = scanProgress?.type === 'progress' ? scanProgress.percentage : 0;
-	const scanStatusText = ((): string => {
-		if (!scanProgress) return '';
-		if (scanProgress.type === 'started') {
-			return `Scanning ${scanProgress.total_hosts} hosts, ${scanProgress.total_ports} ports each`;
-		}
-		if (scanProgress.type === 'progress') {
-			return `${scanProgress.scanned_hosts} / ${scanProgress.total_hosts} hosts`;
-		}
-		return '';
-	})();
+	const scanStatusText = getScanStatusText(scanProgress);
 	const scanCurrentIp = scanProgress?.type === 'progress' ? scanProgress.current_ip : null;
 	const scanDiscoveredHosts = scanProgress?.type === 'progress' ? scanProgress.discovered_hosts : 0;
 	const scanDiscoveredPorts = scanProgress?.type === 'progress' ? scanProgress.discovered_ports : 0;
@@ -262,13 +1633,12 @@ export function UnifiedHostDetailPanel({
 	const hasSshPort = ports.some((p) => p.state === 'open' && p.port === 22);
 
 	const openInBrowser = async () => {
-		const webPort = ports.find((p) => p.state === 'open' && [443, 8443, 80, 8080].includes(p.port));
-		if (!webPort) return;
-		const protocol = [443, 8443].includes(webPort.port) ? 'https' : 'http';
+		const browserPort = findBrowserPort(ports);
+		if (!browserPort) return;
 		const url =
-			webPort.port === 80 || webPort.port === 443
-				? `${protocol}://${primaryIp}`
-				: `${protocol}://${primaryIp}:${webPort.port}`;
+			browserPort.port === 80 || browserPort.port === 443
+				? `${browserPort.protocol}://${primaryIp}`
+				: `${browserPort.protocol}://${primaryIp}:${browserPort.port}`;
 		const { openUrl } = await import('@tauri-apps/plugin-opener');
 		openUrl(url).catch(() => {});
 	};
@@ -277,196 +1647,35 @@ export function UnifiedHostDetailPanel({
 		copyToClipboard(`ssh ${hostname ?? primaryIp}`, 'SSH command').catch(() => {});
 	};
 
-	const tabs = [
-		{ id: 'overview' as const, label: 'Overview', icon: Info, count: null as number | null },
-		{
-			id: 'discovery' as const,
-			label: 'Discovery',
-			icon: Radar,
-			count: discoveries.length > 0 ? discoveries.length : null,
-		},
-		{
-			id: 'services' as const,
-			label: 'Services',
-			icon: Radio,
-			count: mdnsServices.length > 0 ? mdnsServices.length : null,
-		},
-		{
-			id: 'ports' as const,
-			label: 'Ports',
-			icon: Network,
-			count: openPorts.length > 0 ? openPorts.length : null,
-		},
-	];
+	const tabs = buildTabs(discoveries, mdnsServices, openPorts);
 
-	const hasSsdpInfo = Boolean(
-		ssdpDevice &&
-		(ssdpDevice.friendlyName ||
-			ssdpDevice.manufacturer ||
-			ssdpDevice.modelName ||
-			ssdpDevice.deviceType ||
-			ssdpDevice.server)
+	const hasSsdpInfo = computeSsdpHasInfo(ssdpDevice);
+
+	const { name: displayName, source: displaySource } = resolveDisplayIdentity(
+		hostname,
+		hostnameSource,
+		netbiosName,
+		ssdpDevice
 	);
-
-	const displayName = isUsefulHostname(hostname)
-		? hostname
-		: isUsefulHostname(netbiosName)
-			? netbiosName
-			: isUsefulHostname(ssdpDevice?.friendlyName)
-				? (ssdpDevice?.friendlyName ?? null)
-				: null;
-	const displaySource = isUsefulHostname(hostname)
-		? hostnameSource
-		: isUsefulHostname(netbiosName)
-			? 'netbios'
-			: isUsefulHostname(ssdpDevice?.friendlyName)
-				? 'ssdp'
-				: null;
 
 	return (
 		<div className="flex h-full flex-col overflow-hidden">
-			{/* Header */}
-			<div className="shrink-0 border-b bg-surface-3 px-4 py-3">
-				<div className="flex items-start justify-between">
-					<div className="flex items-center gap-3">
-						<div className="rounded-lg bg-primary/10 p-2">
-							<HeaderIcon className="h-5 w-5 text-primary" />
-						</div>
-						<div>
-							{displayName ? (
-								<>
-									<div className="flex items-center gap-2">
-										<h2 className="text-lg font-semibold">{displayName}</h2>
-										{displaySource ? (
-											<span
-												className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground"
-												title={`Resolved via ${displaySource.toUpperCase()}`}
-											>
-												{displaySource.toUpperCase()}
-											</span>
-										) : null}
-										<Tooltip>
-											<TooltipTrigger asChild>
-												<Button
-													variant="ghost"
-													size="icon-sm"
-													className="h-7 w-7 text-muted-foreground hover:bg-muted hover:text-foreground"
-													onClick={() => {
-														copyToClipboard(displayName, 'Hostname').catch(() => {});
-													}}
-												>
-													<Copy className="h-3.5 w-3.5" />
-													<span className="sr-only">Copy hostname</span>
-												</Button>
-											</TooltipTrigger>
-											<TooltipContent>Copy hostname</TooltipContent>
-										</Tooltip>
-									</div>
-									<div className="flex items-center gap-2">
-										<span className="font-mono text-sm tabular-nums text-muted-foreground">
-											{primaryIp}
-										</span>
-										<Tooltip>
-											<TooltipTrigger asChild>
-												<Button
-													variant="ghost"
-													size="icon-sm"
-													className="h-5 w-5 text-muted-foreground hover:bg-muted hover:text-foreground"
-													onClick={() => {
-														copyToClipboard(primaryIp, 'IP address').catch(() => {});
-													}}
-												>
-													<Copy className="h-3 w-3" />
-													<span className="sr-only">Copy IP</span>
-												</Button>
-											</TooltipTrigger>
-											<TooltipContent>Copy IP</TooltipContent>
-										</Tooltip>
-									</div>
-								</>
-							) : (
-								<>
-									<div className="flex items-center gap-2">
-										<h2 className="font-mono text-lg font-semibold tabular-nums">{primaryIp}</h2>
-										<Tooltip>
-											<TooltipTrigger asChild>
-												<Button
-													variant="ghost"
-													size="icon-sm"
-													className="h-7 w-7 text-muted-foreground hover:bg-muted hover:text-foreground"
-													onClick={() => {
-														copyToClipboard(primaryIp, 'IP address').catch(() => {});
-													}}
-												>
-													<Copy className="h-3.5 w-3.5" />
-													<span className="sr-only">Copy IP</span>
-												</Button>
-											</TooltipTrigger>
-											<TooltipContent>Copy IP</TooltipContent>
-										</Tooltip>
-									</div>
-									<p className="text-xs text-muted-foreground">Hostname not resolved</p>
-								</>
-							)}
-							{classification && classification.category !== 'unknown' ? (
-								<div className="mt-1 flex items-center gap-2">
-									<span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium">
-										{DEVICE_CATEGORIES[classification.category].label}
-									</span>
-									{confidenceLabel ? (
-										<span className={cn('text-xs', confidenceColor)}>
-											{confidenceLabel} confidence
-										</span>
-									) : null}
-								</div>
-							) : null}
-						</div>
-					</div>
-					{/* Quick actions */}
-					<div className="flex items-center gap-1">
-						{hasWebPort ? (
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<Button
-										variant="ghost"
-										size="icon-sm"
-										className="h-7 w-7 text-muted-foreground hover:bg-muted hover:text-foreground"
-										onClick={() => {
-											openInBrowser().catch(() => {});
-										}}
-									>
-										<Globe className="h-3.5 w-3.5" />
-										<span className="sr-only">Open in browser</span>
-									</Button>
-								</TooltipTrigger>
-								<TooltipContent>Open in browser</TooltipContent>
-							</Tooltip>
-						) : null}
-						{hasSshPort ? (
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<Button
-										variant="ghost"
-										size="icon-sm"
-										className="h-7 w-7 text-muted-foreground hover:bg-muted hover:text-foreground"
-										onClick={copySshCommand}
-									>
-										<Terminal className="h-3.5 w-3.5" />
-										<span className="sr-only">Copy SSH command</span>
-									</Button>
-								</TooltipTrigger>
-								<TooltipContent>Copy SSH command</TooltipContent>
-							</Tooltip>
-						) : null}
-						{scanDurationMs ? (
-							<div className="ml-1 flex items-center gap-1 text-xs text-muted-foreground">
-								<Clock className="h-3 w-3" />
-								<span>{formatDuration(scanDurationMs)}</span>
-							</div>
-						) : null}
-					</div>
-				</div>
-			</div>
+			<HostDetailHeader
+				HeaderIcon={HeaderIcon}
+				displayName={displayName}
+				displaySource={displaySource}
+				primaryIp={primaryIp}
+				classification={classification}
+				confidenceLabel={confidenceLabel}
+				confidenceColor={confidenceColor}
+				hasWebPort={hasWebPort}
+				hasSshPort={hasSshPort}
+				scanDurationMs={scanDurationMs}
+				onOpenInBrowser={() => {
+					openInBrowser().catch(() => {});
+				}}
+				onCopySshCommand={copySshCommand}
+			/>
 
 			<Tabs
 				value={activeTab}
@@ -493,895 +1702,56 @@ export function UnifiedHostDetailPanel({
 				{/* Tab Content */}
 				<div className="flex-1 overflow-auto p-4">
 					<TabsContent value="overview" className="mt-0 animate-fade-in outline-none">
-						{/* Summary Stats */}
-						<div className="mb-4 grid grid-cols-2 gap-2">
-							<Card density="compact">
-								<CardContent>
-									<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-										<Hash className="h-3 w-3" />
-										IPs
-									</div>
-									<div className="mt-0.5 text-base font-semibold tabular-nums">{ips.length}</div>
-								</CardContent>
-							</Card>
-							<Card density="compact">
-								<CardContent>
-									<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-										<CheckCircle2 className="h-3 w-3 text-success" />
-										Open Ports
-									</div>
-									<div className="mt-0.5 text-base font-semibold tabular-nums">
-										{openPorts.length}
-									</div>
-								</CardContent>
-							</Card>
-							<Card density="compact">
-								<CardContent>
-									<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-										<Radar className="h-3 w-3 text-primary" />
-										Discovery
-									</div>
-									<div className="mt-0.5 text-base font-semibold tabular-nums">
-										{discoveries.length}
-									</div>
-								</CardContent>
-							</Card>
-							<Card density="compact">
-								<CardContent>
-									<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-										<Radio className="h-3 w-3 text-info" />
-										Services
-									</div>
-									<div className="mt-0.5 text-base font-semibold tabular-nums">
-										{mdnsServices.length}
-									</div>
-								</CardContent>
-							</Card>
-						</div>
-
-						{/* IP Addresses Section */}
-						{ips.length > 1 || ipv6Addresses.length > 0 ? (
-							<div className="mb-4">
-								<SectionLabel icon={Hash}>IP Addresses</SectionLabel>
-								<div className="space-y-2">
-									{ipv4Addresses.length > 0 ? (
-										<Card density="compact">
-											<CardContent>
-												<div className="mb-1.5 text-xs font-medium text-muted-foreground">IPv4</div>
-												<div className="flex flex-wrap gap-2">
-													{ipv4Addresses.map((ip) => (
-														<Button
-															key={ip}
-															variant="ghost"
-															size="sm"
-															className="h-auto gap-1.5 rounded bg-muted px-2 py-1 font-mono text-xs hover:bg-muted/80"
-															title={`Copy ${ip}`}
-															onClick={() => {
-																copyToClipboard(ip, 'IP address').catch(() => {});
-															}}
-														>
-															{ip}
-															<Copy className="h-3 w-3 text-muted-foreground" />
-														</Button>
-													))}
-												</div>
-											</CardContent>
-										</Card>
-									) : null}
-									{ipv6Addresses.length > 0 ? (
-										<Card density="compact">
-											<CardContent>
-												<div className="mb-1.5 text-xs font-medium text-muted-foreground">IPv6</div>
-												<div className="space-y-1">
-													{ipv6Addresses.map((ip) => (
-														<Button
-															key={ip}
-															variant="ghost"
-															size="sm"
-															className="h-auto w-full justify-between gap-2 rounded bg-muted px-2 py-1 font-mono text-xs hover:bg-muted/80"
-															title={`Copy ${ip}`}
-															onClick={() => {
-																copyToClipboard(ip, 'IP address').catch(() => {});
-															}}
-														>
-															<span className="truncate">{ip}</span>
-															<Copy className="h-3 w-3 shrink-0 text-muted-foreground" />
-														</Button>
-													))}
-												</div>
-											</CardContent>
-										</Card>
-									) : null}
-								</div>
-							</div>
-						) : null}
-
-						{/* Device Classification */}
-						{classification && classification.category !== 'unknown' ? (
-							<div className="mb-4">
-								<SectionLabel icon={HeaderIcon}>Device Type</SectionLabel>
-								<Card density="compact">
-									<CardContent>
-										<div className="flex items-center justify-between">
-											<div className="flex items-center gap-2">
-												<span className="text-sm font-medium">
-													{DEVICE_CATEGORIES[classification.category].label}
-												</span>
-												{confidenceLabel ? (
-													<span
-														className={cn(
-															'rounded bg-muted px-1.5 py-0.5 text-xs font-medium',
-															confidenceColor
-														)}
-													>
-														{confidenceLabel}
-													</span>
-												) : null}
-											</div>
-											<span className="text-xs text-muted-foreground">
-												{(classification.confidence * 100).toFixed(0)}%
-											</span>
-										</div>
-										<p className="mt-1 text-xs text-muted-foreground">
-											{DEVICE_CATEGORIES[classification.category].description}
-										</p>
-										{classification.evidence.length > 0 ? (
-											<div className="mt-2 border-t pt-2">
-												<div className="text-xs text-muted-foreground">
-													{classification.evidence.map((evidence) => (
-														<div key={evidence} className="flex items-center gap-1">
-															<span className="text-[8px]">-</span>
-															<span>{evidence}</span>
-														</div>
-													))}
-												</div>
-											</div>
-										) : null}
-									</CardContent>
-								</Card>
-							</div>
-						) : null}
-
-						{/* Device Info */}
-						{macAddress || vendor || netbiosName ? (
-							<div className="mb-4">
-								<SectionLabel icon={Cpu}>Device Info</SectionLabel>
-								<div className="grid grid-cols-2 gap-2">
-									{netbiosName ? (
-										<Card density="compact">
-											<CardContent>
-												<div className="text-xs text-muted-foreground">NetBIOS Name</div>
-												<div className="mt-0.5 flex items-center gap-1.5 font-mono text-sm font-medium">
-													{netbiosName}
-													<Tooltip>
-														<TooltipTrigger asChild>
-															<Button
-																variant="ghost"
-																size="icon-sm"
-																className="h-5 w-5 text-muted-foreground hover:bg-muted hover:text-foreground"
-																onClick={() => {
-																	copyToClipboard(netbiosName, 'NetBIOS name').catch(() => {});
-																}}
-															>
-																<Copy className="h-3 w-3" />
-																<span className="sr-only">Copy NetBIOS name</span>
-															</Button>
-														</TooltipTrigger>
-														<TooltipContent>Copy NetBIOS name</TooltipContent>
-													</Tooltip>
-												</div>
-											</CardContent>
-										</Card>
-									) : null}
-									{macAddress ? (
-										<Card density="compact">
-											<CardContent>
-												<div className="text-xs text-muted-foreground">MAC Address</div>
-												<div className="mt-0.5 flex items-center gap-1.5 font-mono text-sm font-medium">
-													{macAddress}
-													<Tooltip>
-														<TooltipTrigger asChild>
-															<Button
-																variant="ghost"
-																size="icon-sm"
-																className="h-5 w-5 text-muted-foreground hover:bg-muted hover:text-foreground"
-																onClick={() => {
-																	copyToClipboard(macAddress, 'MAC address').catch(() => {});
-																}}
-															>
-																<Copy className="h-3 w-3" />
-																<span className="sr-only">Copy MAC address</span>
-															</Button>
-														</TooltipTrigger>
-														<TooltipContent>Copy MAC address</TooltipContent>
-													</Tooltip>
-												</div>
-											</CardContent>
-										</Card>
-									) : null}
-									{vendor ? (
-										<Card
-											density="compact"
-											className={cn(netbiosName && macAddress && 'col-span-2')}
-										>
-											<CardContent>
-												<div className="text-xs text-muted-foreground">Vendor</div>
-												<div className="mt-0.5 text-sm">{vendor}</div>
-											</CardContent>
-										</Card>
-									) : null}
-								</div>
-							</div>
-						) : null}
-
-						{/* SSDP/UPnP Device Info */}
-						{hasSsdpInfo && ssdpDevice ? (
-							<div className="mb-4">
-								<SectionLabel icon={Wifi}>SSDP/UPnP Device</SectionLabel>
-								<Card density="compact">
-									<CardContent>
-										{ssdpDevice.friendlyName ? (
-											<div>
-												<div className="text-xs font-medium text-muted-foreground">
-													Friendly Name
-												</div>
-												<div className="text-sm font-medium">{ssdpDevice.friendlyName}</div>
-											</div>
-										) : null}
-										{ssdpDevice.manufacturer || ssdpDevice.modelName ? (
-											<div className={ssdpDevice.friendlyName ? 'mt-2 border-t pt-2' : ''}>
-												<div className="text-xs font-medium text-muted-foreground">
-													{ssdpDevice.manufacturer && ssdpDevice.modelName
-														? 'Manufacturer / Model'
-														: ssdpDevice.manufacturer
-															? 'Manufacturer'
-															: 'Model'}
-												</div>
-												<div className="text-sm">
-													{[ssdpDevice.manufacturer, ssdpDevice.modelName]
-														.filter(Boolean)
-														.join(' ')}
-													{ssdpDevice.modelNumber ? (
-														<span className="text-muted-foreground">
-															{' '}
-															({ssdpDevice.modelNumber})
-														</span>
-													) : null}
-												</div>
-											</div>
-										) : null}
-										{ssdpDevice.deviceType ? (
-											<div
-												className={
-													ssdpDevice.friendlyName || ssdpDevice.manufacturer || ssdpDevice.modelName
-														? 'mt-2 border-t pt-2'
-														: ''
-												}
-											>
-												<div className="text-xs font-medium text-muted-foreground">Device Type</div>
-												<div className="font-mono text-xs text-muted-foreground">
-													{ssdpDevice.deviceType}
-												</div>
-											</div>
-										) : null}
-										{ssdpDevice.server ? (
-											<div className="mt-2 border-t pt-2">
-												<div className="text-xs font-medium text-muted-foreground">Server</div>
-												<div className="font-mono text-xs text-muted-foreground">
-													{ssdpDevice.server}
-												</div>
-											</div>
-										) : null}
-									</CardContent>
-								</Card>
-							</div>
-						) : null}
-
-						{/* WS-Discovery Info */}
-						{wsDiscovery &&
-						(wsDiscovery.deviceTypes.length > 0 || wsDiscovery.scopes.length > 0) ? (
-							<div className="mb-4">
-								<SectionLabel icon={Globe}>WS-Discovery</SectionLabel>
-								<Card density="compact">
-									<CardContent>
-										{wsDiscovery.deviceTypes.length > 0 ? (
-											<div>
-												<div className="text-xs font-medium text-muted-foreground">
-													Device Types
-												</div>
-												<div className="mt-1 space-y-0.5">
-													{wsDiscovery.deviceTypes.map((dtype) => (
-														<div key={dtype} className="font-mono text-xs text-muted-foreground">
-															{dtype}
-														</div>
-													))}
-												</div>
-											</div>
-										) : null}
-										{wsDiscovery.scopes.length > 0 ? (
-											<div
-												className={wsDiscovery.deviceTypes.length > 0 ? 'mt-2 border-t pt-2' : ''}
-											>
-												<div className="text-xs font-medium text-muted-foreground">Scopes</div>
-												<div className="mt-1 max-h-20 space-y-0.5 overflow-y-auto">
-													{wsDiscovery.scopes.map((scope) => (
-														<div
-															key={scope}
-															className="break-all font-mono text-xs text-muted-foreground"
-														>
-															{scope}
-														</div>
-													))}
-												</div>
-											</div>
-										) : null}
-									</CardContent>
-								</Card>
-							</div>
-						) : null}
-
-						{/* SNMP Info */}
-						{snmpInfo &&
-						(snmpInfo.sysName ||
-							snmpInfo.sysDescr ||
-							snmpInfo.sysLocation ||
-							snmpInfo.sysContact) ? (
-							<div className="mb-4">
-								<SectionLabel icon={Server}>SNMP</SectionLabel>
-								<Card density="compact">
-									<CardContent className="space-y-2">
-										{snmpInfo.sysName ? (
-											<div>
-												<div className="text-xs font-medium text-muted-foreground">System Name</div>
-												<div className="text-sm">{snmpInfo.sysName}</div>
-											</div>
-										) : null}
-										{snmpInfo.sysDescr ? (
-											<div>
-												<div className="text-xs font-medium text-muted-foreground">Description</div>
-												<div className="break-words text-xs text-muted-foreground">
-													{snmpInfo.sysDescr}
-												</div>
-											</div>
-										) : null}
-										{snmpInfo.sysLocation ? (
-											<div>
-												<div className="text-xs font-medium text-muted-foreground">Location</div>
-												<div className="text-sm">{snmpInfo.sysLocation}</div>
-											</div>
-										) : null}
-										{snmpInfo.sysContact ? (
-											<div>
-												<div className="text-xs font-medium text-muted-foreground">Contact</div>
-												<div className="text-sm">{snmpInfo.sysContact}</div>
-											</div>
-										) : null}
-									</CardContent>
-								</Card>
-							</div>
-						) : null}
-
-						{/* Service Banners */}
-						{serviceBanners && serviceBanners.length > 0 ? (
-							<div className="mb-4">
-								<SectionLabel icon={Terminal}>Service Banners</SectionLabel>
-								<Card density="compact">
-									<CardContent>
-										<div className="flex flex-wrap gap-1.5">
-											{serviceBanners.map((banner) => (
-												<span
-													key={`${banner.protocol}-${banner.version ?? ''}-${banner.raw}`}
-													className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs"
-													title={banner.raw}
-												>
-													<span className="font-medium text-foreground">{banner.protocol}</span>
-													{banner.version ? (
-														<span className="text-muted-foreground"> {banner.version}</span>
-													) : null}
-												</span>
-											))}
-										</div>
-									</CardContent>
-								</Card>
-							</div>
-						) : null}
-
-						{/* TLS Certificate Names */}
-						{tlsNames && tlsNames.length > 0 ? (
-							<div className="mb-4">
-								<SectionLabel icon={Shield}>TLS Certificate</SectionLabel>
-								<Card density="compact">
-									<CardContent>
-										<div className="text-xs font-medium text-muted-foreground">
-											Subject Alternative Names
-										</div>
-										<div className="mt-1 space-y-0.5">
-											{tlsNames.map((name) => (
-												<div key={name} className="font-mono text-sm">
-													{name}
-												</div>
-											))}
-										</div>
-									</CardContent>
-								</Card>
-							</div>
-						) : null}
+						<OverviewTab
+							ips={ips}
+							ipv4Addresses={ipv4Addresses}
+							ipv6Addresses={ipv6Addresses}
+							openPorts={openPorts}
+							discoveriesCount={discoveries.length}
+							mdnsServicesCount={mdnsServices.length}
+							classification={classification}
+							HeaderIcon={HeaderIcon}
+							confidenceLabel={confidenceLabel}
+							confidenceColor={confidenceColor}
+							netbiosName={netbiosName}
+							macAddress={macAddress}
+							vendor={vendor}
+							hasSsdpInfo={hasSsdpInfo}
+							ssdpDevice={ssdpDevice}
+							wsDiscovery={wsDiscovery}
+							snmpInfo={snmpInfo}
+							tlsNames={tlsNames}
+							serviceBanners={serviceBanners}
+						/>
 					</TabsContent>
 
 					<TabsContent value="ports" className="mt-0 animate-fade-in outline-none">
-						{/* Scan controls / progress */}
-						{scanDisabled && scanProgress ? (
-							<Card density="compact" className="mb-4">
-								<CardContent>
-									<div className="mb-2 flex items-center justify-between">
-										<div className="flex items-center gap-2">
-											<Loader2 className="h-4 w-4 animate-spin text-primary" />
-											<span className="text-sm font-medium">Scanning Ports...</span>
-										</div>
-										<div className="flex items-center gap-2">
-											<span className="text-sm font-medium text-primary">
-												{scanPercentage.toFixed(0)}%
-											</span>
-											{onCancel ? (
-												<Button
-													variant="ghost"
-													size="sm"
-													className="h-7 gap-1 px-2 text-xs text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-													onClick={onCancel}
-												>
-													<Square className="h-3 w-3" />
-													Cancel
-												</Button>
-											) : null}
-										</div>
-									</div>
-									<div className="mb-2 h-1.5 w-full overflow-hidden rounded-full bg-muted">
-										<div
-											className="h-full bg-primary transition-all duration-300"
-											style={{ width: `${scanPercentage}%` }}
-										/>
-									</div>
-									<div className="flex items-center justify-between text-xs text-muted-foreground">
-										<span>{scanStatusText}</span>
-										<div className="flex items-center gap-3">
-											{scanCurrentIp ? <span className="font-mono">{scanCurrentIp}</span> : null}
-											{scanDiscoveredHosts > 0 ? (
-												<span className="text-success">{scanDiscoveredHosts} hosts</span>
-											) : null}
-											{scanDiscoveredPorts > 0 ? (
-												<span className="text-success">{scanDiscoveredPorts} ports</span>
-											) : null}
-										</div>
-									</div>
-								</CardContent>
-							</Card>
-						) : onScan ? (
-							<Card density="compact" className="mb-4">
-								<CardContent>
-									<div className="flex items-center gap-2">
-										<Select
-											value={localScanMode}
-											onValueChange={(v) => setLocalScanMode(v as ScanMode)}
-										>
-											<SelectTrigger size="sm" className="flex-1">
-												<SelectValue />
-											</SelectTrigger>
-											<SelectContent>
-												{SCAN_MODES.map((mode) => (
-													<SelectItem key={mode.value} value={mode.value}>
-														{mode.label}
-													</SelectItem>
-												))}
-											</SelectContent>
-										</Select>
-										<Button
-											variant="default"
-											size="sm"
-											className="h-8 shrink-0 gap-1.5 px-3 text-xs"
-											disabled={scanDisabled}
-											onClick={() => onScan(primaryIp, localScanMode)}
-										>
-											<Play className="h-3.5 w-3.5" />
-											{ports.length > 0 ? 'Re-scan' : 'Scan'}
-										</Button>
-									</div>
-									<p className="mt-1.5 text-xs text-muted-foreground">
-										{SCAN_MODES.find((m) => m.value === localScanMode)?.description ?? ''}
-									</p>
-								</CardContent>
-							</Card>
-						) : null}
-
-						{ports.length === 0 && scanDisabled && scanProgress ? (
-							<div
-								className="space-y-1.5"
-								role="status"
-								aria-busy="true"
-								aria-label="Loading ports"
-							>
-								{Array.from({ length: 5 }, (_, i) => (
-									// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
-									<div key={i} className="flex items-center gap-2">
-										<Skeleton className="h-4 w-24" />
-										<Skeleton className="ml-auto h-4 w-12" />
-									</div>
-								))}
-							</div>
-						) : ports.length === 0 ? (
-							<EmbeddedEmptyState
-								icon={Network}
-								title="No Port Scan Data"
-								description="Select a scan mode and run a port scan to detect open services."
-							/>
-						) : (
-							<>
-								<Card density="compact" className="mb-4">
-									<CardContent>
-										<div className="flex items-center justify-between text-sm">
-											<span className="font-medium">Port Summary</span>
-											<span className="text-xs text-muted-foreground">{ports.length} scanned</span>
-										</div>
-										<div className="mt-2 flex gap-4 text-xs">
-											<span className="flex items-center gap-1.5 text-success">
-												<CheckCircle2 className="h-3 w-3" aria-hidden="true" />
-												{openPorts.length} open
-											</span>
-											<span className="flex items-center gap-1.5 text-warning">
-												<Shield className="h-3 w-3" aria-hidden="true" />
-												{filteredPorts.length} filtered
-											</span>
-											<span className="flex items-center gap-1.5 text-destructive">
-												<XCircle className="h-3 w-3" aria-hidden="true" />
-												{closedPorts.length} closed
-											</span>
-										</div>
-										<div className="mt-2 flex h-1.5 overflow-hidden rounded-full bg-muted">
-											{openPorts.length > 0 ? (
-												<div
-													className="bg-success"
-													style={{ width: `${(openPorts.length / ports.length) * 100}%` }}
-												/>
-											) : null}
-											{filteredPorts.length > 0 ? (
-												<div
-													className="bg-warning"
-													style={{ width: `${(filteredPorts.length / ports.length) * 100}%` }}
-												/>
-											) : null}
-											{closedPorts.length > 0 ? (
-												<div
-													className="bg-destructive"
-													style={{ width: `${(closedPorts.length / ports.length) * 100}%` }}
-												/>
-											) : null}
-										</div>
-									</CardContent>
-								</Card>
-
-								{/* Open Ports */}
-								{openPorts.length > 0 ? (
-									<div className="mb-4">
-										<SectionLabel
-											icon={CheckCircle2}
-											iconClass="h-4 w-4 text-success"
-											title={`Open Ports (${openPorts.length})`}
-										/>
-										<div className="space-y-2">
-											{openPorts.map((port) => {
-												const PortIcon = getPortIcon(port.port);
-												const serviceName = getServiceName(port);
-												return (
-													<Card
-														key={port.port}
-														density="compact"
-														className="transition-colors hover:border-border/80"
-													>
-														<CardContent>
-															<div className="flex items-start justify-between">
-																<div className="flex items-start gap-3">
-																	<div className="rounded bg-success/10 p-1.5">
-																		<PortIcon className="h-4 w-4 text-success" />
-																	</div>
-																	<div className="min-w-0 flex-1">
-																		<div className="flex items-center gap-2">
-																			<span className="font-mono text-base font-semibold tabular-nums">
-																				{port.port}
-																			</span>
-																			{serviceName ? (
-																				<span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium">
-																					{serviceName}
-																				</span>
-																			) : null}
-																		</div>
-																		{port.banner ? (
-																			<details className="mt-2">
-																				<summary className="flex cursor-pointer items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
-																					<ChevronRight className="h-3 w-3 transition-transform [[open]>&]:rotate-90" />
-																					Banner / Version Info
-																				</summary>
-																				<div className="mt-1.5 rounded bg-muted/50 p-2 font-mono text-xs leading-relaxed text-muted-foreground">
-																					{port.banner}
-																				</div>
-																			</details>
-																		) : null}
-																		{port.tlsCert ? (
-																			<details className="mt-2">
-																				<summary className="flex cursor-pointer items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
-																					<ChevronRight className="h-3 w-3 transition-transform [[open]>&]:rotate-90" />
-																					<Lock className="h-3 w-3" />
-																					TLS Certificate
-																					{port.tlsCert.isSelfSigned ? (
-																						<span className="rounded bg-warning/10 px-1.5 py-0.5 text-xs font-medium text-warning">
-																							Self-signed
-																						</span>
-																					) : null}
-																				</summary>
-																				<div className="mt-1.5 space-y-1.5 rounded bg-muted/50 p-2 text-xs">
-																					{port.tlsCert.commonName ? (
-																						<div className="flex gap-1">
-																							<span className="shrink-0 font-medium text-muted-foreground">
-																								CN:
-																							</span>
-																							<span className="break-all font-mono">
-																								{port.tlsCert.commonName}
-																							</span>
-																						</div>
-																					) : null}
-																					{port.tlsCert.issuer ? (
-																						<div className="flex gap-1">
-																							<span className="shrink-0 font-medium text-muted-foreground">
-																								Issuer:
-																							</span>
-																							<span className="break-all font-mono">
-																								{port.tlsCert.issuer}
-																							</span>
-																						</div>
-																					) : null}
-																					{port.tlsCert.subjectAltNames &&
-																					port.tlsCert.subjectAltNames.length > 0 ? (
-																						<div>
-																							<span className="font-medium text-muted-foreground">
-																								SAN:
-																							</span>
-																							<div className="ml-3 mt-0.5 space-y-0.5">
-																								{port.tlsCert.subjectAltNames.map((san) => (
-																									<div key={san} className="break-all font-mono">
-																										{san}
-																									</div>
-																								))}
-																							</div>
-																						</div>
-																					) : null}
-																				</div>
-																			</details>
-																		) : null}
-																	</div>
-																</div>
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<Button
-																			variant="ghost"
-																			size="icon-sm"
-																			className="h-6 w-6 text-muted-foreground hover:bg-muted hover:text-foreground"
-																			onClick={() => {
-																				copyToClipboard(String(port.port), 'Port number').catch(
-																					() => {}
-																				);
-																			}}
-																		>
-																			<Copy className="h-3 w-3" />
-																			<span className="sr-only">Copy port</span>
-																		</Button>
-																	</TooltipTrigger>
-																	<TooltipContent>Copy port</TooltipContent>
-																</Tooltip>
-															</div>
-														</CardContent>
-													</Card>
-												);
-											})}
-										</div>
-									</div>
-								) : null}
-
-								{/* Filtered Ports */}
-								{filteredPorts.length > 0 ? (
-									<div className="mb-4">
-										<SectionLabel
-											icon={Shield}
-											iconClass="h-4 w-4 text-warning"
-											title={`Filtered Ports (${filteredPorts.length})`}
-										/>
-										<div className="flex flex-wrap gap-2">
-											{filteredPorts.map((port) => {
-												const serviceName = getServiceName(port);
-												return (
-													<div
-														key={port.port}
-														className="flex items-center gap-1.5 rounded border bg-warning/5 px-2 py-1 text-xs"
-														title={
-															serviceName
-																? `${port.port}/${serviceName} - Firewall or security software blocking`
-																: `Port ${port.port} - Firewall or security software blocking`
-														}
-													>
-														<span className="font-mono font-medium">{port.port}</span>
-														{serviceName ? (
-															<span className="text-muted-foreground">/{serviceName}</span>
-														) : null}
-													</div>
-												);
-											})}
-										</div>
-									</div>
-								) : null}
-
-								{/* Closed Ports */}
-								{closedPorts.length > 0 ? (
-									<div className="mb-4">
-										<SectionLabel
-											icon={XCircle}
-											iconClass="h-4 w-4 text-destructive"
-											title={`Closed Ports (${closedPorts.length})`}
-										/>
-										<div className="flex flex-wrap gap-2">
-											{closedPorts.map((port) => {
-												const serviceName = getServiceName(port);
-												return (
-													<div
-														key={port.port}
-														className="flex items-center gap-1.5 rounded border bg-destructive/5 px-2 py-1 text-xs"
-														title={
-															serviceName
-																? `${port.port}/${serviceName} - No service listening`
-																: `Port ${port.port} - No service listening`
-														}
-													>
-														<span className="font-mono font-medium">{port.port}</span>
-														{serviceName ? (
-															<span className="text-muted-foreground">/{serviceName}</span>
-														) : null}
-													</div>
-												);
-											})}
-										</div>
-									</div>
-								) : null}
-							</>
-						)}
+						<PortsTab
+							ports={ports}
+							openPorts={openPorts}
+							filteredPorts={filteredPorts}
+							closedPorts={closedPorts}
+							primaryIp={primaryIp}
+							scanDisabled={scanDisabled}
+							scanProgress={scanProgress}
+							scanPercentage={scanPercentage}
+							scanStatusText={scanStatusText}
+							scanCurrentIp={scanCurrentIp}
+							scanDiscoveredHosts={scanDiscoveredHosts}
+							scanDiscoveredPorts={scanDiscoveredPorts}
+							localScanMode={localScanMode}
+							onLocalScanModeChange={setLocalScanMode}
+							onScan={onScan}
+							onCancel={onCancel}
+						/>
 					</TabsContent>
 
 					<TabsContent value="discovery" className="mt-0 animate-fade-in outline-none">
-						{discoveries.length === 0 ? (
-							<EmbeddedEmptyState
-								icon={Radar}
-								title="No Discovery Data"
-								description="Run host discovery to detect this device using various network protocols."
-								fillHeight
-							/>
-						) : (
-							<div className="space-y-2">
-								{discoveries.map((discovery) => (
-									<Card
-										key={discovery.method}
-										density="compact"
-										className="transition-colors hover:border-border/80"
-									>
-										<CardContent>
-											<div className="flex items-center justify-between">
-												<div className="flex items-center gap-3">
-													<div
-														className={cn(
-															'rounded p-1.5',
-															discovery.error ? 'bg-destructive/10' : 'bg-success/10'
-														)}
-													>
-														{discovery.error ? (
-															<XCircle className="h-4 w-4 text-destructive" />
-														) : (
-															<CheckCircle2 className="h-4 w-4 text-success" />
-														)}
-													</div>
-													<div>
-														<span className="font-medium">
-															{formatMethodName(discovery.method)}
-														</span>
-														<p className="text-xs text-muted-foreground">
-															{getMethodDescription(discovery.method)}
-														</p>
-														{discovery.error ? (
-															<p className="mt-0.5 text-xs text-destructive">{discovery.error}</p>
-														) : null}
-													</div>
-												</div>
-												<div className="flex items-center gap-1 text-xs text-muted-foreground">
-													<Clock className="h-3 w-3" />
-													<span>{formatDuration(discovery.durationMs)}</span>
-												</div>
-											</div>
-										</CardContent>
-									</Card>
-								))}
-							</div>
-						)}
+						<DiscoveryTab discoveries={discoveries} />
 					</TabsContent>
 
 					<TabsContent value="services" className="mt-0 animate-fade-in outline-none">
-						{!mdnsServices || mdnsServices.length === 0 ? (
-							<EmbeddedEmptyState
-								icon={Radio}
-								title="No mDNS Services"
-								description="This host is not advertising any services via mDNS/Bonjour."
-								fillHeight
-							/>
-						) : (
-							<div className="space-y-2">
-								{mdnsServices.map((service) => (
-									<Card
-										key={`${service.instanceName}-${service.serviceType}`}
-										density="compact"
-										className="transition-colors hover:border-border/80"
-									>
-										<CardContent>
-											<div className="flex items-start justify-between">
-												<div className="min-w-0 flex-1">
-													<div className="flex items-center gap-2">
-														<span className="truncate font-medium">{service.instanceName}</span>
-														<span className="shrink-0 rounded bg-info/10 px-1.5 py-0.5 text-xs font-medium text-info">
-															{service.serviceType
-																.replace(/\._tcp\.local\.$/, '')
-																.replace(/^_/, '')}
-														</span>
-													</div>
-													<div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
-														<span className="font-mono">Port {service.port}</span>
-													</div>
-													{service.properties.length > 0 ? (
-														<details className="mt-2">
-															<summary className="flex cursor-pointer items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
-																<ChevronRight className="h-3 w-3 transition-transform [[open]>&]:rotate-90" />
-																TXT Properties ({service.properties.length})
-															</summary>
-															<div className="mt-1.5 max-h-24 overflow-y-auto rounded bg-muted/50 p-2 text-xs">
-																{service.properties.map(([key, value]) => (
-																	<div key={`${key}-${value}`} className="flex gap-2">
-																		<span className="font-medium text-muted-foreground">
-																			{key}:
-																		</span>
-																		<span className="break-all font-mono">
-																			{value || '(empty)'}
-																		</span>
-																	</div>
-																))}
-															</div>
-														</details>
-													) : null}
-												</div>
-												<Tooltip>
-													<TooltipTrigger asChild>
-														<Button
-															variant="ghost"
-															size="icon-sm"
-															className="h-6 w-6 shrink-0 text-muted-foreground hover:bg-muted hover:text-foreground"
-															onClick={() => {
-																copyToClipboard(
-																	`${service.instanceName} (${service.serviceType}:${service.port})`,
-																	'Service info'
-																).catch(() => {});
-															}}
-														>
-															<Copy className="h-3 w-3" />
-															<span className="sr-only">Copy service info</span>
-														</Button>
-													</TooltipTrigger>
-													<TooltipContent>Copy service info</TooltipContent>
-												</Tooltip>
-											</div>
-										</CardContent>
-									</Card>
-								))}
-							</div>
-						)}
+						<ServicesTab mdnsServices={mdnsServices} />
 					</TabsContent>
 				</div>
 			</Tabs>

--- a/src/lib/components/status/index.ts
+++ b/src/lib/components/status/index.ts
@@ -20,4 +20,4 @@ export { StatusBadge } from './status-badge';
 export type { StatusBadgeProps, StatusBadgeStatus } from './status-badge';
 
 export { ValidityBadge } from './validity-badge';
-export type { ValidityBadgeProps } from './validity-badge';
+export type { ValidityBadgeProps, ValidityState } from './validity-badge';

--- a/src/lib/components/status/validity-badge.tsx
+++ b/src/lib/components/status/validity-badge.tsx
@@ -1,35 +1,96 @@
-import { CircleCheck, CircleX } from 'lucide-react';
+import { Check, CircleCheck, CircleX, X } from 'lucide-react';
 
-interface ValidityBadgeProps {
+import { Badge } from '@/lib/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+type ValidityState = 'empty' | 'valid' | 'invalid';
+
+interface ValidityBadgeStateProps {
+	readonly state: ValidityState;
+	readonly error?: string;
+	readonly validLabel?: string;
+	readonly invalidLabel?: string;
+	readonly emptyLabel?: string;
+	readonly className?: string;
+}
+
+interface ValidityBadgeLegacyProps {
+	// Legacy boolean tri-state: null -> 'empty', true -> 'valid', false -> 'invalid'.
 	readonly valid: boolean | null;
 	readonly validLabel?: string;
 	readonly invalidLabel?: string;
+	readonly className?: string;
 }
 
-export function ValidityBadge({
-	valid,
-	validLabel = 'Valid',
-	invalidLabel = 'Invalid',
-}: ValidityBadgeProps) {
-	if (valid === true) {
+type ValidityBadgeProps = ValidityBadgeStateProps | ValidityBadgeLegacyProps;
+
+const isLegacyProps = (props: ValidityBadgeProps): props is ValidityBadgeLegacyProps =>
+	'valid' in props;
+
+const toState = (valid: boolean | null): ValidityState =>
+	valid === null ? 'empty' : valid ? 'valid' : 'invalid';
+
+export function ValidityBadge(props: ValidityBadgeProps) {
+	const state = isLegacyProps(props) ? toState(props.valid) : props.state;
+	const error = isLegacyProps(props) ? undefined : props.error;
+	const validLabel = props.validLabel ?? 'Valid';
+	const invalidLabel = props.invalidLabel ?? 'Invalid';
+	const emptyLabel = isLegacyProps(props) ? undefined : (props.emptyLabel ?? 'empty');
+	const className = props.className;
+
+	if (state === 'empty') {
+		// Legacy callers expect `null` (no badge rendered) when valid is null.
+		if (isLegacyProps(props)) return null;
 		return (
-			<span className="flex items-center gap-1 rounded-full bg-success/10 px-1.5 py-0.5 text-xs font-medium text-success">
-				<CircleCheck className="h-3.5 w-3.5" />
-				{validLabel}
-			</span>
+			<Badge variant="outline" className={cn('text-muted-foreground', className)}>
+				{emptyLabel}
+			</Badge>
 		);
 	}
 
-	if (valid === false) {
+	if (state === 'valid') {
+		// Legacy callers render the pill style for compatibility with StatusBar.
+		if (isLegacyProps(props)) {
+			return (
+				<span
+					className={cn(
+						'flex items-center gap-1 rounded-full bg-success/10 px-1.5 py-0.5 text-xs font-medium text-success',
+						className
+					)}
+				>
+					<CircleCheck className="h-3.5 w-3.5" />
+					{validLabel}
+				</span>
+			);
+		}
 		return (
-			<span className="flex items-center gap-1 rounded-full bg-destructive/10 px-1.5 py-0.5 text-xs font-medium text-destructive">
+			<Badge variant="outline" className={cn('bg-success/10 text-success', className)}>
+				<Check className="mr-1 h-3 w-3" aria-hidden="true" />
+				{validLabel.toLowerCase()}
+			</Badge>
+		);
+	}
+
+	if (isLegacyProps(props)) {
+		return (
+			<span
+				className={cn(
+					'flex items-center gap-1 rounded-full bg-destructive/10 px-1.5 py-0.5 text-xs font-medium text-destructive',
+					className
+				)}
+			>
 				<CircleX className="h-3.5 w-3.5" />
 				{invalidLabel}
 			</span>
 		);
 	}
 
-	return null;
+	return (
+		<Badge variant="outline" className={cn('bg-destructive/10 text-destructive', className)}>
+			<X className="mr-1 h-3 w-3" aria-hidden="true" />
+			{error ? error : invalidLabel.toLowerCase()}
+		</Badge>
+	);
 }
 
-export type { ValidityBadgeProps };
+export type { ValidityBadgeProps, ValidityState };

--- a/src/routes/network-scanner.tsx
+++ b/src/routes/network-scanner.tsx
@@ -45,7 +45,7 @@ import {
 	ResizablePanelGroup,
 } from '@/lib/components/ui/resizable';
 import { Skeleton } from '@/lib/components/ui/skeleton';
-import { classifyHosts } from '@/lib/services/device-classifier';
+import { classifyHosts, type DeviceClassification } from '@/lib/services/device-classifier';
 import {
 	cancelDiscovery,
 	cancelNetworkScan,
@@ -126,6 +126,1011 @@ const replaceWithResolvedResults = (
 	const resolvedMethods = new Set(resolved.map((r) => r.method));
 	return [...current.filter((r) => !resolvedMethods.has(r.method)), ...resolved];
 };
+
+interface StatusContentArgs {
+	readonly results: ScanResults | null;
+	readonly isScanning: boolean;
+	readonly progress: ScanProgress | null;
+	readonly unifiedHostCount: number;
+}
+
+const renderStatusContent = ({
+	results,
+	isScanning,
+	progress,
+	unifiedHostCount,
+}: StatusContentArgs): React.ReactNode => {
+	if (results) {
+		return (
+			<>
+				<StatItem label="Hosts" value={results.hostsWithOpenPorts} />
+				<StatItem label="Ports" value={results.totalOpenPorts} />
+				<StatItem label="Duration" value={formatDuration(results.scanDurationMs)} />
+			</>
+		);
+	}
+	if (isScanning && progress?.type === 'progress') {
+		return <StatItem label="Progress" value={`${progress.percentage.toFixed(0)}%`} />;
+	}
+	if (unifiedHostCount > 0) {
+		return <StatItem label="Hosts" value={unifiedHostCount} />;
+	}
+	return null;
+};
+
+const pickAutoFillInterface = (info: LocalNetworkInfo): NetworkInterface | null => {
+	if (info.primaryIpv4?.suggestedCidr) return info.primaryIpv4;
+	if (info.interfaces.length === 0) return null;
+	return info.interfaces.find((i) => !i.isLoopback && i.suggestedCidr) ?? null;
+};
+
+const formatProgressText = (progress: ScanProgress | null): string => {
+	if (progress?.type === 'progress') {
+		return `${progress.scanned_hosts} / ${progress.total_hosts} hosts`;
+	}
+	if (progress?.type === 'started') {
+		return `Scanning ${progress.total_hosts} hosts, ${progress.total_ports} ports each`;
+	}
+	return '';
+};
+
+const resolveKeydownIndex = (
+	key: string,
+	currentIdx: number,
+	listLength: number
+): number | null => {
+	switch (key) {
+		case 'ArrowDown':
+			return currentIdx < 0 ? 0 : Math.min(currentIdx + 1, listLength - 1);
+		case 'ArrowUp':
+			return currentIdx < 0 ? 0 : Math.max(currentIdx - 1, 0);
+		case 'Home':
+			return 0;
+		case 'End':
+			return listLength - 1;
+		default:
+			return null;
+	}
+};
+
+const reportDiscoverySuccess = (hostsFound: number) => {
+	if (hostsFound > 0) {
+		toast.success('Discovery completed', {
+			description: `Found ${hostsFound} hosts`,
+		});
+		return;
+	}
+	toast.info('Discovery completed', { description: 'No hosts found' });
+};
+
+const reportDiscoveryError = (e: unknown) => {
+	const msg = e instanceof Error ? e.message : String(e);
+	if (!msg.includes('cancelled')) {
+		toast.error('Discovery failed', { description: msg });
+	}
+};
+
+interface DiscoveryChannelHandlerDeps {
+	readonly currentDiscoveryIdRef: React.RefObject<string | null>;
+	readonly discoveryId: string;
+	readonly setMethodProgress: React.Dispatch<React.SetStateAction<Map<string, DiscoveryProgress>>>;
+	readonly setDiscoveryResults: React.Dispatch<React.SetStateAction<DiscoveryResult[]>>;
+	readonly autoSelectFirstHost: (hosts: readonly string[]) => void;
+}
+
+const createDiscoveryChannelHandler =
+	({
+		currentDiscoveryIdRef,
+		discoveryId,
+		setMethodProgress,
+		setDiscoveryResults,
+		autoSelectFirstHost,
+	}: DiscoveryChannelHandlerDeps) =>
+	(message: DiscoveryEvent) => {
+		// Ignore events from a stale discovery (cancelled and replaced).
+		if (currentDiscoveryIdRef.current !== discoveryId) return;
+
+		switch (message.event) {
+			case 'methodStarted':
+				setMethodProgress((prev) => {
+					const next = new Map(prev);
+					next.set(message.data.method, {
+						method: message.data.method,
+						status: 'running',
+						hostsFound: 0,
+						durationMs: null,
+						error: null,
+					});
+					return next;
+				});
+				return;
+			case 'methodCompleted': {
+				const { result } = message.data;
+				setMethodProgress((prev) => {
+					const next = new Map(prev);
+					next.set(result.method, {
+						method: result.method,
+						status: result.error ? 'error' : 'completed',
+						hostsFound: result.hosts.length,
+						durationMs: result.durationMs,
+						error: result.error ?? null,
+					});
+					return next;
+				});
+				setDiscoveryResults((prev) => [...prev, result]);
+				autoSelectFirstHost(result.hosts);
+				return;
+			}
+			case 'completed':
+				setDiscoveryResults((prev) => replaceWithResolvedResults(prev, message.data.results));
+				return;
+			case 'resolvingHostnames':
+			case 'cancelled':
+				return;
+		}
+	};
+
+interface PortListDetailsProps {
+	readonly label: string;
+	readonly ports: readonly number[];
+	readonly maxHeight?: string;
+}
+
+function PortListDetails({ label, ports, maxHeight = 'max-h-32' }: PortListDetailsProps) {
+	return (
+		<details className="mt-2 rounded border border-border bg-card">
+			<summary className="flex cursor-pointer items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground">
+				<ChevronRight className="h-3 w-3 transition-transform [[open]>&]:rotate-90" />
+				{label} ({ports.length})
+			</summary>
+			<div className={cn(maxHeight, 'overflow-y-auto border-t border-border')}>
+				<div className="grid grid-cols-2 gap-px bg-border">
+					{ports.map((port) => (
+						<div
+							key={port}
+							className="flex items-center justify-between bg-background px-2 py-1"
+							title={WELL_KNOWN_SERVICES[port] ?? `Port ${port}`}
+						>
+							<span className="font-mono text-xs font-medium tabular-nums">{port}</span>
+							<span className="truncate text-xs text-muted-foreground">
+								{WELL_KNOWN_SERVICES[port] ?? ''}
+							</span>
+						</div>
+					))}
+				</div>
+			</div>
+		</details>
+	);
+}
+
+interface TargetSectionProps {
+	readonly target: string;
+	readonly onTargetChange: (value: string) => void;
+	readonly isScanning: boolean;
+	readonly isLoadingInterfaces: boolean;
+	readonly usableInterfaces: readonly NetworkInterface[] | undefined;
+	readonly onLoadInterfaces: () => void;
+	readonly onSelectInterface: (iface: NetworkInterface) => void;
+}
+
+function TargetSection({
+	target,
+	onTargetChange,
+	isScanning,
+	isLoadingInterfaces,
+	usableInterfaces,
+	onLoadInterfaces,
+	onSelectInterface,
+}: TargetSectionProps) {
+	return (
+		<FormSection title="Target">
+			<div className="space-y-2">
+				<FormInput
+					label="Host / IP / CIDR"
+					value={target}
+					onValueChange={onTargetChange}
+					placeholder="192.168.1.1 or 192.168.1.0/24"
+					size="compact"
+				/>
+				{target && !isValidTarget(target) ? <FormError message="Invalid target format" /> : null}
+				<ActionButton
+					label="Detect Local Network"
+					icon={RefreshCw}
+					loading={isLoadingInterfaces}
+					loadingLabel="Detecting..."
+					disabled={isScanning}
+					variant="outline"
+					onClick={onLoadInterfaces}
+				/>
+			</div>
+			{usableInterfaces && usableInterfaces.length > 0 ? (
+				<div className="mt-2 space-y-1">
+					<p className="text-xs font-medium text-muted-foreground">Available interfaces:</p>
+					<div className="max-h-32 space-y-1 overflow-y-auto">
+						{usableInterfaces.map((iface) => (
+							<ListItemButton
+								key={iface.ip}
+								variant="card"
+								size="sm"
+								wrap
+								onClick={() => onSelectInterface(iface)}
+							>
+								<span className="flex min-w-0 flex-col items-start gap-0.5">
+									<span className="font-medium">{iface.name}</span>
+									<span className="break-all font-mono text-2xs text-muted-foreground">
+										{iface.suggestedCidr}
+									</span>
+								</span>
+							</ListItemButton>
+						))}
+					</div>
+				</div>
+			) : null}
+		</FormSection>
+	);
+}
+
+interface HostDiscoverySectionProps {
+	readonly discoveryMethods: ReadonlySet<DiscoveryMethod>;
+	readonly toggleDiscoveryMethod: (method: DiscoveryMethod) => void;
+	readonly isDiscovering: boolean;
+	readonly isScanning: boolean;
+	readonly resolveDns: boolean;
+	readonly setResolveDns: (value: boolean) => void;
+	readonly resolveMdns: boolean;
+	readonly setResolveMdns: (value: boolean) => void;
+	readonly resolveNetbios: boolean;
+	readonly setResolveNetbios: (value: boolean) => void;
+	readonly resolveHostname: boolean;
+	readonly resolveTimeoutMs: number;
+	readonly setResolveTimeoutMs: (value: number) => void;
+	readonly target: string;
+	readonly discoveryResults: readonly DiscoveryResult[];
+	readonly onDiscover: () => void;
+	readonly onCancelDiscovery: () => void;
+}
+
+function HostDiscoverySection({
+	discoveryMethods,
+	toggleDiscoveryMethod,
+	isDiscovering,
+	isScanning,
+	resolveDns,
+	setResolveDns,
+	resolveMdns,
+	setResolveMdns,
+	resolveNetbios,
+	setResolveNetbios,
+	resolveHostname,
+	resolveTimeoutMs,
+	setResolveTimeoutMs,
+	target,
+	discoveryResults,
+	onDiscover,
+	onCancelDiscovery,
+}: HostDiscoverySectionProps) {
+	return (
+		<FormSection title="Host Discovery">
+			<p className="mb-2 text-xs leading-snug text-muted-foreground">
+				Find active hosts before port scanning.
+			</p>
+			<FormCheckboxGroup>
+				{DISCOVERY_METHODS.map((method) => (
+					<FormCheckbox
+						key={method.value}
+						label={method.label}
+						checked={discoveryMethods.has(method.value)}
+						disabled={isDiscovering || isScanning}
+						onCheckedChange={() => toggleDiscoveryMethod(method.value)}
+						size="compact"
+					/>
+				))}
+			</FormCheckboxGroup>
+
+			<Accordion type="multiple" defaultValue={['name-resolution']} className="mt-3">
+				<AccordionItem value="name-resolution" className="rounded border border-border bg-card">
+					<AccordionTrigger className="px-2 py-1.5 text-xs font-medium hover:no-underline [&>svg]:h-3.5 [&>svg]:w-3.5">
+						<span>Name Resolution</span>
+					</AccordionTrigger>
+					<AccordionContent className="border-t border-border/30 px-2 pb-2">
+						<FormCheckboxGroup className="pt-2">
+							<FormCheckbox
+								label="DNS PTR"
+								checked={resolveDns}
+								onCheckedChange={setResolveDns}
+								size="compact"
+							/>
+							<FormCheckbox
+								label="mDNS (.local)"
+								checked={resolveMdns}
+								onCheckedChange={setResolveMdns}
+								size="compact"
+							/>
+							<FormCheckbox
+								label="NetBIOS"
+								checked={resolveNetbios}
+								onCheckedChange={setResolveNetbios}
+								size="compact"
+							/>
+							{resolveHostname ? (
+								<div className="mt-2 border-t border-border pt-2">
+									<FormSlider
+										label="Timeout"
+										value={resolveTimeoutMs}
+										onValueChange={setResolveTimeoutMs}
+										min={500}
+										max={5000}
+										step={500}
+										hint={`${resolveTimeoutMs}ms`}
+										size="compact"
+									/>
+								</div>
+							) : null}
+						</FormCheckboxGroup>
+					</AccordionContent>
+				</AccordionItem>
+			</Accordion>
+
+			{discoveryMethods.size > 0 ? (
+				<div className="mt-3">
+					{isDiscovering ? (
+						<ActionButton
+							label="Cancel Discovery"
+							icon={Square}
+							variant="destructive"
+							onClick={onCancelDiscovery}
+						/>
+					) : (
+						<ActionButton
+							label="Find Hosts"
+							icon={Radar}
+							disabled={!isValidTarget(target) || isScanning}
+							variant="outline"
+							onClick={onDiscover}
+						/>
+					)}
+				</div>
+			) : null}
+			{discoveryResults.length > 0 ? <DiscoveryResultsCard results={discoveryResults} /> : null}
+		</FormSection>
+	);
+}
+
+interface DiscoveryResultsCardProps {
+	readonly results: readonly DiscoveryResult[];
+}
+
+function DiscoveryResultsCard({ results }: DiscoveryResultsCardProps) {
+	return (
+		<Card density="compact" className="mt-2">
+			<CardContent className="p-2">
+				<p className="text-xs font-medium text-muted-foreground">Results:</p>
+				<div className="mt-1 max-h-20 space-y-0.5 overflow-y-auto">
+					{results.map((result) => (
+						<div key={result.method} className="text-xs">
+							<span className="font-medium">
+								{DISCOVERY_METHODS.find((m) => m.value === result.method)?.label ?? result.method}:
+							</span>{' '}
+							{result.error ? (
+								<span className="text-destructive">{result.error}</span>
+							) : (
+								<span className="text-muted-foreground">{result.hosts.length} host(s)</span>
+							)}
+						</div>
+					))}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface PortScanSectionProps {
+	readonly scanMode: ScanMode;
+	readonly setScanMode: (mode: ScanMode) => void;
+	readonly portPreset: PortPreset;
+	readonly setPortPreset: (preset: PortPreset) => void;
+	readonly portRange: string;
+	readonly setPortRange: (value: string) => void;
+	readonly portRangeTouched: boolean;
+	readonly setPortRangeTouched: (value: boolean) => void;
+	readonly concurrency: number;
+	readonly setConcurrency: (value: number) => void;
+	readonly timeoutMs: number;
+	readonly setTimeoutMs: (value: number) => void;
+	readonly isScanning: boolean;
+	readonly canScan: boolean;
+	readonly isPortRangeValid: boolean;
+	readonly onScan: () => void;
+	readonly onCancelScan: () => void;
+}
+
+function PortScanSection({
+	scanMode,
+	setScanMode,
+	portPreset,
+	setPortPreset,
+	portRange,
+	setPortRange,
+	portRangeTouched,
+	setPortRangeTouched,
+	concurrency,
+	setConcurrency,
+	timeoutMs,
+	setTimeoutMs,
+	isScanning,
+	canScan,
+	isPortRangeValid,
+	onScan,
+	onCancelScan,
+}: PortScanSectionProps) {
+	return (
+		<FormSection title="Port Scan">
+			<FormMode<ScanMode>
+				label="Scan Mode"
+				value={scanMode}
+				layout="stacked"
+				descriptionDisplay="selected"
+				options={SCAN_MODES.map((m) => ({
+					value: m.value,
+					label: m.label,
+					description: m.description,
+				}))}
+				onValueChange={(v) => setScanMode(v)}
+			/>
+
+			{scanMode === 'quick' ? (
+				<PortListDetails label="Target Ports" ports={QUICK_SCAN_PORTS} maxHeight="max-h-48" />
+			) : null}
+
+			{scanMode === 'custom' ? (
+				<CustomScanPortSelection
+					portPreset={portPreset}
+					setPortPreset={setPortPreset}
+					portRange={portRange}
+					setPortRange={setPortRange}
+					portRangeTouched={portRangeTouched}
+					setPortRangeTouched={setPortRangeTouched}
+				/>
+			) : null}
+
+			<div className="mt-3 border-t border-border/30 pt-3">
+				<p className="mb-2 text-xs font-semibold uppercase tracking-wide text-foreground/70">
+					Scan Settings
+				</p>
+				<FormSlider
+					label="Concurrency"
+					value={concurrency}
+					onValueChange={setConcurrency}
+					min={MIN_CONCURRENCY}
+					max={MAX_CONCURRENCY}
+					step={10}
+					hint={`${concurrency}`}
+					size="compact"
+				/>
+				<FormSlider
+					label="Timeout"
+					value={timeoutMs}
+					onValueChange={setTimeoutMs}
+					min={MIN_TIMEOUT_MS}
+					max={MAX_TIMEOUT_MS}
+					step={100}
+					hint={`${timeoutMs}ms`}
+					size="compact"
+				/>
+			</div>
+
+			<div className="mt-3">
+				{isScanning ? (
+					<ActionButton
+						label="Cancel Scan"
+						icon={Square}
+						variant="destructive"
+						onClick={onCancelScan}
+					/>
+				) : (
+					<ActionButton
+						label="Scan Ports"
+						icon={Play}
+						loading={isScanning}
+						loadingLabel="Scanning..."
+						disabled={!canScan || !isPortRangeValid}
+						shortcut
+						onClick={onScan}
+					/>
+				)}
+			</div>
+		</FormSection>
+	);
+}
+
+interface CustomScanPortSelectionProps {
+	readonly portPreset: PortPreset;
+	readonly setPortPreset: (preset: PortPreset) => void;
+	readonly portRange: string;
+	readonly setPortRange: (value: string) => void;
+	readonly portRangeTouched: boolean;
+	readonly setPortRangeTouched: (value: boolean) => void;
+}
+
+function CustomScanPortSelection({
+	portPreset,
+	setPortPreset,
+	portRange,
+	setPortRange,
+	portRangeTouched,
+	setPortRangeTouched,
+}: CustomScanPortSelectionProps) {
+	return (
+		<div className="mt-3 border-t border-border pt-3">
+			<FormMode<PortPreset>
+				label="Port Selection"
+				value={portPreset}
+				layout="stacked"
+				descriptionDisplay="selected"
+				options={PORT_PRESETS.map((p) => ({
+					value: p.value,
+					label: p.label,
+					description: p.description,
+				}))}
+				onValueChange={(v) => setPortPreset(v)}
+			/>
+
+			{portPreset === 'well_known' ? (
+				<p className="mt-1.5 text-xs text-muted-foreground">Standard ports 1-1024 (1,024 ports)</p>
+			) : portPreset === 'web' ? (
+				<PortListDetails label="Web Ports" ports={WEB_PORTS} />
+			) : portPreset === 'database' ? (
+				<PortListDetails label="Database Ports" ports={DATABASE_PORTS} />
+			) : portPreset === 'custom' ? (
+				<div className="mt-2">
+					<FormInput
+						label="Port Range"
+						value={portRange}
+						onValueChange={setPortRange}
+						placeholder="80,443,8080 or 1-1024"
+						onBlur={() => setPortRangeTouched(true)}
+						size="compact"
+					/>
+					{portRangeTouched && portRange && !isValidPortRange(portRange) ? (
+						<FormError className="mt-1" message="Invalid port range format" />
+					) : (
+						<p className="mt-1 text-xs text-muted-foreground">
+							Examples: 80,443,8080 or 1-1024 or 22,80-100,443
+						</p>
+					)}
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+interface ResultsExportSectionProps {
+	readonly onClear: () => void;
+	readonly onExportJson: () => void;
+	readonly onExportCsv: () => void;
+}
+
+function ResultsExportSection({ onClear, onExportJson, onExportCsv }: ResultsExportSectionProps) {
+	return (
+		<FormSection title="Results">
+			<div className="space-y-2">
+				<ActionButton label="Clear Results" variant="outline" onClick={onClear} />
+				<ActionButton
+					label="Export JSON"
+					icon={Download}
+					variant="outline"
+					onClick={onExportJson}
+				/>
+				<ActionButton label="Export CSV" icon={Download} variant="outline" onClick={onExportCsv} />
+			</div>
+		</FormSection>
+	);
+}
+
+interface DiscoveryMethodChipProps {
+	readonly method: DiscoveryMethod;
+	readonly methodProg: DiscoveryProgress | undefined;
+}
+
+function DiscoveryMethodChip({ method, methodProg }: DiscoveryMethodChipProps) {
+	const label = DISCOVERY_METHODS.find((m) => m.value === method)?.label ?? method;
+	return (
+		<div className="min-w-32 flex-1 space-y-1">
+			<div className="flex items-center justify-between text-xs">
+				<span className="truncate font-medium" title={label}>
+					{label}
+				</span>
+				<DiscoveryMethodStatusIcon status={methodProg?.status} />
+			</div>
+			<div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+				<div
+					className={cn(
+						'h-full transition-all duration-300',
+						methodProg?.status === 'running' && 'animate-pulse bg-primary',
+						methodProg?.status === 'completed' && 'bg-success',
+						methodProg?.status === 'error' && 'bg-destructive'
+					)}
+					style={{
+						width: `${
+							methodProg?.status === 'completed' || methodProg?.status === 'error'
+								? 100
+								: methodProg?.status === 'running'
+									? 60
+									: 0
+						}%`,
+					}}
+				/>
+			</div>
+			<div className="flex items-center justify-between text-xs tabular-nums text-muted-foreground">
+				{methodProg?.hostsFound !== undefined && methodProg.hostsFound > 0 ? (
+					<span className="text-success">{methodProg.hostsFound} hosts</span>
+				) : (
+					<span>&nbsp;</span>
+				)}
+				{methodProg?.durationMs !== undefined && methodProg?.durationMs !== null ? (
+					<span>{(methodProg.durationMs / 1000).toFixed(1)}s</span>
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+interface DiscoveryMethodStatusIconProps {
+	readonly status: DiscoveryProgress['status'] | undefined;
+}
+
+function DiscoveryMethodStatusIcon({ status }: DiscoveryMethodStatusIconProps) {
+	if (status === 'completed') return <Check className="h-3 w-3 shrink-0 text-success" />;
+	if (status === 'error') return <X className="h-3 w-3 shrink-0 text-destructive" />;
+	if (status === 'running')
+		return <Loader2 className="h-3 w-3 shrink-0 animate-spin text-primary" />;
+	return <Clock className="h-3 w-3 shrink-0 text-muted-foreground" />;
+}
+
+interface DiscoveryProgressPanelProps {
+	readonly discoveryMethods: ReadonlySet<DiscoveryMethod>;
+	readonly methodProgress: Map<string, DiscoveryProgress>;
+	readonly onCancel: () => void;
+}
+
+function DiscoveryProgressPanel({
+	discoveryMethods,
+	methodProgress,
+	onCancel,
+}: DiscoveryProgressPanelProps) {
+	return (
+		<div className="shrink-0 border-b bg-surface-2 px-4 py-3">
+			<div className="mb-2 flex items-center justify-between">
+				<div className="flex items-center gap-2">
+					<Loader2 className="h-4 w-4 animate-spin text-primary" />
+					<span className="text-sm font-medium">Finding Hosts...</span>
+					<span className="text-xs text-muted-foreground">
+						Running {discoveryMethods.size} method
+						{discoveryMethods.size > 1 ? 's' : ''} in parallel
+					</span>
+				</div>
+				<ActionButton
+					label="Cancel"
+					variant="ghost"
+					size="sm"
+					className="w-auto text-muted-foreground hover:bg-interactive-hover hover:text-destructive"
+					onClick={onCancel}
+				/>
+			</div>
+			<div className="flex flex-wrap gap-2">
+				{[...discoveryMethods].map((method) => (
+					<DiscoveryMethodChip
+						key={method}
+						method={method}
+						methodProg={methodProgress.get(method)}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}
+
+interface ScanProgressPanelProps {
+	readonly progressText: string;
+	readonly progressPercentage: number;
+	readonly progressCurrentIp: string | null;
+	readonly progressDiscoveredHosts: number;
+	readonly progressDiscoveredPorts: number;
+	readonly onCancel: () => void;
+}
+
+function ScanProgressPanel({
+	progressText,
+	progressPercentage,
+	progressCurrentIp,
+	progressDiscoveredHosts,
+	progressDiscoveredPorts,
+	onCancel,
+}: ScanProgressPanelProps) {
+	return (
+		<div
+			className="shrink-0 border-b bg-surface-2 px-4 py-3"
+			role="status"
+			aria-live="polite"
+			aria-atomic="false"
+		>
+			<div className="mb-2 flex items-center justify-between">
+				<div className="flex items-center gap-2">
+					<Loader2 className="h-4 w-4 animate-spin text-primary" />
+					<span className="text-sm font-medium">Scanning Ports...</span>
+					<span className="text-xs text-muted-foreground">{progressText}</span>
+				</div>
+				<div className="flex items-center gap-3">
+					<span className="text-sm font-medium tabular-nums text-primary">
+						{progressPercentage.toFixed(0)}%
+					</span>
+					<ActionButton
+						label="Cancel"
+						variant="ghost"
+						size="sm"
+						className="w-auto text-muted-foreground hover:bg-interactive-hover hover:text-destructive"
+						onClick={onCancel}
+					/>
+				</div>
+			</div>
+			<div className="mb-2 h-2 w-full overflow-hidden rounded-full bg-muted">
+				<div
+					className="h-full bg-primary transition-all duration-300"
+					style={{ width: `${progressPercentage}%` }}
+				/>
+			</div>
+			<div className="flex items-center justify-between text-xs">
+				<div className="flex items-center gap-4">
+					{progressCurrentIp ? (
+						<span className="flex items-center gap-1 text-muted-foreground">
+							<span>Next:</span>
+							<span className="font-mono font-medium text-foreground">{progressCurrentIp}</span>
+						</span>
+					) : null}
+				</div>
+				<div className="flex items-center gap-4">
+					{progressDiscoveredHosts > 0 ? (
+						<span className="flex items-center gap-1 text-success">
+							<Server className="h-3 w-3" />
+							<span className="font-medium">{progressDiscoveredHosts}</span>
+							<span>hosts found</span>
+						</span>
+					) : null}
+					{progressDiscoveredPorts > 0 ? (
+						<span className="flex items-center gap-1 text-success">
+							<Network className="h-3 w-3" />
+							<span className="font-medium">{progressDiscoveredPorts}</span>
+							<span>ports open</span>
+						</span>
+					) : null}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+interface HostListPaneProps {
+	readonly unifiedHosts: readonly UnifiedHost[];
+	readonly totalOpenPorts: number;
+	readonly selectedHostId: string | null;
+	readonly recentlyDiscoveredIds: ReadonlySet<string>;
+	readonly hostClassifications: ReadonlyMap<string, DeviceClassification>;
+	readonly onSelectHost: (id: string) => void;
+	readonly onListKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+	readonly hostsWithoutScans: readonly UnifiedHost[];
+	readonly isScanning: boolean;
+	readonly onScanAllUnscanned: () => void;
+}
+
+function HostListPane({
+	unifiedHosts,
+	totalOpenPorts,
+	selectedHostId,
+	recentlyDiscoveredIds,
+	hostClassifications,
+	onSelectHost,
+	onListKeyDown,
+	hostsWithoutScans,
+	isScanning,
+	onScanAllUnscanned,
+}: HostListPaneProps) {
+	return (
+		<div className="flex h-full flex-col border-r">
+			<div
+				className="flex h-9 shrink-0 items-center justify-between border-b bg-surface-3 px-3"
+				role="status"
+				aria-live="polite"
+				aria-atomic="true"
+			>
+				<span className="text-xs font-medium text-muted-foreground">
+					Hosts ({unifiedHosts.length})
+				</span>
+				{totalOpenPorts > 0 ? (
+					<span className="text-xs text-success">{totalOpenPorts} open ports</span>
+				) : null}
+			</div>
+			<div
+				className="flex-1 overflow-auto outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-inset"
+				role="listbox"
+				tabIndex={0}
+				aria-label="Discovered hosts"
+				onKeyDown={onListKeyDown}
+			>
+				{unifiedHosts.map((host) => {
+					const displayHostname = getDisplayHostname(host);
+					return (
+						<UnifiedHostListItem
+							key={host.id}
+							hostId={host.id}
+							ips={host.ips}
+							hostname={displayHostname?.name ?? null}
+							hostnameSource={displayHostname?.source ?? null}
+							macAddress={host.macAddress}
+							vendor={host.vendor}
+							openPortCount={host.ports.filter((p) => p.state === 'open').length}
+							discoveryMethodCount={host.discoveryMethods.length}
+							mdnsServiceCount={host.mdnsServices.length}
+							selected={selectedHostId === host.id}
+							isNew={recentlyDiscoveredIds.has(host.id)}
+							deviceCategory={hostClassifications.get(host.id)?.category}
+							hasPortScan={host.ports.length > 0}
+							onClick={() => onSelectHost(host.id)}
+						/>
+					);
+				})}
+			</div>
+			{hostsWithoutScans.length > 0 ? (
+				<div className="shrink-0 border-t bg-surface-3 p-2">
+					<ActionButton
+						label={`Scan ${hostsWithoutScans.length} Unscanned Hosts`}
+						icon={Play}
+						size="sm"
+						variant="outline"
+						disabled={isScanning}
+						onClick={onScanAllUnscanned}
+					/>
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+function LoadingHostsSkeleton() {
+	return (
+		<div className="space-y-1.5 p-2" role="status" aria-busy="true" aria-label="Loading hosts">
+			{Array.from({ length: 6 }, (_, i) => (
+				// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
+				<div key={i} className="flex items-center gap-2">
+					<Skeleton className="h-4 w-32" />
+					<Skeleton className="ml-auto h-4 w-12" />
+				</div>
+			))}
+		</div>
+	);
+}
+
+interface MainContentProps {
+	readonly isDiscovering: boolean;
+	readonly isScanning: boolean;
+	readonly unifiedHosts: readonly UnifiedHost[];
+	readonly error: string | null;
+	readonly hostListPaneProps: HostListPaneProps;
+	readonly hostDetailProps: HostDetailOrEmptyProps;
+}
+
+function MainContent({
+	isDiscovering,
+	isScanning,
+	unifiedHosts,
+	error,
+	hostListPaneProps,
+	hostDetailProps,
+}: MainContentProps) {
+	if ((isDiscovering || isScanning) && unifiedHosts.length === 0 && !error) {
+		return <LoadingHostsSkeleton />;
+	}
+	if (unifiedHosts.length > 0) {
+		return (
+			<ResizablePanelGroup orientation="horizontal" className="h-full">
+				<ResizablePanel defaultSize="42" minSize="20" maxSize="60">
+					<HostListPane {...hostListPaneProps} />
+				</ResizablePanel>
+				<ResizableHandle withHandle />
+				<ResizablePanel defaultSize="58" minSize="40">
+					<HostDetailOrEmpty {...hostDetailProps} />
+				</ResizablePanel>
+			</ResizablePanelGroup>
+		);
+	}
+	if (error) {
+		return <ErrorDisplay variant="centered" message={error} />;
+	}
+	return (
+		<EmptyState
+			icon={Radar}
+			title="Enter a target and start scanning"
+			description="IP address, hostname, or CIDR notation"
+		/>
+	);
+}
+
+interface HostDetailOrEmptyProps {
+	readonly selectedHost: UnifiedHost | null;
+	readonly hostClassifications: ReadonlyMap<string, DeviceClassification>;
+	readonly isScanning: boolean;
+	readonly progress: ScanProgress | null;
+	readonly onScanDiscoveredHost: (ip: string, mode: ScanMode) => void;
+	readonly onCancel: () => void;
+}
+
+function HostDetailOrEmpty({
+	selectedHost,
+	hostClassifications,
+	isScanning,
+	progress,
+	onScanDiscoveredHost,
+	onCancel,
+}: HostDetailOrEmptyProps) {
+	if (!selectedHost) {
+		return <EmptyState icon={Server} title="Select a host to view details" />;
+	}
+	return (
+		<UnifiedHostDetailPanel
+			ips={selectedHost.ips}
+			hostname={selectedHost.hostname}
+			hostnameSource={selectedHost.hostnameSource}
+			netbiosName={selectedHost.netbiosName}
+			macAddress={selectedHost.macAddress}
+			vendor={selectedHost.vendor}
+			mdnsServices={selectedHost.mdnsServices}
+			ssdpDevice={selectedHost.ssdpDevice}
+			wsDiscovery={selectedHost.wsDiscovery}
+			snmpInfo={selectedHost.snmpInfo}
+			tlsNames={selectedHost.tlsNames}
+			serviceBanners={selectedHost.serviceBanners}
+			classification={hostClassifications.get(selectedHost.id) ?? null}
+			discoveryMethods={selectedHost.discoveryMethods}
+			discoveries={selectedHost.discoveries}
+			ports={selectedHost.ports}
+			scanDurationMs={selectedHost.scanDurationMs}
+			onScan={onScanDiscoveredHost}
+			onCancel={onCancel}
+			scanDisabled={isScanning}
+			scanProgress={isScanning ? progress : null}
+		/>
+	);
+}
+
+interface ResultsFooterProps {
+	readonly results: ScanResults;
+}
+
+function ResultsFooter({ results }: ResultsFooterProps) {
+	return (
+		<div className="shrink-0 border-t bg-surface-3 px-4 py-2">
+			<div className="flex items-center justify-between text-xs tabular-nums text-muted-foreground">
+				<div className="flex items-center gap-4">
+					<span className="flex items-center gap-1">
+						<Server className="h-3 w-3" />
+						{results.totalHostsScanned} hosts scanned
+					</span>
+					<span className="flex items-center gap-1">
+						<CheckCircle2 className="h-3 w-3 text-success" />
+						{results.hostsWithOpenPorts} with open ports
+					</span>
+					<span className="flex items-center gap-1">
+						<Network className="h-3 w-3" />
+						{results.totalOpenPorts} ports open
+					</span>
+				</div>
+				<span className="flex items-center gap-1">
+					<Clock className="h-3 w-3" />
+					{formatDuration(results.scanDurationMs)}
+				</span>
+			</div>
+		</div>
+	);
+}
 
 export const Route = createFileRoute('/network-scanner')({
 	component: NetworkScannerPage,
@@ -235,12 +1240,7 @@ function NetworkScannerPage() {
 	const progressCurrentIp = progress?.type === 'progress' ? progress.current_ip : null;
 	const progressDiscoveredHosts = progress?.type === 'progress' ? progress.discovered_hosts : 0;
 	const progressDiscoveredPorts = progress?.type === 'progress' ? progress.discovered_ports : 0;
-	const progressText =
-		progress?.type === 'progress'
-			? `${progress.scanned_hosts} / ${progress.total_hosts} hosts`
-			: progress?.type === 'started'
-				? `Scanning ${progress.total_hosts} hosts, ${progress.total_ports} ports each`
-				: '';
+	const progressText = formatProgressText(progress);
 
 	const setTarget = useCallback((next: string) => patch({ target: next }), [patch]);
 	const setScanMode = useCallback((next: ScanMode) => patch({ scanMode: next }), [patch]);
@@ -249,56 +1249,122 @@ function NetworkScannerPage() {
 		[patch]
 	);
 
-	const handleProgressEvent = useCallback((event: ScanProgress) => {
-		setProgress(event);
+	const onHostDiscovered = useCallback((host: HostResult) => {
+		setDiscoveredHosts((prev) => [...prev, host]);
+		const hostKey = getMergeKey(host.ip, host.hostname ?? null);
 
-		if (event.type === 'host_discovered') {
-			setDiscoveredHosts((prev) => [...prev, event.host]);
-			const hostKey = getMergeKey(event.host.ip, event.host.hostname ?? null);
-
-			// Mark as recently discovered for animation
+		setRecentlyDiscoveredIds((prev) => {
+			const next = new Set(prev);
+			next.add(hostKey);
+			return next;
+		});
+		setTimeout(() => {
 			setRecentlyDiscoveredIds((prev) => {
 				const next = new Set(prev);
-				next.add(hostKey);
+				next.delete(hostKey);
 				return next;
 			});
+		}, 1500);
 
-			// Remove from recently discovered after animation completes
-			setTimeout(() => {
-				setRecentlyDiscoveredIds((prev) => {
-					const next = new Set(prev);
-					next.delete(hostKey);
-					return next;
-				});
-			}, 1500);
-
-			// Auto-select first host only once (don't override user selection)
-			if (!hasAutoSelectedRef.current) {
-				setSelectedHostId((prev) => {
-					if (prev !== null) return prev;
-					hasAutoSelectedRef.current = true;
-					return hostKey;
-				});
-			}
-		} else if (event.type === 'completed') {
-			setResults(event.results);
-			setIsScanning(false);
-			setRecentlyDiscoveredIds(new Set());
-			toast.success('Scan completed', {
-				description: `Found ${event.results.totalOpenPorts} open ports on ${event.results.hostsWithOpenPorts} hosts`,
+		if (!hasAutoSelectedRef.current) {
+			setSelectedHostId((prev) => {
+				if (prev !== null) return prev;
+				hasAutoSelectedRef.current = true;
+				return hostKey;
 			});
-		} else if (event.type === 'error') {
-			setError(event.message);
+		}
+	}, []);
+
+	const onScanCompleted = useCallback((results: ScanResults) => {
+		setResults(results);
+		setIsScanning(false);
+		setRecentlyDiscoveredIds(new Set());
+		toast.success('Scan completed', {
+			description: `Found ${results.totalOpenPorts} open ports on ${results.hostsWithOpenPorts} hosts`,
+		});
+	}, []);
+
+	const onScanError = useCallback((message: string) => {
+		setError(message);
+		setIsScanning(false);
+		setRecentlyDiscoveredIds(new Set());
+		toast.error('Scan failed', { description: message });
+	}, []);
+
+	const handleProgressEvent = useCallback(
+		(event: ScanProgress) => {
+			setProgress(event);
+			if (event.type === 'host_discovered') {
+				onHostDiscovered(event.host);
+			} else if (event.type === 'completed') {
+				onScanCompleted(event.results);
+			} else if (event.type === 'error') {
+				onScanError(event.message);
+			}
+		},
+		[onHostDiscovered, onScanCompleted, onScanError]
+	);
+
+	const buildScanOptions = useCallback(
+		() => ({
+			target: target.trim(),
+			mode: scanMode,
+			portPreset,
+			portRange: needsPortRange ? portRange.trim() : undefined,
+			concurrency,
+			timeoutMs,
+			resolveHostname,
+			resolution: resolveHostname
+				? {
+						dns: resolveDns,
+						mdns: resolveMdns,
+						netbios: resolveNetbios,
+						timeoutMs: resolveTimeoutMs,
+					}
+				: undefined,
+		}),
+		[
+			target,
+			scanMode,
+			portPreset,
+			portRange,
+			needsPortRange,
+			concurrency,
+			timeoutMs,
+			resolveHostname,
+			resolveDns,
+			resolveMdns,
+			resolveNetbios,
+			resolveTimeoutMs,
+		]
+	);
+
+	const finalizeScan = useCallback(
+		(scanId: string) => {
+			if (currentScanIdRef.current !== scanId) return;
+			if (unlistenRef.current) {
+				unlistenRef.current();
+				unlistenRef.current = null;
+			}
+			stopTimer();
 			setIsScanning(false);
-			setRecentlyDiscoveredIds(new Set());
-			toast.error('Scan failed', { description: event.message });
+			currentScanIdRef.current = null;
+		},
+		[stopTimer]
+	);
+
+	const reportScanError = useCallback((scanId: string, e: unknown) => {
+		if (currentScanIdRef.current !== scanId) return;
+		const message = e instanceof Error ? e.message : String(e);
+		setError(message);
+		if (!message.includes('cancelled')) {
+			toast.error('Scan failed', { description: message });
 		}
 	}, []);
 
 	const handleScan = useCallback(async () => {
 		if (!canScan || !isPortRangeValid) return;
 
-		// Cancel any running scan before starting a new one
 		const previousScanId = currentScanIdRef.current;
 		if (previousScanId) {
 			await cancelNetworkScan(previousScanId);
@@ -311,10 +1377,8 @@ function NetworkScannerPage() {
 		startTimer();
 		setError(null);
 		setResults(null);
-		// Don't clear discoveredHosts to allow merging with discovery results
 		setProgress(null);
 
-		// Setup progress listener
 		try {
 			unlistenRef.current = await listenToScanProgress(handleProgressEvent);
 		} catch {
@@ -326,65 +1390,21 @@ function NetworkScannerPage() {
 		}
 
 		try {
-			await startNetworkScan(
-				{
-					target: target.trim(),
-					mode: scanMode,
-					portPreset,
-					portRange: needsPortRange ? portRange.trim() : undefined,
-					concurrency,
-					timeoutMs,
-					resolveHostname,
-					resolution: resolveHostname
-						? {
-								dns: resolveDns,
-								mdns: resolveMdns,
-								netbios: resolveNetbios,
-								timeoutMs: resolveTimeoutMs,
-							}
-						: undefined,
-				},
-				scanId
-			);
+			await startNetworkScan(buildScanOptions(), scanId);
 		} catch (e) {
-			if (currentScanIdRef.current === scanId) {
-				const message = e instanceof Error ? e.message : String(e);
-				setError(message);
-				// Don't show error toast for cancellation
-				if (!message.includes('cancelled')) {
-					toast.error('Scan failed', { description: message });
-				}
-			}
+			reportScanError(scanId, e);
 		} finally {
-			// Only clean up if this is still the current scan
-			if (currentScanIdRef.current === scanId) {
-				if (unlistenRef.current) {
-					unlistenRef.current();
-					unlistenRef.current = null;
-				}
-				stopTimer();
-				setIsScanning(false);
-				currentScanIdRef.current = null;
-			}
+			finalizeScan(scanId);
 		}
 	}, [
 		canScan,
 		isPortRangeValid,
-		target,
-		scanMode,
-		portPreset,
-		portRange,
-		needsPortRange,
-		concurrency,
-		timeoutMs,
-		resolveHostname,
-		resolveDns,
-		resolveMdns,
-		resolveNetbios,
-		resolveTimeoutMs,
+		buildScanOptions,
 		startTimer,
 		stopTimer,
 		handleProgressEvent,
+		finalizeScan,
+		reportScanError,
 	]);
 
 	const handleCancel = useCallback(async () => {
@@ -443,23 +1463,14 @@ function NetworkScannerPage() {
 		try {
 			const info = await getLocalNetworkInterfaces();
 			setNetworkInfo(info);
-			// Auto-fill with primary IPv4 CIDR if available
-			const primary = info.primaryIpv4;
-			if (primary?.suggestedCidr) {
-				setTarget(primary.suggestedCidr);
+			const pick = pickAutoFillInterface(info);
+			if (pick?.suggestedCidr) {
+				setTarget(pick.suggestedCidr);
 				toast.success('Target auto-filled', {
-					description: `Using ${primary.name} (${primary.ip})`,
+					description: `Using ${pick.name} (${pick.ip})`,
 				});
 			} else if (info.interfaces.length > 0) {
-				const usable = info.interfaces.find((i) => !i.isLoopback && i.suggestedCidr);
-				if (usable?.suggestedCidr) {
-					setTarget(usable.suggestedCidr);
-					toast.success('Target auto-filled', {
-						description: `Using ${usable.name} (${usable.ip})`,
-					});
-				} else {
-					toast.warning('No suitable network interface found');
-				}
+				toast.warning('No suitable network interface found');
 			}
 		} catch (e) {
 			toast.error('Failed to load network interfaces', {
@@ -521,81 +1532,28 @@ function NetworkScannerPage() {
 		currentDiscoveryIdRef.current = discoveryId;
 
 		const channel = new Channel<DiscoveryEvent>();
-		channel.onmessage = (message: DiscoveryEvent) => {
-			// Ignore events from a stale discovery (cancelled and replaced)
-			if (currentDiscoveryIdRef.current !== discoveryId) return;
+		channel.onmessage = createDiscoveryChannelHandler({
+			currentDiscoveryIdRef,
+			discoveryId,
+			setMethodProgress,
+			setDiscoveryResults,
+			autoSelectFirstHost,
+		});
 
-			switch (message.event) {
-				case 'methodStarted':
-					setMethodProgress((prev) => {
-						const next = new Map(prev);
-						next.set(message.data.method, {
-							method: message.data.method,
-							status: 'running',
-							hostsFound: 0,
-							durationMs: null,
-							error: null,
-						});
-						return next;
-					});
-					break;
-				case 'methodCompleted': {
-					const { result } = message.data;
-					setMethodProgress((prev) => {
-						const next = new Map(prev);
-						next.set(result.method, {
-							method: result.method,
-							status: result.error ? 'error' : 'completed',
-							hostsFound: result.hosts.length,
-							durationMs: result.durationMs,
-							error: result.error ?? null,
-						});
-						return next;
-					});
-					// Merge result immediately — unifiedHosts re-derives → UI updates
-					setDiscoveryResults((prev) => [...prev, result]);
-					autoSelectFirstHost(result.hosts);
-					break;
-				}
-				case 'resolvingHostnames':
-					// Could show "Resolving hostnames..." in UI if desired
-					break;
-				case 'completed':
-					setDiscoveryResults((prev) => replaceWithResolvedResults(prev, message.data.results));
-					break;
-				case 'cancelled':
-					break;
-			}
+		const discoveryOptions: DiscoveryOptions = {
+			methods: [...discoveryMethods],
+			timeoutMs,
+			concurrency,
+			synPorts: [...DEFAULT_SYN_PORTS],
+			resolveNetbios,
 		};
 
 		try {
-			const discoveryOptions: DiscoveryOptions = {
-				methods: [...discoveryMethods],
-				timeoutMs,
-				concurrency,
-				synPorts: [...DEFAULT_SYN_PORTS],
-				resolveNetbios,
-			};
-
 			await discoverHosts([target.trim()], discoveryOptions, channel, discoveryId);
-
-			// Use merged unifiedHosts count (accurate, deduplicated)
-			if (unifiedHosts.length > 0) {
-				toast.success('Discovery completed', {
-					description: `Found ${unifiedHosts.length} hosts`,
-				});
-			} else {
-				toast.info('Discovery completed', {
-					description: 'No hosts found',
-				});
-			}
+			reportDiscoverySuccess(unifiedHosts.length);
 		} catch (e) {
-			const msg = e instanceof Error ? e.message : String(e);
-			if (!msg.includes('cancelled')) {
-				toast.error('Discovery failed', { description: msg });
-			}
+			reportDiscoveryError(e);
 		} finally {
-			// Only clean up if this is still the current discovery
 			if (currentDiscoveryIdRef.current === discoveryId) {
 				stopTimer();
 				setIsDiscovering(false);
@@ -617,27 +1575,11 @@ function NetworkScannerPage() {
 	};
 
 	const handleHostListKeydown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-		if (!['ArrowUp', 'ArrowDown', 'Home', 'End'].includes(e.key)) return;
 		if (unifiedHosts.length === 0) return;
-		e.preventDefault();
 		const currentIdx = unifiedHosts.findIndex((h) => h.id === selectedHostId);
-
-		// Resolve target index via IIFE switch; null short-circuits non-nav keys.
-		const nextIdx = ((): number | null => {
-			switch (e.key) {
-				case 'ArrowDown':
-					return currentIdx < 0 ? 0 : Math.min(currentIdx + 1, unifiedHosts.length - 1);
-				case 'ArrowUp':
-					return currentIdx < 0 ? 0 : Math.max(currentIdx - 1, 0);
-				case 'Home':
-					return 0;
-				case 'End':
-					return unifiedHosts.length - 1;
-				default:
-					return null;
-			}
-		})();
+		const nextIdx = resolveKeydownIndex(e.key, currentIdx, unifiedHosts.length);
 		if (nextIdx === null) return;
+		e.preventDefault();
 		const next = unifiedHosts[nextIdx];
 		if (next) {
 			selectHost(next.id);
@@ -651,388 +1593,83 @@ function NetworkScannerPage() {
 		handleScan().catch(() => {});
 	};
 
-	const statusContent = results ? (
-		<>
-			<StatItem label="Hosts" value={results.hostsWithOpenPorts} />
-			<StatItem label="Ports" value={results.totalOpenPorts} />
-			<StatItem label="Duration" value={formatDuration(results.scanDurationMs)} />
-		</>
-	) : isScanning && progress?.type === 'progress' ? (
-		<StatItem label="Progress" value={`${progress.percentage.toFixed(0)}%`} />
-	) : unifiedHosts.length > 0 ? (
-		<StatItem label="Hosts" value={unifiedHosts.length} />
-	) : null;
+	const statusContent = renderStatusContent({
+		results,
+		isScanning,
+		progress,
+		unifiedHostCount: unifiedHosts.length,
+	});
 
 	const usableInterfaces = networkInfo?.interfaces.filter((i) => !i.isLoopback && i.suggestedCidr);
 
 	const rail = (
 		<>
-			{/* 1. Target */}
-			<FormSection title="Target">
-				<div className="space-y-2">
-					<FormInput
-						label="Host / IP / CIDR"
-						value={target}
-						onValueChange={setTarget}
-						placeholder="192.168.1.1 or 192.168.1.0/24"
-						size="compact"
-					/>
-					{target && !isValidTarget(target) ? <FormError message="Invalid target format" /> : null}
-					<ActionButton
-						label="Detect Local Network"
-						icon={RefreshCw}
-						loading={isLoadingInterfaces}
-						loadingLabel="Detecting..."
-						disabled={isScanning}
-						variant="outline"
-						onClick={() => {
-							handleLoadInterfaces().catch(() => {});
-						}}
-					/>
-				</div>
-				{usableInterfaces && usableInterfaces.length > 0 ? (
-					<div className="mt-2 space-y-1">
-						<p className="text-xs font-medium text-muted-foreground">Available interfaces:</p>
-						<div className="max-h-32 space-y-1 overflow-y-auto">
-							{usableInterfaces.map((iface) => (
-								<ListItemButton
-									key={iface.ip}
-									variant="card"
-									size="sm"
-									wrap
-									onClick={() => handleSelectInterface(iface)}
-								>
-									<span className="flex min-w-0 flex-col items-start gap-0.5">
-										<span className="font-medium">{iface.name}</span>
-										<span className="break-all font-mono text-2xs text-muted-foreground">
-											{iface.suggestedCidr}
-										</span>
-									</span>
-								</ListItemButton>
-							))}
-						</div>
-					</div>
-				) : null}
-			</FormSection>
+			<TargetSection
+				target={target}
+				onTargetChange={setTarget}
+				isScanning={isScanning}
+				isLoadingInterfaces={isLoadingInterfaces}
+				usableInterfaces={usableInterfaces}
+				onLoadInterfaces={() => {
+					handleLoadInterfaces().catch(() => {});
+				}}
+				onSelectInterface={handleSelectInterface}
+			/>
 
-			{/* 2. Host Discovery */}
-			<FormSection title="Host Discovery">
-				<p className="mb-2 text-xs leading-snug text-muted-foreground">
-					Find active hosts before port scanning.
-				</p>
-				<FormCheckboxGroup>
-					{DISCOVERY_METHODS.map((method) => {
-						const isSelected = discoveryMethods.has(method.value);
-						const isDisabled = isDiscovering || isScanning;
-						return (
-							<FormCheckbox
-								key={method.value}
-								label={method.label}
-								checked={isSelected}
-								disabled={isDisabled}
-								onCheckedChange={() => toggleDiscoveryMethod(method.value)}
-								size="compact"
-							/>
-						);
-					})}
-				</FormCheckboxGroup>
+			<HostDiscoverySection
+				discoveryMethods={discoveryMethods}
+				toggleDiscoveryMethod={toggleDiscoveryMethod}
+				isDiscovering={isDiscovering}
+				isScanning={isScanning}
+				resolveDns={resolveDns}
+				setResolveDns={setResolveDns}
+				resolveMdns={resolveMdns}
+				setResolveMdns={setResolveMdns}
+				resolveNetbios={resolveNetbios}
+				setResolveNetbios={setResolveNetbios}
+				resolveHostname={resolveHostname}
+				resolveTimeoutMs={resolveTimeoutMs}
+				setResolveTimeoutMs={setResolveTimeoutMs}
+				target={target}
+				discoveryResults={discoveryResults}
+				onDiscover={() => {
+					handleDiscovery().catch(() => {});
+				}}
+				onCancelDiscovery={() => {
+					handleCancelDiscovery().catch(() => {});
+				}}
+			/>
 
-				{/* Name Resolution (collapsible) */}
-				<Accordion type="multiple" defaultValue={['name-resolution']} className="mt-3">
-					<AccordionItem value="name-resolution" className="rounded border border-border bg-card">
-						<AccordionTrigger className="px-2 py-1.5 text-xs font-medium hover:no-underline [&>svg]:h-3.5 [&>svg]:w-3.5">
-							<span>Name Resolution</span>
-						</AccordionTrigger>
-						<AccordionContent className="border-t border-border/30 px-2 pb-2">
-							<FormCheckboxGroup className="pt-2">
-								<FormCheckbox
-									label="DNS PTR"
-									checked={resolveDns}
-									onCheckedChange={setResolveDns}
-									size="compact"
-								/>
-								<FormCheckbox
-									label="mDNS (.local)"
-									checked={resolveMdns}
-									onCheckedChange={setResolveMdns}
-									size="compact"
-								/>
-								<FormCheckbox
-									label="NetBIOS"
-									checked={resolveNetbios}
-									onCheckedChange={setResolveNetbios}
-									size="compact"
-								/>
-								{resolveHostname ? (
-									<div className="mt-2 border-t border-border pt-2">
-										<FormSlider
-											label="Timeout"
-											value={resolveTimeoutMs}
-											onValueChange={setResolveTimeoutMs}
-											min={500}
-											max={5000}
-											step={500}
-											hint={`${resolveTimeoutMs}ms`}
-											size="compact"
-										/>
-									</div>
-								) : null}
-							</FormCheckboxGroup>
-						</AccordionContent>
-					</AccordionItem>
-				</Accordion>
+			<PortScanSection
+				scanMode={scanMode}
+				setScanMode={setScanMode}
+				portPreset={portPreset}
+				setPortPreset={setPortPreset}
+				portRange={portRange}
+				setPortRange={setPortRange}
+				portRangeTouched={portRangeTouched}
+				setPortRangeTouched={setPortRangeTouched}
+				concurrency={concurrency}
+				setConcurrency={setConcurrency}
+				timeoutMs={timeoutMs}
+				setTimeoutMs={setTimeoutMs}
+				isScanning={isScanning}
+				canScan={canScan}
+				isPortRangeValid={isPortRangeValid}
+				onScan={() => {
+					handleScan().catch(() => {});
+				}}
+				onCancelScan={() => {
+					handleCancel().catch(() => {});
+				}}
+			/>
 
-				{discoveryMethods.size > 0 ? (
-					<div className="mt-3">
-						{isDiscovering ? (
-							<ActionButton
-								label="Cancel Discovery"
-								icon={Square}
-								variant="destructive"
-								onClick={() => {
-									handleCancelDiscovery().catch(() => {});
-								}}
-							/>
-						) : (
-							<ActionButton
-								label="Find Hosts"
-								icon={Radar}
-								disabled={!isValidTarget(target) || isScanning}
-								variant="outline"
-								onClick={() => {
-									handleDiscovery().catch(() => {});
-								}}
-							/>
-						)}
-					</div>
-				) : null}
-				{discoveryResults.length > 0 ? (
-					<Card density="compact" className="mt-2">
-						<CardContent className="p-2">
-							<p className="text-xs font-medium text-muted-foreground">Results:</p>
-							<div className="mt-1 max-h-20 space-y-0.5 overflow-y-auto">
-								{discoveryResults.map((result) => (
-									<div key={result.method} className="text-xs">
-										<span className="font-medium">
-											{DISCOVERY_METHODS.find((m) => m.value === result.method)?.label ??
-												result.method}
-											:
-										</span>{' '}
-										{result.error ? (
-											<span className="text-destructive">{result.error}</span>
-										) : (
-											<span className="text-muted-foreground">{result.hosts.length} host(s)</span>
-										)}
-									</div>
-								))}
-							</div>
-						</CardContent>
-					</Card>
-				) : null}
-			</FormSection>
-
-			{/* 3. Port Scan */}
-			<FormSection title="Port Scan">
-				<FormMode<ScanMode>
-					label="Scan Mode"
-					value={scanMode}
-					layout="stacked"
-					descriptionDisplay="selected"
-					options={SCAN_MODES.map((m) => ({
-						value: m.value,
-						label: m.label,
-						description: m.description,
-					}))}
-					onValueChange={(v) => setScanMode(v)}
-				/>
-
-				{/* Quick Scan Port Details */}
-				{scanMode === 'quick' ? (
-					<details className="mt-2 rounded border border-border bg-card">
-						<summary className="flex cursor-pointer items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground">
-							<ChevronRight className="h-3 w-3 transition-transform [[open]>&]:rotate-90" />
-							Target Ports ({QUICK_SCAN_PORTS.length})
-						</summary>
-						<div className="max-h-48 overflow-y-auto border-t border-border">
-							<div className="grid grid-cols-2 gap-px bg-border">
-								{QUICK_SCAN_PORTS.map((port) => (
-									<div
-										key={port}
-										className="flex items-center justify-between bg-background px-2 py-1"
-										title={WELL_KNOWN_SERVICES[port] ?? `Port ${port}`}
-									>
-										<span className="font-mono text-xs font-medium tabular-nums">{port}</span>
-										<span className="truncate text-xs text-muted-foreground">
-											{WELL_KNOWN_SERVICES[port] ?? ''}
-										</span>
-									</div>
-								))}
-							</div>
-						</div>
-					</details>
-				) : null}
-
-				{/* Port Selection (custom mode only) */}
-				{scanMode === 'custom' ? (
-					<div className="mt-3 border-t border-border pt-3">
-						<FormMode<PortPreset>
-							label="Port Selection"
-							value={portPreset}
-							layout="stacked"
-							descriptionDisplay="selected"
-							options={PORT_PRESETS.map((p) => ({
-								value: p.value,
-								label: p.label,
-								description: p.description,
-							}))}
-							onValueChange={(v) => setPortPreset(v)}
-						/>
-
-						{portPreset === 'well_known' ? (
-							<p className="mt-1.5 text-xs text-muted-foreground">
-								Standard ports 1-1024 (1,024 ports)
-							</p>
-						) : portPreset === 'web' ? (
-							<details className="mt-2 rounded border border-border bg-card">
-								<summary className="flex cursor-pointer items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground">
-									<ChevronRight className="h-3 w-3 transition-transform [[open]>&]:rotate-90" />
-									Web Ports ({WEB_PORTS.length})
-								</summary>
-								<div className="max-h-32 overflow-y-auto border-t border-border">
-									<div className="grid grid-cols-2 gap-px bg-border">
-										{WEB_PORTS.map((port) => (
-											<div
-												key={port}
-												className="flex items-center justify-between bg-background px-2 py-1"
-												title={WELL_KNOWN_SERVICES[port] ?? `Port ${port}`}
-											>
-												<span className="font-mono text-xs font-medium tabular-nums">{port}</span>
-												<span className="truncate text-xs text-muted-foreground">
-													{WELL_KNOWN_SERVICES[port] ?? ''}
-												</span>
-											</div>
-										))}
-									</div>
-								</div>
-							</details>
-						) : portPreset === 'database' ? (
-							<details className="mt-2 rounded border border-border bg-card">
-								<summary className="flex cursor-pointer items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground">
-									<ChevronRight className="h-3 w-3 transition-transform [[open]>&]:rotate-90" />
-									Database Ports ({DATABASE_PORTS.length})
-								</summary>
-								<div className="max-h-32 overflow-y-auto border-t border-border">
-									<div className="grid grid-cols-2 gap-px bg-border">
-										{DATABASE_PORTS.map((port) => (
-											<div
-												key={port}
-												className="flex items-center justify-between bg-background px-2 py-1"
-												title={WELL_KNOWN_SERVICES[port] ?? `Port ${port}`}
-											>
-												<span className="font-mono text-xs font-medium tabular-nums">{port}</span>
-												<span className="truncate text-xs text-muted-foreground">
-													{WELL_KNOWN_SERVICES[port] ?? ''}
-												</span>
-											</div>
-										))}
-									</div>
-								</div>
-							</details>
-						) : portPreset === 'custom' ? (
-							<div className="mt-2">
-								<FormInput
-									label="Port Range"
-									value={portRange}
-									onValueChange={setPortRange}
-									placeholder="80,443,8080 or 1-1024"
-									onBlur={() => setPortRangeTouched(true)}
-									size="compact"
-								/>
-								{portRangeTouched && portRange && !isValidPortRange(portRange) ? (
-									<FormError className="mt-1" message="Invalid port range format" />
-								) : (
-									<p className="mt-1 text-xs text-muted-foreground">
-										Examples: 80,443,8080 or 1-1024 or 22,80-100,443
-									</p>
-								)}
-							</div>
-						) : null}
-					</div>
-				) : null}
-
-				{/* Scan Settings */}
-				<div className="mt-3 border-t border-border/30 pt-3">
-					<p className="mb-2 text-xs font-semibold uppercase tracking-wide text-foreground/70">
-						Scan Settings
-					</p>
-					<FormSlider
-						label="Concurrency"
-						value={concurrency}
-						onValueChange={setConcurrency}
-						min={MIN_CONCURRENCY}
-						max={MAX_CONCURRENCY}
-						step={10}
-						hint={`${concurrency}`}
-						size="compact"
-					/>
-					<FormSlider
-						label="Timeout"
-						value={timeoutMs}
-						onValueChange={setTimeoutMs}
-						min={MIN_TIMEOUT_MS}
-						max={MAX_TIMEOUT_MS}
-						step={100}
-						hint={`${timeoutMs}ms`}
-						size="compact"
-					/>
-				</div>
-
-				{/* Action Button */}
-				<div className="mt-3">
-					{isScanning ? (
-						<ActionButton
-							label="Cancel Scan"
-							icon={Square}
-							variant="destructive"
-							onClick={() => {
-								handleCancel().catch(() => {});
-							}}
-						/>
-					) : (
-						<ActionButton
-							label="Scan Ports"
-							icon={Play}
-							loading={isScanning}
-							loadingLabel="Scanning..."
-							disabled={!canScan || !isPortRangeValid}
-							shortcut
-							onClick={() => {
-								handleScan().catch(() => {});
-							}}
-						/>
-					)}
-				</div>
-			</FormSection>
-
-			{/* 4. Results */}
 			{results ? (
-				<FormSection title="Results">
-					<div className="space-y-2">
-						<ActionButton label="Clear Results" variant="outline" onClick={handleClear} />
-						<ActionButton
-							label="Export JSON"
-							icon={Download}
-							variant="outline"
-							onClick={handleExportJson}
-						/>
-						<ActionButton
-							label="Export CSV"
-							icon={Download}
-							variant="outline"
-							onClick={handleExportCsv}
-						/>
-					</div>
-				</FormSection>
+				<ResultsExportSection
+					onClear={handleClear}
+					onExportJson={handleExportJson}
+					onExportCsv={handleExportCsv}
+				/>
 			) : null}
 		</>
 	);
@@ -1047,315 +1684,63 @@ function NetworkScannerPage() {
 			rail={rail}
 		>
 			<div className="relative flex h-full flex-col overflow-hidden">
-				{/* Discovery Progress Panel */}
+				{/* Discovery / scan progress panels */}
 				{isDiscovering ? (
-					<div className="shrink-0 border-b bg-surface-2 px-4 py-3">
-						<div className="mb-2 flex items-center justify-between">
-							<div className="flex items-center gap-2">
-								<Loader2 className="h-4 w-4 animate-spin text-primary" />
-								<span className="text-sm font-medium">Finding Hosts...</span>
-								<span className="text-xs text-muted-foreground">
-									Running {discoveryMethods.size} method
-									{discoveryMethods.size > 1 ? 's' : ''} in parallel
-								</span>
-							</div>
-							<ActionButton
-								label="Cancel"
-								variant="ghost"
-								size="sm"
-								// Progress panel is bg-surface-2; pair text hover with interactive-hover
-								// background so the affordance is visible.
-								className="w-auto text-muted-foreground hover:bg-interactive-hover hover:text-destructive"
-								onClick={() => {
-									handleCancelDiscovery().catch(() => {});
-								}}
-							/>
-						</div>
-						{/* Per-method progress — flex-wrap so labels flow onto multiple rows on narrow viewports */}
-						<div className="flex flex-wrap gap-2">
-							{[...discoveryMethods].map((method) => {
-								const methodProg = methodProgress.get(method);
-								return (
-									<div key={method} className="min-w-32 flex-1 space-y-1">
-										<div className="flex items-center justify-between text-xs">
-											<span
-												className="truncate font-medium"
-												title={DISCOVERY_METHODS.find((m) => m.value === method)?.label ?? method}
-											>
-												{DISCOVERY_METHODS.find((m) => m.value === method)?.label ?? method}
-											</span>
-											{methodProg?.status === 'completed' ? (
-												<Check className="h-3 w-3 shrink-0 text-success" />
-											) : methodProg?.status === 'error' ? (
-												<X className="h-3 w-3 shrink-0 text-destructive" />
-											) : methodProg?.status === 'running' ? (
-												<Loader2 className="h-3 w-3 shrink-0 animate-spin text-primary" />
-											) : (
-												<Clock className="h-3 w-3 shrink-0 text-muted-foreground" />
-											)}
-										</div>
-										<div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
-											<div
-												className={cn(
-													'h-full transition-all duration-300',
-													methodProg?.status === 'running' && 'animate-pulse bg-primary',
-													methodProg?.status === 'completed' && 'bg-success',
-													methodProg?.status === 'error' && 'bg-destructive'
-												)}
-												style={{
-													width: `${
-														methodProg?.status === 'completed' || methodProg?.status === 'error'
-															? 100
-															: methodProg?.status === 'running'
-																? 60
-																: 0
-													}%`,
-												}}
-											/>
-										</div>
-										<div className="flex items-center justify-between text-xs tabular-nums text-muted-foreground">
-											{methodProg?.hostsFound !== undefined && methodProg.hostsFound > 0 ? (
-												<span className="text-success">{methodProg.hostsFound} hosts</span>
-											) : (
-												<span>&nbsp;</span>
-											)}
-											{methodProg?.durationMs !== undefined && methodProg?.durationMs !== null ? (
-												<span>{(methodProg.durationMs / 1000).toFixed(1)}s</span>
-											) : null}
-										</div>
-									</div>
-								);
-							})}
-						</div>
-					</div>
+					<DiscoveryProgressPanel
+						discoveryMethods={discoveryMethods}
+						methodProgress={methodProgress}
+						onCancel={() => {
+							handleCancelDiscovery().catch(() => {});
+						}}
+					/>
 				) : isScanning ? (
-					<div
-						className="shrink-0 border-b bg-surface-2 px-4 py-3"
-						role="status"
-						aria-live="polite"
-						aria-atomic="false"
-					>
-						{/* Main progress info */}
-						<div className="mb-2 flex items-center justify-between">
-							<div className="flex items-center gap-2">
-								<Loader2 className="h-4 w-4 animate-spin text-primary" />
-								<span className="text-sm font-medium">Scanning Ports...</span>
-								<span className="text-xs text-muted-foreground">{progressText}</span>
-							</div>
-							<div className="flex items-center gap-3">
-								<span className="text-sm font-medium tabular-nums text-primary">
-									{progressPercentage.toFixed(0)}%
-								</span>
-								<ActionButton
-									label="Cancel"
-									variant="ghost"
-									size="sm"
-									// Progress panel is bg-surface-2; pair text hover with interactive-hover
-									// background so the affordance is visible.
-									className="w-auto text-muted-foreground hover:bg-interactive-hover hover:text-destructive"
-									onClick={() => {
-										handleCancel().catch(() => {});
-									}}
-								/>
-							</div>
-						</div>
-
-						{/* Progress bar */}
-						<div className="mb-2 h-2 w-full overflow-hidden rounded-full bg-muted">
-							<div
-								className="h-full bg-primary transition-all duration-300"
-								style={{ width: `${progressPercentage}%` }}
-							/>
-						</div>
-
-						{/* Detailed stats */}
-						<div className="flex items-center justify-between text-xs">
-							<div className="flex items-center gap-4">
-								{progressCurrentIp ? (
-									<span className="flex items-center gap-1 text-muted-foreground">
-										<span>Next:</span>
-										<span className="font-mono font-medium text-foreground">
-											{progressCurrentIp}
-										</span>
-									</span>
-								) : null}
-							</div>
-							<div className="flex items-center gap-4">
-								{progressDiscoveredHosts > 0 ? (
-									<span className="flex items-center gap-1 text-success">
-										<Server className="h-3 w-3" />
-										<span className="font-medium">{progressDiscoveredHosts}</span>
-										<span>hosts found</span>
-									</span>
-								) : null}
-								{progressDiscoveredPorts > 0 ? (
-									<span className="flex items-center gap-1 text-success">
-										<Network className="h-3 w-3" />
-										<span className="font-medium">{progressDiscoveredPorts}</span>
-										<span>ports open</span>
-									</span>
-								) : null}
-							</div>
-						</div>
-					</div>
+					<ScanProgressPanel
+						progressText={progressText}
+						progressPercentage={progressPercentage}
+						progressCurrentIp={progressCurrentIp}
+						progressDiscoveredHosts={progressDiscoveredHosts}
+						progressDiscoveredPorts={progressDiscoveredPorts}
+						onCancel={() => {
+							handleCancel().catch(() => {});
+						}}
+					/>
 				) : null}
 
-				{/* Main Content */}
 				<div className="flex-1 overflow-hidden">
-					{(isDiscovering || isScanning) && unifiedHosts.length === 0 && !error ? (
-						<div
-							className="space-y-1.5 p-2"
-							role="status"
-							aria-busy="true"
-							aria-label="Loading hosts"
-						>
-							{Array.from({ length: 6 }, (_, i) => (
-								// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
-								<div key={i} className="flex items-center gap-2">
-									<Skeleton className="h-4 w-32" />
-									<Skeleton className="ml-auto h-4 w-12" />
-								</div>
-							))}
-						</div>
-					) : unifiedHosts.length > 0 ? (
-						<ResizablePanelGroup orientation="horizontal" className="h-full">
-							{/* Left Pane: Host List */}
-							<ResizablePanel defaultSize="42" minSize="20" maxSize="60">
-								<div className="flex h-full flex-col border-r">
-									<div
-										className="flex h-9 shrink-0 items-center justify-between border-b bg-surface-3 px-3"
-										role="status"
-										aria-live="polite"
-										aria-atomic="true"
-									>
-										<span className="text-xs font-medium text-muted-foreground">
-											Hosts ({unifiedHosts.length})
-										</span>
-										{totalOpenPorts > 0 ? (
-											<span className="text-xs text-success">{totalOpenPorts} open ports</span>
-										) : null}
-									</div>
-									{/* Host List */}
-									<div
-										className="flex-1 overflow-auto outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-inset"
-										role="listbox"
-										tabIndex={0}
-										aria-label="Discovered hosts"
-										onKeyDown={handleHostListKeydown}
-									>
-										{unifiedHosts.map((host) => {
-											const displayHostname = getDisplayHostname(host);
-											return (
-												<UnifiedHostListItem
-													key={host.id}
-													hostId={host.id}
-													ips={host.ips}
-													hostname={displayHostname?.name ?? null}
-													hostnameSource={displayHostname?.source ?? null}
-													macAddress={host.macAddress}
-													vendor={host.vendor}
-													openPortCount={host.ports.filter((p) => p.state === 'open').length}
-													discoveryMethodCount={host.discoveryMethods.length}
-													mdnsServiceCount={host.mdnsServices.length}
-													selected={selectedHostId === host.id}
-													isNew={recentlyDiscoveredIds.has(host.id)}
-													deviceCategory={hostClassifications.get(host.id)?.category}
-													hasPortScan={host.ports.length > 0}
-													onClick={() => selectHost(host.id)}
-												/>
-											);
-										})}
-									</div>
-									{/* Scan All Button (only if we have hosts without port scans) */}
-									{hostsWithoutScans.length > 0 ? (
-										<div className="shrink-0 border-t bg-surface-3 p-2">
-											<ActionButton
-												label={`Scan ${hostsWithoutScans.length} Unscanned Hosts`}
-												icon={Play}
-												size="sm"
-												variant="outline"
-												disabled={isScanning}
-												onClick={() => {
-													setTarget(hostsWithoutScans.flatMap((h) => h.ips).join(','));
-													handleScan().catch(() => {});
-												}}
-											/>
-										</div>
-									) : null}
-								</div>
-							</ResizablePanel>
-
-							<ResizableHandle withHandle />
-
-							{/* Right Pane: Host Detail */}
-							<ResizablePanel defaultSize="58" minSize="40">
-								{selectedHost ? (
-									<UnifiedHostDetailPanel
-										ips={selectedHost.ips}
-										hostname={selectedHost.hostname}
-										hostnameSource={selectedHost.hostnameSource}
-										netbiosName={selectedHost.netbiosName}
-										macAddress={selectedHost.macAddress}
-										vendor={selectedHost.vendor}
-										mdnsServices={selectedHost.mdnsServices}
-										ssdpDevice={selectedHost.ssdpDevice}
-										wsDiscovery={selectedHost.wsDiscovery}
-										snmpInfo={selectedHost.snmpInfo}
-										tlsNames={selectedHost.tlsNames}
-										serviceBanners={selectedHost.serviceBanners}
-										classification={hostClassifications.get(selectedHost.id) ?? null}
-										discoveryMethods={selectedHost.discoveryMethods}
-										discoveries={selectedHost.discoveries}
-										ports={selectedHost.ports}
-										scanDurationMs={selectedHost.scanDurationMs}
-										onScan={handleScanDiscoveredHost}
-										onCancel={() => {
-											handleCancel().catch(() => {});
-										}}
-										scanDisabled={isScanning}
-										scanProgress={isScanning ? progress : null}
-									/>
-								) : (
-									<EmptyState icon={Server} title="Select a host to view details" />
-								)}
-							</ResizablePanel>
-						</ResizablePanelGroup>
-					) : error ? (
-						<ErrorDisplay variant="centered" message={error} />
-					) : (
-						<EmptyState
-							icon={Radar}
-							title="Enter a target and start scanning"
-							description="IP address, hostname, or CIDR notation"
-						/>
-					)}
+					<MainContent
+						isDiscovering={isDiscovering}
+						isScanning={isScanning}
+						unifiedHosts={unifiedHosts}
+						error={error}
+						hostListPaneProps={{
+							unifiedHosts,
+							totalOpenPorts,
+							selectedHostId,
+							recentlyDiscoveredIds,
+							hostClassifications,
+							onSelectHost: selectHost,
+							onListKeyDown: handleHostListKeydown,
+							hostsWithoutScans,
+							isScanning,
+							onScanAllUnscanned: () => {
+								setTarget(hostsWithoutScans.flatMap((h) => h.ips).join(','));
+								handleScan().catch(() => {});
+							},
+						}}
+						hostDetailProps={{
+							selectedHost,
+							hostClassifications,
+							isScanning,
+							progress,
+							onScanDiscoveredHost: handleScanDiscoveredHost,
+							onCancel: () => {
+								handleCancel().catch(() => {});
+							},
+						}}
+					/>
 				</div>
 
-				{/* Summary Footer */}
-				{results ? (
-					<div className="shrink-0 border-t bg-surface-3 px-4 py-2">
-						<div className="flex items-center justify-between text-xs tabular-nums text-muted-foreground">
-							<div className="flex items-center gap-4">
-								<span className="flex items-center gap-1">
-									<Server className="h-3 w-3" />
-									{results.totalHostsScanned} hosts scanned
-								</span>
-								<span className="flex items-center gap-1">
-									<CheckCircle2 className="h-3 w-3 text-success" />
-									{results.hostsWithOpenPorts} with open ports
-								</span>
-								<span className="flex items-center gap-1">
-									<Network className="h-3 w-3" />
-									{results.totalOpenPorts} ports open
-								</span>
-							</div>
-							<span className="flex items-center gap-1">
-								<Clock className="h-3 w-3" />
-								{formatDuration(results.scanDurationMs)}
-							</span>
-						</div>
-					</div>
-				) : null}
+				{results ? <ResultsFooter results={results} /> : null}
 			</div>
 		</ToolShell>
 	);

--- a/src/routes/regex-tester.tsx
+++ b/src/routes/regex-tester.tsx
@@ -1,22 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useEffect } from 'react';
-import {
-	Check,
-	Eye,
-	FlaskConical,
-	GitBranch,
-	Info,
-	Search,
-	Sparkles,
-	Workflow,
-	X,
-} from 'lucide-react';
+import { Eye, FlaskConical, GitBranch, Info, Search, Sparkles, Workflow } from 'lucide-react';
 
 import { CopyButton } from '@/lib/components/action';
 import { FormError, FormInfo, FormSection, FormTextarea } from '@/lib/components/form';
 import { PatternEditor, RailroadView } from '@/lib/components/regex';
 import { ToolShell } from '@/lib/components/shell';
-import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { EmbeddedEmptyState, StatItem, ValidityBadge } from '@/lib/components/status';
 import {
 	Accordion,
 	AccordionContent,
@@ -36,6 +26,7 @@ import {
 	compileRegex,
 	countCaptureGroups,
 	DEFAULT_FLAGS,
+	type FeatureUsage,
 	FLAG_INFO,
 	findFeatures,
 	findMatches,
@@ -43,6 +34,7 @@ import {
 	type RegexFlags,
 	type RegexMatch,
 	replaceText,
+	type Result,
 	SAMPLE_PATTERN,
 	SAMPLE_REPLACEMENT,
 	SAMPLE_TEST_TEXT,
@@ -178,6 +170,347 @@ function RenderNode({ node, depth }: RenderNodeProps) {
 				) : null}
 			</CardContent>
 		</Card>
+	);
+}
+
+interface MatchGroupListProps {
+	readonly match: RegexMatch;
+}
+
+function MatchGroupList({ match }: MatchGroupListProps) {
+	const hasPositional = match.groups.length > 0;
+	const namedEntries = Object.entries(match.namedGroups);
+	const hasNamed = namedEntries.length > 0;
+	if (!hasPositional && !hasNamed) return null;
+	return (
+		<>
+			{hasPositional ? (
+				<div className="mt-1.5 space-y-1">
+					{match.groups.map((group, gIdx) => {
+						const color = groupColor(gIdx + 1);
+						return (
+							<div
+								// biome-ignore lint/suspicious/noArrayIndexKey: groups in stable order
+								key={gIdx}
+								className="flex items-baseline gap-2 text-2xs"
+							>
+								<Badge className={cn('font-mono', color.bgSoft, color.text, color.border)}>
+									${gIdx + 1}
+								</Badge>
+								<code className="break-all font-mono text-muted-foreground">
+									{group.value || '∅'}
+								</code>
+							</div>
+						);
+					})}
+				</div>
+			) : null}
+			{hasNamed ? (
+				<div className="mt-1.5 space-y-1">
+					{namedEntries.map(([name, group], nIdx) => {
+						const color = groupColor(nIdx + 1);
+						return (
+							<div key={name} className="flex items-baseline gap-2 text-2xs">
+								<Badge className={cn('font-mono', color.bgSoft, color.text, color.border)}>
+									{name}
+								</Badge>
+								<code className="break-all font-mono text-muted-foreground">
+									{group.value || '∅'}
+								</code>
+							</div>
+						);
+					})}
+				</div>
+			) : null}
+		</>
+	);
+}
+
+interface MatchesAccordionProps {
+	readonly matches: readonly RegexMatch[];
+	readonly compiledOk: boolean;
+}
+
+function MatchesAccordion({ matches, compiledOk }: MatchesAccordionProps) {
+	return (
+		<AccordionItem value="matches">
+			<AccordionTrigger>
+				<div className="flex items-center gap-2">
+					<Search className="h-4 w-4 text-muted-foreground" />
+					<span className="text-sm font-medium">Matches</span>
+					<Badge variant="outline" className="font-mono text-2xs">
+						{matches.length}
+					</Badge>
+				</div>
+			</AccordionTrigger>
+			<AccordionContent>
+				{matches.length > 0 ? (
+					<div className="space-y-2">
+						{matches.map((match, mIdx) => (
+							// biome-ignore lint/suspicious/noArrayIndexKey: matches in stable order
+							<Card key={mIdx} density="compact">
+								<CardContent>
+									<div className="flex items-center gap-2">
+										<Badge variant="outline" className="font-mono text-2xs">
+											@{match.index}
+										</Badge>
+										<code className="break-all font-mono text-xs">{match.fullMatch}</code>
+									</div>
+									<MatchGroupList match={match} />
+								</CardContent>
+							</Card>
+						))}
+					</div>
+				) : (
+					<EmbeddedEmptyState
+						icon={Search}
+						title="No matches"
+						description={
+							compiledOk
+								? 'The pattern compiled but found no matches.'
+								: 'Fix the pattern error above to see matches.'
+						}
+					/>
+				)}
+			</AccordionContent>
+		</AccordionItem>
+	);
+}
+
+interface StructureAccordionProps {
+	readonly visualization: Result<VizNode>;
+}
+
+function StructureAccordion({ visualization }: StructureAccordionProps) {
+	return (
+		<AccordionItem value="structure">
+			<AccordionTrigger>
+				<div className="flex items-center gap-2">
+					<GitBranch className="h-4 w-4 text-muted-foreground" />
+					<span className="text-sm font-medium">Structure</span>
+				</div>
+			</AccordionTrigger>
+			<AccordionContent>
+				{visualization.ok ? (
+					<RenderNode node={visualization.value} depth={0} />
+				) : (
+					<p className="text-xs text-destructive">{visualization.error}</p>
+				)}
+			</AccordionContent>
+		</AccordionItem>
+	);
+}
+
+interface ExplainAccordionProps {
+	readonly flags: RegexFlags;
+	readonly flagString: string;
+	readonly captureGroupCount: number;
+	readonly features: readonly FeatureUsage[];
+}
+
+function ExplainAccordion({
+	flags,
+	flagString,
+	captureGroupCount,
+	features,
+}: ExplainAccordionProps) {
+	const activeFlags = FLAG_INFO.filter((info) => flags[info.id]);
+	return (
+		<AccordionItem value="explain">
+			<AccordionTrigger>
+				<div className="flex items-center gap-2">
+					<Info className="h-4 w-4 text-muted-foreground" />
+					<span className="text-sm font-medium">Explain</span>
+				</div>
+			</AccordionTrigger>
+			<AccordionContent>
+				<div className="space-y-3">
+					<Card density="compact">
+						<CardContent>
+							<div className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+								Active flags
+							</div>
+							<div className="mt-1 flex flex-wrap gap-1">
+								{activeFlags.map((info) => (
+									<Badge key={info.id} variant="outline" className="font-mono text-2xs">
+										{info.char} {info.label}
+									</Badge>
+								))}
+								{flagString === '' ? (
+									<span className="text-2xs text-muted-foreground">None enabled</span>
+								) : null}
+							</div>
+						</CardContent>
+					</Card>
+					<Card density="compact">
+						<CardContent>
+							<div className="flex items-center justify-between">
+								<span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+									Capture groups
+								</span>
+								<Badge variant="outline" className="font-mono text-2xs">
+									{captureGroupCount}
+								</Badge>
+							</div>
+						</CardContent>
+					</Card>
+					<Card density="compact">
+						<CardContent>
+							<div className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+								Detected features
+							</div>
+							{features.length > 0 ? (
+								<ul className="mt-1.5 space-y-1">
+									{features.map((feature) => (
+										<li key={feature.token} className="flex items-baseline gap-2 text-2xs">
+											<code className="rounded bg-muted px-1 py-0.5 font-mono">
+												{feature.token}
+											</code>
+											<span className="text-muted-foreground">{feature.description}</span>
+										</li>
+									))}
+								</ul>
+							) : (
+								<p className="mt-1 text-2xs text-muted-foreground">Plain text pattern.</p>
+							)}
+						</CardContent>
+					</Card>
+				</div>
+			</AccordionContent>
+		</AccordionItem>
+	);
+}
+
+interface InlinePreviewProps {
+	readonly segments: readonly Segment[];
+}
+
+function InlinePreview({ segments }: InlinePreviewProps) {
+	return (
+		<div>
+			<div className="mb-1.5 text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+				Inline preview
+			</div>
+			<pre className="whitespace-pre-wrap break-all rounded-md border bg-muted p-3 font-mono text-sm">
+				{segments.map((seg, idx) => (
+					// biome-ignore lint/suspicious/noArrayIndexKey: segments are stable
+					<PreviewSegment key={idx} seg={seg} />
+				))}
+			</pre>
+		</div>
+	);
+}
+
+interface PreviewSegmentProps {
+	readonly seg: Segment;
+}
+
+function PreviewSegment({ seg }: PreviewSegmentProps) {
+	if (seg.matchIndex >= 0 && seg.groupIndex > 0) {
+		return <span className={cn('rounded px-0.5', groupColor(seg.groupIndex).bg)}>{seg.text}</span>;
+	}
+	if (seg.matchIndex >= 0) {
+		return <span className={cn('rounded px-0.5', matchBackdropColor)}>{seg.text}</span>;
+	}
+	return <span>{seg.text}</span>;
+}
+
+interface ReplaceCardProps {
+	readonly replaceEnabled: boolean;
+	readonly onToggle: () => void;
+	readonly replacement: string;
+	readonly onReplacementChange: (value: string) => void;
+	readonly replaceResult: Result<string>;
+	readonly replaceSegments: readonly Segment[];
+}
+
+function ReplaceCard({
+	replaceEnabled,
+	onToggle,
+	replacement,
+	onReplacementChange,
+	replaceResult,
+	replaceSegments,
+}: ReplaceCardProps) {
+	return (
+		<Card density="compact">
+			<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
+				<div className="flex items-center gap-2">
+					<Sparkles className="h-4 w-4 text-muted-foreground" />
+					<CardTitle className="text-sm font-medium">Replace</CardTitle>
+				</div>
+				<Button
+					variant={replaceEnabled ? 'default' : 'outline'}
+					size="sm"
+					className="h-7"
+					onClick={onToggle}
+				>
+					{replaceEnabled ? 'On' : 'Off'}
+				</Button>
+			</CardHeader>
+			<CardContent className="space-y-3">
+				{replaceEnabled ? (
+					<ReplaceCardBody
+						replacement={replacement}
+						onReplacementChange={onReplacementChange}
+						replaceResult={replaceResult}
+						replaceSegments={replaceSegments}
+					/>
+				) : (
+					<p className="text-sm text-muted-foreground">
+						Toggle the switch above to apply a replacement to the test text.
+					</p>
+				)}
+			</CardContent>
+		</Card>
+	);
+}
+
+interface ReplaceCardBodyProps {
+	readonly replacement: string;
+	readonly onReplacementChange: (value: string) => void;
+	readonly replaceResult: Result<string>;
+	readonly replaceSegments: readonly Segment[];
+}
+
+function ReplaceCardBody({
+	replacement,
+	onReplacementChange,
+	replaceResult,
+	replaceSegments,
+}: ReplaceCardBodyProps) {
+	return (
+		<>
+			<FormTextarea
+				label="Replacement"
+				value={replacement}
+				onValueChange={onReplacementChange}
+				placeholder="$1 [at] $2"
+				hint="Use $1, $2... for positional groups; $<name> for named groups; $& for the full match."
+				rows={2}
+				className="font-mono text-sm"
+			/>
+			{replaceResult.ok ? (
+				<>
+					<div>
+						<div className="mb-1.5 text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+							Result
+						</div>
+						<pre className="overflow-auto whitespace-pre-wrap break-all rounded-md border bg-muted p-3 font-mono text-sm">
+							{replaceSegments.map((seg, idx) => (
+								// biome-ignore lint/suspicious/noArrayIndexKey: segments are stable
+								<span key={idx}>{seg.text}</span>
+							))}
+						</pre>
+					</div>
+					<div className="flex justify-end">
+						<CopyButton text={replaceResult.value} toastLabel="Result" size="sm" />
+					</div>
+				</>
+			) : (
+				<p className="text-sm text-destructive">{replaceResult.error}</p>
+			)}
+		</>
 	);
 }
 
@@ -336,20 +669,7 @@ function RegexTesterPage() {
 						</div>
 						<div className="flex flex-wrap items-center gap-2 text-xs">
 							<output aria-live="polite" aria-atomic="true" className="contents">
-								{validity === 'empty' ? (
-									<Badge variant="outline" className="text-muted-foreground">
-										empty
-									</Badge>
-								) : compiled.ok ? (
-									<Badge variant="outline" className="bg-success/10 text-success">
-										<Check className="mr-1 h-3 w-3" aria-hidden="true" /> valid
-									</Badge>
-								) : (
-									<Badge variant="outline" className="bg-destructive/10 text-destructive">
-										<X className="mr-1 h-3 w-3" aria-hidden="true" />
-										{compiled.error}
-									</Badge>
-								)}
+								<ValidityBadge state={validity} error={errorMessage} />
 							</output>
 							<Badge variant="outline">
 								{captureGroupCount} capture group{captureGroupCount === 1 ? '' : 's'}
@@ -427,273 +747,30 @@ function RegexTesterPage() {
 									rows={6}
 									className="font-mono text-sm"
 								/>
-								{matches.length > 0 || testText ? (
-									<div>
-										<div className="mb-1.5 text-2xs font-medium uppercase tracking-wide text-muted-foreground">
-											Inline preview
-										</div>
-										<pre className="whitespace-pre-wrap break-all rounded-md border bg-muted p-3 font-mono text-sm">
-											{segments.map((seg, idx) =>
-												seg.matchIndex >= 0 && seg.groupIndex > 0 ? (
-													<span
-														// biome-ignore lint/suspicious/noArrayIndexKey: segments are stable
-														key={idx}
-														className={cn('rounded px-0.5', groupColor(seg.groupIndex).bg)}
-													>
-														{seg.text}
-													</span>
-												) : seg.matchIndex >= 0 ? (
-													<span
-														// biome-ignore lint/suspicious/noArrayIndexKey: segments are stable
-														key={idx}
-														className={cn('rounded px-0.5', matchBackdropColor)}
-													>
-														{seg.text}
-													</span>
-												) : (
-													// biome-ignore lint/suspicious/noArrayIndexKey: segments are stable
-													<span key={idx}>{seg.text}</span>
-												)
-											)}
-										</pre>
-									</div>
-								) : null}
+								{matches.length > 0 || testText ? <InlinePreview segments={segments} /> : null}
 							</CardContent>
 						</Card>
 
-						<Card density="compact">
-							<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
-								<div className="flex items-center gap-2">
-									<Sparkles className="h-4 w-4 text-muted-foreground" />
-									<CardTitle className="text-sm font-medium">Replace</CardTitle>
-								</div>
-								<Button
-									variant={replaceEnabled ? 'default' : 'outline'}
-									size="sm"
-									className="h-7"
-									onClick={() => setReplaceEnabled((v) => !v)}
-								>
-									{replaceEnabled ? 'On' : 'Off'}
-								</Button>
-							</CardHeader>
-							<CardContent className="space-y-3">
-								{replaceEnabled ? (
-									<>
-										<FormTextarea
-											label="Replacement"
-											value={replacement}
-											onValueChange={setReplacement}
-											placeholder="$1 [at] $2"
-											hint="Use $1, $2... for positional groups; $<name> for named groups; $& for the full match."
-											rows={2}
-											className="font-mono text-sm"
-										/>
-										{replaceResult.ok ? (
-											<>
-												<div>
-													<div className="mb-1.5 text-2xs font-medium uppercase tracking-wide text-muted-foreground">
-														Result
-													</div>
-													<pre className="overflow-auto whitespace-pre-wrap break-all rounded-md border bg-muted p-3 font-mono text-sm">
-														{replaceSegments.map((seg, idx) => (
-															// biome-ignore lint/suspicious/noArrayIndexKey: segments are stable
-															<span key={idx}>{seg.text}</span>
-														))}
-													</pre>
-												</div>
-												<div className="flex justify-end">
-													<CopyButton text={replaceResult.value} toastLabel="Result" size="sm" />
-												</div>
-											</>
-										) : (
-											<p className="text-sm text-destructive">{replaceResult.error}</p>
-										)}
-									</>
-								) : (
-									<p className="text-sm text-muted-foreground">
-										Toggle the switch above to apply a replacement to the test text.
-									</p>
-								)}
-							</CardContent>
-						</Card>
+						<ReplaceCard
+							replaceEnabled={replaceEnabled}
+							onToggle={() => setReplaceEnabled((v) => !v)}
+							replacement={replacement}
+							onReplacementChange={setReplacement}
+							replaceResult={replaceResult}
+							replaceSegments={replaceSegments}
+						/>
 					</div>
 
 					<div className="w-[var(--rail-w-wide)] shrink-0 overflow-auto border-l bg-surface-2 p-4">
 						<Accordion type="multiple" defaultValue={['matches', 'explain']} className="w-full">
-							<AccordionItem value="matches">
-								<AccordionTrigger>
-									<div className="flex items-center gap-2">
-										<Search className="h-4 w-4 text-muted-foreground" />
-										<span className="text-sm font-medium">Matches</span>
-										<Badge variant="outline" className="font-mono text-2xs">
-											{matches.length}
-										</Badge>
-									</div>
-								</AccordionTrigger>
-								<AccordionContent>
-									{matches.length > 0 ? (
-										<div className="space-y-2">
-											{matches.map((match, mIdx) => (
-												// biome-ignore lint/suspicious/noArrayIndexKey: matches in stable order
-												<Card key={mIdx} density="compact">
-													<CardContent>
-														<div className="flex items-center gap-2">
-															<Badge variant="outline" className="font-mono text-2xs">
-																@{match.index}
-															</Badge>
-															<code className="break-all font-mono text-xs">{match.fullMatch}</code>
-														</div>
-														{match.groups.length > 0 ? (
-															<div className="mt-1.5 space-y-1">
-																{match.groups.map((group, gIdx) => {
-																	const color = groupColor(gIdx + 1);
-																	return (
-																		<div
-																			// biome-ignore lint/suspicious/noArrayIndexKey: groups in stable order
-																			key={gIdx}
-																			className="flex items-baseline gap-2 text-2xs"
-																		>
-																			<Badge
-																				className={cn(
-																					'font-mono',
-																					color.bgSoft,
-																					color.text,
-																					color.border
-																				)}
-																			>
-																				${gIdx + 1}
-																			</Badge>
-																			<code className="break-all font-mono text-muted-foreground">
-																				{group.value || '∅'}
-																			</code>
-																		</div>
-																	);
-																})}
-															</div>
-														) : null}
-														{Object.keys(match.namedGroups).length > 0 ? (
-															<div className="mt-1.5 space-y-1">
-																{Object.entries(match.namedGroups).map(([name, group], nIdx) => {
-																	const color = groupColor(nIdx + 1);
-																	return (
-																		<div key={name} className="flex items-baseline gap-2 text-2xs">
-																			<Badge
-																				className={cn(
-																					'font-mono',
-																					color.bgSoft,
-																					color.text,
-																					color.border
-																				)}
-																			>
-																				{name}
-																			</Badge>
-																			<code className="break-all font-mono text-muted-foreground">
-																				{group.value || '∅'}
-																			</code>
-																		</div>
-																	);
-																})}
-															</div>
-														) : null}
-													</CardContent>
-												</Card>
-											))}
-										</div>
-									) : (
-										<EmbeddedEmptyState
-											icon={Search}
-											title="No matches"
-											description={
-												compiled.ok
-													? 'The pattern compiled but found no matches.'
-													: 'Fix the pattern error above to see matches.'
-											}
-										/>
-									)}
-								</AccordionContent>
-							</AccordionItem>
-
-							<AccordionItem value="structure">
-								<AccordionTrigger>
-									<div className="flex items-center gap-2">
-										<GitBranch className="h-4 w-4 text-muted-foreground" />
-										<span className="text-sm font-medium">Structure</span>
-									</div>
-								</AccordionTrigger>
-								<AccordionContent>
-									{visualization.ok ? (
-										<RenderNode node={visualization.value} depth={0} />
-									) : (
-										<p className="text-xs text-destructive">{visualization.error}</p>
-									)}
-								</AccordionContent>
-							</AccordionItem>
-
-							<AccordionItem value="explain">
-								<AccordionTrigger>
-									<div className="flex items-center gap-2">
-										<Info className="h-4 w-4 text-muted-foreground" />
-										<span className="text-sm font-medium">Explain</span>
-									</div>
-								</AccordionTrigger>
-								<AccordionContent>
-									<div className="space-y-3">
-										<Card density="compact">
-											<CardContent>
-												<div className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
-													Active flags
-												</div>
-												<div className="mt-1 flex flex-wrap gap-1">
-													{FLAG_INFO.filter((info) => flags[info.id]).map((info) => (
-														<Badge key={info.id} variant="outline" className="font-mono text-2xs">
-															{info.char} {info.label}
-														</Badge>
-													))}
-													{flagString === '' ? (
-														<span className="text-2xs text-muted-foreground">None enabled</span>
-													) : null}
-												</div>
-											</CardContent>
-										</Card>
-										<Card density="compact">
-											<CardContent>
-												<div className="flex items-center justify-between">
-													<span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
-														Capture groups
-													</span>
-													<Badge variant="outline" className="font-mono text-2xs">
-														{captureGroupCount}
-													</Badge>
-												</div>
-											</CardContent>
-										</Card>
-										<Card density="compact">
-											<CardContent>
-												<div className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
-													Detected features
-												</div>
-												{features.length > 0 ? (
-													<ul className="mt-1.5 space-y-1">
-														{features.map((feature) => (
-															<li
-																key={feature.token}
-																className="flex items-baseline gap-2 text-2xs"
-															>
-																<code className="rounded bg-muted px-1 py-0.5 font-mono">
-																	{feature.token}
-																</code>
-																<span className="text-muted-foreground">{feature.description}</span>
-															</li>
-														))}
-													</ul>
-												) : (
-													<p className="mt-1 text-2xs text-muted-foreground">Plain text pattern.</p>
-												)}
-											</CardContent>
-										</Card>
-									</div>
-								</AccordionContent>
-							</AccordionItem>
+							<MatchesAccordion matches={matches} compiledOk={compiled.ok} />
+							<StructureAccordion visualization={visualization} />
+							<ExplainAccordion
+								flags={flags}
+								flagString={flagString}
+								captureGroupCount={captureGroupCount}
+								features={features}
+							/>
 						</Accordion>
 					</div>
 				</div>


### PR DESCRIPTION
## Summary

Closes the post-migration follow-up backlog flagged in PR #262 / #263:

- **ValidityBadge** primitive expresses the trichotomy (`empty` / `valid` / `invalid`) and surfaces an optional error string.
- **SectionLabel** primitive drops its deprecated `title` prop.
- **Cognitive complexity** warnings reduced on four targeted files via child-component extraction.

No behavioral changes; pure refactor.

## Changes

### Refactored

- `ValidityBadge` accepts `state: 'empty' | 'valid' | 'invalid'` + optional `error?` string. The legacy `valid: boolean | null` form is preserved for `StatusBar` backward compatibility.
- `SectionLabel` props reduced to `icon?` / `iconClass?` / `className?` / `children`. Three remaining `title=` call sites in `unified-host-detail-panel.tsx` migrated to children form.
- `UnifiedHostDetailPanel` split into `OverviewTab`, `PortsTab`, `DiscoveryTab`, `ServicesTab`, plus `HostDetailHeader`, `OpenPortCard`, and a dozen smaller section components.
- `RegexTesterPage` extracts `MatchesAccordion`, `StructureAccordion`, `ExplainAccordion`, `InlinePreview`, and `ReplaceCard`. Inline `<Badge>` trichotomy migrated to `<ValidityBadge state={validity} error={errorMessage} />`.
- `NetworkScannerPage` extracts `TargetSection`, `HostDiscoverySection`, `PortScanSection`, `DiscoveryProgressPanel`, `ScanProgressPanel`, `HostListPane`, `HostDetailOrEmpty`, `MainContent`, and several pure helpers (`formatProgressText`, `resolveKeydownIndex`, `pickAutoFillInterface`, `createDiscoveryChannelHandler`).
- `json/format-tab.tsx` extracts a top-level `computeFormattedOutput` helper plus a `buildFormatTransforms` pipeline.

## Test plan

- [x] `bun run check` passes
- [x] `bun run lint` passes (warnings allowed on untargeted files; targeted files dropped below threshold)
- [x] `bun run format:check` passes
- [x] No `let` introduced (project policy)
- [ ] Smoke verify Regex Tester validity badge and Network Scanner detail tabs
