### PR TITLE
refactor(hooks): introduce useClipboardActions and migrate formatter tabs

### DIFF
--- a/src/lib/components/formatter-tabs/json/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/format-tab.tsx
@@ -1,6 +1,5 @@
 import { FileText } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
-import { toast } from 'sonner';
 
 import { CodeEditor, type ContextMenuItem } from '@/lib/components/editor';
 import {
@@ -13,6 +12,7 @@ import {
 import { SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
 import { EmptyOutputPane } from '@/lib/components/status';
+import { useClipboardActions } from '@/lib/hooks';
 import {
 	defaultJsonFormatOptions,
 	type JsonFormatOptions,
@@ -206,27 +206,10 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 		});
 	}, [input, validation.valid, formatError, onStatsChange]);
 
-	const handlePaste = async () => {
-		try {
-			const text = await navigator.clipboard.readText();
-			if (text) onInputChange(text);
-		} catch {
-			// Clipboard access denied.
-		}
-	};
-
-	const handleClear = () => {
-		onInputChange('');
-	};
-
-	const handleCopy = async () => {
-		try {
-			await navigator.clipboard.writeText(output);
-			toast.success('Copied to clipboard');
-		} catch {
-			toast.error('Failed to copy to clipboard');
-		}
-	};
+	const { handlePaste, handleClear, handleCopy } = useClipboardActions({
+		onInputChange,
+		output,
+	});
 
 	const handleSample = () => {
 		onInputChange(SAMPLE_JSON);

--- a/src/lib/components/formatter-tabs/json/generate-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/generate-tab.tsx
@@ -33,9 +33,9 @@ import {
 	type TargetLanguage,
 	type TypeScriptOptions,
 } from '@/lib/services/code-generators';
+import { useClipboardActions } from '@/lib/hooks';
 import { parseJson, validateJson } from '@/lib/services/formatters';
 import { useJsonFormatterOptions } from '@/lib/stores';
-import { copyToClipboard, pasteFromClipboard } from '@/lib/utils/file-operations';
 
 import { JsonFormatSection } from './json-format-section';
 
@@ -316,20 +316,11 @@ export function GenerateTab({ input, onInputChange, onStatsChange }: GenerateTab
 		});
 	}, [input, inputValidation.valid, generateError, onStatsChange]);
 
-	const handlePaste = async () => {
-		const text = await pasteFromClipboard();
-		if (text) onInputChange(text);
-	};
-
-	const handleClear = () => {
-		onInputChange('{}');
-	};
-
-	const handleCopy = () => {
-		copyToClipboard(generatedCode).catch(() => {
-			// Clipboard write failed; ignore.
-		});
-	};
+	const { handlePaste, handleClear, handleCopy } = useClipboardActions({
+		onInputChange,
+		output: generatedCode,
+		emptyValue: '{}',
+	});
 
 	return (
 		<div className="flex flex-1 overflow-hidden">

--- a/src/lib/components/formatter-tabs/json/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/query-tab.tsx
@@ -12,9 +12,9 @@ import {
 import { SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
 import { EmptyOutputPane } from '@/lib/components/status';
+import { useClipboardActions } from '@/lib/hooks';
 import { executeJsonPath, validateJson } from '@/lib/services/formatters';
 import { useJsonFormatterOptions } from '@/lib/stores';
-import { copyToClipboard, pasteFromClipboard } from '@/lib/utils/file-operations';
 
 import { JsonFormatSection } from './json-format-section';
 
@@ -115,20 +115,14 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 		});
 	}, [input, inputValidation.valid, queryError, onStatsChange]);
 
-	const handlePaste = async () => {
-		const text = await pasteFromClipboard();
-		if (text) onInputChange(text);
-	};
+	const { handlePaste, handleCopy } = useClipboardActions({
+		onInputChange,
+		output: queryResult,
+	});
 
 	const handleClear = () => {
 		onInputChange('{}');
 		setQueryPath('$.');
-	};
-
-	const handleCopyResult = () => {
-		copyToClipboard(queryResult).catch(() => {
-			// Clipboard write failed; ignore.
-		});
 	};
 
 	return (
@@ -256,7 +250,7 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 							mode="readonly"
 							editorMode="json"
 							placeholder="Query result..."
-							onCopy={handleCopyResult}
+							onCopy={handleCopy}
 						/>
 					)
 				}

--- a/src/lib/components/formatter-tabs/xml/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/format-tab.tsx
@@ -1,6 +1,5 @@
 import { FileText } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
-import { toast } from 'sonner';
 
 import { CodeEditor, type ContextMenuItem } from '@/lib/components/editor';
 import {
@@ -13,6 +12,7 @@ import {
 import { SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
 import { EmptyOutputPane } from '@/lib/components/status';
+import { useClipboardActions } from '@/lib/hooks';
 import {
 	defaultXmlFormatOptions,
 	formatXml,
@@ -114,27 +114,10 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 		});
 	}, [input, validation.valid, formatError, onStatsChange]);
 
-	const handlePaste = async () => {
-		try {
-			const text = await navigator.clipboard.readText();
-			if (text) onInputChange(text);
-		} catch {
-			// Clipboard access denied.
-		}
-	};
-
-	const handleClear = () => {
-		onInputChange('');
-	};
-
-	const handleCopy = async () => {
-		try {
-			await navigator.clipboard.writeText(output);
-			toast.success('Copied to clipboard');
-		} catch {
-			toast.error('Failed to copy to clipboard');
-		}
-	};
+	const { handlePaste, handleClear, handleCopy } = useClipboardActions({
+		onInputChange,
+		output,
+	});
 
 	const handleSample = () => {
 		onInputChange(SAMPLE_XML);

--- a/src/lib/components/formatter-tabs/xml/generate-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/generate-tab.tsx
@@ -33,8 +33,8 @@ import {
 	type TargetLanguage,
 	type TypeScriptOptions,
 } from '@/lib/services/code-generators';
+import { useClipboardActions } from '@/lib/hooks';
 import { xmlToJsonObject } from '@/lib/services/formatters';
-import { copyToClipboard, pasteFromClipboard } from '@/lib/utils/file-operations';
 
 type JavaClassStyle = 'record' | 'pojo' | 'lombok' | 'immutables';
 type JavaSerialization = 'none' | 'jackson' | 'gson' | 'moshi';
@@ -316,20 +316,10 @@ export function GenerateTab({ input, onInputChange, onStatsChange }: GenerateTab
 		});
 	}, [input, inputValidation.valid, generateError, onStatsChange]);
 
-	const handlePaste = async () => {
-		const text = await pasteFromClipboard();
-		if (text) onInputChange(text);
-	};
-
-	const handleClear = () => {
-		onInputChange('');
-	};
-
-	const handleCopy = () => {
-		copyToClipboard(generatedCode).catch(() => {
-			// Clipboard write failed; ignore.
-		});
-	};
+	const { handlePaste, handleClear, handleCopy } = useClipboardActions({
+		onInputChange,
+		output: generatedCode,
+	});
 
 	return (
 		<div className="flex flex-1 overflow-hidden">

--- a/src/lib/components/formatter-tabs/xml/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/query-tab.tsx
@@ -6,8 +6,8 @@ import { FormInput, FormSection } from '@/lib/components/form';
 import { SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
 import { EmptyOutputPane } from '@/lib/components/status';
+import { useClipboardActions } from '@/lib/hooks';
 import { executeXPath, formatXml } from '@/lib/services/formatters';
-import { copyToClipboard, pasteFromClipboard } from '@/lib/utils/file-operations';
 
 interface TabStats {
 	readonly input: string;
@@ -79,20 +79,14 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 		});
 	}, [input, inputValidation.valid, queryError, onStatsChange]);
 
-	const handlePaste = async () => {
-		const text = await pasteFromClipboard();
-		if (text) onInputChange(text);
-	};
+	const { handlePaste, handleCopy } = useClipboardActions({
+		onInputChange,
+		output: queryOutput,
+	});
 
 	const handleClear = () => {
 		onInputChange('');
 		setXpathExpression('//');
-	};
-
-	const handleCopyOutput = () => {
-		copyToClipboard(queryOutput).catch(() => {
-			// Clipboard write failed; ignore.
-		});
 	};
 
 	return (
@@ -175,7 +169,7 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 							mode="readonly"
 							editorMode="xml"
 							placeholder="Query results will appear here..."
-							onCopy={handleCopyOutput}
+							onCopy={handleCopy}
 						/>
 					)
 				}

--- a/src/lib/components/formatter-tabs/yaml/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/format-tab.tsx
@@ -1,6 +1,5 @@
 import { FileText } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
-import { toast } from 'sonner';
 import * as yaml from 'yaml';
 
 import { CodeEditor, type ContextMenuItem } from '@/lib/components/editor';
@@ -15,6 +14,7 @@ import {
 import { SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
 import { EmptyOutputPane } from '@/lib/components/status';
+import { useClipboardActions } from '@/lib/hooks';
 import { SAMPLE_YAML, sortKeysDeep, validateYaml } from '@/lib/services/formatters';
 
 type FormatMode = 'format' | 'minify';
@@ -133,27 +133,10 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 		});
 	}, [input, validation.valid, formatError, onStatsChange]);
 
-	const handlePaste = async () => {
-		try {
-			const text = await navigator.clipboard.readText();
-			if (text) onInputChange(text);
-		} catch {
-			// Clipboard access denied.
-		}
-	};
-
-	const handleClear = () => {
-		onInputChange('');
-	};
-
-	const handleCopy = async () => {
-		try {
-			await navigator.clipboard.writeText(output);
-			toast.success('Copied to clipboard');
-		} catch {
-			toast.error('Failed to copy to clipboard');
-		}
-	};
+	const { handlePaste, handleClear, handleCopy } = useClipboardActions({
+		onInputChange,
+		output,
+	});
 
 	const handleSample = () => {
 		onInputChange(SAMPLE_YAML);

--- a/src/lib/components/formatter-tabs/yaml/generate-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/generate-tab.tsx
@@ -14,6 +14,7 @@ import {
 import { SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
 import { EmptyOutputPane } from '@/lib/components/status';
+import { useClipboardActions } from '@/lib/hooks';
 import {
 	type CSharpOptions,
 	generateCode,
@@ -34,7 +35,6 @@ import {
 	type TargetLanguage,
 	type TypeScriptOptions,
 } from '@/lib/services/code-generators';
-import { copyToClipboard, pasteFromClipboard } from '@/lib/utils/file-operations';
 
 type JavaClassStyle = 'record' | 'pojo' | 'lombok' | 'immutables';
 type JavaSerialization = 'none' | 'jackson' | 'gson' | 'moshi';
@@ -314,20 +314,10 @@ export function GenerateTab({ input, onInputChange, onStatsChange }: GenerateTab
 		});
 	}, [input, inputValidation.valid, generateError, onStatsChange]);
 
-	const handlePaste = async () => {
-		const text = await pasteFromClipboard();
-		if (text) onInputChange(text);
-	};
-
-	const handleClear = () => {
-		onInputChange('');
-	};
-
-	const handleCopy = () => {
-		copyToClipboard(generatedCode).catch(() => {
-			// Clipboard write failed; ignore.
-		});
-	};
+	const { handlePaste, handleClear, handleCopy } = useClipboardActions({
+		onInputChange,
+		output: generatedCode,
+	});
 
 	return (
 		<div className="flex flex-1 overflow-hidden">

--- a/src/lib/components/formatter-tabs/yaml/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/query-tab.tsx
@@ -13,8 +13,8 @@ import {
 import { SplitPane } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
 import { EmptyOutputPane } from '@/lib/components/status';
+import { useClipboardActions } from '@/lib/hooks';
 import { executeJsonPath } from '@/lib/services/formatters';
-import { copyToClipboard, pasteFromClipboard } from '@/lib/utils/file-operations';
 
 type QueryOutputFormat = 'yaml' | 'json';
 
@@ -119,20 +119,14 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 		});
 	}, [input, inputValidation.valid, queryError, onStatsChange]);
 
-	const handlePaste = async () => {
-		const text = await pasteFromClipboard();
-		if (text) onInputChange(text);
-	};
+	const { handlePaste, handleCopy } = useClipboardActions({
+		onInputChange,
+		output: queryResult,
+	});
 
 	const handleClear = () => {
 		onInputChange('');
 		setQueryPath('$.');
-	};
-
-	const handleCopyResult = () => {
-		copyToClipboard(queryResult).catch(() => {
-			// Clipboard write failed; ignore.
-		});
 	};
 
 	return (
@@ -258,7 +252,7 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 							mode="readonly"
 							editorMode={queryOutputFormat}
 							placeholder="Query result..."
-							onCopy={handleCopyResult}
+							onCopy={handleCopy}
 						/>
 					)
 				}

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useClipboardActions } from './use-clipboard-actions';
 export { useDocumentTitle } from './use-document-title';
 export {
 	useFormatterPage,

--- a/src/lib/hooks/use-clipboard-actions.ts
+++ b/src/lib/hooks/use-clipboard-actions.ts
@@ -1,0 +1,46 @@
+import { copyToClipboard, pasteFromClipboard } from '@/lib/utils/file-operations';
+
+interface UseClipboardActionsConfig {
+	// Called with the pasted clipboard text. Also called with `emptyValue`
+	// when `handleClear` fires.
+	readonly onInputChange?: (value: string) => void;
+	// Text copied to clipboard when `handleCopy` fires. Defaults to '' (no-op).
+	readonly output?: string;
+	// Value passed to `onInputChange` from `handleClear`. Defaults to ''.
+	// Set to `'{}'` for JSON-input generate tabs, etc.
+	readonly emptyValue?: string;
+}
+
+interface UseClipboardActionsReturn {
+	readonly handlePaste: () => Promise<void>;
+	readonly handleClear: () => void;
+	readonly handleCopy: () => Promise<void>;
+}
+
+// Shared clipboard handlers for tool tabs and routes that wire `CodeEditor`'s
+// `onPaste` / `onClear` / `onCopy` props. Both `pasteFromClipboard` and
+// `copyToClipboard` from `@/lib/utils/file-operations` already toast success
+// and failure ("Pasted" / "Paste failed", "Copied" / "Copy failed"), so the
+// hook only owns the boilerplate of feeding the clipboard text into
+// `onInputChange` and resetting the input to `emptyValue` on clear. The
+// callsite-specific copy target is passed as `output`.
+export function useClipboardActions({
+	onInputChange,
+	output = '',
+	emptyValue = '',
+}: UseClipboardActionsConfig): UseClipboardActionsReturn {
+	const handlePaste = async () => {
+		const text = await pasteFromClipboard();
+		if (text && onInputChange) onInputChange(text);
+	};
+
+	const handleClear = () => {
+		onInputChange?.(emptyValue);
+	};
+
+	const handleCopy = async () => {
+		await copyToClipboard(output);
+	};
+
+	return { handlePaste, handleClear, handleCopy };
+}


### PR DESCRIPTION
## Summary

Second refactor of the deep-DRY series. The clipboard handler trio (`handlePaste`, `handleClear`, `handleCopy` / `handleCopyResult` / `handleCopyOutput`) was duplicated across 12+ formatter-tab files, with two parallel implementations:

1. The Tauri-friendly utilities `pasteFromClipboard` / `copyToClipboard` from `@/lib/utils/file-operations` — used in generate-tab × 3 and query-tab × 3.
2. Inline `navigator.clipboard.readText/writeText` calls with hand-rolled try/catch + `toast.success('Copied to clipboard')` toasts — used in format-tab × 3.

Both shapes did the same thing, but the second variant doesn't work reliably in production Tauri builds (the underlying clipboard utility is meant for browser contexts, not WKWebView/WebView2 sandboxes).

## Changes

### `feat(hooks)`: `useClipboardActions`

`src/lib/hooks/use-clipboard-actions.ts` — single hook returning `{ handlePaste, handleClear, handleCopy }`. All three delegate to the Tauri-friendly utilities so every consumer routes through the same code path. `emptyValue` defaults to `''`; JSON-generate opts into `'{}'` so a cleared input still parses.

```tsx
const { handlePaste, handleClear, handleCopy } = useClipboardActions({
  onInputChange,
  output,
});
```

### Migrate 9 formatter tabs

| Files | Hook usage |
|-------|-----------|
| `formatter-tabs/{json,xml,yaml}/format-tab.tsx` | full trio |
| `formatter-tabs/{json,xml,yaml}/query-tab.tsx` | `handlePaste` + `handleCopy` only; `handleClear` stays inline because it also resets per-tab query-path state |
| `formatter-tabs/{json,xml,yaml}/generate-tab.tsx` | full trio; JSON passes `emptyValue='{}'` |

`copyToClipboard` and `pasteFromClipboard` imports drop out of every consumer. `toast` drops from the three format-tab files where it was only used for the now-removed clipboard toasts.

## Out of scope

* `schema-tab` × 3 — `handleClear` resets multiple pieces of internal state (`schemaDefinition`, `schemaValidationResult`, `schemaError`); copy handlers branch between `inferredSchema` and `schemaDefinition`. Needs a richer hook shape — separate PR.
* `compare-tab` template — two input editors, no single `output` prop to copy from.
* The 6 standalone routes (`base64`, `sql`, `url`, `jwt`, `hash`, `string-case-converter`) — slated for a follow-up; their handlers vary more.

## Net change

```
11 files changed, 96 insertions(+), 147 deletions(-)
```

After subtracting the ~47-line new hook file, this is ~−100 lines of duplicated boilerplate across 9 tabs. Plus a correctness improvement: every clipboard path now uses the Tauri utility, eliminating any chance of silent `navigator.clipboard` failures in production builds.

## Test plan

- [x] `bun run check` passes
- [x] Pre-commit hooks green (frontend-lint + frontend-format)
- [ ] Manual smoke: JSON / XML / YAML format tab — paste sample input via the editor toolbar, copy output via the result editor's copy button, clear via the clear button
- [ ] Manual smoke: JSON / XML / YAML query tab — same drill; verify clear still resets the query path
- [ ] Manual smoke: JSON generate tab — clear resets input to `'{}'` (not empty string)
- [ ] Manual smoke (production / Tauri build): verify clipboard actions still work in the bundled webview, not just dev browser
