### PR TITLE
refactor(ui): realign primitives with shadcn radix-nova registry

### DIFF
--- a/src/lib/components/ui/accordion.tsx
+++ b/src/lib/components/ui/accordion.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Accordion as AccordionPrimitive } from 'radix-ui';
 
 import { cn } from '@/lib/utils/index';
-import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+import { ChevronDownIcon } from 'lucide-react';
 
 function Accordion({ className, ...props }: React.ComponentProps<typeof AccordionPrimitive.Root>) {
 	return (
@@ -45,11 +45,7 @@ function AccordionTrigger({
 				{children}
 				<ChevronDownIcon
 					data-slot="accordion-trigger-icon"
-					className="pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
-				/>
-				<ChevronUpIcon
-					data-slot="accordion-trigger-icon"
-					className="pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+					className="pointer-events-none shrink-0 transition-transform duration-200 group-aria-expanded/accordion-trigger:rotate-180"
 				/>
 			</AccordionPrimitive.Trigger>
 		</AccordionPrimitive.Header>

--- a/src/lib/components/ui/checkbox.tsx
+++ b/src/lib/components/ui/checkbox.tsx
@@ -4,29 +4,24 @@ import { Checkbox as CheckboxPrimitive } from 'radix-ui';
 import { cn } from '@/lib/utils/index';
 import { CheckIcon } from 'lucide-react';
 
-// Forward refs so Tooltip.Trigger asChild and other Slot-based wrappers
-// can correctly attach refs onto the underlying Radix Root element.
-const Checkbox = React.forwardRef<
-	React.ElementRef<typeof CheckboxPrimitive.Root>,
-	React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
->(({ className, ...props }, ref) => (
-	<CheckboxPrimitive.Root
-		ref={ref}
-		data-slot="checkbox"
-		className={cn(
-			'peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary',
-			className
-		)}
-		{...props}
-	>
-		<CheckboxPrimitive.Indicator
-			data-slot="checkbox-indicator"
-			className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
+function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+	return (
+		<CheckboxPrimitive.Root
+			data-slot="checkbox"
+			className={cn(
+				'peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary',
+				className
+			)}
+			{...props}
 		>
-			<CheckIcon />
-		</CheckboxPrimitive.Indicator>
-	</CheckboxPrimitive.Root>
-));
-Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+			<CheckboxPrimitive.Indicator
+				data-slot="checkbox-indicator"
+				className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
+			>
+				<CheckIcon />
+			</CheckboxPrimitive.Indicator>
+		</CheckboxPrimitive.Root>
+	);
+}
 
 export { Checkbox };

--- a/src/lib/components/ui/dropdown-menu.tsx
+++ b/src/lib/components/ui/dropdown-menu.tsx
@@ -22,7 +22,6 @@ function DropdownMenuTrigger({
 
 function DropdownMenuContent({
 	className,
-	align = 'start',
 	sideOffset = 4,
 	...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
@@ -31,7 +30,6 @@ function DropdownMenuContent({
 			<DropdownMenuPrimitive.Content
 				data-slot="dropdown-menu-content"
 				sideOffset={sideOffset}
-				align={align}
 				className={cn(
 					'z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
 					className

--- a/src/lib/components/ui/radio-group.tsx
+++ b/src/lib/components/ui/radio-group.tsx
@@ -3,42 +3,40 @@ import { RadioGroup as RadioGroupPrimitive } from 'radix-ui';
 
 import { cn } from '@/lib/utils/index';
 
-// Forward refs so Tooltip.Trigger asChild and other Slot-based wrappers
-// can correctly attach refs onto the underlying Radix Root/Item elements.
-const RadioGroup = React.forwardRef<
-	React.ElementRef<typeof RadioGroupPrimitive.Root>,
-	React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
->(({ className, ...props }, ref) => (
-	<RadioGroupPrimitive.Root
-		ref={ref}
-		data-slot="radio-group"
-		className={cn('grid w-full gap-2', className)}
-		{...props}
-	/>
-));
-RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+function RadioGroup({
+	className,
+	...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+	return (
+		<RadioGroupPrimitive.Root
+			data-slot="radio-group"
+			className={cn('grid w-full gap-2', className)}
+			{...props}
+		/>
+	);
+}
 
-const RadioGroupItem = React.forwardRef<
-	React.ElementRef<typeof RadioGroupPrimitive.Item>,
-	React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
->(({ className, ...props }, ref) => (
-	<RadioGroupPrimitive.Item
-		ref={ref}
-		data-slot="radio-group-item"
-		className={cn(
-			'group/radio-group-item peer relative flex aspect-square size-4 shrink-0 rounded-full border border-input outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary',
-			className
-		)}
-		{...props}
-	>
-		<RadioGroupPrimitive.Indicator
-			data-slot="radio-group-indicator"
-			className="flex size-4 items-center justify-center"
+function RadioGroupItem({
+	className,
+	...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+	return (
+		<RadioGroupPrimitive.Item
+			data-slot="radio-group-item"
+			className={cn(
+				'group/radio-group-item peer relative flex aspect-square size-4 shrink-0 rounded-full border border-input outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary',
+				className
+			)}
+			{...props}
 		>
-			<span className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-foreground" />
-		</RadioGroupPrimitive.Indicator>
-	</RadioGroupPrimitive.Item>
-));
-RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+			<RadioGroupPrimitive.Indicator
+				data-slot="radio-group-indicator"
+				className="flex size-4 items-center justify-center"
+			>
+				<span className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-foreground" />
+			</RadioGroupPrimitive.Indicator>
+		</RadioGroupPrimitive.Item>
+	);
+}
 
 export { RadioGroup, RadioGroupItem };

--- a/src/lib/components/ui/select.tsx
+++ b/src/lib/components/ui/select.tsx
@@ -4,173 +4,168 @@ import { Select as SelectPrimitive } from 'radix-ui';
 import { cn } from '@/lib/utils/index';
 import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from 'lucide-react';
 
-// Root is a controller component without a DOM ref; leave as plain function.
 function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
 	return <SelectPrimitive.Root data-slot="select" {...props} />;
 }
 
-// Forward refs so Tooltip.Trigger asChild and other Slot-based wrappers
-// can correctly attach refs onto the underlying Radix DOM elements.
-const SelectGroup = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.Group>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Group>
->(({ className, ...props }, ref) => (
-	<SelectPrimitive.Group
-		ref={ref}
-		data-slot="select-group"
-		className={cn('scroll-my-1 p-1', className)}
-		{...props}
-	/>
-));
-SelectGroup.displayName = SelectPrimitive.Group.displayName;
+function SelectGroup({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
+	return (
+		<SelectPrimitive.Group
+			data-slot="select-group"
+			className={cn('scroll-my-1 p-1', className)}
+			{...props}
+		/>
+	);
+}
 
-const SelectValue = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.Value>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Value>
->(({ ...props }, ref) => <SelectPrimitive.Value ref={ref} data-slot="select-value" {...props} />);
-SelectValue.displayName = SelectPrimitive.Value.displayName;
+function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
+	return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
 
-const SelectTrigger = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.Trigger>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & {
-		size?: 'sm' | 'default';
-	}
->(({ className, size = 'default', children, ...props }, ref) => (
-	<SelectPrimitive.Trigger
-		ref={ref}
-		data-slot="select-trigger"
-		data-size={size}
-		className={cn(
-			"flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-			className
-		)}
-		{...props}
-	>
-		{children}
-		<SelectPrimitive.Icon asChild>
-			<ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
-		</SelectPrimitive.Icon>
-	</SelectPrimitive.Trigger>
-));
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
-
-const SelectContent = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.Content>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = 'popper', align = 'center', ...props }, ref) => (
-	<SelectPrimitive.Portal>
-		<SelectPrimitive.Content
-			ref={ref}
-			data-slot="select-content"
+function SelectTrigger({
+	className,
+	size = 'default',
+	children,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+	size?: 'sm' | 'default';
+}) {
+	return (
+		<SelectPrimitive.Trigger
+			data-slot="select-trigger"
+			data-size={size}
 			className={cn(
-				'relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
-				position === 'popper' &&
-					'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+				"flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className
 			)}
-			position={position}
-			align={align}
 			{...props}
 		>
-			<SelectScrollUpButton />
-			<SelectPrimitive.Viewport
+			{children}
+			<SelectPrimitive.Icon asChild>
+				<ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+			</SelectPrimitive.Icon>
+		</SelectPrimitive.Trigger>
+	);
+}
+
+function SelectContent({
+	className,
+	children,
+	position = 'popper',
+	align = 'center',
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+	return (
+		<SelectPrimitive.Portal>
+			<SelectPrimitive.Content
+				data-slot="select-content"
 				className={cn(
+					'relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
 					position === 'popper' &&
-						'h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width) scroll-my-1'
+						'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+					className
 				)}
+				position={position}
+				align={align}
+				{...props}
 			>
-				{children}
-			</SelectPrimitive.Viewport>
-			<SelectScrollDownButton />
-		</SelectPrimitive.Content>
-	</SelectPrimitive.Portal>
-));
-SelectContent.displayName = SelectPrimitive.Content.displayName;
+				<SelectScrollUpButton />
+				<SelectPrimitive.Viewport
+					className={cn(
+						position === 'popper' &&
+							'h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width) scroll-my-1'
+					)}
+				>
+					{children}
+				</SelectPrimitive.Viewport>
+				<SelectScrollDownButton />
+			</SelectPrimitive.Content>
+		</SelectPrimitive.Portal>
+	);
+}
 
-const SelectLabel = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.Label>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
->(({ className, ...props }, ref) => (
-	<SelectPrimitive.Label
-		ref={ref}
-		data-slot="select-label"
-		className={cn('px-1.5 py-1 text-xs text-muted-foreground', className)}
-		{...props}
-	/>
-));
-SelectLabel.displayName = SelectPrimitive.Label.displayName;
+function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
+	return (
+		<SelectPrimitive.Label
+			data-slot="select-label"
+			className={cn('px-1.5 py-1 text-xs text-muted-foreground', className)}
+			{...props}
+		/>
+	);
+}
 
-const SelectItem = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.Item>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
-	<SelectPrimitive.Item
-		ref={ref}
-		data-slot="select-item"
-		className={cn(
-			"relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
-			className
-		)}
-		{...props}
-	>
-		<span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center">
-			<SelectPrimitive.ItemIndicator>
-				<CheckIcon className="pointer-events-none" />
-			</SelectPrimitive.ItemIndicator>
-		</span>
-		<SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-	</SelectPrimitive.Item>
-));
-SelectItem.displayName = SelectPrimitive.Item.displayName;
+function SelectItem({
+	className,
+	children,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+	return (
+		<SelectPrimitive.Item
+			data-slot="select-item"
+			className={cn(
+				"relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+				className
+			)}
+			{...props}
+		>
+			<span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center">
+				<SelectPrimitive.ItemIndicator>
+					<CheckIcon className="pointer-events-none" />
+				</SelectPrimitive.ItemIndicator>
+			</span>
+			<SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+		</SelectPrimitive.Item>
+	);
+}
 
-const SelectSeparator = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.Separator>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
->(({ className, ...props }, ref) => (
-	<SelectPrimitive.Separator
-		ref={ref}
-		data-slot="select-separator"
-		className={cn('pointer-events-none -mx-1 my-1 h-px bg-border', className)}
-		{...props}
-	/>
-));
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+function SelectSeparator({
+	className,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+	return (
+		<SelectPrimitive.Separator
+			data-slot="select-separator"
+			className={cn('pointer-events-none -mx-1 my-1 h-px bg-border', className)}
+			{...props}
+		/>
+	);
+}
 
-const SelectScrollUpButton = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
->(({ className, ...props }, ref) => (
-	<SelectPrimitive.ScrollUpButton
-		ref={ref}
-		data-slot="select-scroll-up-button"
-		className={cn(
-			"z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
-			className
-		)}
-		{...props}
-	>
-		<ChevronUpIcon />
-	</SelectPrimitive.ScrollUpButton>
-));
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+function SelectScrollUpButton({
+	className,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+	return (
+		<SelectPrimitive.ScrollUpButton
+			data-slot="select-scroll-up-button"
+			className={cn(
+				"z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+				className
+			)}
+			{...props}
+		>
+			<ChevronUpIcon />
+		</SelectPrimitive.ScrollUpButton>
+	);
+}
 
-const SelectScrollDownButton = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
->(({ className, ...props }, ref) => (
-	<SelectPrimitive.ScrollDownButton
-		ref={ref}
-		data-slot="select-scroll-down-button"
-		className={cn(
-			"z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
-			className
-		)}
-		{...props}
-	>
-		<ChevronDownIcon />
-	</SelectPrimitive.ScrollDownButton>
-));
-SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
+function SelectScrollDownButton({
+	className,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+	return (
+		<SelectPrimitive.ScrollDownButton
+			data-slot="select-scroll-down-button"
+			className={cn(
+				"z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+				className
+			)}
+			{...props}
+		>
+			<ChevronDownIcon />
+		</SelectPrimitive.ScrollDownButton>
+	);
+}
 
 export {
 	Select,

--- a/src/lib/components/ui/sheet.tsx
+++ b/src/lib/components/ui/sheet.tsx
@@ -29,7 +29,7 @@ function SheetOverlay({
 		<SheetPrimitive.Overlay
 			data-slot="sheet-overlay"
 			className={cn(
-				'fixed inset-0 z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
+				'fixed inset-0 z-50 bg-black/50 duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
 				className
 			)}
 			{...props}

--- a/src/lib/components/ui/slider.tsx
+++ b/src/lib/components/ui/slider.tsx
@@ -3,12 +3,14 @@ import { Slider as SliderPrimitive } from 'radix-ui';
 
 import { cn } from '@/lib/utils/index';
 
-// Forward refs so Tooltip.Trigger asChild and other Slot-based wrappers
-// can correctly attach refs onto the underlying Radix Root/Track/Range/Thumb elements.
-const Slider = React.forwardRef<
-	React.ElementRef<typeof SliderPrimitive.Root>,
-	React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, defaultValue, value, min = 0, max = 100, ...props }, ref) => {
+function Slider({
+	className,
+	defaultValue,
+	value,
+	min = 0,
+	max = 100,
+	...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
 	const _values = React.useMemo(
 		() => (Array.isArray(value) ? value : Array.isArray(defaultValue) ? defaultValue : [min, max]),
 		[value, defaultValue, min, max]
@@ -16,7 +18,6 @@ const Slider = React.forwardRef<
 
 	return (
 		<SliderPrimitive.Root
-			ref={ref}
 			data-slot="slider"
 			defaultValue={defaultValue}
 			value={value}
@@ -36,55 +37,45 @@ const Slider = React.forwardRef<
 			))}
 		</SliderPrimitive.Root>
 	);
-});
-Slider.displayName = SliderPrimitive.Root.displayName;
+}
 
-const SliderTrack = React.forwardRef<
-	React.ElementRef<typeof SliderPrimitive.Track>,
-	React.ComponentPropsWithoutRef<typeof SliderPrimitive.Track>
->(({ className, ...props }, ref) => (
-	<SliderPrimitive.Track
-		ref={ref}
-		data-slot="slider-track"
-		className={cn(
-			'relative grow overflow-hidden rounded-full bg-muted data-horizontal:h-1 data-horizontal:w-full data-vertical:h-full data-vertical:w-1',
-			className
-		)}
-		{...props}
-	/>
-));
-SliderTrack.displayName = SliderPrimitive.Track.displayName;
+function SliderTrack({ className, ...props }: React.ComponentProps<typeof SliderPrimitive.Track>) {
+	return (
+		<SliderPrimitive.Track
+			data-slot="slider-track"
+			className={cn(
+				'relative grow overflow-hidden rounded-full bg-muted data-horizontal:h-1 data-horizontal:w-full data-vertical:h-full data-vertical:w-1',
+				className
+			)}
+			{...props}
+		/>
+	);
+}
 
-const SliderRange = React.forwardRef<
-	React.ElementRef<typeof SliderPrimitive.Range>,
-	React.ComponentPropsWithoutRef<typeof SliderPrimitive.Range>
->(({ className, ...props }, ref) => (
-	<SliderPrimitive.Range
-		ref={ref}
-		data-slot="slider-range"
-		className={cn(
-			'absolute bg-primary select-none data-horizontal:h-full data-vertical:w-full',
-			className
-		)}
-		{...props}
-	/>
-));
-SliderRange.displayName = SliderPrimitive.Range.displayName;
+function SliderRange({ className, ...props }: React.ComponentProps<typeof SliderPrimitive.Range>) {
+	return (
+		<SliderPrimitive.Range
+			data-slot="slider-range"
+			className={cn(
+				'absolute bg-primary select-none data-horizontal:h-full data-vertical:w-full',
+				className
+			)}
+			{...props}
+		/>
+	);
+}
 
-const SliderThumb = React.forwardRef<
-	React.ElementRef<typeof SliderPrimitive.Thumb>,
-	React.ComponentPropsWithoutRef<typeof SliderPrimitive.Thumb>
->(({ className, ...props }, ref) => (
-	<SliderPrimitive.Thumb
-		ref={ref}
-		data-slot="slider-thumb"
-		className={cn(
-			'relative block size-3 shrink-0 rounded-full border border-ring bg-white ring-ring/50 transition-[color,box-shadow] select-none after:absolute after:-inset-2 hover:ring-3 focus-visible:ring-3 focus-visible:outline-hidden active:ring-3 disabled:pointer-events-none disabled:opacity-50',
-			className
-		)}
-		{...props}
-	/>
-));
-SliderThumb.displayName = SliderPrimitive.Thumb.displayName;
+function SliderThumb({ className, ...props }: React.ComponentProps<typeof SliderPrimitive.Thumb>) {
+	return (
+		<SliderPrimitive.Thumb
+			data-slot="slider-thumb"
+			className={cn(
+				'relative block size-3 shrink-0 rounded-full border border-ring bg-white ring-ring/50 transition-[color,box-shadow] select-none after:absolute after:-inset-2 hover:ring-3 focus-visible:ring-3 focus-visible:outline-hidden active:ring-3 disabled:pointer-events-none disabled:opacity-50',
+				className
+			)}
+			{...props}
+		/>
+	);
+}
 
 export { Slider };

--- a/src/lib/components/ui/textarea.tsx
+++ b/src/lib/components/ui/textarea.tsx
@@ -2,12 +2,9 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils/index';
 
-// Forward refs so Tooltip.Trigger asChild and other Slot-based wrappers
-// can correctly attach refs onto the underlying textarea element.
-const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentPropsWithoutRef<'textarea'>>(
-	({ className, ...props }, ref) => (
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+	return (
 		<textarea
-			ref={ref}
 			data-slot="textarea"
 			className={cn(
 				'flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
@@ -15,8 +12,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentPropsWitho
 			)}
 			{...props}
 		/>
-	)
-);
-Textarea.displayName = 'Textarea';
+	);
+}
 
 export { Textarea };

--- a/src/lib/components/ui/toggle-group.tsx
+++ b/src/lib/components/ui/toggle-group.tsx
@@ -22,22 +22,21 @@ const ToggleGroupContext = React.createContext<
 	orientation: 'horizontal',
 });
 
-// Forward refs so Tooltip.Trigger asChild and other Slot-based wrappers
-// can correctly attach refs onto the underlying Radix Root/Item elements.
-const ToggleGroup = React.forwardRef<
-	React.ElementRef<typeof ToggleGroupPrimitive.Root>,
-	React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
-		VariantProps<typeof toggleVariants> & {
-			spacing?: number;
-			orientation?: 'horizontal' | 'vertical';
-		}
->(
-	(
-		{ className, variant, size, spacing = 0, orientation = 'horizontal', children, ...props },
-		ref
-	) => (
+function ToggleGroup({
+	className,
+	variant,
+	size,
+	spacing = 0,
+	orientation = 'horizontal',
+	children,
+	...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+	VariantProps<typeof toggleVariants> & {
+		spacing?: number;
+		orientation?: 'horizontal' | 'vertical';
+	}) {
+	return (
 		<ToggleGroupPrimitive.Root
-			ref={ref}
 			data-slot="toggle-group"
 			data-variant={variant}
 			data-size={size}
@@ -54,20 +53,20 @@ const ToggleGroup = React.forwardRef<
 				{children}
 			</ToggleGroupContext.Provider>
 		</ToggleGroupPrimitive.Root>
-	)
-);
-ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName;
+	);
+}
 
-const ToggleGroupItem = React.forwardRef<
-	React.ElementRef<typeof ToggleGroupPrimitive.Item>,
-	React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
-		VariantProps<typeof toggleVariants>
->(({ className, children, variant = 'default', size = 'default', ...props }, ref) => {
+function ToggleGroupItem({
+	className,
+	children,
+	variant = 'default',
+	size = 'default',
+	...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> & VariantProps<typeof toggleVariants>) {
 	const context = React.useContext(ToggleGroupContext);
 
 	return (
 		<ToggleGroupPrimitive.Item
-			ref={ref}
 			data-slot="toggle-group-item"
 			data-variant={context.variant || variant}
 			data-size={context.size || size}
@@ -85,7 +84,6 @@ const ToggleGroupItem = React.forwardRef<
 			{children}
 		</ToggleGroupPrimitive.Item>
 	);
-});
-ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName;
+}
 
 export { ToggleGroup, ToggleGroupItem };


### PR DESCRIPTION
## Summary

Phase C of the UI/UX polish series. Brings the shadcn/ui primitives back in line with the current radix-nova registry pattern. Functional behavior is unchanged across the four commits; the work is a structural / stylistic alignment with upstream conventions plus one visual-regression fix that mirrors the Phase A `DialogOverlay` change.

## Commits

### `e3d8b30` — `refactor(ui)`: migrate primitives from `forwardRef` to plain functions

Six primitives previously wrapped their Radix root with `React.forwardRef<…, React.ComponentPropsWithoutRef<…>>` plus a `displayName` assignment. The current shadcn radix-nova registry uses plain functions with `React.ComponentProps<typeof …>` and lets Radix's internal `Slot` forward refs through composition (e.g. `Tooltip.Trigger asChild`).

| File | Components |
|------|------------|
| `ui/checkbox.tsx` | `Checkbox` |
| `ui/radio-group.tsx` | `RadioGroup`, `RadioGroupItem` |
| `ui/select.tsx` | `SelectGroup`, `SelectValue`, `SelectTrigger`, `SelectContent`, `SelectLabel`, `SelectItem`, `SelectSeparator`, `SelectScrollUpButton`, `SelectScrollDownButton` |
| `ui/slider.tsx` | `Slider`, `SliderTrack`, `SliderRange`, `SliderThumb` |
| `ui/textarea.tsx` | `Textarea` |
| `ui/toggle-group.tsx` | `ToggleGroup`, `ToggleGroupItem` |

Project-specific divergences are preserved (e.g. `ToggleGroup.spacing = 0` segmented-control default, `Slider` value-array memoization, `SelectTrigger.size` extra prop, `SelectContent.position = 'popper'` from PR #268).

### `d0e044e` — `refactor(ui)(dropdown-menu)`: drop `align="start"` default

`DropdownMenuContent` previously defaulted `align` to `"start"`, while the shadcn radix-nova registry sets no default (so Radix's own `"center"` applies). The single in-repo call site (`routes/markdown-editor.tsx:572`) already passes `align="start"` explicitly, so removing the default has zero behavioural impact on current consumers.

### `8a5f7df` — `refactor(ui)(accordion)`: use one rotating chevron icon

`AccordionTrigger` rendered both `ChevronDownIcon` and `ChevronUpIcon` and toggled their visibility via `group-aria-expanded:hidden` / `:inline`. The shadcn radix-nova registry instead renders a single chevron that rotates via `transition-transform group-aria-expanded:rotate-180`. Matches upstream, drops the unused `ChevronUpIcon` import, gives the open/close affordance a smooth motion under normal-motion preferences (still gated by the global reduced-motion rule from PR #270), and removes one redundant DOM element from every accordion trigger.

### `6f44095` — `fix(ui)(sheet)`: restore solid overlay without backdrop blur

Same pattern as PR #269's `DialogOverlay` fix, but on `SheetOverlay`: `bg-black/10` + `supports-backdrop-filter:backdrop-blur-xs` → `bg-black/50` solid (no blur). Sheet is built on Radix's Dialog primitive (hence the `Dialog as SheetPrimitive` import alias), and shadcn applies the same overlay treatment to both — the divergence was an oversight when the React port was bootstrapped. Restores parity with Dialog and proper visual hierarchy when a Sheet opens over content.

## Net change

```
9 files changed, 271 insertions(+), 303 deletions(-)
```

## Test plan

- [x] `bun run check` passes (TypeScript + Biome + validate-pages + audit-design)
- [x] Pre-commit hooks green on every commit (frontend-lint + frontend-format)
- [ ] Manual smoke: Form selects (`Variant` / `Line Break` in `/base64-encoder`, mode selects across the formatter family) still open, navigate, and close correctly
- [ ] Manual smoke: Checkbox + RadioGroup inside `FormSection` rails still toggle and persist
- [ ] Manual smoke: Slider thumb / track in `/password-generator` still drags
- [ ] Manual smoke: ToggleGroup mode toggles (Encode/Decode in `/base64-encoder`, etc.) keep segmented-control look
- [ ] Manual smoke: Sheet overlays (mobile sidebar) now show solid backdrop without blur
- [ ] Manual smoke: Accordion expand / collapse animates the chevron rotation in `/settings`
