### PR TITLE
fix(ui): six post-migration bug fixes (Phase A of UI polish)

### DIFF
--- a/src/lib/components/editor/code/code-editor.tsx
+++ b/src/lib/components/editor/code/code-editor.tsx
@@ -182,7 +182,7 @@ function ViewToggle({ viewMode, canShowTree, editorMode, onChange }: ViewToggleP
 				value="code"
 				aria-label="Code View"
 				title="Code View"
-				className="h-6 w-6 rounded p-0 data-[state=on]:bg-background data-[state=on]:shadow-sm"
+				className="h-6 w-6 rounded p-0 aria-pressed:bg-background aria-pressed:shadow-sm"
 			>
 				<CodeIcon className="h-3.5 w-3.5" />
 			</ToggleGroupItem>
@@ -191,7 +191,7 @@ function ViewToggle({ viewMode, canShowTree, editorMode, onChange }: ViewToggleP
 				aria-label="Split View"
 				title="Split View"
 				disabled={!canShowTree}
-				className="h-6 w-6 rounded p-0 data-[state=on]:bg-background data-[state=on]:shadow-sm"
+				className="h-6 w-6 rounded p-0 aria-pressed:bg-background aria-pressed:shadow-sm"
 			>
 				<Columns2 className="h-3.5 w-3.5" />
 			</ToggleGroupItem>
@@ -200,7 +200,7 @@ function ViewToggle({ viewMode, canShowTree, editorMode, onChange }: ViewToggleP
 				aria-label="Tree View"
 				title="Tree View"
 				disabled={!canShowTree}
-				className="h-6 w-6 rounded p-0 data-[state=on]:bg-background data-[state=on]:shadow-sm"
+				className="h-6 w-6 rounded p-0 aria-pressed:bg-background aria-pressed:shadow-sm"
 			>
 				<ListTree className="h-3.5 w-3.5" />
 			</ToggleGroupItem>

--- a/src/lib/components/ui/dialog.tsx
+++ b/src/lib/components/ui/dialog.tsx
@@ -29,7 +29,7 @@ function DialogOverlay({
 		<DialogPrimitive.Overlay
 			data-slot="dialog-overlay"
 			className={cn(
-				'fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
+				'fixed inset-0 isolate z-50 bg-black/50 duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
 				className
 			)}
 			{...props}

--- a/src/lib/components/ui/list-item-button.tsx
+++ b/src/lib/components/ui/list-item-button.tsx
@@ -57,6 +57,7 @@ export function ListItemButton({
 	wrap = false,
 	type = 'button',
 	role,
+	tabIndex,
 	children,
 	style,
 	...rest
@@ -65,12 +66,20 @@ export function ListItemButton({
 		variant === 'tree-node' && depth > 0 ? { paddingLeft: `${depth * 12}px`, ...style } : style;
 
 	// aria-selected only applies to roles that support it (option, treeitem, etc.).
-	const ariaSelected = role === 'option' || role === 'treeitem' ? selected : undefined;
+	const isComposite = role === 'option' || role === 'treeitem';
+	const ariaSelected = isComposite ? selected : undefined;
+
+	// Composite-widget children (listbox option, tree item) participate in their
+	// parent's keyboard model — the container holds the single tab stop and
+	// handles arrow navigation. Default tabIndex to -1 so Tab does not stop on
+	// every child; allow the caller to override when needed.
+	const resolvedTabIndex = tabIndex ?? (isComposite ? -1 : undefined);
 
 	return (
 		<button
 			type={type}
 			role={role}
+			tabIndex={resolvedTabIndex}
 			data-slot="list-item-button"
 			data-selected={selected}
 			aria-selected={ariaSelected}

--- a/src/lib/components/ui/resizable.tsx
+++ b/src/lib/components/ui/resizable.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as ResizablePrimitive from 'react-resizable-panels';
+import { GripVerticalIcon } from 'lucide-react';
 
 import { cn } from '@/lib/utils/index';
 
@@ -39,7 +40,11 @@ const ResizableHandle = React.forwardRef<
 		)}
 		{...props}
 	>
-		{withHandle && <div className="z-10 flex h-6 w-1 shrink-0 rounded-lg bg-border" />}
+		{withHandle && (
+			<div className="z-10 flex h-4 w-3 items-center justify-center rounded-xs border bg-border">
+				<GripVerticalIcon className="size-2.5" />
+			</div>
+		)}
 	</ResizablePrimitive.Separator>
 ));
 ResizableHandle.displayName = ResizablePrimitive.Separator.displayName;

--- a/src/lib/components/ui/tabs.tsx
+++ b/src/lib/components/ui/tabs.tsx
@@ -66,10 +66,18 @@ function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPr
 }
 
 function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+	// Radix sets `tabIndex={0}` on TabsContent when its subtree has no focusable
+	// element, so the panel itself can receive keyboard focus. `outline-none`
+	// alone leaves that focus invisible. Pair it with a `focus-visible:` ring so
+	// keyboard users still see where focus is. Matches the focus-ring tokens used
+	// across the project's other primitives.
 	return (
 		<TabsPrimitive.Content
 			data-slot="tabs-content"
-			className={cn('flex-1 text-sm outline-none', className)}
+			className={cn(
+				'flex-1 rounded-md text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+				className
+			)}
 			{...props}
 		/>
 	);

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -141,7 +141,7 @@ function RootLayout() {
 
 	return (
 		<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-			<Toaster richColors />
+			<Toaster />
 			<KeyboardShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
 			<TooltipProvider delayDuration={150}>
 				<div className="flex h-screen flex-col">


### PR DESCRIPTION
## Summary

Phase A of the UI/UX polish series. Six independent bug fixes surfaced by the post-React-migration audit, each restoring official upstream behavior or a documented project convention.

Each commit is atomic so the PR can be reviewed (or reverted) at the per-bug grain.

## Fixes

| Commit | File | Bug | Reference |
|--------|------|-----|-----------|
| `d086cf2` | `ui/resizable.tsx` | `withHandle` rendered a bare `h-6 w-1 rounded-lg bg-border` bar with no visible drag affordance. Now ships the upstream bordered handle with a centred `GripVerticalIcon`. | shadcn radix-nova registry `resizable.tsx` |
| `6e05f95` | `ui/dialog.tsx` | `DialogOverlay` used `bg-black/10` plus `supports-backdrop-filter:backdrop-blur-xs`, giving only a faint tint. Restored `bg-black/50` solid overlay without blur. | shadcn radix-nova registry `dialog.tsx` |
| `7d0d89d` | `editor/code/code-editor.tsx` | View-mode toggles (Code / Split / Tree) styled the active state via `data-[state=on]:`. Per the project rule `feedback_tooltip_overrides_data_state.md` and the established pattern at `routes/regex-tester.tsx:659`, switched to `aria-pressed:` (which Radix `ToggleGroupItem` emits natively and survives any future `Tooltip.Trigger asChild` wrapping). | Project memory |
| `97133d5` | `routes/__root.tsx` | `<Toaster richColors />` painted coloured backgrounds while `ui/sonner.tsx` already supplied explicit semantic icons — double styling. Dropped the `richColors` flag; icons-only encoding stays. | shadcn sonner integration guidance |
| `0f0c153` | `ui/tabs.tsx` | `TabsContent` had only `outline-none` and no focus-visible ring. Radix sets `tabIndex={0}` on TabsContent when its subtree has no focusable element, so the panel itself takes a tab stop with no visible indicator. Added the same `focus-visible:ring-2 focus-visible:ring-ring/50` ring used elsewhere. | WAI-ARIA tabs pattern |
| `1ddabb9` | `ui/list-item-button.tsx` | Listbox-style routes (network-scanner, network-interfaces) put `tabIndex={0}` on the `role="listbox"` container while every inner `ListItemButton` was a natural tab stop, breaking the active-descendant contract — Tab walked every row. Defaulted `tabIndex={-1}` when role is `option` / `treeitem`, mirroring how the component already conditions `aria-selected` on role. | WAI-ARIA listbox pattern |

## Test plan

- [x] `bun run check` passes (TypeScript + Biome + validate-pages + audit-design)
- [x] Pre-commit hooks (`lefthook`) green on each of the six commits (frontend-lint + frontend-format)
- [ ] Manual smoke: open a `Dialog`, verify backdrop opacity restored
- [ ] Manual smoke: hover the divider between Markdown editor halves — drag handle now shows GripVertical icon
- [ ] Manual smoke: keyboard-tab into a network-scanner host list — Tab should reach the listbox once, arrow keys navigate
- [ ] Manual smoke: toggle Code / Split / Tree views in the JSON formatter — active state visible
