### PR TITLE
refactor(formatter-tabs): add EmbeddedEmptyState to convert/generate output panes

### DIFF
--- a/src/lib/components/formatter-tabs/json/generate-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/generate-tab.tsx
@@ -1,3 +1,4 @@
+import { Code } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { CodeEditor } from '@/lib/components/editor';
@@ -9,8 +10,9 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SplitPane } from '@/lib/components/layout';
+import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
+import { EmbeddedEmptyState } from '@/lib/components/status';
 import {
 	type CSharpOptions,
 	type GoOptions,
@@ -850,14 +852,28 @@ export function GenerateTab({ input, onInputChange, onStatsChange }: GenerateTab
 					/>
 				}
 				right={
-					<CodeEditor
-						title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
-						value={generatedCode}
-						mode="readonly"
-						editorMode={generateEditorMode}
-						placeholder="Generated code will appear here..."
-						onCopy={handleCopy}
-					/>
+					input.trim().length === 0 ? (
+						<div className="flex h-full flex-col overflow-hidden">
+							<SectionHeader title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`} />
+							<div className="flex-1">
+								<EmbeddedEmptyState
+									icon={Code}
+									title="Enter JSON to generate code"
+									description={`The ${LANGUAGE_INFO[generateLanguage].label} class definitions will appear here.`}
+									fillHeight
+								/>
+							</div>
+						</div>
+					) : (
+						<CodeEditor
+							title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
+							value={generatedCode}
+							mode="readonly"
+							editorMode={generateEditorMode}
+							placeholder="Generated code will appear here..."
+							onCopy={handleCopy}
+						/>
+					)
 				}
 			/>
 		</div>

--- a/src/lib/components/formatter-tabs/xml/generate-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/generate-tab.tsx
@@ -1,3 +1,4 @@
+import { Code } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { CodeEditor } from '@/lib/components/editor';
@@ -9,8 +10,9 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SplitPane } from '@/lib/components/layout';
+import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
+import { EmbeddedEmptyState } from '@/lib/components/status';
 import {
 	type CSharpOptions,
 	generateCode,
@@ -848,14 +850,28 @@ export function GenerateTab({ input, onInputChange, onStatsChange }: GenerateTab
 					/>
 				}
 				right={
-					<CodeEditor
-						title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
-						value={generatedCode}
-						mode="readonly"
-						editorMode={generateEditorMode}
-						placeholder="Generated code will appear here..."
-						onCopy={handleCopy}
-					/>
+					input.trim().length === 0 ? (
+						<div className="flex h-full flex-col overflow-hidden">
+							<SectionHeader title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`} />
+							<div className="flex-1">
+								<EmbeddedEmptyState
+									icon={Code}
+									title="Enter XML to generate code"
+									description={`The ${LANGUAGE_INFO[generateLanguage].label} class definitions will appear here.`}
+									fillHeight
+								/>
+							</div>
+						</div>
+					) : (
+						<CodeEditor
+							title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
+							value={generatedCode}
+							mode="readonly"
+							editorMode={generateEditorMode}
+							placeholder="Generated code will appear here..."
+							onCopy={handleCopy}
+						/>
+					)
 				}
 			/>
 		</div>

--- a/src/lib/components/formatter-tabs/yaml/generate-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/generate-tab.tsx
@@ -1,3 +1,4 @@
+import { Code } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import * as yaml from 'yaml';
 
@@ -10,8 +11,9 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SplitPane } from '@/lib/components/layout';
+import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
+import { EmbeddedEmptyState } from '@/lib/components/status';
 import {
 	type CSharpOptions,
 	generateCode,
@@ -846,14 +848,28 @@ export function GenerateTab({ input, onInputChange, onStatsChange }: GenerateTab
 					/>
 				}
 				right={
-					<CodeEditor
-						title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
-						value={generatedCode}
-						mode="readonly"
-						editorMode={generateEditorMode}
-						placeholder="Generated code will appear here..."
-						onCopy={handleCopy}
-					/>
+					input.trim().length === 0 ? (
+						<div className="flex h-full flex-col overflow-hidden">
+							<SectionHeader title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`} />
+							<div className="flex-1">
+								<EmbeddedEmptyState
+									icon={Code}
+									title="Enter YAML to generate code"
+									description={`The ${LANGUAGE_INFO[generateLanguage].label} class definitions will appear here.`}
+									fillHeight
+								/>
+							</div>
+						</div>
+					) : (
+						<CodeEditor
+							title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
+							value={generatedCode}
+							mode="readonly"
+							editorMode={generateEditorMode}
+							placeholder="Generated code will appear here..."
+							onCopy={handleCopy}
+						/>
+					)
 				}
 			/>
 		</div>

--- a/src/lib/components/template/convert-tab.tsx
+++ b/src/lib/components/template/convert-tab.tsx
@@ -1,8 +1,10 @@
+import { ArrowRightLeft } from 'lucide-react';
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 
 import { CodeEditor, type EditorMode } from '@/lib/components/editor';
-import { SplitPane } from '@/lib/components/layout';
+import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
+import { EmbeddedEmptyState } from '@/lib/components/status';
 
 type ValidationResult = { valid: boolean | null } & Record<string, unknown>;
 type StatsResult = { input: string; valid: boolean | null; error: string } & Record<
@@ -122,14 +124,28 @@ export function ConvertTab({
 					/>
 				}
 				right={
-					<CodeEditor
-						title={outputTitle}
-						value={output}
-						mode="readonly"
-						editorMode={outputEditorMode}
-						placeholder="Converted output..."
-						onCopy={handleCopyOutput}
-					/>
+					input.trim().length === 0 ? (
+						<div className="flex h-full flex-col overflow-hidden">
+							<SectionHeader title={outputTitle ?? 'Output'} />
+							<div className="flex-1">
+								<EmbeddedEmptyState
+									icon={ArrowRightLeft}
+									title={`Enter ${inputEditorMode.toUpperCase()} to convert`}
+									description="The converted document will appear here."
+									fillHeight
+								/>
+							</div>
+						</div>
+					) : (
+						<CodeEditor
+							title={outputTitle}
+							value={output}
+							mode="readonly"
+							editorMode={outputEditorMode}
+							placeholder="Converted output..."
+							onCopy={handleCopyOutput}
+						/>
+					)
 				}
 			/>
 		</div>


### PR DESCRIPTION
## Summary

Phase D-2 follow-up — extends the empty-state pattern that PR #273 applied to format/query tabs to the remaining single-output tab families (convert, generate).

Schema and compare tab families remain off-pattern intentionally:

- **compare** has two input editors (no output pane), so an empty state would replace user input UI.
- **schema** has a dual-mode right pane that toggles between an inferred output editor and a user-supplied schema input editor; an empty state would mask the validation-input mode.

## Files

| File | Coverage | Icon | Title |
|------|----------|------|-------|
| `template/convert-tab.tsx` | Shared template — covers JSON / XML / YAML convert tabs in one place | `ArrowRightLeft` | `Enter ${inputEditorMode.toUpperCase()} to convert` |
| `formatter-tabs/json/generate-tab.tsx` | Per-format because each route owns its language picker | `Code` | "Enter JSON to generate code" |
| `formatter-tabs/xml/generate-tab.tsx` | Per-format | `Code` | "Enter XML to generate code" |
| `formatter-tabs/yaml/generate-tab.tsx` | Per-format | `Code` | "Enter YAML to generate code" |

All four follow the same `<SectionHeader … /> + <EmbeddedEmptyState fillHeight />` wrapper that `yaml/format-tab.tsx:376-398` and PR #273 already established. The generate-tab description string names the currently-selected target language via `LANGUAGE_INFO[generateLanguage].label`.

## Net change

```
4 files changed, 100 insertions(+), 36 deletions(-)
```

## Test plan

- [x] `bun run check` passes
- [x] Pre-commit hooks green (frontend-lint + frontend-format)
- [ ] Manual smoke: open Convert tab on JSON / XML / YAML with empty input — output side shows the new empty state with `ArrowRightLeft` icon
- [ ] Manual smoke: open Generate tab on each format with empty input — output side shows `Code` icon empty state, description reflects current language selection (e.g. switch to Java → description mentions Java)
- [ ] Manual smoke: type any non-whitespace input — output pane swaps back to the existing `CodeEditor`
