### PR TITLE
fix(tauri)(release): point frontendDist at Vite's dist/

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
 		"beforeDevCommand": "bun run dev",
 		"devUrl": "http://localhost:1420",
 		"beforeBuildCommand": "bun run build",
-		"frontendDist": "../build"
+		"frontendDist": "../dist"
 	},
 	"app": {
 		"withGlobalTauri": true,


### PR DESCRIPTION
## Summary

Hotfix for the Release workflow which has been failing on every push to `main` since PR #262 (React migration).

## Root cause

`src-tauri/tauri.conf.json` still referenced the SvelteKit-era output directory:

```jsonc
"frontendDist": "../build"
```

The React port replaces SvelteKit with Vite, which writes its build output to `dist/` (not `build/`). The `Release` workflow runs `tauri build`, which inspects `frontendDist` to bundle web assets into the desktop binary — and aborted with:

```
Error Unable to find your web assets, did you forget to build your web app?
Your frontendDist is set to "../build" (which is `.../build`).
```

This affected every Release run since the migration merged (PR #262 → #263 → #264 all show the same Release failure).

## Fix

Point `frontendDist` at `../dist`. No other config changes; `beforeBuildCommand` (`bun run build`) and `devUrl` (`http://localhost:1420`) stay as-is.

## Test plan

- [x] `bun run check` passes (no impact — config file only)
- [ ] Confirm Release workflow turns green after merge
