### PR TITLE
refactor(formatter-tabs): add EmbeddedEmptyState to format/query output panes

### DIFF
--- a/src/lib/components/formatter-tabs/json/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/format-tab.tsx
@@ -1,3 +1,4 @@
+import { FileText } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -9,8 +10,9 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SplitPane } from '@/lib/components/layout';
+import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
+import { EmbeddedEmptyState } from '@/lib/components/status';
 import {
 	defaultJsonFormatOptions,
 	type JsonFormatOptions,
@@ -428,14 +430,28 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 					/>
 				}
 				right={
-					<CodeEditor
-						title="Output"
-						value={output}
-						mode="readonly"
-						editorMode="json"
-						placeholder="Formatted output..."
-						onCopy={handleCopy}
-					/>
+					input.trim().length === 0 ? (
+						<div className="flex h-full flex-col overflow-hidden">
+							<SectionHeader title="Output" />
+							<div className="flex-1">
+								<EmbeddedEmptyState
+									icon={FileText}
+									title="Enter JSON to format"
+									description="The formatted (or minified) document will appear here."
+									fillHeight
+								/>
+							</div>
+						</div>
+					) : (
+						<CodeEditor
+							title="Output"
+							value={output}
+							mode="readonly"
+							editorMode="json"
+							placeholder="Formatted output..."
+							onCopy={handleCopy}
+						/>
+					)
 				}
 			/>
 		</div>

--- a/src/lib/components/formatter-tabs/json/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/query-tab.tsx
@@ -1,3 +1,4 @@
+import { Search } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { CodeEditor } from '@/lib/components/editor';
@@ -8,8 +9,9 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SplitPane } from '@/lib/components/layout';
+import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
+import { EmbeddedEmptyState } from '@/lib/components/status';
 import { executeJsonPath, validateJson } from '@/lib/services/formatters';
 import { useJsonFormatterOptions } from '@/lib/stores';
 import { copyToClipboard, pasteFromClipboard } from '@/lib/utils/file-operations';
@@ -240,14 +242,28 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 					/>
 				}
 				right={
-					<CodeEditor
-						title="Result"
-						value={queryResult}
-						mode="readonly"
-						editorMode="json"
-						placeholder="Query result..."
-						onCopy={handleCopyResult}
-					/>
+					input.trim().length === 0 ? (
+						<div className="flex h-full flex-col overflow-hidden">
+							<SectionHeader title="Result" />
+							<div className="flex-1">
+								<EmbeddedEmptyState
+									icon={Search}
+									title="Enter JSON to query"
+									description="Run a JSONPath expression to see matching values here."
+									fillHeight
+								/>
+							</div>
+						</div>
+					) : (
+						<CodeEditor
+							title="Result"
+							value={queryResult}
+							mode="readonly"
+							editorMode="json"
+							placeholder="Query result..."
+							onCopy={handleCopyResult}
+						/>
+					)
 				}
 			/>
 		</div>

--- a/src/lib/components/formatter-tabs/xml/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/format-tab.tsx
@@ -1,3 +1,4 @@
+import { FileText } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -9,8 +10,9 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SplitPane } from '@/lib/components/layout';
+import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
+import { EmbeddedEmptyState } from '@/lib/components/status';
 import {
 	defaultXmlFormatOptions,
 	formatXml,
@@ -274,14 +276,28 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 					/>
 				}
 				right={
-					<CodeEditor
-						title="Output"
-						value={output}
-						mode="readonly"
-						editorMode="xml"
-						placeholder="Formatted output..."
-						onCopy={handleCopy}
-					/>
+					input.trim().length === 0 ? (
+						<div className="flex h-full flex-col overflow-hidden">
+							<SectionHeader title="Output" />
+							<div className="flex-1">
+								<EmbeddedEmptyState
+									icon={FileText}
+									title="Enter XML to format"
+									description="The formatted (or minified) document will appear here."
+									fillHeight
+								/>
+							</div>
+						</div>
+					) : (
+						<CodeEditor
+							title="Output"
+							value={output}
+							mode="readonly"
+							editorMode="xml"
+							placeholder="Formatted output..."
+							onCopy={handleCopy}
+						/>
+					)
 				}
 			/>
 		</div>

--- a/src/lib/components/formatter-tabs/xml/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/query-tab.tsx
@@ -1,9 +1,11 @@
+import { Search } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { CodeEditor } from '@/lib/components/editor';
 import { FormInput, FormSection } from '@/lib/components/form';
-import { SplitPane } from '@/lib/components/layout';
+import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
+import { EmbeddedEmptyState } from '@/lib/components/status';
 import { executeXPath, formatXml } from '@/lib/services/formatters';
 import { copyToClipboard, pasteFromClipboard } from '@/lib/utils/file-operations';
 
@@ -159,14 +161,28 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 					/>
 				}
 				right={
-					<CodeEditor
-						title="Result"
-						value={queryOutput}
-						mode="readonly"
-						editorMode="xml"
-						placeholder="Query results will appear here..."
-						onCopy={handleCopyOutput}
-					/>
+					input.trim().length === 0 ? (
+						<div className="flex h-full flex-col overflow-hidden">
+							<SectionHeader title="Result" />
+							<div className="flex-1">
+								<EmbeddedEmptyState
+									icon={Search}
+									title="Enter XML to query"
+									description="Run an XPath expression to see matching nodes here."
+									fillHeight
+								/>
+							</div>
+						</div>
+					) : (
+						<CodeEditor
+							title="Result"
+							value={queryOutput}
+							mode="readonly"
+							editorMode="xml"
+							placeholder="Query results will appear here..."
+							onCopy={handleCopyOutput}
+						/>
+					)
 				}
 			/>
 		</div>

--- a/src/lib/components/formatter-tabs/yaml/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/query-tab.tsx
@@ -1,3 +1,4 @@
+import { Search } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import * as yaml from 'yaml';
 
@@ -9,8 +10,9 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SplitPane } from '@/lib/components/layout';
+import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
+import { EmbeddedEmptyState } from '@/lib/components/status';
 import { executeJsonPath } from '@/lib/services/formatters';
 import { copyToClipboard, pasteFromClipboard } from '@/lib/utils/file-operations';
 
@@ -242,14 +244,28 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 					/>
 				}
 				right={
-					<CodeEditor
-						title="Result"
-						value={queryResult}
-						mode="readonly"
-						editorMode={queryOutputFormat}
-						placeholder="Query result..."
-						onCopy={handleCopyResult}
-					/>
+					input.trim().length === 0 ? (
+						<div className="flex h-full flex-col overflow-hidden">
+							<SectionHeader title="Result" />
+							<div className="flex-1">
+								<EmbeddedEmptyState
+									icon={Search}
+									title="Enter YAML to query"
+									description="Run a JSONPath expression to see matching values here."
+									fillHeight
+								/>
+							</div>
+						</div>
+					) : (
+						<CodeEditor
+							title="Result"
+							value={queryResult}
+							mode="readonly"
+							editorMode={queryOutputFormat}
+							placeholder="Query result..."
+							onCopy={handleCopyResult}
+						/>
+					)
 				}
 			/>
 		</div>


### PR DESCRIPTION
## Summary

Phase D-2 of the UI/UX polish series. Brings five formatter tabs onto the empty-state pattern that `formatter-tabs/yaml/format-tab.tsx` already used, so the pre-input state across JSON, XML, and YAML format / query tabs is consistent.

Previously each tab's output pane showed only the underlying `CodeEditor` with a placeholder string (e.g. `"Formatted output..."`, `"Query result..."`). The result read as an empty editor rather than as a guided affordance telling users what would appear there.

## Files

Same `<SectionHeader title=… />` + `<EmbeddedEmptyState fillHeight />` wrapper that `yaml/format-tab.tsx:376-398` already uses:

| File | Icon | Title | Description |
|------|------|-------|-------------|
| `formatter-tabs/json/format-tab.tsx` | `FileText` | "Enter JSON to format" | "The formatted (or minified) document will appear here." |
| `formatter-tabs/xml/format-tab.tsx` | `FileText` | "Enter XML to format" | "The formatted (or minified) document will appear here." |
| `formatter-tabs/json/query-tab.tsx` | `Search` | "Enter JSON to query" | "Run a JSONPath expression to see matching values here." |
| `formatter-tabs/xml/query-tab.tsx` | `Search` | "Enter XML to query" | "Run an XPath expression to see matching nodes here." |
| `formatter-tabs/yaml/query-tab.tsx` | `Search` | "Enter YAML to query" | "Run a JSONPath expression to see matching values here." |

## Out of scope (deferred)

The `schema-tab` family (`formatter-tabs/{json,xml,yaml}/schema-tab.tsx`) renders two output panes per tab (generated schema + user-supplied schema), so adapting the single-output pattern needs more thought.

The `convert-tab`, `generate-tab`, and `compare-tab` families don't have the `right={ <CodeEditor … /> }` shape at all — their output renders inline or through different layouts — so no single mechanical rewrite applies. Each can be revisited individually if a similar visual imbalance shows up.

## Net change

```
5 files changed, 125 insertions(+), 45 deletions(-)
```

## Test plan

- [x] `bun run check` passes (TypeScript + Biome + validate-pages + audit-design)
- [x] Pre-commit hooks green (frontend-lint + frontend-format)
- [ ] Manual smoke: visit `/json-formatter` Format tab with empty input — output side shows the `Enter JSON to format` empty state with `FileText` icon and a "Output" SectionHeader
- [ ] Manual smoke: same for `/xml-formatter` Format
- [ ] Manual smoke: visit Query tab on JSON / XML / YAML formatters with empty input — output side shows the `Enter … to query` empty state with `Search` icon
- [ ] Manual smoke: type any non-whitespace input — output pane swaps back to the existing `CodeEditor`
