### PR TITLE
refactor(hooks): introduce useDocumentTitle and unify route titles

### DIFF
--- a/src/lib/components/template/tabbed-formatter-page.tsx
+++ b/src/lib/components/template/tabbed-formatter-page.tsx
@@ -1,7 +1,8 @@
 import { ArrowRightLeft, Code2, FileCheck, GitCompare, Play, Search } from 'lucide-react';
-import { useEffect, type ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import { ToolShell } from '@/lib/components/shell';
+import { useDocumentTitle } from '@/lib/hooks';
 import {
 	useFormatterPage,
 	type FormatterTabType,
@@ -59,14 +60,7 @@ export function TabbedFormatterPage<TStats>({
 }: TabbedFormatterPageProps<TStats>) {
 	const page = useFormatterPage<TStats>({ calculateStats, persistKey });
 
-	// Set document title to mirror Svelte's `<svelte:head><title>` behaviour.
-	useEffect(() => {
-		const previous = document.title;
-		document.title = `${title} - Kogu`;
-		return () => {
-			document.title = previous;
-		};
-	}, [title]);
+	useDocumentTitle(title);
 
 	const handleTabChange = (tab: string) => {
 		page.tabSync.setActiveTab(tab as FormatterTabType);

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useDocumentTitle } from './use-document-title';
 export {
 	useFormatterPage,
 	FORMATTER_TABS,

--- a/src/lib/hooks/use-document-title.ts
+++ b/src/lib/hooks/use-document-title.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+const APP_NAME = 'Kogu';
+const TITLE_SEPARATOR = '—';
+
+// Set the document title for the lifetime of the component, restoring the
+// previous value on unmount. The final title is `"${title} ${TITLE_SEPARATOR}
+// Kogu"`. Centralises the side-effect that every tool route used to spell
+// out by hand, and pins one canonical separator (em-dash) across the app —
+// before extraction the routes split between `—` and `-` for the same
+// position.
+export function useDocumentTitle(title: string): void {
+	useEffect(() => {
+		const previous = document.title;
+		document.title = `${title} ${TITLE_SEPARATOR} ${APP_NAME}`;
+		return () => {
+			document.title = previous;
+		};
+	}, [title]);
+}

--- a/src/routes/base64-encoder.tsx
+++ b/src/routes/base64-encoder.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Code2 } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -15,6 +15,7 @@ import {
 import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { useDocumentTitle } from '@/lib/hooks';
 import {
 	BASE64_MIME_TYPES,
 	type Base64DecodeOptions,
@@ -59,9 +60,7 @@ function Base64EncoderPage() {
 		defaultBase64DecodeOptions.autoDetectVariant
 	);
 
-	useEffect(() => {
-		document.title = 'Base64 Encoder — Kogu';
-	}, []);
+	useDocumentTitle('Base64 Encoder');
 
 	const encodeOptions: Partial<Base64EncodeOptions> = {
 		variant,

--- a/src/routes/bcrypt-generator.tsx
+++ b/src/routes/bcrypt-generator.tsx
@@ -15,6 +15,7 @@ import {
 	StatItem,
 } from '@/lib/components/status';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { useDocumentTitle } from '@/lib/hooks';
 import {
 	type BcryptCostInfo,
 	type BcryptHashResult,
@@ -60,9 +61,7 @@ function BcryptGeneratorPage() {
 	const [elapsedMs, setElapsedMs] = useState(0);
 	const timerIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-	useEffect(() => {
-		document.title = 'BCrypt Generator — Kogu';
-	}, []);
+	useDocumentTitle('BCrypt Generator');
 
 	useEffect(() => {
 		getBcryptCostInfo(cost)

--- a/src/routes/cron-expression-builder.tsx
+++ b/src/routes/cron-expression-builder.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Calendar, Check, Clock, FlaskConical, Pencil, Search, Sparkles, X } from 'lucide-react';
 
 import { CopyButton } from '@/lib/components/action';
@@ -17,6 +17,7 @@ import {
 } from '@/lib/components/ui/card';
 import { useActiveTab, useTabStore } from '@/lib/stores';
 import { cn } from '@/lib/utils';
+import { useDocumentTitle } from '@/lib/hooks';
 import {
 	buildExpression,
 	CRON_FIELDS,
@@ -61,9 +62,7 @@ function CronExpressionBuilderPage() {
 	const [buildParts, setBuildParts] = useState<CronParts>({ ...DEFAULT_CRON_PARTS });
 	const [parseInput, setParseInput] = useState<string>('');
 
-	useEffect(() => {
-		document.title = 'Cron Expression Builder — Kogu';
-	}, []);
+	useDocumentTitle('Cron Expression Builder');
 
 	const buildExpr = buildExpression(buildParts);
 	const buildFieldValidations = Object.fromEntries(

--- a/src/routes/curl-builder.tsx
+++ b/src/routes/curl-builder.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
 	Code2,
 	FileCode,
@@ -34,6 +34,7 @@ import {
 } from '@/lib/components/ui/card';
 import { useActiveTab, useTabStore } from '@/lib/stores';
 import { cn } from '@/lib/utils';
+import { useDocumentTitle } from '@/lib/hooks';
 import {
 	AUTH_SCHEMES,
 	BODY_MODES,
@@ -105,9 +106,7 @@ function CurlBuilderPage() {
 	const [parseInput, setParseInput] = useState<string>('');
 	const [codeLang, setCodeLang] = useState<Language>('fetch');
 
-	useEffect(() => {
-		document.title = 'cURL Builder — Kogu';
-	}, []);
+	useDocumentTitle('cURL Builder');
 
 	const headers = useMemo(() => parseHeaderLines(headersText), [headersText]);
 

--- a/src/routes/diff-viewer.tsx
+++ b/src/routes/diff-viewer.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Equal, GitCompare, Layers, Minus, Plus, SplitSquareHorizontal } from 'lucide-react';
 import { readText } from '@tauri-apps/plugin-clipboard-manager';
 
@@ -14,6 +14,7 @@ import {
 } from '@/lib/components/form';
 import { ToolShell } from '@/lib/components/shell';
 import { EmptyState } from '@/lib/components/status';
+import { useDocumentTitle } from '@/lib/hooks';
 import {
 	areTextsIdentical,
 	computeEnhancedDiff,
@@ -61,9 +62,7 @@ function DiffViewerPage() {
 	const [contextLines, setContextLines] = useState(3);
 	const [showInlineDiff, setShowInlineDiff] = useState(true);
 
-	useEffect(() => {
-		document.title = 'Diff Viewer — Kogu';
-	}, []);
+	useDocumentTitle('Diff Viewer');
 
 	const diffOptions: Partial<DiffOptions> = { ignoreWhitespace, ignoreCase, trimLines };
 

--- a/src/routes/gpg-key-generator.tsx
+++ b/src/routes/gpg-key-generator.tsx
@@ -23,6 +23,7 @@ import {
 	StatItem,
 } from '@/lib/components/status';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { useDocumentTitle } from '@/lib/hooks';
 import {
 	buildGpgUserId,
 	cancelWorkerOperation,
@@ -66,9 +67,7 @@ function GpgKeyGeneratorPage() {
 	const [elapsedMs, setElapsedMs] = useState(0);
 	const timerIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-	useEffect(() => {
-		document.title = 'GPG Key Generator — Kogu';
-	}, []);
+	useDocumentTitle('GPG Key Generator');
 
 	useEffect(() => {
 		checkCliAvailability()

--- a/src/routes/hash-generator.tsx
+++ b/src/routes/hash-generator.tsx
@@ -1,10 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Hash, ShieldAlert, ShieldCheck } from 'lucide-react';
 
 import { CopyButton } from '@/lib/components/action';
 import { CodeEditor } from '@/lib/components/editor';
 import { FormInfo, FormSection } from '@/lib/components/form';
+import { useDocumentTitle } from '@/lib/hooks';
 import { SectionHeader } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, LiveStatusRegion, StatItem } from '@/lib/components/status';
@@ -25,9 +26,7 @@ function HashGeneratorPage() {
 	const [textInput, setTextInput] = useState('');
 	const [showOptions, setShowOptions] = useState(true);
 
-	useEffect(() => {
-		document.title = 'Hash Generator — Kogu';
-	}, []);
+	useDocumentTitle('Hash Generator');
 
 	const textHashes = useMemo(() => {
 		if (!textInput.trim()) return [];

--- a/src/routes/jwt-decoder.tsx
+++ b/src/routes/jwt-decoder.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { AlertTriangle, CheckCircle, Clock, Info, KeyRound } from 'lucide-react';
 
 import { CopyButton } from '@/lib/components/action';
@@ -10,6 +10,7 @@ import { ToolShell } from '@/lib/components/shell';
 import { EmptyState, LiveStatusRegion } from '@/lib/components/status';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/lib/components/ui/tooltip';
+import { useDocumentTitle } from '@/lib/hooks';
 import {
 	decodeJwt,
 	JWT_STANDARD_CLAIMS,
@@ -64,9 +65,7 @@ function JwtDecoderPage() {
 	const [input, setInput] = useState('');
 	const [showOptions, setShowOptions] = useState(true);
 
-	useEffect(() => {
-		document.title = 'JWT Decoder — Kogu';
-	}, []);
+	useDocumentTitle('JWT Decoder');
 
 	const { decoded, error } = ((): { decoded: JwtDecoded | null; error: string } => {
 		if (!input.trim()) return { decoded: null, error: '' };

--- a/src/routes/markdown-editor.tsx
+++ b/src/routes/markdown-editor.tsx
@@ -54,6 +54,7 @@ import {
 } from '@/lib/components/ui/dropdown-menu';
 import { ListItemButton } from '@/lib/components/ui/list-item-button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/lib/components/ui/tooltip';
+import { useDocumentTitle } from '@/lib/hooks';
 import {
 	applyFormat,
 	exportAsHtml,
@@ -264,9 +265,7 @@ function MarkdownEditorPage() {
 	activeEditorRef.current = activeEditor;
 	inputRef.current = input;
 
-	useEffect(() => {
-		document.title = 'Markdown Editor - Kogu';
-	}, []);
+	useDocumentTitle('Markdown Editor');
 
 	const stats = useMemo(() => getMarkdownStats(input), [input]);
 	const toc = useMemo(() => generateToc(input), [input]);

--- a/src/routes/network-interfaces.tsx
+++ b/src/routes/network-interfaces.tsx
@@ -43,6 +43,7 @@ import {
 	sortInterfaces,
 } from '@/lib/services/network-interfaces';
 import { cn } from '@/lib/utils';
+import { useDocumentTitle } from '@/lib/hooks';
 
 const getInterfaceTypeIcon = (type: string) => {
 	if (type === 'WiFi') return Wifi;
@@ -124,9 +125,7 @@ function NetworkInterfacesPage() {
 	const [showLoopback, setShowLoopback] = useState(false);
 	const [sortField, setSortField] = useState<SortField>('status');
 
-	useEffect(() => {
-		document.title = 'Network Interfaces — Kogu';
-	}, []);
+	useDocumentTitle('Network Interfaces');
 
 	const fetchInterfaces = useCallback(async () => {
 		setLoading(true);

--- a/src/routes/network-scanner.tsx
+++ b/src/routes/network-scanner.tsx
@@ -92,6 +92,7 @@ import {
 } from '@/lib/services/network-scanner';
 import { createToolOptionsStore } from '@/lib/stores';
 import { cn } from '@/lib/utils';
+import { useDocumentTitle } from '@/lib/hooks';
 
 interface NetworkScannerOptions {
 	readonly target: string;
@@ -1185,9 +1186,7 @@ function NetworkScannerPage() {
 	// React batching (scan progress events arrive faster than render).
 	const unlistenRef = useRef<(() => void) | null>(null);
 
-	useEffect(() => {
-		document.title = 'Network Scanner — Kogu';
-	}, []);
+	useDocumentTitle('Network Scanner');
 
 	const startTimer = useCallback(() => {
 		setElapsedMs(0);

--- a/src/routes/password-generator.tsx
+++ b/src/routes/password-generator.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Lock, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -16,6 +16,7 @@ import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, LiveStatusRegion, StatItem } from '@/lib/components/status';
 import { Card, CardContent } from '@/lib/components/ui/card';
 import { createToolOptionsStore } from '@/lib/stores';
+import { useDocumentTitle } from '@/lib/hooks';
 import {
 	buildCharacterPool,
 	calculateEntropy,
@@ -53,9 +54,7 @@ function PasswordGeneratorPage() {
 	const [showOptions, setShowOptions] = useState(true);
 	const [flashCounter, setFlashCounter] = useState(0);
 
-	useEffect(() => {
-		document.title = 'Password Generator — Kogu';
-	}, []);
+	useDocumentTitle('Password Generator');
 
 	const pool = buildCharacterPool(options);
 	const entropy = calculateEntropy(options.length, pool.length);

--- a/src/routes/qr-code-generator.tsx
+++ b/src/routes/qr-code-generator.tsx
@@ -33,6 +33,7 @@ import { EmbeddedEmptyState, LiveStatusRegion, StatItem } from '@/lib/components
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/lib/components/ui/tooltip';
+import { useDocumentTitle } from '@/lib/hooks';
 import {
 	CONTENT_KINDS,
 	CORNER_DOT_TYPES,
@@ -114,9 +115,7 @@ function QrCodeGeneratorPage() {
 	const previewRef = useRef<HTMLDivElement | null>(null);
 	const qrInstanceRef = useRef<ReturnType<typeof createQr> | null>(null);
 
-	useEffect(() => {
-		document.title = 'QR Code Generator — Kogu';
-	}, []);
+	useDocumentTitle('QR Code Generator');
 
 	const currentContent = contents[activeKind];
 	const encodedData = encodeQrContent(currentContent);

--- a/src/routes/regex-tester.tsx
+++ b/src/routes/regex-tester.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect } from 'react';
 import { Eye, FlaskConical, GitBranch, Info, Search, Sparkles, Workflow } from 'lucide-react';
 
 import { CopyButton } from '@/lib/components/action';
@@ -40,6 +39,7 @@ import {
 	SAMPLE_TEST_TEXT,
 } from '@/lib/services/regex';
 import { type VizNode, type VizNodeKind, visualizeRegex } from '@/lib/services/regex-viz';
+import { useDocumentTitle } from '@/lib/hooks';
 
 interface Segment {
 	readonly text: string;
@@ -528,9 +528,7 @@ function RegexTesterPage() {
 	const [replacement, setReplacement] = useState('');
 	const [showOptions, setShowOptions] = useState(true);
 
-	useEffect(() => {
-		document.title = 'Regex Tester — Kogu';
-	}, []);
+	useDocumentTitle('Regex Tester');
 
 	const loadSample = () => {
 		setPattern(SAMPLE_PATTERN);

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -36,6 +36,7 @@ import {
 	updateSettings,
 } from '@/lib/services/settings';
 import { getGoogleFontsByCategory, loadGoogleFont } from '@/lib/services/google-fonts';
+import { useDocumentTitle } from '@/lib/hooks';
 
 export const Route = createFileRoute('/settings')({
 	component: SettingsPage,
@@ -55,9 +56,7 @@ function SettingsPage() {
 	const googleUiFonts = getGoogleFontsByCategory('sans-serif');
 	const googleCodeFonts = getGoogleFontsByCategory('monospace');
 
-	useEffect(() => {
-		document.title = 'Settings — Kogu';
-	}, []);
+	useDocumentTitle('Settings');
 
 	useEffect(() => {
 		getSettings()

--- a/src/routes/sql-formatter.tsx
+++ b/src/routes/sql-formatter.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Database } from 'lucide-react';
 import { toast } from 'sonner';
 import type { SqlLanguage } from 'sql-formatter';
@@ -15,6 +15,7 @@ import {
 import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { useDocumentTitle } from '@/lib/hooks';
 import {
 	calculateSqlStats,
 	defaultSqlFormatOptions,
@@ -63,9 +64,7 @@ function SqlFormatterPage() {
 		defaultSqlFormatOptions.newlineBeforeSemicolon
 	);
 
-	useEffect(() => {
-		document.title = 'SQL Formatter — Kogu';
-	}, []);
+	useDocumentTitle('SQL Formatter');
 
 	const tabWidth = Number.parseInt(tabWidthStr, 10) || 2;
 	const expressionWidth = Number.parseInt(expressionWidthStr, 10) || 50;

--- a/src/routes/ssh-key-generator.tsx
+++ b/src/routes/ssh-key-generator.tsx
@@ -22,6 +22,7 @@ import {
 	StatItem,
 } from '@/lib/components/status';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { useDocumentTitle } from '@/lib/hooks';
 import {
 	cancelWorkerOperation,
 	checkCliAvailability,
@@ -69,9 +70,7 @@ function SshKeyGeneratorPage() {
 	const [showFingerprint, setShowFingerprint] = useState(true);
 	const [showEquivalentCommand, setShowEquivalentCommand] = useState(true);
 
-	useEffect(() => {
-		document.title = 'SSH Key Generator — Kogu';
-	}, []);
+	useDocumentTitle('SSH Key Generator');
 
 	useEffect(() => {
 		checkCliAvailability()

--- a/src/routes/string-case-converter.tsx
+++ b/src/routes/string-case-converter.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { CaseSensitive } from 'lucide-react';
 import { readText } from '@tauri-apps/plugin-clipboard-manager';
 
@@ -16,6 +16,7 @@ import { SectionHeader } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Card, CardContent } from '@/lib/components/ui/card';
+import { useDocumentTitle } from '@/lib/hooks';
 import {
 	CASE_DEFINITIONS,
 	convertToAllCases,
@@ -38,9 +39,7 @@ function StringCaseConverterPage() {
 	const [removeEmptyLines, setRemoveEmptyLines] = useState(false);
 	const [reverseLines, setReverseLines] = useState(false);
 
-	useEffect(() => {
-		document.title = 'String Case Converter — Kogu';
-	}, []);
+	useDocumentTitle('String Case Converter');
 
 	const processedInput = (() => {
 		if (!input.trim()) return '';

--- a/src/routes/url-encoder.tsx
+++ b/src/routes/url-encoder.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { ArrowRightLeft, BookOpen, ExternalLink, Hammer, Link2, Plus, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -23,6 +23,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/ca
 import { Input } from '@/lib/components/ui/input';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/lib/components/ui/tooltip';
 import { useActiveTab, useTabStore } from '@/lib/stores';
+import { useDocumentTitle } from '@/lib/hooks';
 import {
 	buildUrl,
 	decodeUrlWithOptions,
@@ -99,9 +100,7 @@ function UrlEncoderPage() {
 		{ key: 'name', value: 'test' },
 	]);
 
-	useEffect(() => {
-		document.title = 'URL Encoder — Kogu';
-	}, []);
+	useDocumentTitle('URL Encoder');
 
 	const encodeOptions: Partial<UrlEncodeOptions> = {
 		mode: encodeMode,

--- a/src/routes/uuid-generator.tsx
+++ b/src/routes/uuid-generator.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Fingerprint, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -18,6 +18,7 @@ import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, LiveStatusRegion, StatItem } from '@/lib/components/status';
 import { Card, CardContent } from '@/lib/components/ui/card';
 import { createToolOptionsStore } from '@/lib/stores';
+import { useDocumentTitle } from '@/lib/hooks';
 import {
 	DEFAULT_COUNT,
 	DEFAULT_FORMAT_OPTIONS,
@@ -60,9 +61,7 @@ function UuidGeneratorPage() {
 	const [showOptions, setShowOptions] = useState(true);
 	const [flashCounter, setFlashCounter] = useState(0);
 
-	useEffect(() => {
-		document.title = 'UUID Generator — Kogu';
-	}, []);
+	useDocumentTitle('UUID Generator');
 
 	const needsNamespace = requiresNamespace(version);
 	const canGenerate = !needsNamespace || (namespace.length > 0 && nameInput.length > 0);


### PR DESCRIPTION
## Summary

First refactor of the deep-DRY series flagged in the post-Phase-I audit. Twenty tool routes plus `TabbedFormatterPage` each spelled out the same `useEffect(() => { document.title = '… — Kogu'; }, [])` block by hand. Worse, the spelling had drifted — most routes used the em-dash `—`, but `TabbedFormatterPage` and `markdown-editor.tsx` used an ASCII hyphen `-`. Whether the window title showed up with `—` or `-` depended on which tab you opened.

## Changes

### `feat(hooks)`: `useDocumentTitle`

`src/lib/hooks/use-document-title.ts` — sets `document.title` to `` `${title} — Kogu` `` on mount and on title change, and restores the previous value on unmount (the latter matches what `TabbedFormatterPage` already did but the hand-rolled blocks didn't). The hook hard-codes the em-dash separator so future routes can't drift back to the hyphen.

```tsx
useDocumentTitle('Hash Generator');
```

### Migrate 20 routes + 1 template

| File | Before | After |
|------|--------|-------|
| 20 × `routes/*.tsx` | 3-line `useEffect` | 1-line hook call |
| `template/tabbed-formatter-page.tsx` | 7-line `useEffect` with hyphen | 1-line hook call |

`useEffect` imports drop out of the 11 routes where it was the only consumer (verified by Biome `noUnusedImports`).

## Net change

```
23 files changed, 75 insertions(+), 81 deletions(-)
```

Subtracting the 18-line new hook file, this is ~−24 lines of duplicated `useEffect` blocks across the routes, plus:

- A single source of truth for the title-suffix contract.
- A consistent em-dash across every tool window title.
- An automatic title-restore on unmount that hand-rolled blocks didn't have.

## Test plan

- [x] `bun run check` passes (TS + Biome + audit-design)
- [x] Pre-commit hooks green (frontend-lint + frontend-format)
- [ ] Manual smoke: open every tool tab, verify window title reads `"<Tool Name> — Kogu"` with an em-dash separator
- [ ] Manual smoke: navigate away from a tool tab, verify title resets to whatever was previously shown
