### PR TITLE
refactor(status): consolidate empty-output and live-region patterns into primitives

### DIFF
--- a/src/lib/components/formatter-tabs/json/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/format-tab.tsx
@@ -10,9 +10,9 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SectionHeader, SplitPane } from '@/lib/components/layout';
+import { SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmbeddedEmptyState } from '@/lib/components/status';
+import { EmptyOutputPane } from '@/lib/components/status';
 import {
 	defaultJsonFormatOptions,
 	type JsonFormatOptions,
@@ -431,17 +431,12 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 				}
 				right={
 					input.trim().length === 0 ? (
-						<div className="flex h-full flex-col overflow-hidden">
-							<SectionHeader title="Output" />
-							<div className="flex-1">
-								<EmbeddedEmptyState
-									icon={FileText}
-									title="Enter JSON to format"
-									description="The formatted (or minified) document will appear here."
-									fillHeight
-								/>
-							</div>
-						</div>
+						<EmptyOutputPane
+							headerTitle="Output"
+							icon={FileText}
+							title="Enter JSON to format"
+							description="The formatted (or minified) document will appear here."
+						/>
 					) : (
 						<CodeEditor
 							title="Output"

--- a/src/lib/components/formatter-tabs/json/generate-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/generate-tab.tsx
@@ -10,9 +10,9 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SectionHeader, SplitPane } from '@/lib/components/layout';
+import { SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmbeddedEmptyState } from '@/lib/components/status';
+import { EmptyOutputPane } from '@/lib/components/status';
 import {
 	type CSharpOptions,
 	type GoOptions,
@@ -853,17 +853,12 @@ export function GenerateTab({ input, onInputChange, onStatsChange }: GenerateTab
 				}
 				right={
 					input.trim().length === 0 ? (
-						<div className="flex h-full flex-col overflow-hidden">
-							<SectionHeader title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`} />
-							<div className="flex-1">
-								<EmbeddedEmptyState
-									icon={Code}
-									title="Enter JSON to generate code"
-									description={`The ${LANGUAGE_INFO[generateLanguage].label} class definitions will appear here.`}
-									fillHeight
-								/>
-							</div>
-						</div>
+						<EmptyOutputPane
+							headerTitle={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
+							icon={Code}
+							title="Enter JSON to generate code"
+							description={`The ${LANGUAGE_INFO[generateLanguage].label} class definitions will appear here.`}
+						/>
 					) : (
 						<CodeEditor
 							title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}

--- a/src/lib/components/formatter-tabs/json/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/query-tab.tsx
@@ -9,9 +9,9 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SectionHeader, SplitPane } from '@/lib/components/layout';
+import { SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmbeddedEmptyState } from '@/lib/components/status';
+import { EmptyOutputPane } from '@/lib/components/status';
 import { executeJsonPath, validateJson } from '@/lib/services/formatters';
 import { useJsonFormatterOptions } from '@/lib/stores';
 import { copyToClipboard, pasteFromClipboard } from '@/lib/utils/file-operations';
@@ -243,17 +243,12 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 				}
 				right={
 					input.trim().length === 0 ? (
-						<div className="flex h-full flex-col overflow-hidden">
-							<SectionHeader title="Result" />
-							<div className="flex-1">
-								<EmbeddedEmptyState
-									icon={Search}
-									title="Enter JSON to query"
-									description="Run a JSONPath expression to see matching values here."
-									fillHeight
-								/>
-							</div>
-						</div>
+						<EmptyOutputPane
+							headerTitle="Result"
+							icon={Search}
+							title="Enter JSON to query"
+							description="Run a JSONPath expression to see matching values here."
+						/>
 					) : (
 						<CodeEditor
 							title="Result"

--- a/src/lib/components/formatter-tabs/xml/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/format-tab.tsx
@@ -10,9 +10,9 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SectionHeader, SplitPane } from '@/lib/components/layout';
+import { SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmbeddedEmptyState } from '@/lib/components/status';
+import { EmptyOutputPane } from '@/lib/components/status';
 import {
 	defaultXmlFormatOptions,
 	formatXml,
@@ -277,17 +277,12 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 				}
 				right={
 					input.trim().length === 0 ? (
-						<div className="flex h-full flex-col overflow-hidden">
-							<SectionHeader title="Output" />
-							<div className="flex-1">
-								<EmbeddedEmptyState
-									icon={FileText}
-									title="Enter XML to format"
-									description="The formatted (or minified) document will appear here."
-									fillHeight
-								/>
-							</div>
-						</div>
+						<EmptyOutputPane
+							headerTitle="Output"
+							icon={FileText}
+							title="Enter XML to format"
+							description="The formatted (or minified) document will appear here."
+						/>
 					) : (
 						<CodeEditor
 							title="Output"

--- a/src/lib/components/formatter-tabs/xml/generate-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/generate-tab.tsx
@@ -10,9 +10,9 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SectionHeader, SplitPane } from '@/lib/components/layout';
+import { SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmbeddedEmptyState } from '@/lib/components/status';
+import { EmptyOutputPane } from '@/lib/components/status';
 import {
 	type CSharpOptions,
 	generateCode,
@@ -851,17 +851,12 @@ export function GenerateTab({ input, onInputChange, onStatsChange }: GenerateTab
 				}
 				right={
 					input.trim().length === 0 ? (
-						<div className="flex h-full flex-col overflow-hidden">
-							<SectionHeader title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`} />
-							<div className="flex-1">
-								<EmbeddedEmptyState
-									icon={Code}
-									title="Enter XML to generate code"
-									description={`The ${LANGUAGE_INFO[generateLanguage].label} class definitions will appear here.`}
-									fillHeight
-								/>
-							</div>
-						</div>
+						<EmptyOutputPane
+							headerTitle={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
+							icon={Code}
+							title="Enter XML to generate code"
+							description={`The ${LANGUAGE_INFO[generateLanguage].label} class definitions will appear here.`}
+						/>
 					) : (
 						<CodeEditor
 							title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}

--- a/src/lib/components/formatter-tabs/xml/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/query-tab.tsx
@@ -3,9 +3,9 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { CodeEditor } from '@/lib/components/editor';
 import { FormInput, FormSection } from '@/lib/components/form';
-import { SectionHeader, SplitPane } from '@/lib/components/layout';
+import { SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmbeddedEmptyState } from '@/lib/components/status';
+import { EmptyOutputPane } from '@/lib/components/status';
 import { executeXPath, formatXml } from '@/lib/services/formatters';
 import { copyToClipboard, pasteFromClipboard } from '@/lib/utils/file-operations';
 
@@ -162,17 +162,12 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 				}
 				right={
 					input.trim().length === 0 ? (
-						<div className="flex h-full flex-col overflow-hidden">
-							<SectionHeader title="Result" />
-							<div className="flex-1">
-								<EmbeddedEmptyState
-									icon={Search}
-									title="Enter XML to query"
-									description="Run an XPath expression to see matching nodes here."
-									fillHeight
-								/>
-							</div>
-						</div>
+						<EmptyOutputPane
+							headerTitle="Result"
+							icon={Search}
+							title="Enter XML to query"
+							description="Run an XPath expression to see matching nodes here."
+						/>
 					) : (
 						<CodeEditor
 							title="Result"

--- a/src/lib/components/formatter-tabs/yaml/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/format-tab.tsx
@@ -12,9 +12,9 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SectionHeader, SplitPane } from '@/lib/components/layout';
+import { SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmbeddedEmptyState } from '@/lib/components/status';
+import { EmptyOutputPane } from '@/lib/components/status';
 import { SAMPLE_YAML, sortKeysDeep, validateYaml } from '@/lib/services/formatters';
 
 type FormatMode = 'format' | 'minify';
@@ -374,17 +374,12 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 				}
 				right={
 					input.trim().length === 0 ? (
-						<div className="flex h-full flex-col overflow-hidden">
-							<SectionHeader title="Output" />
-							<div className="flex-1">
-								<EmbeddedEmptyState
-									icon={FileText}
-									title="Enter YAML to format"
-									description="The formatted (or minified) document will appear here."
-									fillHeight
-								/>
-							</div>
-						</div>
+						<EmptyOutputPane
+							headerTitle="Output"
+							icon={FileText}
+							title="Enter YAML to format"
+							description="The formatted (or minified) document will appear here."
+						/>
 					) : (
 						<CodeEditor
 							title="Output"

--- a/src/lib/components/formatter-tabs/yaml/generate-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/generate-tab.tsx
@@ -11,9 +11,9 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SectionHeader, SplitPane } from '@/lib/components/layout';
+import { SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmbeddedEmptyState } from '@/lib/components/status';
+import { EmptyOutputPane } from '@/lib/components/status';
 import {
 	type CSharpOptions,
 	generateCode,
@@ -849,17 +849,12 @@ export function GenerateTab({ input, onInputChange, onStatsChange }: GenerateTab
 				}
 				right={
 					input.trim().length === 0 ? (
-						<div className="flex h-full flex-col overflow-hidden">
-							<SectionHeader title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`} />
-							<div className="flex-1">
-								<EmbeddedEmptyState
-									icon={Code}
-									title="Enter YAML to generate code"
-									description={`The ${LANGUAGE_INFO[generateLanguage].label} class definitions will appear here.`}
-									fillHeight
-								/>
-							</div>
-						</div>
+						<EmptyOutputPane
+							headerTitle={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
+							icon={Code}
+							title="Enter YAML to generate code"
+							description={`The ${LANGUAGE_INFO[generateLanguage].label} class definitions will appear here.`}
+						/>
 					) : (
 						<CodeEditor
 							title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}

--- a/src/lib/components/formatter-tabs/yaml/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/query-tab.tsx
@@ -10,9 +10,9 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SectionHeader, SplitPane } from '@/lib/components/layout';
+import { SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmbeddedEmptyState } from '@/lib/components/status';
+import { EmptyOutputPane } from '@/lib/components/status';
 import { executeJsonPath } from '@/lib/services/formatters';
 import { copyToClipboard, pasteFromClipboard } from '@/lib/utils/file-operations';
 
@@ -245,17 +245,12 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 				}
 				right={
 					input.trim().length === 0 ? (
-						<div className="flex h-full flex-col overflow-hidden">
-							<SectionHeader title="Result" />
-							<div className="flex-1">
-								<EmbeddedEmptyState
-									icon={Search}
-									title="Enter YAML to query"
-									description="Run a JSONPath expression to see matching values here."
-									fillHeight
-								/>
-							</div>
-						</div>
+						<EmptyOutputPane
+							headerTitle="Result"
+							icon={Search}
+							title="Enter YAML to query"
+							description="Run a JSONPath expression to see matching values here."
+						/>
 					) : (
 						<CodeEditor
 							title="Result"

--- a/src/lib/components/status/empty-output-pane.tsx
+++ b/src/lib/components/status/empty-output-pane.tsx
@@ -1,0 +1,33 @@
+import type { LucideIcon } from 'lucide-react';
+
+import { SectionHeader } from '@/lib/components/layout/section-header';
+
+import { EmbeddedEmptyState } from './embedded-empty-state';
+
+interface EmptyOutputPaneProps {
+	// SectionHeader title rendered at the top of the pane.
+	readonly headerTitle: string;
+	// Lucide icon for the empty-state graphic.
+	readonly icon: LucideIcon;
+	// Empty-state title (e.g. "Enter JSON to format").
+	readonly title: string;
+	// Empty-state description (e.g. "The formatted document will appear here.").
+	readonly description: string;
+}
+
+// Wraps `SectionHeader` + `EmbeddedEmptyState fillHeight` in the flex-col +
+// `flex-1` shell that every "output pane is empty" branch of a formatter tab
+// used to render inline. Single source of truth for the structural skeleton;
+// the icon/title/description vary per tab and stay configurable.
+export function EmptyOutputPane({ headerTitle, icon, title, description }: EmptyOutputPaneProps) {
+	return (
+		<div className="flex h-full flex-col overflow-hidden">
+			<SectionHeader title={headerTitle} />
+			<div className="flex-1">
+				<EmbeddedEmptyState icon={icon} title={title} description={description} fillHeight />
+			</div>
+		</div>
+	);
+}
+
+export type { EmptyOutputPaneProps };

--- a/src/lib/components/status/index.ts
+++ b/src/lib/components/status/index.ts
@@ -4,11 +4,17 @@ export type { DetectedInfoProps, DetectedItem } from './detected-info';
 export { EmbeddedEmptyState } from './embedded-empty-state';
 export type { EmbeddedEmptyStateProps } from './embedded-empty-state';
 
+export { EmptyOutputPane } from './empty-output-pane';
+export type { EmptyOutputPaneProps } from './empty-output-pane';
+
 export { EmptyState } from './empty-state';
 export type { EmptyStateProps } from './empty-state';
 
 export { ErrorDisplay } from './error-display';
 export type { ErrorDisplayProps } from './error-display';
+
+export { LiveStatusRegion } from './live-status-region';
+export type { LiveStatusRegionProps } from './live-status-region';
 
 export { LoadingOverlay } from './loading-overlay';
 export type { LoadingOverlayProps } from './loading-overlay';

--- a/src/lib/components/status/live-status-region.tsx
+++ b/src/lib/components/status/live-status-region.tsx
@@ -1,0 +1,33 @@
+import type { ComponentProps } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface LiveStatusRegionProps extends ComponentProps<'div'> {
+	// `aria-atomic` mode. `"false"` (default) announces only the diff inside the
+	// region — appropriate for multi-row outputs (generator lists, key-pair
+	// sections) where re-announcing the entire region would be noisy. Pass
+	// `"true"` for single-cell status that should always be read in full
+	// (cron-expression-builder schedule lines, regex match summary).
+	readonly atomic?: 'true' | 'false';
+}
+
+// Polite live region for tool output. Bakes in the
+// `role="status" aria-live="polite" aria-atomic="..."` triad used across
+// every tool route that announces a freshly produced result. Single source of
+// truth for the screen-reader contract; callers only need to bring the
+// className / children, and pick `atomic` if the default `"false"` is not
+// what they want.
+export function LiveStatusRegion({
+	className,
+	atomic = 'false',
+	children,
+	...props
+}: LiveStatusRegionProps) {
+	return (
+		<div role="status" aria-live="polite" aria-atomic={atomic} className={cn(className)} {...props}>
+			{children}
+		</div>
+	);
+}
+
+export type { LiveStatusRegionProps };

--- a/src/lib/components/template/convert-tab.tsx
+++ b/src/lib/components/template/convert-tab.tsx
@@ -2,9 +2,9 @@ import { ArrowRightLeft } from 'lucide-react';
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 
 import { CodeEditor, type EditorMode } from '@/lib/components/editor';
-import { SectionHeader, SplitPane } from '@/lib/components/layout';
+import { SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmbeddedEmptyState } from '@/lib/components/status';
+import { EmptyOutputPane } from '@/lib/components/status';
 
 type ValidationResult = { valid: boolean | null } & Record<string, unknown>;
 type StatsResult = { input: string; valid: boolean | null; error: string } & Record<
@@ -125,17 +125,12 @@ export function ConvertTab({
 				}
 				right={
 					input.trim().length === 0 ? (
-						<div className="flex h-full flex-col overflow-hidden">
-							<SectionHeader title={outputTitle ?? 'Output'} />
-							<div className="flex-1">
-								<EmbeddedEmptyState
-									icon={ArrowRightLeft}
-									title={`Enter ${inputEditorMode.toUpperCase()} to convert`}
-									description="The converted document will appear here."
-									fillHeight
-								/>
-							</div>
-						</div>
+						<EmptyOutputPane
+							headerTitle={outputTitle ?? 'Output'}
+							icon={ArrowRightLeft}
+							title={`Enter ${inputEditorMode.toUpperCase()} to convert`}
+							description="The converted document will appear here."
+						/>
 					) : (
 						<CodeEditor
 							title={outputTitle}

--- a/src/routes/bcrypt-generator.tsx
+++ b/src/routes/bcrypt-generator.tsx
@@ -7,7 +7,13 @@ import { ActionButton, CopyButton } from '@/lib/components/action';
 import { FormInfo, FormInput, FormMode, FormSection, FormSlider } from '@/lib/components/form';
 import { SectionHeader } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
-import { EmptyState, ErrorDisplay, LoadingOverlay, StatItem } from '@/lib/components/status';
+import {
+	EmptyState,
+	ErrorDisplay,
+	LiveStatusRegion,
+	LoadingOverlay,
+	StatItem,
+} from '@/lib/components/status';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import {
 	type BcryptCostInfo,
@@ -366,12 +372,7 @@ function BcryptGeneratorPage() {
 					title={activeTab === 'generate' ? 'Generated Hash' : 'Verification Result'}
 				/>
 
-				<div
-					className="flex-1 overflow-auto p-4"
-					role="status"
-					aria-live="polite"
-					aria-atomic="false"
-				>
+				<LiveStatusRegion className="flex-1 overflow-auto p-4">
 					{activeTab === 'generate' ? (
 						hashResult ? (
 							<div key={flashCounter} className="animate-flash-success space-y-4 rounded-md">
@@ -463,7 +464,7 @@ function BcryptGeneratorPage() {
 					) : (
 						<EmptyState icon={ShieldCheck} title="Enter a password and hash to verify" />
 					)}
-				</div>
+				</LiveStatusRegion>
 			</div>
 		</ToolShell>
 	);

--- a/src/routes/gpg-key-generator.tsx
+++ b/src/routes/gpg-key-generator.tsx
@@ -15,7 +15,13 @@ import {
 } from '@/lib/components/form';
 import { SectionHeader } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
-import { EmptyState, ErrorDisplay, LoadingOverlay, StatItem } from '@/lib/components/status';
+import {
+	EmptyState,
+	ErrorDisplay,
+	LiveStatusRegion,
+	LoadingOverlay,
+	StatItem,
+} from '@/lib/components/status';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import {
 	buildGpgUserId,
@@ -343,12 +349,7 @@ function GpgKeyGeneratorPage() {
 				/>
 				<SectionHeader title="Generated Keys" />
 
-				<div
-					className="flex-1 overflow-auto p-4"
-					role="status"
-					aria-live="polite"
-					aria-atomic="false"
-				>
+				<LiveStatusRegion className="flex-1 overflow-auto p-4">
 					{keyResult ? (
 						<div key={flashCounter} className="animate-flash-success space-y-4 rounded-md">
 							{showKeyInfo ? (
@@ -484,7 +485,7 @@ function GpgKeyGeneratorPage() {
 							description="Name and email are required"
 						/>
 					)}
-				</div>
+				</LiveStatusRegion>
 			</div>
 		</ToolShell>
 	);

--- a/src/routes/hash-generator.tsx
+++ b/src/routes/hash-generator.tsx
@@ -7,7 +7,7 @@ import { CodeEditor } from '@/lib/components/editor';
 import { FormInfo, FormSection } from '@/lib/components/form';
 import { SectionHeader } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
-import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { EmbeddedEmptyState, LiveStatusRegion, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import {
@@ -121,12 +121,7 @@ function HashGeneratorPage() {
 				</div>
 				<div className="flex flex-1 flex-col overflow-hidden">
 					<SectionHeader title="Hash Results" />
-					<div
-						className="flex-1 overflow-auto p-4"
-						role="status"
-						aria-live="polite"
-						aria-atomic="false"
-					>
+					<LiveStatusRegion className="flex-1 overflow-auto p-4">
 						{textHashes.length > 0 ? (
 							<div className="space-y-3">
 								{textHashes.map((result) => (
@@ -173,7 +168,7 @@ function HashGeneratorPage() {
 								fillHeight
 							/>
 						)}
-					</div>
+					</LiveStatusRegion>
 				</div>
 			</div>
 		</ToolShell>

--- a/src/routes/jwt-decoder.tsx
+++ b/src/routes/jwt-decoder.tsx
@@ -7,7 +7,7 @@ import { CodeEditor } from '@/lib/components/editor';
 import { FormInfo, FormSection } from '@/lib/components/form';
 import { SectionHeader } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
-import { EmptyState } from '@/lib/components/status';
+import { EmptyState, LiveStatusRegion } from '@/lib/components/status';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/lib/components/ui/tooltip';
 import {
@@ -181,12 +181,7 @@ function JwtDecoderPage() {
 				<div className="flex flex-1 flex-col overflow-hidden">
 					<SectionHeader title="Decoded Token" />
 					{decoded ? (
-						<div
-							className="flex-1 space-y-4 overflow-auto p-4"
-							role="status"
-							aria-live="polite"
-							aria-atomic="false"
-						>
+						<LiveStatusRegion className="flex-1 space-y-4 overflow-auto p-4">
 							{decoded.isExpired ? (
 								<div className="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
 									<AlertTriangle className="h-4 w-4" />
@@ -310,7 +305,7 @@ function JwtDecoderPage() {
 									</p>
 								</CardContent>
 							</Card>
-						</div>
+						</LiveStatusRegion>
 					) : (
 						<div className="flex-1">
 							{error ? (

--- a/src/routes/network-scanner.tsx
+++ b/src/routes/network-scanner.tsx
@@ -30,7 +30,7 @@ import {
 } from '@/lib/components/form';
 import { UnifiedHostDetailPanel, UnifiedHostListItem } from '@/lib/components/network-scanner';
 import { ToolShell } from '@/lib/components/shell';
-import { EmptyState, ErrorDisplay, StatItem } from '@/lib/components/status';
+import { EmptyState, ErrorDisplay, LiveStatusRegion, StatItem } from '@/lib/components/status';
 import {
 	Accordion,
 	AccordionContent,
@@ -848,12 +848,7 @@ function ScanProgressPanel({
 	onCancel,
 }: ScanProgressPanelProps) {
 	return (
-		<div
-			className="shrink-0 border-b bg-surface-2 px-4 py-3"
-			role="status"
-			aria-live="polite"
-			aria-atomic="false"
-		>
+		<LiveStatusRegion className="shrink-0 border-b bg-surface-2 px-4 py-3">
 			<div className="mb-2 flex items-center justify-between">
 				<div className="flex items-center gap-2">
 					<Loader2 className="h-4 w-4 animate-spin text-primary" />
@@ -905,7 +900,7 @@ function ScanProgressPanel({
 					) : null}
 				</div>
 			</div>
-		</div>
+		</LiveStatusRegion>
 	);
 }
 
@@ -936,11 +931,9 @@ function HostListPane({
 }: HostListPaneProps) {
 	return (
 		<div className="flex h-full flex-col border-r">
-			<div
+			<LiveStatusRegion
+				atomic="true"
 				className="flex h-9 shrink-0 items-center justify-between border-b bg-surface-3 px-3"
-				role="status"
-				aria-live="polite"
-				aria-atomic="true"
 			>
 				<span className="text-xs font-medium text-muted-foreground">
 					Hosts ({unifiedHosts.length})
@@ -948,7 +941,7 @@ function HostListPane({
 				{totalOpenPorts > 0 ? (
 					<span className="text-xs text-success">{totalOpenPorts} open ports</span>
 				) : null}
-			</div>
+			</LiveStatusRegion>
 			<div
 				className="flex-1 overflow-auto outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-inset"
 				role="listbox"

--- a/src/routes/password-generator.tsx
+++ b/src/routes/password-generator.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/lib/components/form';
 import { SectionHeader } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
-import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { EmbeddedEmptyState, LiveStatusRegion, StatItem } from '@/lib/components/status';
 import { Card, CardContent } from '@/lib/components/ui/card';
 import { createToolOptionsStore } from '@/lib/stores';
 import {
@@ -264,12 +264,7 @@ function PasswordGeneratorPage() {
 						) : null
 					}
 				/>
-				<div
-					className="flex-1 overflow-auto p-4"
-					role="status"
-					aria-live="polite"
-					aria-atomic="false"
-				>
+				<LiveStatusRegion className="flex-1 overflow-auto p-4">
 					{results.length > 0 ? (
 						<div key={flashCounter} className="animate-flash-success space-y-2 rounded-md">
 							{results.map((password) => (
@@ -289,7 +284,7 @@ function PasswordGeneratorPage() {
 							fillHeight
 						/>
 					)}
-				</div>
+				</LiveStatusRegion>
 			</div>
 		</ToolShell>
 	);

--- a/src/routes/qr-code-generator.tsx
+++ b/src/routes/qr-code-generator.tsx
@@ -29,7 +29,7 @@ import {
 } from '@/lib/components/form';
 import { SectionHeader } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
-import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { EmbeddedEmptyState, LiveStatusRegion, StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/lib/components/ui/tooltip';
@@ -705,12 +705,7 @@ function QrCodeGeneratorPage() {
 					}
 				/>
 
-				<div
-					className="flex-1 overflow-auto p-6"
-					role="status"
-					aria-live="polite"
-					aria-atomic="false"
-				>
+				<LiveStatusRegion className="flex-1 overflow-auto p-6">
 					<div className="mx-auto flex max-w-3xl flex-col gap-6">
 						<Card density="compact" className="overflow-hidden">
 							<CardContent className="flex items-center justify-center p-8">
@@ -750,7 +745,7 @@ function QrCodeGeneratorPage() {
 							</CardContent>
 						</Card>
 					</div>
-				</div>
+				</LiveStatusRegion>
 			</div>
 		</ToolShell>
 	);

--- a/src/routes/ssh-key-generator.tsx
+++ b/src/routes/ssh-key-generator.tsx
@@ -14,7 +14,13 @@ import {
 } from '@/lib/components/form';
 import { SectionHeader } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
-import { EmptyState, ErrorDisplay, LoadingOverlay, StatItem } from '@/lib/components/status';
+import {
+	EmptyState,
+	ErrorDisplay,
+	LiveStatusRegion,
+	LoadingOverlay,
+	StatItem,
+} from '@/lib/components/status';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import {
 	cancelWorkerOperation,
@@ -307,12 +313,7 @@ function SshKeyGeneratorPage() {
 				/>
 				<SectionHeader title="Generated Keys" />
 
-				<div
-					className="flex-1 overflow-auto p-4"
-					role="status"
-					aria-live="polite"
-					aria-atomic="false"
-				>
+				<LiveStatusRegion className="flex-1 overflow-auto p-4">
 					{keyResult ? (
 						<div key={flashCounter} className="animate-flash-success space-y-4 rounded-md">
 							{showFingerprint ? (
@@ -414,7 +415,7 @@ function SshKeyGeneratorPage() {
 					) : (
 						<EmptyState icon={Key} title="Configure options and generate an SSH key pair" />
 					)}
-				</div>
+				</LiveStatusRegion>
 			</div>
 		</ToolShell>
 	);

--- a/src/routes/uuid-generator.tsx
+++ b/src/routes/uuid-generator.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/lib/components/form';
 import { SectionHeader } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
-import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { EmbeddedEmptyState, LiveStatusRegion, StatItem } from '@/lib/components/status';
 import { Card, CardContent } from '@/lib/components/ui/card';
 import { createToolOptionsStore } from '@/lib/stores';
 import {
@@ -258,12 +258,7 @@ function UuidGeneratorPage() {
 						) : null
 					}
 				/>
-				<div
-					className="flex-1 overflow-auto p-4"
-					role="status"
-					aria-live="polite"
-					aria-atomic="false"
-				>
+				<LiveStatusRegion className="flex-1 overflow-auto p-4">
 					{results.length > 0 ? (
 						<div key={flashCounter} className="animate-flash-success space-y-2 rounded-md">
 							{results.map((uuid) => (
@@ -283,7 +278,7 @@ function UuidGeneratorPage() {
 							fillHeight
 						/>
 					)}
-				</div>
+				</LiveStatusRegion>
 			</div>
 		</ToolShell>
 	);


### PR DESCRIPTION
## Summary

Addresses the DRY/SSOT concern raised on the polish-series PRs: the recent phases (especially #273, #275, #276) had each route or tab repeat the same structural JSX (empty-output wrapper, live-region triad) inline, even though the same shapes were reused 10+ times.

Two new primitives + one mechanical migration across **20 call sites**.

## New primitives

### `EmptyOutputPane` (`status/empty-output-pane.tsx`)

Wraps the `<div className="flex h-full flex-col overflow-hidden"><SectionHeader title=… /><div className="flex-1"><EmbeddedEmptyState fillHeight … /></div></div>` shell into a single component. Per-tab icon / title / description stay configurable.

```tsx
<EmptyOutputPane
  headerTitle="Output"
  icon={FileText}
  title="Enter JSON to format"
  description="The formatted (or minified) document will appear here."
/>
```

### `LiveStatusRegion` (`status/live-status-region.tsx`)

Bakes in the `role="status" aria-live="polite" aria-atomic="…"` triad. Defaults `atomic` to `"false"` (the most common shape — multi-row generator output); callers can pass `"true"` for single-cell summaries that should re-announce in full.

```tsx
<LiveStatusRegion className="flex-1 overflow-auto p-4">
  {results.length > 0 ? <List … /> : <EmbeddedEmptyState … />}
</LiveStatusRegion>
```

Both ride through the existing `@/lib/components/status` barrel so consumers pick them up alongside `EmbeddedEmptyState`, `EmptyState`, `ErrorDisplay`, etc.

## Callsite migrations

| Primitive | Callsites |
|-----------|-----------|
| `EmptyOutputPane` (10) | `template/convert-tab.tsx`, `formatter-tabs/{json,xml,yaml}/format-tab.tsx`, `formatter-tabs/{json,xml,yaml}/query-tab.tsx`, `formatter-tabs/{json,xml,yaml}/generate-tab.tsx` |
| `LiveStatusRegion` (10) | `routes/hash-generator.tsx`, `routes/jwt-decoder.tsx`, `routes/network-scanner.tsx` (×2 — scan progress + host count; the latter passes `atomic="true"`), `routes/bcrypt-generator.tsx`, `routes/gpg-key-generator.tsx`, `routes/ssh-key-generator.tsx`, `routes/qr-code-generator.tsx`, `routes/uuid-generator.tsx`, `routes/password-generator.tsx` |

`SectionHeader` and `EmbeddedEmptyState` imports drop out of the formatter-tab consumers because the wrapper now lives inside `EmptyOutputPane`.

## Out of scope

* `cron-expression-builder.tsx`'s aria-live regions sit on `CardContent` rather than a plain `<div>` and need a different shape (or no wrapper). Left alone.
* `network-scanner.tsx:1000` and `network-interfaces.tsx:653` use `role="status" aria-busy="true"` for skeleton loading; they're a different live-region semantic and not in scope.

## Net change

```
22 files changed, 200 insertions(+), 207 deletions(-)
```

Subtracting the +72 lines of the two new primitives, this is a **-79 line** reduction across the 20 callsites — and a single source of truth for both the empty-output shape and the screen-reader announcement contract.

## Test plan

- [x] `bun run check` passes
- [x] Pre-commit hooks green on both commits (frontend-lint + frontend-format)
- [ ] Visual smoke: open JSON / XML / YAML formatter tabs with empty input — the same empty-pane shape as before (header + centred icon + title + description)
- [ ] Visual smoke: open convert / generate tabs on each format — same empty-pane shape
- [ ] VoiceOver smoke: generate a hash, key pair, QR code, UUID, password — VO still announces newly produced results (the `polite + atomic=false` contract is preserved)
- [ ] VoiceOver smoke: `network-scanner` host list count re-announces in full when the count changes (the `atomic="true"` path)
