### PR TITLE
refactor(css): drop unused animation keyframes and extend reduced-motion gate

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -341,9 +341,6 @@
 	--color-border-strong: var(--border-strong);
 	--color-accent-brand: var(--accent-brand);
 	--animate-fade-in: fade-in var(--duration-base) ease-out;
-	--animate-slide-in: slide-in var(--duration-base) ease-out;
-	--animate-slide-up: slide-up var(--duration-slow) var(--ease-standard);
-	--animate-scale-in: scale-in var(--duration-base) var(--ease-standard);
 	/*
 	 * Motion duration tokens exposed as Tailwind utilities (`duration-fast`,
 	 * `duration-base`, `duration-slow`). Tailwind v4 reads from the
@@ -445,39 +442,6 @@
 	}
 }
 
-@keyframes slide-in {
-	from {
-		opacity: 0;
-		transform: translateY(4px);
-	}
-	to {
-		opacity: 1;
-		transform: translateY(0);
-	}
-}
-
-@keyframes slide-up {
-	from {
-		opacity: 0;
-		transform: translateY(8px);
-	}
-	to {
-		opacity: 1;
-		transform: translateY(0);
-	}
-}
-
-@keyframes scale-in {
-	from {
-		opacity: 0;
-		transform: scale(0.95);
-	}
-	to {
-		opacity: 1;
-		transform: scale(1);
-	}
-}
-
 /*
  * Accordion height keyframes. The CSS variable on the `to`/`from` side is
  * populated by the underlying accordion primitive at runtime. radix-ui
@@ -503,11 +467,19 @@
 	}
 }
 
+/*
+ * Reduced-motion gate. Covers both the project's custom `animate-fade-in`
+ * + accordion utilities and the `tw-animate-css` `.animate-in` /
+ * `.animate-out` classes that every Radix primitive (Dialog, Popover,
+ * Sheet, Tooltip, DropdownMenu, Select, ContextMenu, HoverCard, etc.)
+ * relies on for entry/exit motion. Without the `.animate-in`/`.animate-out`
+ * entries here, users with `prefers-reduced-motion` would still see
+ * every overlay slide/fade/zoom into view.
+ */
 @media (prefers-reduced-motion: reduce) {
+	.animate-in,
+	.animate-out,
 	.animate-fade-in,
-	.animate-slide-in,
-	.animate-slide-up,
-	.animate-scale-in,
 	[data-state='open'].animate-accordion-down,
 	[data-state='closed'].animate-accordion-up {
 		animation: none;


### PR DESCRIPTION
## Summary

Phase B of the UI/UX polish series. Two related Tailwind v4 / animation cleanups on `src/app.css`. No behavioral regressions; the visible motion is unchanged (except that users with `prefers-reduced-motion` now actually get reduced motion).

## Changes

### Dead-code removal — three unused keyframes + tokens

Carried over from the Svelte port: `slide-in`, `slide-up`, and `scale-in` keyframes plus their matching `--animate-*` theme tokens (`--animate-slide-in`, `--animate-slide-up`, `--animate-scale-in`) had **zero consumers** in the React codebase. Removed.

`fade-in` is preserved because seven active call sites use `animate-fade-in` with the project's specific `--duration-base` timing (`tool-shell.tsx`, `unified-host-detail-panel.tsx` ×4, `loading-overlay.tsx`, `empty-state.tsx`), which the `tw-animate-css` defaults do not match.

### Reduced-motion gate extended

The `prefers-reduced-motion` block only covered the project's custom utilities (`.animate-fade-in`, `.animate-accordion-*`). Every Radix primitive — `Dialog`, `Popover`, `Sheet`, `Tooltip`, `DropdownMenu`, `Select`, `ContextMenu`, `HoverCard`, `Accordion`, `Command`, etc. — drives entry/exit motion through `tw-animate-css`'s `.animate-in` / `.animate-out` utilities (see e.g. `ui/dialog.tsx:54`, `ui/popover.tsx`, `ui/select.tsx:67`). The previous gate did not target either utility, so users with `prefers-reduced-motion: reduce` still saw every overlay slide-in, zoom-in, and fade.

Added `.animate-in` and `.animate-out` to the gate so the reduced-motion contract holds across the whole UI.

```css
@media (prefers-reduced-motion: reduce) {
  .animate-in,
  .animate-out,
  .animate-fade-in,
  [data-state='open'].animate-accordion-down,
  [data-state='closed'].animate-accordion-up {
    animation: none;
  }
}
```

## Net change

```
src/app.css | 50 +++++++++++---------------------------------------
1 file changed, 11 insertions(+), 39 deletions(-)
```

## Test plan

- [x] `bun run check` passes (TypeScript + Biome + validate-pages + audit-design)
- [x] Pre-commit hooks (`lefthook`) green — frontend-format
- [ ] Manual smoke (macOS): open any Radix overlay (Dialog / Popover / Select dropdown); verify entry animation still plays under normal motion preference
- [ ] Manual smoke (macOS): enable System Settings → Accessibility → Display → Reduce motion; open the same overlays; verify animations are gated off
- [ ] Manual smoke: Accordion expand / collapse still animates with the dynamic `--radix-accordion-content-height` height
- [ ] Manual smoke: `animate-fade-in` still works on `EmptyState`, `LoadingOverlay`, and `ToolShell`
