### PR TITLE
fix(a11y): announce generator results via aria-live regions

### DIFF
--- a/src/routes/bcrypt-generator.tsx
+++ b/src/routes/bcrypt-generator.tsx
@@ -366,7 +366,12 @@ function BcryptGeneratorPage() {
 					title={activeTab === 'generate' ? 'Generated Hash' : 'Verification Result'}
 				/>
 
-				<div className="flex-1 overflow-auto p-4">
+				<div
+					className="flex-1 overflow-auto p-4"
+					role="status"
+					aria-live="polite"
+					aria-atomic="false"
+				>
 					{activeTab === 'generate' ? (
 						hashResult ? (
 							<div key={flashCounter} className="animate-flash-success space-y-4 rounded-md">

--- a/src/routes/gpg-key-generator.tsx
+++ b/src/routes/gpg-key-generator.tsx
@@ -343,7 +343,12 @@ function GpgKeyGeneratorPage() {
 				/>
 				<SectionHeader title="Generated Keys" />
 
-				<div className="flex-1 overflow-auto p-4">
+				<div
+					className="flex-1 overflow-auto p-4"
+					role="status"
+					aria-live="polite"
+					aria-atomic="false"
+				>
 					{keyResult ? (
 						<div key={flashCounter} className="animate-flash-success space-y-4 rounded-md">
 							{showKeyInfo ? (

--- a/src/routes/password-generator.tsx
+++ b/src/routes/password-generator.tsx
@@ -264,7 +264,12 @@ function PasswordGeneratorPage() {
 						) : null
 					}
 				/>
-				<div className="flex-1 overflow-auto p-4">
+				<div
+					className="flex-1 overflow-auto p-4"
+					role="status"
+					aria-live="polite"
+					aria-atomic="false"
+				>
 					{results.length > 0 ? (
 						<div key={flashCounter} className="animate-flash-success space-y-2 rounded-md">
 							{results.map((password) => (

--- a/src/routes/qr-code-generator.tsx
+++ b/src/routes/qr-code-generator.tsx
@@ -705,7 +705,12 @@ function QrCodeGeneratorPage() {
 					}
 				/>
 
-				<div className="flex-1 overflow-auto p-6">
+				<div
+					className="flex-1 overflow-auto p-6"
+					role="status"
+					aria-live="polite"
+					aria-atomic="false"
+				>
 					<div className="mx-auto flex max-w-3xl flex-col gap-6">
 						<Card density="compact" className="overflow-hidden">
 							<CardContent className="flex items-center justify-center p-8">

--- a/src/routes/ssh-key-generator.tsx
+++ b/src/routes/ssh-key-generator.tsx
@@ -307,7 +307,12 @@ function SshKeyGeneratorPage() {
 				/>
 				<SectionHeader title="Generated Keys" />
 
-				<div className="flex-1 overflow-auto p-4">
+				<div
+					className="flex-1 overflow-auto p-4"
+					role="status"
+					aria-live="polite"
+					aria-atomic="false"
+				>
 					{keyResult ? (
 						<div key={flashCounter} className="animate-flash-success space-y-4 rounded-md">
 							{showFingerprint ? (

--- a/src/routes/uuid-generator.tsx
+++ b/src/routes/uuid-generator.tsx
@@ -258,7 +258,12 @@ function UuidGeneratorPage() {
 						) : null
 					}
 				/>
-				<div className="flex-1 overflow-auto p-4">
+				<div
+					className="flex-1 overflow-auto p-4"
+					role="status"
+					aria-live="polite"
+					aria-atomic="false"
+				>
 					{results.length > 0 ? (
 						<div key={flashCounter} className="animate-flash-success space-y-2 rounded-md">
 							{results.map((uuid) => (


### PR DESCRIPTION
## Summary

Phase G of the UI/UX polish series. Closes an accessibility gap across the generator routes: six routes rendered newly produced results inside a plain `<div className="flex-1 overflow-auto p-…">` with no live-region semantics, so screen-reader users got no indication when a new hash, key pair, QR canvas, UUID list, or password list appeared.

The contract is already followed in sibling routes (`hash-generator`, `cron-expression-builder`, `jwt-decoder`, `regex-tester`): wrap the output container with `role="status" aria-live="polite" aria-atomic="false"`.

## Files

| Route | Output surface |
|-------|----------------|
| `routes/bcrypt-generator.tsx` | "Generated Hash" / "Verification Result" container (tabs share one element) |
| `routes/gpg-key-generator.tsx` | "Generated Keys" container |
| `routes/ssh-key-generator.tsx` | "Generated Keys" container |
| `routes/qr-code-generator.tsx` | QR preview scroll container |
| `routes/uuid-generator.tsx` | "Generated UUIDs" list container |
| `routes/password-generator.tsx` | "Generated Passwords" list container |

`polite` keeps the announcement non-interruptive; `aria-atomic="false"` makes multi-row output (UUID and password lists, GPG / SSH key sections) announce only the diff rather than the whole region, matching the existing convention.

Reference: [WAI-ARIA live region pattern](https://www.w3.org/WAI/ARIA/apg/practices/notifications/).

## Net change

```
6 files changed, 36 insertions(+), 6 deletions(-)
```

## Test plan

- [x] `bun run check` passes
- [x] Pre-commit hooks green (frontend-lint + frontend-format)
- [ ] VoiceOver smoke: generate a BCrypt hash — VO announces the hash
- [ ] VoiceOver smoke: generate UUIDs or passwords in batch — VO announces the new rows
- [ ] VoiceOver smoke: render a QR code — VO announces the preview region update
