### PR TITLE
refactor(utils): consolidate three formatBytes implementations

### DIFF
--- a/src/lib/services/encoders.test.ts
+++ b/src/lib/services/encoders.test.ts
@@ -24,14 +24,18 @@ import {
 // ============================================================================
 
 describe('formatBytes', () => {
+	// Magnitude-aware precision: 2 decimals for values < 10, 1 decimal for
+	// values < 100, integer otherwise. Single source of truth lives in
+	// `@/lib/utils/format` and is re-exported by this service module.
 	it.each([
 		[0, '0 B'],
 		[100, '100 B'],
 		[1023, '1023 B'],
-		[1024, '1.0 KB'],
-		[1536, '1.5 KB'],
-		[1048576, '1.0 MB'],
-		[2621440, '2.5 MB'],
+		[1024, '1.00 KB'],
+		[1536, '1.50 KB'],
+		[1048576, '1.00 MB'],
+		[2621440, '2.50 MB'],
+		[1073741824, '1.00 GB'],
 	])('formats %d bytes as "%s"', (bytes, expected) => {
 		expect(formatBytes(bytes)).toBe(expected);
 	});

--- a/src/lib/services/encoders.ts
+++ b/src/lib/services/encoders.ts
@@ -7,14 +7,10 @@ import CryptoJS from 'crypto-js';
 // Utility Functions
 // ============================================================================
 
-/**
- * Format bytes to human-readable size.
- */
-export const formatBytes = (bytes: number): string => {
-	if (bytes < 1024) return `${bytes} B`;
-	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-};
+// `formatBytes` previously had its own copy here; the canonical implementation
+// now lives in `@/lib/utils/format`. Re-export so existing consumers keep
+// their import path until they migrate.
+export { formatBytes } from '@/lib/utils';
 
 // ============================================================================
 // Base64 Encoder/Decoder

--- a/src/lib/services/formatters/utils.ts
+++ b/src/lib/services/formatters/utils.ts
@@ -4,13 +4,10 @@
 
 import type { JsonFormatOptions, StatsAccumulator } from './types.js';
 
-/** Format bytes to human readable string */
-export const formatBytes = (bytes: number): string =>
-	bytes < 1024
-		? `${bytes} B`
-		: bytes < 1024 * 1024
-			? `${(bytes / 1024).toFixed(2)} KB`
-			: `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+// `formatBytes` previously had its own copy here; the canonical implementation
+// now lives in `@/lib/utils/format`. Re-export so existing service consumers
+// (json/xml/yaml/sql formatter stats) keep their relative import path.
+export { formatBytes } from '@/lib/utils';
 
 /** Get indent string from options */
 export const getIndentString = (options: JsonFormatOptions): string =>

--- a/src/lib/services/network-interfaces.ts
+++ b/src/lib/services/network-interfaces.ts
@@ -66,16 +66,10 @@ export const getDetailedNetworkInterfaces = (): Promise<DetailedNetworkInterface
 // Formatting Utilities
 // =============================================================================
 
-const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'] as const;
-
-/** Format byte count to human-readable string (e.g., "1.23 GB") */
-export const formatBytes = (bytes: number): string => {
-	if (bytes === 0) return '0 B';
-	const i = Math.floor(Math.log(bytes) / Math.log(1024));
-	const idx = Math.min(i, BYTE_UNITS.length - 1);
-	const value = bytes / 1024 ** idx;
-	return `${value < 10 ? value.toFixed(2) : value < 100 ? value.toFixed(1) : Math.round(value)} ${BYTE_UNITS[idx]}`;
-};
+// `formatBytes` previously had its own copy here; the canonical implementation
+// now lives in `@/lib/utils/format`. Re-export so existing consumers keep
+// their import path.
+export { formatBytes } from '@/lib/utils';
 
 const SPEED_UNITS = ['bps', 'Kbps', 'Mbps', 'Gbps', 'Tbps'] as const;
 

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,0 +1,29 @@
+const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'] as const;
+
+// Magnitude-aware decimal precision: ≤2 digits significand for values < 10,
+// ≤1 digit for values < 100, integer otherwise. Reads "1.23 GB" / "12.3 GB" /
+// "123 GB" rather than fixed `.toFixed(1)` which under-precisions small values
+// and over-precisions large ones.
+const formatWithPrecision = (value: number): string => {
+	if (value < 10) return value.toFixed(2);
+	if (value < 100) return value.toFixed(1);
+	return Math.round(value).toString();
+};
+
+// Format byte count to human-readable string (e.g. "1.23 GB").
+//
+// Single source of truth for byte-size display across the app. Replaces three
+// near-identical implementations that diverged in decimal precision and max
+// unit: `services/encoders.ts` (1-decimal, capped at MB),
+// `services/formatters/utils.ts` (2-decimal, capped at MB), and
+// `services/network-interfaces.ts` (magnitude-precision, up to PB).
+//
+// The canonical shape mirrors the network-interfaces version because it
+// produces the most readable output across the largest range (e.g. a regex
+// pattern matching 1 GB of input shouldn't read as "1024.00 MB").
+export const formatBytes = (bytes: number): string => {
+	if (bytes === 0) return '0 B';
+	const index = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), BYTE_UNITS.length - 1);
+	const value = bytes / 1024 ** index;
+	return `${formatWithPrecision(value)} ${BYTE_UNITS[index]}`;
+};

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,1 +1,2 @@
 export { cn } from './cn';
+export { formatBytes } from './format';


### PR DESCRIPTION
## Summary

Third refactor of the deep-DRY series. The audit flagged three near-identical `formatBytes` implementations diverging only in decimal precision and max unit:

| File | Precision | Max unit |
|------|-----------|----------|
| `services/encoders.ts` | fixed 1-decimal | MB |
| `services/formatters/utils.ts` | fixed 2-decimal | MB |
| `services/network-interfaces.ts` | magnitude-aware | PB |

The drift was visible: a 1 GiB file rendered as `"1024.00 MB"` in JSON / XML / YAML formatter stats but `"1.00 GB"` in network-interfaces — even though both call sites are producing the same kind of human-readable byte count.

## Changes

### `feat(utils)`: `formatBytes` (canonical)

`src/lib/utils/format.ts` — magnitude-aware precision (2 decimals for values < 10, 1 decimal for values < 100, integer otherwise), full `B / KB / MB / GB / TB / PB` ladder. Exported from `@/lib/utils`.

The shape matches the prior network-interfaces implementation because it produces the most readable output across the widest range (no `"1024 MB"` overhang, no `"0.00 KB"` underflow).

### Service-local copies → re-exports

`services/encoders.ts`, `services/formatters/utils.ts`, and `services/network-interfaces.ts` each had their own `formatBytes` — now replaced with `export { formatBytes } from '@/lib/utils';` so existing consumers keep their import path until they migrate.

### Test expectations updated

`services/encoders.test.ts` previously asserted the 1-decimal shape (`'1.0 KB'`, `'2.5 MB'`). Update to the new canonical shape (`'1.00 KB'`, `'2.50 MB'`) and add a 1 GB data point that exercises the magnitude ladder.

```diff
- [1024, '1.0 KB'],
- [1536, '1.5 KB'],
- [1048576, '1.0 MB'],
- [2621440, '2.5 MB'],
+ [1024, '1.00 KB'],
+ [1536, '1.50 KB'],
+ [1048576, '1.00 MB'],
+ [2621440, '2.50 MB'],
+ [1073741824, '1.00 GB'],
```

## Net change

```
6 files changed, 50 insertions(+), 29 deletions(-)
```

Subtracting the new ~30-line canonical implementation, this is a real ~−10 line reduction across the duplicated source. The bigger win is correctness: every byte-count surface in the app now renders the same way for the same input.

## Test plan

- [x] `bun run check` passes
- [x] `bun run test` — all 141 tests pass (incl. the updated `formatBytes` expectations and the new 1 GB data point)
- [x] Pre-commit hooks green (frontend-lint + frontend-format)
- [ ] Visual smoke: open `/network-interfaces`, verify rx/tx byte columns render with magnitude precision (`"1.23 GB"`, etc.) — unchanged
- [ ] Visual smoke: open `/hash-generator`, paste long input, verify the size readout now matches the network-interfaces style (e.g. `"2.50 MB"` instead of `"2.5 MB"`)
- [ ] Visual smoke: open JSON / XML / YAML formatter Format tabs with multi-megabyte input — size stats now match the canonical shape
