### PR TITLE
refactor(routes): align empty / error surfaces with shared status primitives

### DIFF
--- a/src/routes/diff-viewer.tsx
+++ b/src/routes/diff-viewer.tsx
@@ -13,6 +13,7 @@ import {
 	FormSlider,
 } from '@/lib/components/form';
 import { ToolShell } from '@/lib/components/shell';
+import { EmptyState } from '@/lib/components/status';
 import {
 	areTextsIdentical,
 	computeEnhancedDiff,
@@ -223,12 +224,11 @@ function DiffViewerPage() {
 	);
 
 	const emptyState = (
-		<div className="flex flex-1 items-center justify-center text-muted-foreground">
-			<div className="text-center">
-				<SplitSquareHorizontal className="mx-auto mb-2 h-12 w-12 opacity-50" />
-				<p className="text-sm">Enter text on both sides to compare</p>
-			</div>
-		</div>
+		<EmptyState
+			icon={SplitSquareHorizontal}
+			title="Enter text on both sides"
+			description="Add input on the left and right to see differences."
+		/>
 	);
 
 	const identicalState = (

--- a/src/routes/markdown-editor.tsx
+++ b/src/routes/markdown-editor.tsx
@@ -39,7 +39,7 @@ import { FormInfo, FormMode, FormSection } from '@/lib/components/form';
 import { SplitPane } from '@/lib/components/layout';
 import { MarkdownContextMenuItems, Vizel } from '@/lib/components/markdown';
 import { ToolShell } from '@/lib/components/shell';
-import { StatItem } from '@/lib/components/status';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
 import {
 	ContextMenu,
@@ -701,12 +701,12 @@ function MarkdownEditorPage() {
 										// biome-ignore lint/security/noDangerouslySetInnerHtml: htmlOutput originates from the local markdownToHtmlAsync pipeline; content is generated from user input that already lives in the same process.
 										<div dangerouslySetInnerHTML={{ __html: htmlOutput }} />
 									) : (
-										<div className="flex h-full items-center justify-center text-muted-foreground">
-											<div className="text-center">
-												<Eye className="mx-auto mb-2 h-12 w-12 opacity-50" />
-												<p className="text-sm">Preview will appear here</p>
-											</div>
-										</div>
+										<EmbeddedEmptyState
+											icon={Eye}
+											title="Preview will appear here"
+											description="Type Markdown on the left to render it on the right."
+											fillHeight
+										/>
 									)}
 								</div>
 							</div>

--- a/src/routes/network-interfaces.tsx
+++ b/src/routes/network-interfaces.tsx
@@ -5,7 +5,6 @@ import {
 	ArrowDown,
 	ArrowUp,
 	Cable,
-	Circle,
 	Flag,
 	Globe,
 	Network,
@@ -20,7 +19,7 @@ import { CopyButton } from '@/lib/components/action';
 import { FormCheckbox, FormCheckboxGroup, FormSection, FormSelect } from '@/lib/components/form';
 import { SectionHeader, SectionLabel } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
-import { EmptyState, StatItem } from '@/lib/components/status';
+import { EmptyState, ErrorDisplay, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent } from '@/lib/components/ui/card';
@@ -664,7 +663,7 @@ function NetworkInterfacesPage() {
 							))}
 						</div>
 					) : error ? (
-						<EmptyState icon={Circle} title="Failed to load interfaces" description={error} />
+						<ErrorDisplay variant="centered" title="Failed to load interfaces" message={error} />
 					) : (
 						<EmptyState icon={Server} title="No interfaces match the current filters" />
 					)}


### PR DESCRIPTION
## Summary

Phase D-1 of the UI/UX polish series. Three small drift corrections that bring routes back onto the project's shared status primitives, so the empty / loading / error vocabulary is consistent across the app.

The audit also flagged two raw-input drift cases (`url-encoder.tsx` `<label>`+`<Input>`, `regex/pattern-editor.tsx` raw `<textarea>`) — both intentionally diverge from the corresponding primitive (inline-Sample button layout, syntax-highlighted overlay textarea) and require a `FormInput` extension or an explicit `Textarea` divergence rule. They will be handled in a follow-up PR.

The remaining state-unification item (formatter-tabs Empty state coverage across 17 tab files) is intentionally separated into Phase D-2.

## Commits

### `b4ff021` — `refactor(routes)`: use status primitives for empty states

Two routes rendered empty states with hand-rolled inline markup (`<div className="flex h-full items-center justify-center text-muted-foreground">` + nested `<div className="text-center">`) instead of the project's `EmptyState` / `EmbeddedEmptyState` primitives:

| File | Surface | Primitive chosen |
|------|---------|------------------|
| `routes/diff-viewer.tsx` | full-page "Enter text on both sides to compare" | `EmptyState` (full-height with rounded icon container) |
| `routes/markdown-editor.tsx` | preview-pane "Preview will appear here" | `EmbeddedEmptyState fillHeight` (smaller, fits inside a pane — matches the `formatter-tabs/yaml/format-tab.tsx` reference) |

Both surfaces now pick up the shared typography, spacing, `animate-fade-in` entry, and `prefers-reduced-motion` behaviour from those primitives.

### `b5ea2c8` — `refactor(routes)(network-interfaces)`: use ErrorDisplay for failure state

`network-interfaces.tsx` rendered "Failed to load interfaces" with `EmptyState icon={Circle}` — the same visual treatment as a benign "no results match the current filters" empty state. Every other route that surfaces a fetch / parse error (`bcrypt-generator`, `ssh-key-generator`, `gpg-key-generator`, `network-scanner`) uses `ErrorDisplay variant="centered"`, which applies destructive coloring (`border-destructive/50 bg-destructive/10`, `AlertTriangle` icon, `text-destructive` body) so users can distinguish a real error from an empty state.

Switched the failure branch to `ErrorDisplay`; kept `EmptyState` for the genuinely empty "no interfaces match" case. Dropped the now-unused `Circle` import.

## Net change

```
src/routes/diff-viewer.tsx        | 12 ++++++------
src/routes/markdown-editor.tsx    | 14 +++++++-------
src/routes/network-interfaces.tsx |  9 ++++++---
3 files changed, 19 insertions(+), 16 deletions(-)
```

## Test plan

- [x] `bun run check` passes (TypeScript + Biome + validate-pages + audit-design)
- [x] Pre-commit hooks green on both commits (frontend-lint + frontend-format)
- [ ] Manual smoke: `/diff-viewer` with empty Left & Right shows the new `EmptyState` (rounded icon container, full-height)
- [ ] Manual smoke: `/markdown-editor` with empty input shows the new `EmbeddedEmptyState` inside the preview pane
- [ ] Manual smoke: `/network-interfaces` with simulated fetch error shows the destructive-coloured `ErrorDisplay`; with empty filters still shows the neutral `EmptyState`
