### PR TITLE
fix(tsconfig): include react/react-dom types and src/**/*.ts

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,13 +29,13 @@
 		"sourceMap": true,
 
 		"lib": ["ES2023", "DOM", "DOM.Iterable"],
-		"types": ["vite/client", "@testing-library/jest-dom", "bun-types"],
+		"types": ["vite/client", "@testing-library/jest-dom", "bun-types", "react", "react-dom"],
 
 		"paths": {
 			"@/*": ["./src/*"],
 			"@lib/*": ["./src/lib/*"]
 		}
 	},
-	"include": ["src/**/*.tsx", "src/route-tree.gen.ts", "vite.config.ts"],
+	"include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"],
 	"exclude": ["node_modules", "src-tauri/target", "dist"]
 }


### PR DESCRIPTION
## Summary

Resolves two tsserver-visibility issues that affect editor diagnostics in Zed (and VS Code by extension) without surfacing in `bun run check`.

## Defect 1 — ts2875 `react/jsx-runtime` not found

`compilerOptions.types` previously listed only `["vite/client", "@testing-library/jest-dom", "bun-types"]`. When `types` is explicitly populated, TypeScript stops auto-loading other `@types/*` packages — including `@types/react`. Editor tsservers raise ts2875 against every `.tsx` file because the synthetic `react/jsx-runtime` import added by `jsx: "react-jsx"` has nowhere to resolve.

`tsc` itself resolves jsx-runtime through the `jsx: react-jsx` code path independently of `types`, so `bun run check` stayed green and the regression slipped past CI.

**Fix**: add `"react"` and `"react-dom"` to the `types` array. Preserves the existing curated list (excludes `@types/node` to keep Bun globals correct).

## Defect 2 — `include` did not cover `src/**/*.ts`

`include` matched only `src/**/*.tsx` + `src/route-tree.gen.ts` + `vite.config.ts`. Service / store / hook / util `.ts` files were pulled in transitively via imports at compile time, but the language server treated them as external and didn't project-scope diagnostics correctly.

**Fix**: replace with `["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"]` so both .ts and .tsx are first-class project files.

## Test plan

- [x] `bun run check` passes (no runtime impact)
- [ ] Zed: ts2875 disappears on every `.tsx` file
- [ ] Zed: project-scoped diagnostics work in `src/lib/services/*.ts` etc.
