### PR TITLE
feat(form): add FormInput trailing slot and migrate url-encoder

### DIFF
--- a/src/lib/components/form/form-input.tsx
+++ b/src/lib/components/form/form-input.tsx
@@ -1,5 +1,5 @@
 import { Eye, EyeOff } from 'lucide-react';
-import { useState, type ChangeEvent, type FocusEvent } from 'react';
+import { useState, type ChangeEvent, type FocusEvent, type ReactNode } from 'react';
 
 import { Button } from '@/lib/components/ui/button';
 import { Input } from '@/lib/components/ui/input';
@@ -16,6 +16,11 @@ interface FormInputProps {
 	readonly hint?: string;
 	readonly size?: 'default' | 'compact';
 	readonly className?: string;
+	// Render adjacent to the Input on the right (e.g. a Sample / Reset / Copy
+	// button). When set, the input + trailing are laid out as a flex row so
+	// the trailing element keeps its natural width. Mutually exclusive with
+	// `showToggle`; pass one or the other.
+	readonly trailing?: ReactNode;
 	readonly onValueChange?: (value: string) => void;
 	readonly onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
 }
@@ -29,6 +34,7 @@ export function FormInput({
 	hint,
 	size = 'default',
 	className,
+	trailing,
 	onValueChange,
 	onBlur,
 }: FormInputProps) {
@@ -54,35 +60,46 @@ export function FormInput({
 
 	const toggleLabel = showValue ? 'Hide password' : 'Show password';
 
+	const input = (
+		<Input
+			type={inputType}
+			placeholder={placeholder}
+			value={value}
+			onChange={handleInput}
+			onBlur={onBlur}
+			className={cn(trailing ? 'flex-1' : '', inputClass)}
+		/>
+	);
+
 	return (
 		<div className="space-y-1">
 			<Label className={labelClass}>{label}</Label>
-			<div className="relative">
-				<Input
-					type={inputType}
-					placeholder={placeholder}
-					value={value}
-					onChange={handleInput}
-					onBlur={onBlur}
-					className={inputClass}
-				/>
-				{showToggle && type === 'password' ? (
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								variant="ghost"
-								size="icon-sm"
-								className="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-								onClick={() => setShowValue((prev) => !prev)}
-							>
-								{showValue ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-								<span className="sr-only">{toggleLabel}</span>
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>{toggleLabel}</TooltipContent>
-					</Tooltip>
-				) : null}
-			</div>
+			{trailing ? (
+				<div className="flex items-center gap-2">
+					{input}
+					{trailing}
+				</div>
+			) : (
+				<div className="relative">
+					{input}
+					{showToggle && type === 'password' ? (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon-sm"
+									className="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+									onClick={() => setShowValue((prev) => !prev)}
+								>
+									{showValue ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+									<span className="sr-only">{toggleLabel}</span>
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>{toggleLabel}</TooltipContent>
+						</Tooltip>
+					) : null}
+				</div>
+			)}
 			{hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
 		</div>
 	);

--- a/src/routes/url-encoder.tsx
+++ b/src/routes/url-encoder.tsx
@@ -416,25 +416,18 @@ function UrlEncoderPage() {
 	const renderParseTab = () => (
 		<div className="flex flex-1 flex-col overflow-hidden p-4">
 			<div className="mb-4">
-				<label
-					htmlFor="url-parse-input"
-					className="mb-1 block text-xs font-medium text-muted-foreground"
-				>
-					URL to Parse
-				</label>
-				<div className="flex gap-2">
-					<Input
-						id="url-parse-input"
-						type="text"
-						placeholder="https://example.com/path?query=value"
-						value={parseInput}
-						onChange={(e) => setParseInput(e.currentTarget.value)}
-						className="flex-1 font-mono text-sm"
-					/>
-					<Button variant="outline" size="sm" onClick={handleParseSample}>
-						Sample
-					</Button>
-				</div>
+				<FormInput
+					label="URL to Parse"
+					value={parseInput}
+					onValueChange={setParseInput}
+					placeholder="https://example.com/path?query=value"
+					className="font-mono"
+					trailing={
+						<Button variant="outline" size="sm" onClick={handleParseSample}>
+							Sample
+						</Button>
+					}
+				/>
 			</div>
 
 			{parsedUrl ? (
@@ -513,19 +506,12 @@ function UrlEncoderPage() {
 	const renderBuildTab = () => (
 		<div className="flex flex-1 flex-col overflow-hidden p-4">
 			<div className="mb-4">
-				<label
-					htmlFor="url-base-input"
-					className="mb-1 block text-xs font-medium text-muted-foreground"
-				>
-					Base URL
-				</label>
-				<Input
-					id="url-base-input"
-					type="text"
-					placeholder="https://example.com/path"
+				<FormInput
+					label="Base URL"
 					value={baseUrl}
-					onChange={(e) => setBaseUrl(e.currentTarget.value)}
-					className="font-mono text-sm"
+					onValueChange={setBaseUrl}
+					placeholder="https://example.com/path"
+					className="font-mono"
 				/>
 			</div>
 


### PR DESCRIPTION
## Summary

Phase E of the UI/UX polish series. Closes the form-rhythm exception that PR #272's audit identified at `routes/url-encoder.tsx:419-435,516-529`: two call sites paired raw `<label htmlFor>` + `<Input>` + (optional) `<Button>` markup instead of using the project's `FormInput` wrapper, because `FormInput` had no way to render a button adjacent to its input.

## Changes

### `feat(form)(form-input)`: add `trailing` slot

Added an optional `trailing?: ReactNode` prop to `FormInput`. When set, the input and trailing element are laid out as a `flex items-center gap-2` row — the trailing keeps its natural width while the input absorbs the remaining space via `flex-1`. The new branch is mutually exclusive with the existing password `showToggle` behaviour, which keeps its `relative` + absolutely-positioned variant intact.

```tsx
<FormInput
  label="URL to Parse"
  value={parseInput}
  onValueChange={setParseInput}
  placeholder="https://example.com/path?query=value"
  className="font-mono"
  trailing={
    <Button variant="outline" size="sm" onClick={handleParseSample}>
      Sample
    </Button>
  }
/>
```

### Migrate url-encoder

`routes/url-encoder.tsx`:

- Parse tab "URL to Parse" — now uses `FormInput` + `trailing={<Button>Sample</Button>}`.
- Build tab "Base URL" — now uses plain `FormInput`.

The query-parameter rows further down the Build tab keep their bare `<Input>` usage (they're inline key/value pairs without visible labels) and are out of scope for this pass.

## Net change

```
2 files changed, 61 insertions(+), 58 deletions(-)
```

## Test plan

- [x] `bun run check` passes
- [x] Pre-commit hooks green (frontend-lint + frontend-format)
- [ ] Manual smoke: `/url-encoder` Parse tab — URL input + Sample button are visually aligned, label uses FormInput's text-sm font-medium style
- [ ] Manual smoke: clicking Sample fills the input with the sample URL as before
- [ ] Manual smoke: `/url-encoder` Build tab — Base URL field renders with FormInput shape
- [ ] Manual smoke: any password FormInput (e.g. `/bcrypt-generator`) still shows the show/hide toggle as before (the showToggle branch is unchanged)
