### PR TITLE
fix: restore mouse interaction on Select dropdowns and Title Bar Command

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,7 @@ mod network;
 mod settings;
 
 use tauri::Manager;
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use tauri_plugin_decorum::WebviewWindowExt;
 
 use ast::{AstLanguage, AstParseResult};
@@ -399,23 +400,28 @@ pub fn run() {
         .manage(WorkerProcessState::new())
         .manage(NetworkScannerState::new())
         .setup(|app| {
-            let main_window = app
-                .get_webview_window("main")
-                .ok_or("Failed to get main window")?;
-
             // Windows: enable Snap Layout support via the decorum overlay titlebar.
             // The same call on macOS injects transparent <div data-tauri-drag-region>
             // overlays at the top of the document body, which sit above any in-flow
             // titlebar UI (e.g. the Command search input) and intercept clicks for
             // window drag, leaving controls unfocusable. macOS gets a fully native
             // overlay titlebar via tauri.conf.json's `titleBarStyle: "Overlay"`, so
-            // the decorum overlay is unnecessary and actively harmful there.
-            #[cfg(target_os = "windows")]
-            main_window.create_overlay_titlebar()?;
+            // the decorum overlay is unnecessary and actively harmful there. Linux
+            // needs neither call, so the `main_window` handle is only bound on
+            // platforms that consume it.
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
+            {
+                let main_window = app
+                    .get_webview_window("main")
+                    .ok_or("Failed to get main window")?;
 
-            // macOS: position traffic lights centered in 32px (h-8) title bar.
-            #[cfg(target_os = "macos")]
-            main_window.set_traffic_lights_inset(12.0, 10.0)?;
+                #[cfg(target_os = "windows")]
+                main_window.create_overlay_titlebar()?;
+
+                // macOS: position traffic lights centered in 32px (h-8) title bar.
+                #[cfg(target_os = "macos")]
+                main_window.set_traffic_lights_inset(12.0, 10.0)?;
+            }
 
             // Initialize settings from config directory
             let config_dir = app

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -403,10 +403,17 @@ pub fn run() {
                 .get_webview_window("main")
                 .ok_or("Failed to get main window")?;
 
-            // Create overlay titlebar (handles Windows snap layout)
+            // Windows: enable Snap Layout support via the decorum overlay titlebar.
+            // The same call on macOS injects transparent <div data-tauri-drag-region>
+            // overlays at the top of the document body, which sit above any in-flow
+            // titlebar UI (e.g. the Command search input) and intercept clicks for
+            // window drag, leaving controls unfocusable. macOS gets a fully native
+            // overlay titlebar via tauri.conf.json's `titleBarStyle: "Overlay"`, so
+            // the decorum overlay is unnecessary and actively harmful there.
+            #[cfg(target_os = "windows")]
             main_window.create_overlay_titlebar()?;
 
-            // macOS: position traffic lights centered in 32px (h-8) title bar
+            // macOS: position traffic lights centered in 32px (h-8) title bar.
             #[cfg(target_os = "macos")]
             main_window.set_traffic_lights_inset(12.0, 10.0)?;
 

--- a/src/lib/components/ui/select.tsx
+++ b/src/lib/components/ui/select.tsx
@@ -57,14 +57,13 @@ SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 const SelectContent = React.forwardRef<
 	React.ElementRef<typeof SelectPrimitive.Content>,
 	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = 'item-aligned', align = 'center', ...props }, ref) => (
+>(({ className, children, position = 'popper', align = 'center', ...props }, ref) => (
 	<SelectPrimitive.Portal>
 		<SelectPrimitive.Content
 			ref={ref}
 			data-slot="select-content"
-			data-align-trigger={position === 'item-aligned'}
 			className={cn(
-				'relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+				'relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
 				position === 'popper' &&
 					'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
 				className
@@ -75,10 +74,9 @@ const SelectContent = React.forwardRef<
 		>
 			<SelectScrollUpButton />
 			<SelectPrimitive.Viewport
-				data-position={position}
 				className={cn(
-					'data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)',
-					position === 'popper' && ''
+					position === 'popper' &&
+						'h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width) scroll-my-1'
 				)}
 			>
 				{children}


### PR DESCRIPTION
## Summary

Restores mouse interaction on two UI surfaces that broke during the
Svelte → React migration (PR #262 and follow-ups). Both bugs only
surfaced on macOS, both made affected controls keyboard-only, and both
were traced to deviations from the official upstream defaults.

| # | Surface | Root cause | Fix |
|---|---------|-----------|-----|
| 1 | `<Select>` dropdowns (every page) | `SelectContent` defaulted to Radix's legacy `position="item-aligned"`, leaving the wrapper with `position: fixed` but no `top`/`left`/`transform`; menus pinned to the bottom-left corner of the document, off-screen. | Default to `position="popper"` to match the official shadcn/ui radix variant; the wrapper now picks up a real `transform: translate(x, y)` from `@floating-ui` via Radix's popper primitive. |
| 2 | Title Bar Command search field | `tauri-plugin-decorum::create_overlay_titlebar()` injected two transparent `<div data-tauri-drag-region>` overlays into the body on macOS, stacked above the in-flow `<input>`. They absorbed mousedown events as window-drag input. | Guard the call with `#[cfg(target_os = "windows")]` — macOS already gets a native overlay titlebar from `titleBarStyle: "Overlay"` in `tauri.conf.json` plus `set_traffic_lights_inset`. The Windows snap-layout support that originally motivated the call is preserved. |

## Symptoms (as reported)

- Mouse click on `<Select>` triggers: nothing visible happened, dropdown never appeared.
- Mouse click on Title Bar Command (`Search pages...`): nothing happened.
- Cmd+K still opened the Command palette (window-level keydown bypasses both bugs).
- Once the palette was open via Cmd+K, mouse interaction inside it also seemed dead.

## Diagnosis

### Select dropdowns

Live DOM probe via Tauri MCP `webview_execute_js`, capturing snapshots inside capture-phase pointer listeners:

Before fix — wrapper inline style for an opened `SelectContent`:

```
position: fixed; z-index: 50; display: flex; flex-direction: column;
```

Note the absence of `top`, `left`, and `transform`. The wrapper resolved to `rect: (0, 1135, 198, 96)` in a 1135px-tall viewport — pinned to the body-flow end, fully off-screen for triggers anywhere except the bottom-left.

After fix — same wrapper:

```
position: fixed; left: 0px; top: 0px;
transform: translate(272px, 275px);
--radix-popper-transform-origin: 50% 0px;
z-index: 50;
--radix-popper-available-width: 1899px;
```

The dropdown anchors at `(272, 275)`, directly below the trigger which sat at `(272, 243, 255, 32)`.

### Title Bar Command

`document.elementsFromPoint(986, 16)` at the input center returned the following z-stack from top to bottom:

```
[0] <div data-tauri-drag-region class="">                     // decorum injection #1
[1] <div style="position: fixed; z-index: 100; …" class="">   // decorum injection #2
[2] <input role="combobox" id="radix-_r_7_">                  // the actual input
[3] <div class="flex h-6 items-center gap-2 …">               // the input wrapper
[4] <div class="overflow-visible bg-transparent">             // the Command primitive
[5] <div class="relative w-full max-w-md">                    // the container
[6] <header data-tauri-drag-region class="…">                 // our titlebar
```

The user-facing `<input>` sat under two decorum overlays. The CSS rule `[data-tauri-drag-region] input { -webkit-app-region: no-drag }` does not help because the input is not a descendant of the overlay divs — they are sibling fixed/static elements painted above the input.

The user's first symptom test ("ちなみにキーボードでも操作できませんでした") was likely the secondary fallout: clicking the input did not focus it, so `setOpen(true)` never fired in `title-bar-command.tsx`, so the dropdown never opened and there was nothing to keyboard-navigate.

## Why these fixes are appropriate

- **Select**: aligns with the official shadcn/ui radix variant default. The official primitive at `apps/v4/content/docs/components/radix/select.mdx` recommends `position="popper"`; the rule library at `skills/shadcn/rules/base-vs-radix.md` explicitly states that the Radix variant "utilizes a `position` prop, typically set to `popper`". This restores parity, not a workaround.
- **Tauri**: the original `create_overlay_titlebar()` call carried a comment explaining its purpose: "handles Windows snap layout". The macOS side-effect (overlay div injection) was never required — `titleBarStyle: "Overlay"` in `tauri.conf.json` and `set_traffic_lights_inset` together give us the full custom overlay treatment natively. The `#[cfg(target_os = "windows")]` guard keeps the original Windows behavior.

## Test plan

- [x] `bun run check` — passes (TypeScript + Biome + `validate-pages` + `audit-design`)
- [x] `cargo check` — passes (3m 21s, clean)
- [x] Pre-commit hooks (`lefthook`): frontend-lint, frontend-format, backend-lint (clippy), backend-format — all green
- [x] Live verification on macOS (Tauri dev, WKWebView): Variant Select opens directly below trigger
- [x] Live verification on macOS: Line Break Select opens directly below trigger
- [x] Live verification on macOS: Title Bar Command opens when clicked with the mouse
- [ ] Windows smoke (snap-layout intact) — to be exercised on next Windows build
