### PR TITLE
refactor(css): consolidate inline sizes onto theme tokens and drop focus-ring class

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -540,15 +540,6 @@
 	}
 }
 
-/* Unified focus ring utility */
-.focus-ring {
-	outline: none;
-}
-.focus-ring:focus-visible {
-	outline: 2px solid oklch(from var(--primary) l c h / 30%);
-	outline-offset: 2px;
-}
-
 /*
  * Thin themed scrollbars for a native-app feel.
  *

--- a/src/lib/components/editor/code/tree-view.tsx
+++ b/src/lib/components/editor/code/tree-view.tsx
@@ -416,7 +416,7 @@ export function TreeView({
 	return (
 		<>
 			<div
-				className="group/tree relative select-none font-mono text-[13px] leading-[1.5]"
+				className="group/tree relative select-none font-mono text-sm leading-[1.5]"
 				style={wrapperStyle}
 			>
 				{hasChildren ? (

--- a/src/lib/components/regex/railroad-view.tsx
+++ b/src/lib/components/regex/railroad-view.tsx
@@ -179,7 +179,7 @@ function TerminalGlyph({ n }: { readonly n: TerminalNode }) {
 				y={n.entryY}
 				textAnchor="middle"
 				dominantBaseline="middle"
-				className={`${tone.text} font-mono text-[11px]`}
+				className={`${tone.text} font-mono text-2xs`}
 			>
 				{n.label}
 			</text>

--- a/src/lib/components/ui/sidebar.tsx
+++ b/src/lib/components/ui/sidebar.tsx
@@ -277,7 +277,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<'button'>) {
 			onClick={toggleSidebar}
 			title="Toggle Sidebar"
 			className={cn(
-				'absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2',
+				'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex',
 				'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
 				'[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
 				'group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar',

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -48,7 +48,7 @@ function HomePage() {
 											<Link
 												key={tool.id}
 												to={tool.url as never}
-												className="focus-ring group block rounded-xl"
+												className="group block rounded-xl outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/30"
 											>
 												<Card className="h-full border-border/50 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-border hover:shadow-md">
 													<CardContent className="flex h-full items-center gap-4 p-5">


### PR DESCRIPTION
## Summary

Phase F of the UI/UX polish series. Three small Tailwind-v4 token consolidations that bring class-list intent in line with the design tokens already defined in `src/app.css`. No behavioural or visual change.

## Commits

### `8c4e4a4` — `refactor(css)`: drop custom `.focus-ring` class for v4 utilities

`.focus-ring` was a small custom class in `app.css:543-550` used at exactly one call site (`routes/index.tsx:51`). Tailwind v4 covers the same need natively with `outline-none` + `focus-visible:outline-*`, so the bespoke class earned its keep only as long as it had multiple consumers. Inlined the equivalent utility chain (`outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/30`) at the call site and removed the global block.

### `e801d96` — `fix(ui)(sidebar)`: collapse contradictory ltr/rtl translate

`SidebarRail` carried `ltr:-translate-x-1/2 rtl:-translate-x-1/2` — the same value on both directional variants. The pair adds no behaviour and only obscures intent. Replaced with a single unprefixed `-translate-x-1/2`.

### `bee855a` — `refactor(ui)`: use theme text tokens for matching inline sizes

Two call sites used arbitrary `text-[Npx]` values that exactly match the project's theme tokens (`app.css:376-382`):

* `editor/code/tree-view.tsx:419` — `text-[13px]` → `text-sm` (`--text-sm = 0.8125rem = 13px`).
* `regex/railroad-view.tsx:182` — `text-[11px]` → `text-2xs` (`--text-2xs = 0.6875rem = 11px`).

Running `--font-size-*` overrides applied by the user-settings service now flow through these two call sites the same way they flow through every other typographic surface.

The four remaining inline sizes in `railroad-view.tsx` (`text-[10px]` and `text-[9px]`) are SVG labels intentionally smaller than the smallest project token and have no exact equivalent; they stay as-is.

## Out of scope

Tailwind v4 container queries (the audit's other modernization opportunity) require revisiting the `react-resizable-panels` + sidebar layout shape and will be tackled in a separate PR.

## Net change

```
5 files changed, 4 insertions(+), 13 deletions(-)
```

## Test plan

- [x] `bun run check` passes (TypeScript + Biome + validate-pages + audit-design)
- [x] Pre-commit hooks green on each commit (frontend-lint + frontend-format)
- [ ] Manual smoke: keyboard-tab through home-page tool tiles — focus ring still appears (now via `focus-visible:outline-*` instead of the removed `.focus-ring`)
- [ ] Manual smoke: drag the sidebar rail in LTR layout — unchanged
- [ ] Manual smoke: render a JSON / XML tree in the formatter result pane — tree text size identical
- [ ] Manual smoke: render a regex railroad diagram in `/regex-tester` — label text size identical
