### PR TITLE
refactor(layout): introduce InputOutputSplit and migrate 10 callsites

### DIFF
--- a/src/lib/components/formatter-tabs/json/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/format-tab.tsx
@@ -1,7 +1,7 @@
 import { FileText } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
-import { CodeEditor, type ContextMenuItem } from '@/lib/components/editor';
+import type { ContextMenuItem } from '@/lib/components/editor';
 import {
 	FormCheckbox,
 	FormCheckboxGroup,
@@ -9,9 +9,8 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SplitPane } from '@/lib/components/layout';
+import { InputOutputSplit } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmptyOutputPane } from '@/lib/components/status';
 import { useClipboardActions } from '@/lib/hooks';
 import {
 	defaultJsonFormatOptions,
@@ -396,41 +395,21 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 				</FormSection>
 			</OptionsPanel>
 
-			<SplitPane
-				className="h-full flex-1"
-				left={
-					<CodeEditor
-						title="Input"
-						value={input}
-						onChange={onInputChange}
-						mode="input"
-						editorMode="json"
-						placeholder="Enter JSON here..."
-						onSample={handleSample}
-						onPaste={handlePaste}
-						onClear={handleClear}
-						contextMenuItems={inputContextMenuItems}
-					/>
-				}
-				right={
-					input.trim().length === 0 ? (
-						<EmptyOutputPane
-							headerTitle="Output"
-							icon={FileText}
-							title="Enter JSON to format"
-							description="The formatted (or minified) document will appear here."
-						/>
-					) : (
-						<CodeEditor
-							title="Output"
-							value={output}
-							mode="readonly"
-							editorMode="json"
-							placeholder="Formatted output..."
-							onCopy={handleCopy}
-						/>
-					)
-				}
+			<InputOutputSplit
+				input={input}
+				onInputChange={onInputChange}
+				editorMode="json"
+				inputPlaceholder="Enter JSON here..."
+				onSample={handleSample}
+				onPaste={handlePaste}
+				onClear={handleClear}
+				inputContextMenuItems={inputContextMenuItems}
+				output={output}
+				outputPlaceholder="Formatted output..."
+				onCopy={handleCopy}
+				emptyIcon={FileText}
+				emptyTitle="Enter JSON to format"
+				emptyDescription="The formatted (or minified) document will appear here."
 			/>
 		</div>
 	);

--- a/src/lib/components/formatter-tabs/json/generate-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/generate-tab.tsx
@@ -1,7 +1,6 @@
 import { Code } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
-import { CodeEditor } from '@/lib/components/editor';
 import {
 	FormCheckbox,
 	FormCheckboxGroup,
@@ -10,9 +9,8 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SplitPane } from '@/lib/components/layout';
+import { InputOutputSplit } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmptyOutputPane } from '@/lib/components/status';
 import {
 	type CSharpOptions,
 	type GoOptions,
@@ -828,39 +826,23 @@ export function GenerateTab({ input, onInputChange, onStatsChange }: GenerateTab
 				) : null}
 			</OptionsPanel>
 
-			<SplitPane
+			<InputOutputSplit
 				className="flex-1"
-				left={
-					<CodeEditor
-						title="Input JSON"
-						value={input}
-						onChange={onInputChange}
-						mode="input"
-						editorMode="json"
-						placeholder="Enter JSON here..."
-						onPaste={handlePaste}
-						onClear={handleClear}
-					/>
-				}
-				right={
-					input.trim().length === 0 ? (
-						<EmptyOutputPane
-							headerTitle={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
-							icon={Code}
-							title="Enter JSON to generate code"
-							description={`The ${LANGUAGE_INFO[generateLanguage].label} class definitions will appear here.`}
-						/>
-					) : (
-						<CodeEditor
-							title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
-							value={generatedCode}
-							mode="readonly"
-							editorMode={generateEditorMode}
-							placeholder="Generated code will appear here..."
-							onCopy={handleCopy}
-						/>
-					)
-				}
+				input={input}
+				onInputChange={onInputChange}
+				editorMode="json"
+				inputTitle="Input JSON"
+				inputPlaceholder="Enter JSON here..."
+				onPaste={handlePaste}
+				onClear={handleClear}
+				output={generatedCode}
+				outputEditorMode={generateEditorMode}
+				outputTitle={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
+				outputPlaceholder="Generated code will appear here..."
+				onCopy={handleCopy}
+				emptyIcon={Code}
+				emptyTitle="Enter JSON to generate code"
+				emptyDescription={`The ${LANGUAGE_INFO[generateLanguage].label} class definitions will appear here.`}
 			/>
 		</div>
 	);

--- a/src/lib/components/formatter-tabs/json/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/query-tab.tsx
@@ -1,7 +1,6 @@
 import { Search } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
-import { CodeEditor } from '@/lib/components/editor';
 import {
 	FormCheckbox,
 	FormCheckboxGroup,
@@ -9,9 +8,8 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SplitPane } from '@/lib/components/layout';
+import { InputOutputSplit } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmptyOutputPane } from '@/lib/components/status';
 import { useClipboardActions } from '@/lib/hooks';
 import { executeJsonPath, validateJson } from '@/lib/services/formatters';
 import { useJsonFormatterOptions } from '@/lib/stores';
@@ -221,39 +219,21 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 				</FormSection>
 			</OptionsPanel>
 
-			<SplitPane
+			<InputOutputSplit
 				className="flex-1"
-				left={
-					<CodeEditor
-						title="Input"
-						value={input}
-						onChange={onInputChange}
-						mode="input"
-						editorMode="json"
-						placeholder="Enter JSON here..."
-						onPaste={handlePaste}
-						onClear={handleClear}
-					/>
-				}
-				right={
-					input.trim().length === 0 ? (
-						<EmptyOutputPane
-							headerTitle="Result"
-							icon={Search}
-							title="Enter JSON to query"
-							description="Run a JSONPath expression to see matching values here."
-						/>
-					) : (
-						<CodeEditor
-							title="Result"
-							value={queryResult}
-							mode="readonly"
-							editorMode="json"
-							placeholder="Query result..."
-							onCopy={handleCopy}
-						/>
-					)
-				}
+				input={input}
+				onInputChange={onInputChange}
+				editorMode="json"
+				inputPlaceholder="Enter JSON here..."
+				onPaste={handlePaste}
+				onClear={handleClear}
+				output={queryResult}
+				outputTitle="Result"
+				outputPlaceholder="Query result..."
+				onCopy={handleCopy}
+				emptyIcon={Search}
+				emptyTitle="Enter JSON to query"
+				emptyDescription="Run a JSONPath expression to see matching values here."
 			/>
 		</div>
 	);

--- a/src/lib/components/formatter-tabs/xml/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/format-tab.tsx
@@ -1,7 +1,7 @@
 import { FileText } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
-import { CodeEditor, type ContextMenuItem } from '@/lib/components/editor';
+import type { ContextMenuItem } from '@/lib/components/editor';
 import {
 	FormCheckbox,
 	FormCheckboxGroup,
@@ -9,9 +9,8 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SplitPane } from '@/lib/components/layout';
+import { InputOutputSplit } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmptyOutputPane } from '@/lib/components/status';
 import { useClipboardActions } from '@/lib/hooks';
 import {
 	defaultXmlFormatOptions,
@@ -242,41 +241,21 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 				</FormSection>
 			</OptionsPanel>
 
-			<SplitPane
-				className="h-full flex-1"
-				left={
-					<CodeEditor
-						title="Input"
-						value={input}
-						onChange={onInputChange}
-						mode="input"
-						editorMode="xml"
-						placeholder="Enter XML here..."
-						onSample={handleSample}
-						onPaste={handlePaste}
-						onClear={handleClear}
-						contextMenuItems={inputContextMenuItems}
-					/>
-				}
-				right={
-					input.trim().length === 0 ? (
-						<EmptyOutputPane
-							headerTitle="Output"
-							icon={FileText}
-							title="Enter XML to format"
-							description="The formatted (or minified) document will appear here."
-						/>
-					) : (
-						<CodeEditor
-							title="Output"
-							value={output}
-							mode="readonly"
-							editorMode="xml"
-							placeholder="Formatted output..."
-							onCopy={handleCopy}
-						/>
-					)
-				}
+			<InputOutputSplit
+				input={input}
+				onInputChange={onInputChange}
+				editorMode="xml"
+				inputPlaceholder="Enter XML here..."
+				onSample={handleSample}
+				onPaste={handlePaste}
+				onClear={handleClear}
+				inputContextMenuItems={inputContextMenuItems}
+				output={output}
+				outputPlaceholder="Formatted output..."
+				onCopy={handleCopy}
+				emptyIcon={FileText}
+				emptyTitle="Enter XML to format"
+				emptyDescription="The formatted (or minified) document will appear here."
 			/>
 		</div>
 	);

--- a/src/lib/components/formatter-tabs/xml/generate-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/generate-tab.tsx
@@ -1,7 +1,6 @@
 import { Code } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
-import { CodeEditor } from '@/lib/components/editor';
 import {
 	FormCheckbox,
 	FormCheckboxGroup,
@@ -10,9 +9,8 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SplitPane } from '@/lib/components/layout';
+import { InputOutputSplit } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmptyOutputPane } from '@/lib/components/status';
 import {
 	type CSharpOptions,
 	generateCode,
@@ -825,39 +823,23 @@ export function GenerateTab({ input, onInputChange, onStatsChange }: GenerateTab
 				) : null}
 			</OptionsPanel>
 
-			<SplitPane
+			<InputOutputSplit
 				className="flex-1"
-				left={
-					<CodeEditor
-						title="Input XML"
-						value={input}
-						onChange={onInputChange}
-						mode="input"
-						editorMode="xml"
-						placeholder="Enter XML here..."
-						onPaste={handlePaste}
-						onClear={handleClear}
-					/>
-				}
-				right={
-					input.trim().length === 0 ? (
-						<EmptyOutputPane
-							headerTitle={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
-							icon={Code}
-							title="Enter XML to generate code"
-							description={`The ${LANGUAGE_INFO[generateLanguage].label} class definitions will appear here.`}
-						/>
-					) : (
-						<CodeEditor
-							title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
-							value={generatedCode}
-							mode="readonly"
-							editorMode={generateEditorMode}
-							placeholder="Generated code will appear here..."
-							onCopy={handleCopy}
-						/>
-					)
-				}
+				input={input}
+				onInputChange={onInputChange}
+				editorMode="xml"
+				inputTitle="Input XML"
+				inputPlaceholder="Enter XML here..."
+				onPaste={handlePaste}
+				onClear={handleClear}
+				output={generatedCode}
+				outputEditorMode={generateEditorMode}
+				outputTitle={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
+				outputPlaceholder="Generated code will appear here..."
+				onCopy={handleCopy}
+				emptyIcon={Code}
+				emptyTitle="Enter XML to generate code"
+				emptyDescription={`The ${LANGUAGE_INFO[generateLanguage].label} class definitions will appear here.`}
 			/>
 		</div>
 	);

--- a/src/lib/components/formatter-tabs/xml/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/query-tab.tsx
@@ -1,11 +1,9 @@
 import { Search } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
-import { CodeEditor } from '@/lib/components/editor';
 import { FormInput, FormSection } from '@/lib/components/form';
-import { SplitPane } from '@/lib/components/layout';
+import { InputOutputSplit } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmptyOutputPane } from '@/lib/components/status';
 import { useClipboardActions } from '@/lib/hooks';
 import { executeXPath, formatXml } from '@/lib/services/formatters';
 
@@ -140,39 +138,21 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 				</FormSection>
 			</OptionsPanel>
 
-			<SplitPane
+			<InputOutputSplit
 				className="flex-1"
-				left={
-					<CodeEditor
-						title="Input"
-						value={input}
-						onChange={onInputChange}
-						mode="input"
-						editorMode="xml"
-						placeholder="Enter XML here..."
-						onPaste={handlePaste}
-						onClear={handleClear}
-					/>
-				}
-				right={
-					input.trim().length === 0 ? (
-						<EmptyOutputPane
-							headerTitle="Result"
-							icon={Search}
-							title="Enter XML to query"
-							description="Run an XPath expression to see matching nodes here."
-						/>
-					) : (
-						<CodeEditor
-							title="Result"
-							value={queryOutput}
-							mode="readonly"
-							editorMode="xml"
-							placeholder="Query results will appear here..."
-							onCopy={handleCopy}
-						/>
-					)
-				}
+				input={input}
+				onInputChange={onInputChange}
+				editorMode="xml"
+				inputPlaceholder="Enter XML here..."
+				onPaste={handlePaste}
+				onClear={handleClear}
+				output={queryOutput}
+				outputTitle="Result"
+				outputPlaceholder="Query results will appear here..."
+				onCopy={handleCopy}
+				emptyIcon={Search}
+				emptyTitle="Enter XML to query"
+				emptyDescription="Run an XPath expression to see matching nodes here."
 			/>
 		</div>
 	);

--- a/src/lib/components/formatter-tabs/yaml/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/format-tab.tsx
@@ -2,7 +2,7 @@ import { FileText } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import * as yaml from 'yaml';
 
-import { CodeEditor, type ContextMenuItem } from '@/lib/components/editor';
+import type { ContextMenuItem } from '@/lib/components/editor';
 import {
 	FormCheckbox,
 	FormCheckboxGroup,
@@ -11,9 +11,8 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SplitPane } from '@/lib/components/layout';
+import { InputOutputSplit } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmptyOutputPane } from '@/lib/components/status';
 import { useClipboardActions } from '@/lib/hooks';
 import { SAMPLE_YAML, sortKeysDeep, validateYaml } from '@/lib/services/formatters';
 
@@ -339,41 +338,21 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 				</FormSection>
 			</OptionsPanel>
 
-			<SplitPane
-				className="h-full flex-1"
-				left={
-					<CodeEditor
-						title="Input"
-						value={input}
-						onChange={onInputChange}
-						mode="input"
-						editorMode="yaml"
-						placeholder="Enter YAML here..."
-						onSample={handleSample}
-						onPaste={handlePaste}
-						onClear={handleClear}
-						contextMenuItems={inputContextMenuItems}
-					/>
-				}
-				right={
-					input.trim().length === 0 ? (
-						<EmptyOutputPane
-							headerTitle="Output"
-							icon={FileText}
-							title="Enter YAML to format"
-							description="The formatted (or minified) document will appear here."
-						/>
-					) : (
-						<CodeEditor
-							title="Output"
-							value={output}
-							mode="readonly"
-							editorMode="yaml"
-							placeholder="Formatted output..."
-							onCopy={handleCopy}
-						/>
-					)
-				}
+			<InputOutputSplit
+				input={input}
+				onInputChange={onInputChange}
+				editorMode="yaml"
+				inputPlaceholder="Enter YAML here..."
+				onSample={handleSample}
+				onPaste={handlePaste}
+				onClear={handleClear}
+				inputContextMenuItems={inputContextMenuItems}
+				output={output}
+				outputPlaceholder="Formatted output..."
+				onCopy={handleCopy}
+				emptyIcon={FileText}
+				emptyTitle="Enter YAML to format"
+				emptyDescription="The formatted (or minified) document will appear here."
 			/>
 		</div>
 	);

--- a/src/lib/components/formatter-tabs/yaml/generate-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/generate-tab.tsx
@@ -2,7 +2,6 @@ import { Code } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import * as yaml from 'yaml';
 
-import { CodeEditor } from '@/lib/components/editor';
 import {
 	FormCheckbox,
 	FormCheckboxGroup,
@@ -11,9 +10,8 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SplitPane } from '@/lib/components/layout';
+import { InputOutputSplit } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmptyOutputPane } from '@/lib/components/status';
 import { useClipboardActions } from '@/lib/hooks';
 import {
 	type CSharpOptions,
@@ -823,39 +821,23 @@ export function GenerateTab({ input, onInputChange, onStatsChange }: GenerateTab
 				) : null}
 			</OptionsPanel>
 
-			<SplitPane
+			<InputOutputSplit
 				className="flex-1"
-				left={
-					<CodeEditor
-						title="Input YAML"
-						value={input}
-						onChange={onInputChange}
-						mode="input"
-						editorMode="yaml"
-						placeholder="Enter YAML here..."
-						onPaste={handlePaste}
-						onClear={handleClear}
-					/>
-				}
-				right={
-					input.trim().length === 0 ? (
-						<EmptyOutputPane
-							headerTitle={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
-							icon={Code}
-							title="Enter YAML to generate code"
-							description={`The ${LANGUAGE_INFO[generateLanguage].label} class definitions will appear here.`}
-						/>
-					) : (
-						<CodeEditor
-							title={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
-							value={generatedCode}
-							mode="readonly"
-							editorMode={generateEditorMode}
-							placeholder="Generated code will appear here..."
-							onCopy={handleCopy}
-						/>
-					)
-				}
+				input={input}
+				onInputChange={onInputChange}
+				editorMode="yaml"
+				inputTitle="Input YAML"
+				inputPlaceholder="Enter YAML here..."
+				onPaste={handlePaste}
+				onClear={handleClear}
+				output={generatedCode}
+				outputEditorMode={generateEditorMode}
+				outputTitle={`Generated Code (${LANGUAGE_INFO[generateLanguage].label})`}
+				outputPlaceholder="Generated code will appear here..."
+				onCopy={handleCopy}
+				emptyIcon={Code}
+				emptyTitle="Enter YAML to generate code"
+				emptyDescription={`The ${LANGUAGE_INFO[generateLanguage].label} class definitions will appear here.`}
 			/>
 		</div>
 	);

--- a/src/lib/components/formatter-tabs/yaml/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/query-tab.tsx
@@ -2,7 +2,6 @@ import { Search } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import * as yaml from 'yaml';
 
-import { CodeEditor } from '@/lib/components/editor';
 import {
 	FormCheckbox,
 	FormCheckboxGroup,
@@ -10,9 +9,8 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SplitPane } from '@/lib/components/layout';
+import { InputOutputSplit } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmptyOutputPane } from '@/lib/components/status';
 import { useClipboardActions } from '@/lib/hooks';
 import { executeJsonPath } from '@/lib/services/formatters';
 
@@ -223,39 +221,22 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 				</FormSection>
 			</OptionsPanel>
 
-			<SplitPane
+			<InputOutputSplit
 				className="flex-1"
-				left={
-					<CodeEditor
-						title="Input"
-						value={input}
-						onChange={onInputChange}
-						mode="input"
-						editorMode="yaml"
-						placeholder="Enter YAML here..."
-						onPaste={handlePaste}
-						onClear={handleClear}
-					/>
-				}
-				right={
-					input.trim().length === 0 ? (
-						<EmptyOutputPane
-							headerTitle="Result"
-							icon={Search}
-							title="Enter YAML to query"
-							description="Run a JSONPath expression to see matching values here."
-						/>
-					) : (
-						<CodeEditor
-							title="Result"
-							value={queryResult}
-							mode="readonly"
-							editorMode={queryOutputFormat}
-							placeholder="Query result..."
-							onCopy={handleCopy}
-						/>
-					)
-				}
+				input={input}
+				onInputChange={onInputChange}
+				editorMode="yaml"
+				inputPlaceholder="Enter YAML here..."
+				onPaste={handlePaste}
+				onClear={handleClear}
+				output={queryResult}
+				outputEditorMode={queryOutputFormat}
+				outputTitle="Result"
+				outputPlaceholder="Query result..."
+				onCopy={handleCopy}
+				emptyIcon={Search}
+				emptyTitle="Enter YAML to query"
+				emptyDescription="Run a JSONPath expression to see matching values here."
 			/>
 		</div>
 	);

--- a/src/lib/components/layout/index.ts
+++ b/src/lib/components/layout/index.ts
@@ -1,4 +1,5 @@
 export { AppSidebar, type AppSidebarProps } from './app-sidebar';
+export { InputOutputSplit, type InputOutputSplitProps } from './input-output-split';
 export {
 	KeyboardShortcutsDialog,
 	type KeyboardShortcutsDialogProps,

--- a/src/lib/components/layout/input-output-split.tsx
+++ b/src/lib/components/layout/input-output-split.tsx
@@ -1,0 +1,105 @@
+import type { LucideIcon } from 'lucide-react';
+
+import { CodeEditor, type ContextMenuItem, type EditorMode } from '@/lib/components/editor';
+import { EmptyOutputPane } from '@/lib/components/status';
+import { cn } from '@/lib/utils';
+
+import { SplitPane } from './split-pane';
+
+interface InputOutputSplitProps {
+	// Input editor.
+	readonly input: string;
+	readonly onInputChange: (value: string) => void;
+	readonly editorMode: EditorMode;
+	readonly inputTitle?: string;
+	readonly inputPlaceholder?: string;
+	readonly onSample?: () => void;
+	readonly onPaste?: () => void;
+	readonly onClear?: () => void;
+	readonly inputContextMenuItems?: readonly ContextMenuItem[];
+
+	// Output editor (readonly).
+	readonly output: string;
+	// Defaults to `editorMode`. Override only when the output format differs
+	// from the input (e.g. JSON-to-XML convert).
+	readonly outputEditorMode?: EditorMode;
+	readonly outputTitle?: string;
+	readonly outputPlaceholder?: string;
+	readonly onCopy?: () => void;
+
+	// Empty-state graphic shown in place of the output editor when the input
+	// is empty. The three text props are required — there is no good default.
+	readonly emptyIcon: LucideIcon;
+	readonly emptyTitle: string;
+	readonly emptyDescription: string;
+
+	// SplitPane className override (defaults to `h-full flex-1`).
+	readonly className?: string;
+}
+
+// Single source of truth for the "input editor on the left, readonly output
+// (or empty state) on the right" shell shared by every formatter family tab
+// — format, query, generate, convert — across JSON, XML, and YAML. Bakes in
+// the empty-state branch, the SplitPane wrapper, and the editor mode
+// inheritance so callers only carry per-tab text and handlers.
+export function InputOutputSplit({
+	input,
+	onInputChange,
+	editorMode,
+	inputTitle = 'Input',
+	inputPlaceholder,
+	onSample,
+	onPaste,
+	onClear,
+	inputContextMenuItems,
+	output,
+	outputEditorMode,
+	outputTitle = 'Output',
+	outputPlaceholder,
+	onCopy,
+	emptyIcon,
+	emptyTitle,
+	emptyDescription,
+	className,
+}: InputOutputSplitProps) {
+	return (
+		<SplitPane
+			className={cn('h-full flex-1', className)}
+			left={
+				<CodeEditor
+					title={inputTitle}
+					value={input}
+					onChange={onInputChange}
+					mode="input"
+					editorMode={editorMode}
+					placeholder={inputPlaceholder}
+					onSample={onSample}
+					onPaste={onPaste}
+					onClear={onClear}
+					contextMenuItems={inputContextMenuItems}
+				/>
+			}
+			right={
+				input.trim().length === 0 ? (
+					<EmptyOutputPane
+						headerTitle={outputTitle}
+						icon={emptyIcon}
+						title={emptyTitle}
+						description={emptyDescription}
+					/>
+				) : (
+					<CodeEditor
+						title={outputTitle}
+						value={output}
+						mode="readonly"
+						editorMode={outputEditorMode ?? editorMode}
+						placeholder={outputPlaceholder}
+						onCopy={onCopy}
+					/>
+				)
+			}
+		/>
+	);
+}
+
+export type { InputOutputSplitProps };

--- a/src/lib/components/template/convert-tab.tsx
+++ b/src/lib/components/template/convert-tab.tsx
@@ -1,10 +1,9 @@
 import { ArrowRightLeft } from 'lucide-react';
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 
-import { CodeEditor, type EditorMode } from '@/lib/components/editor';
-import { SplitPane } from '@/lib/components/layout';
+import type { EditorMode } from '@/lib/components/editor';
+import { InputOutputSplit } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { EmptyOutputPane } from '@/lib/components/status';
 
 type ValidationResult = { valid: boolean | null } & Record<string, unknown>;
 type StatsResult = { input: string; valid: boolean | null; error: string } & Record<
@@ -109,39 +108,21 @@ export function ConvertTab({
 				{renderOptions?.()}
 			</OptionsPanel>
 
-			<SplitPane
-				className="h-full flex-1"
-				left={
-					<CodeEditor
-						title="Input"
-						value={input}
-						onChange={onInputChange}
-						mode="input"
-						editorMode={inputEditorMode}
-						placeholder={placeholder}
-						onPaste={handlePaste}
-						onClear={handleClear}
-					/>
-				}
-				right={
-					input.trim().length === 0 ? (
-						<EmptyOutputPane
-							headerTitle={outputTitle ?? 'Output'}
-							icon={ArrowRightLeft}
-							title={`Enter ${inputEditorMode.toUpperCase()} to convert`}
-							description="The converted document will appear here."
-						/>
-					) : (
-						<CodeEditor
-							title={outputTitle}
-							value={output}
-							mode="readonly"
-							editorMode={outputEditorMode}
-							placeholder="Converted output..."
-							onCopy={handleCopyOutput}
-						/>
-					)
-				}
+			<InputOutputSplit
+				input={input}
+				onInputChange={onInputChange}
+				editorMode={inputEditorMode}
+				inputPlaceholder={placeholder}
+				onPaste={handlePaste}
+				onClear={handleClear}
+				output={output}
+				outputEditorMode={outputEditorMode}
+				outputTitle={outputTitle ?? 'Output'}
+				outputPlaceholder="Converted output..."
+				onCopy={handleCopyOutput}
+				emptyIcon={ArrowRightLeft}
+				emptyTitle={`Enter ${inputEditorMode.toUpperCase()} to convert`}
+				emptyDescription="The converted document will appear here."
 			/>
 		</div>
 	);


### PR DESCRIPTION
## Summary

Fourth refactor of the deep-DRY series. The audit flagged the `SplitPane` + input/output `CodeEditor` shell as duplicated across every formatter family tab (format, query, generate) and the shared `convert-tab` template — 10 call sites each spelling out the same 30+ lines of JSX:

```tsx
<SplitPane
  className="h-full flex-1"
  left={
    <CodeEditor title="Input" value={input} onChange={onInputChange} mode="input" ... />
  }
  right={
    input.trim().length === 0 ? (
      <EmptyOutputPane ... />
    ) : (
      <CodeEditor title="Output" value={output} mode="readonly" ... />
    )
  }
/>
```

## Changes

### `feat(layout)`: `InputOutputSplit`

`src/lib/components/layout/input-output-split.tsx` — takes the per-tab text content (titles, placeholders, empty-state icon / title / description), handlers (paste / clear / copy / sample), optional input-context-menu items, an optional `outputEditorMode` for input/output mismatches (JSON-to-XML convert, YAML-to-JSON query), and a SplitPane `className` override. The empty-state branch is baked in: when `input.trim()` is empty, the right pane renders `EmptyOutputPane`; otherwise the readonly `CodeEditor` shows.

```tsx
<InputOutputSplit
  input={input}
  onInputChange={onInputChange}
  editorMode="json"
  inputPlaceholder="Enter JSON here..."
  onSample={handleSample}
  onPaste={handlePaste}
  onClear={handleClear}
  inputContextMenuItems={inputContextMenuItems}
  output={output}
  outputPlaceholder="Formatted output..."
  onCopy={handleCopy}
  emptyIcon={FileText}
  emptyTitle="Enter JSON to format"
  emptyDescription="The formatted (or minified) document will appear here."
/>
```

### Migrate 10 consumers

| Surface | File |
|---------|------|
| Format | `formatter-tabs/{json,xml,yaml}/format-tab.tsx` |
| Query | `formatter-tabs/{json,xml,yaml}/query-tab.tsx` |
| Generate | `formatter-tabs/{json,xml,yaml}/generate-tab.tsx` |
| Convert template | `template/convert-tab.tsx` |

`CodeEditor`, `SplitPane`, and `EmptyOutputPane` imports drop out of every consumer because the wrapper now owns them. `ContextMenuItem` continues to come from `@/lib/components/editor` for the tabs that still declare context-menu entries (now as a `type` import).

## Out of scope

- **schema-tab × 3** — right pane toggles between output editor and user-supplied schema input editor (the dual-mode validation feature). The single-output split doesn't model this.
- **compare-tab template** — two input editors, no output pane to swap.

## Net change

```
12 files changed, 271 insertions(+), 360 deletions(-)
```

After subtracting the ~110-line new component, this is roughly **−300 lines** of duplicated JSX across the 10 tabs.

## Test plan

- [x] `bun run check` passes
- [x] `bun run lint` clean (4 useImportType auto-fixes applied)
- [x] Pre-commit hooks green
- [ ] Visual smoke: open every format / query / generate / convert tab across JSON, XML, YAML with empty input — empty-pane shape unchanged
- [ ] Visual smoke: type input, verify output editor swap, copy / clear / paste handlers fire as before
- [ ] Visual smoke: convert tab (JSON-to-XML, YAML-to-JSON) — output editor mode differs from input editor mode
