### PR TITLE
fix(react)(layout): unlock body pointer-events when Radix leaks scroll-lock

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -131,11 +131,42 @@ function RootLayout() {
 		};
 		document.addEventListener('contextmenu', handleContextMenu, { capture: true });
 
+		// Radix UI's RemoveScroll (used by Select/Dialog/Popover/etc.) sets
+		// `document.body.style.pointer-events = 'none'` while open and clears it on
+		// close. When two overlays open simultaneously, or when an overlay unmounts
+		// before its cleanup effect fires (HMR, route change, double-open during
+		// navigation), the inline style leaks and every subsequent click on the
+		// page below is blocked. Watch the body's inline style: whenever it locks
+		// but no Radix overlay is currently open, clear it.
+		const radixOpenSelector =
+			'[data-state="open"][role="dialog"], ' +
+			'[data-state="open"][data-slot="popover-content"], ' +
+			'[data-state="open"][data-slot="select-content"], ' +
+			'[data-state="open"][data-slot="dropdown-menu-content"], ' +
+			'[data-state="open"][data-slot="context-menu-content"], ' +
+			'[data-state="open"][data-slot="tooltip-content"], ' +
+			'[data-state="open"][data-slot="hover-card-content"]';
+		const unlockBodyIfStuck = () => {
+			if (document.body.style.pointerEvents !== 'none') return;
+			if (document.querySelector(radixOpenSelector)) return;
+			document.body.style.pointerEvents = '';
+		};
+		const bodyStyleObserver = new MutationObserver(() => {
+			// Defer one frame so Radix's own cleanup (which fires synchronously in
+			// the same tick) wins when the dismissal is legitimate.
+			requestAnimationFrame(unlockBodyIfStuck);
+		});
+		bodyStyleObserver.observe(document.body, {
+			attributes: true,
+			attributeFilter: ['style'],
+		});
+
 		return () => {
 			window.removeEventListener('open-shortcuts-help', handleOpenShortcutsHelp);
 			window.removeEventListener('reset-all-settings', handleResetFromPalette);
 			unlistenMenuResetPromise.then((unlisten) => unlisten?.()).catch(() => {});
 			document.removeEventListener('contextmenu', handleContextMenu, { capture: true });
+			bodyStyleObserver.disconnect();
 		};
 	}, [handleResetAllSettings]);
 


### PR DESCRIPTION
## Summary

Defensive fix for a Radix UI body scroll-lock leak that makes Select / Command / Popover items appear unclickable with the mouse.

## Symptom

User reports "Select / Command でマウス操作ができません" (cannot operate Select / Command with the mouse). Mouse interaction stops responding after some overlay-heavy navigation.

## Root cause

Radix UI's `RemoveScroll` primitive (used internally by `Select`, `Dialog`, `Popover`, `DropdownMenu`, `ContextMenu`, etc.) sets `document.body.style.pointer-events = 'none'` while an overlay is open and clears it on close.

When **two overlays open simultaneously**, or when an overlay **unmounts before its cleanup effect fires** (HMR re-render, route change during open, rapid double-open during navigation), the inline style leaks. Because CSS `pointer-events` cascades to descendants, every subsequent click on the page below is silently blocked — looking exactly like "the buttons stopped working".

Verified live in dev via Tauri MCP: walked up the DOM from a `role="listbox"` host-list row that wouldn't accept clicks, and confirmed every ancestor up to `<body>` resolved `pointer-events: none`, with the leak originating from `body { pointer-events: none }` set as an inline style — even though no overlay was currently open.

## Fix

Add a `MutationObserver` in `__root.tsx` that watches `document.body`'s inline style:

1. When the body style mutates and `pointer-events` is `none`...
2. ...defer one animation frame (so Radix's legitimate cleanup wins for proper dismissals)...
3. ...then check if any `[data-state="open"]` overlay still exists (`role="dialog"` + `data-slot` for `popover-content` / `select-content` / `dropdown-menu-content` / `context-menu-content` / `tooltip-content` / `hover-card-content`).
4. If nothing is genuinely open, clear `body.style.pointerEvents`.

The defer is critical — it lets Radix's own cleanup callback (which runs synchronously in the same tick) win when the dismissal is legitimate; only the stuck-open case triggers our defensive clear.

## Test plan

- [x] `bun run check` passes (no behavioral change to type contract)
- [x] Forcing `document.body.style.pointerEvents = 'none'` with no open Radix overlay → cleared within a frame
- [x] Opening a legitimate Select → `body.style.pointerEvents = 'none'` stays as long as the Select is open
- [ ] Smoke verify that mouse clicks on Select Items / Command palette entries work consistently across rapid navigation
