### PR TITLE
refactor(ui): introduce CodeBlock and migrate 14 hand-rolled code surfaces

### DIFF
--- a/src/lib/components/ui/code-block.tsx
+++ b/src/lib/components/ui/code-block.tsx
@@ -1,0 +1,74 @@
+import type { ComponentProps } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface CodeBlockProps extends Omit<ComponentProps<'div'>, 'children'> {
+	// `code` (default) renders `<code className="block break-all">` for inline-y
+	// values (hashes, single-line keys, URLs). `pre` renders `<pre>` for
+	// preserved-format multi-line text (decoded JWT payload, key body).
+	readonly as?: 'code' | 'pre';
+	// Padding ladder: `sm` → `p-2`, `md` → `p-3`. Default `sm`.
+	readonly padding?: 'sm' | 'md';
+	// Text size: `xs` → `text-xs`, `sm` → `text-sm`. Default `xs`.
+	readonly size?: 'xs' | 'sm';
+	// Scrollable height clamp for `pre` variant: `sm` → `max-h-32`, `md` →
+	// `max-h-48`. Ignored on `code`.
+	readonly maxHeight?: 'sm' | 'md';
+	// Enable `whitespace-pre-wrap break-all` on `pre` variant for soft-wrap
+	// of long lines. Ignored on `code` (always wraps via `break-all`).
+	readonly wrap?: boolean;
+	readonly className?: string;
+	readonly children?: React.ReactNode;
+}
+
+const PADDING_CLASS = { sm: 'p-2', md: 'p-3' } as const;
+const SIZE_CLASS = { xs: 'text-xs', sm: 'text-sm' } as const;
+const MAX_HEIGHT_CLASS = { sm: 'max-h-32', md: 'max-h-48' } as const;
+
+// Single source of truth for the `rounded bg-muted ... font-mono ...`
+// code-display block that every generator / decoder / formatter route
+// used to spell out inline. Replaces 14 hand-rolled `<code>` / `<pre>`
+// blocks across hash-generator, bcrypt-generator, ssh-key-generator,
+// gpg-key-generator, jwt-decoder, url-encoder, and others. The variant
+// props cover the three observed shapes:
+//
+//   - `<code className="block break-all rounded bg-muted p-N font-mono text-X">…</code>`
+//   - `<pre className="overflow-auto rounded bg-muted p-N font-mono text-X">…</pre>`
+//   - `<pre className="max-h-N overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-N font-mono text-X">…</pre>`
+export function CodeBlock({
+	as = 'code',
+	padding = 'sm',
+	size = 'xs',
+	maxHeight,
+	wrap = false,
+	className,
+	children,
+	...props
+}: CodeBlockProps) {
+	const base = cn('rounded bg-muted font-mono', PADDING_CLASS[padding], SIZE_CLASS[size]);
+
+	if (as === 'pre') {
+		return (
+			<pre
+				className={cn(
+					base,
+					'overflow-auto',
+					wrap && 'whitespace-pre-wrap break-all',
+					maxHeight && MAX_HEIGHT_CLASS[maxHeight],
+					className
+				)}
+				{...(props as ComponentProps<'pre'>)}
+			>
+				{children}
+			</pre>
+		);
+	}
+
+	return (
+		<code className={cn(base, 'block break-all', className)} {...(props as ComponentProps<'code'>)}>
+			{children}
+		</code>
+	);
+}
+
+export type { CodeBlockProps };

--- a/src/routes/bcrypt-generator.tsx
+++ b/src/routes/bcrypt-generator.tsx
@@ -15,6 +15,7 @@ import {
 	StatItem,
 } from '@/lib/components/status';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { CodeBlock } from '@/lib/components/ui/code-block';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
 	type BcryptCostInfo,
@@ -387,9 +388,9 @@ function BcryptGeneratorPage() {
 										/>
 									</CardHeader>
 									<CardContent>
-										<code className="block break-all rounded bg-muted p-3 font-mono text-sm">
+										<CodeBlock padding="md" size="sm">
 											{hashResult.hash}
-										</code>
+										</CodeBlock>
 									</CardContent>
 								</Card>
 

--- a/src/routes/gpg-key-generator.tsx
+++ b/src/routes/gpg-key-generator.tsx
@@ -23,6 +23,7 @@ import {
 	StatItem,
 } from '@/lib/components/status';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { CodeBlock } from '@/lib/components/ui/code-block';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
 	buildGpgUserId,
@@ -397,9 +398,9 @@ function GpgKeyGeneratorPage() {
 									/>
 								</CardHeader>
 								<CardContent>
-									<pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs">
+									<CodeBlock as="pre" maxHeight="md" wrap>
 										{keyResult.public_key}
-									</pre>
+									</CodeBlock>
 									<p className="mt-2 text-xs text-muted-foreground">
 										Share this key with others so they can encrypt messages to you
 									</p>
@@ -422,9 +423,9 @@ function GpgKeyGeneratorPage() {
 									/>
 								</CardHeader>
 								<CardContent>
-									<pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs">
+									<CodeBlock as="pre" maxHeight="md" wrap>
 										{keyResult.private_key}
-									</pre>
+									</CodeBlock>
 									<p className="mt-2 text-xs text-warning">
 										Never share this key. Import with: <code>gpg --import private-key.asc</code>
 									</p>
@@ -451,9 +452,7 @@ function GpgKeyGeneratorPage() {
 														className="h-6 w-6"
 													/>
 												</div>
-												<code className="block rounded bg-muted p-2 font-mono text-xs">
-													{keyResult.gpg_command_interactive}
-												</code>
+												<CodeBlock>{keyResult.gpg_command_interactive}</CodeBlock>
 											</div>
 
 											<div>
@@ -466,9 +465,9 @@ function GpgKeyGeneratorPage() {
 														className="h-6 w-6"
 													/>
 												</div>
-												<pre className="max-h-32 overflow-auto whitespace-pre-wrap rounded bg-muted p-2 font-mono text-xs">
+												<CodeBlock as="pre" maxHeight="sm" wrap>
 													{keyResult.gpg_command_batch}
-												</pre>
+												</CodeBlock>
 											</div>
 										</div>
 									</CardContent>

--- a/src/routes/hash-generator.tsx
+++ b/src/routes/hash-generator.tsx
@@ -11,6 +11,7 @@ import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, LiveStatusRegion, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { CodeBlock } from '@/lib/components/ui/code-block';
 import {
 	formatBytes,
 	generateAllHashes,
@@ -152,9 +153,7 @@ function HashGeneratorPage() {
 											/>
 										</CardHeader>
 										<CardContent>
-											<code className="block break-all rounded bg-muted p-2 font-mono text-xs">
-												{result.hash}
-											</code>
+											<CodeBlock>{result.hash}</CodeBlock>
 										</CardContent>
 									</Card>
 								))}

--- a/src/routes/jwt-decoder.tsx
+++ b/src/routes/jwt-decoder.tsx
@@ -10,6 +10,7 @@ import { ToolShell } from '@/lib/components/shell';
 import { EmptyState, LiveStatusRegion } from '@/lib/components/status';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/lib/components/ui/tooltip';
+import { CodeBlock } from '@/lib/components/ui/code-block';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
 	decodeJwt,
@@ -223,9 +224,9 @@ function JwtDecoderPage() {
 											) : null}
 										</div>
 									) : null}
-									<pre className="overflow-auto rounded bg-muted p-3 font-mono text-xs">
+									<CodeBlock as="pre" padding="md">
 										{formatJson(decoded.header)}
-									</pre>
+									</CodeBlock>
 								</CardContent>
 							</Card>
 
@@ -241,9 +242,9 @@ function JwtDecoderPage() {
 									/>
 								</CardHeader>
 								<CardContent>
-									<pre className="overflow-auto rounded bg-muted p-3 font-mono text-xs">
+									<CodeBlock as="pre" padding="md">
 										{formatJson(decoded.payload)}
-									</pre>
+									</CodeBlock>
 								</CardContent>
 							</Card>
 
@@ -295,9 +296,7 @@ function JwtDecoderPage() {
 									/>
 								</CardHeader>
 								<CardContent>
-									<code className="block break-all rounded bg-muted p-3 font-mono text-xs">
-										{decoded.signature}
-									</code>
+									<CodeBlock padding="md">{decoded.signature}</CodeBlock>
 									<p className="mt-2 text-xs text-muted-foreground">
 										Note: Signature verification requires the secret key and is not performed
 										client-side.

--- a/src/routes/ssh-key-generator.tsx
+++ b/src/routes/ssh-key-generator.tsx
@@ -22,6 +22,7 @@ import {
 	StatItem,
 } from '@/lib/components/status';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { CodeBlock } from '@/lib/components/ui/code-block';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
 	cancelWorkerOperation,
@@ -328,9 +329,7 @@ function SshKeyGeneratorPage() {
 										/>
 									</CardHeader>
 									<CardContent>
-										<code className="block rounded bg-muted p-2 font-mono text-sm">
-											{keyResult.fingerprint}
-										</code>
+										<CodeBlock size="sm">{keyResult.fingerprint}</CodeBlock>
 									</CardContent>
 								</Card>
 							) : null}
@@ -350,9 +349,9 @@ function SshKeyGeneratorPage() {
 									/>
 								</CardHeader>
 								<CardContent>
-									<pre className="max-h-32 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs">
+									<CodeBlock as="pre" maxHeight="sm" wrap>
 										{keyResult.public_key}
-									</pre>
+									</CodeBlock>
 									<p className="mt-2 text-xs text-muted-foreground">
 										Add this to <code>~/.ssh/authorized_keys</code> on remote servers
 									</p>
@@ -375,9 +374,9 @@ function SshKeyGeneratorPage() {
 									/>
 								</CardHeader>
 								<CardContent>
-									<pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs">
+									<CodeBlock as="pre" maxHeight="md" wrap>
 										{keyResult.private_key}
-									</pre>
+									</CodeBlock>
 									<p className="mt-2 text-xs text-warning">
 										Save this to <code>~/.ssh/{privateKeyFile}</code> with permissions 600
 									</p>
@@ -402,9 +401,7 @@ function SshKeyGeneratorPage() {
 										/>
 									</CardHeader>
 									<CardContent>
-										<code className="block rounded bg-muted p-2 font-mono text-xs">
-											{keyResult.ssh_keygen_command}
-										</code>
+										<CodeBlock>{keyResult.ssh_keygen_command}</CodeBlock>
 									</CardContent>
 								</Card>
 							) : null}

--- a/src/routes/url-encoder.tsx
+++ b/src/routes/url-encoder.tsx
@@ -22,6 +22,7 @@ import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { Input } from '@/lib/components/ui/input';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/lib/components/ui/tooltip';
+import { CodeBlock } from '@/lib/components/ui/code-block';
 import { useActiveTab, useTabStore } from '@/lib/stores';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
@@ -567,7 +568,9 @@ function UrlEncoderPage() {
 					</div>
 				</CardHeader>
 				<CardContent>
-					<code className="block break-all rounded bg-muted p-3 font-mono text-sm">{builtUrl}</code>
+					<CodeBlock padding="md" size="sm">
+						{builtUrl}
+					</CodeBlock>
 				</CardContent>
 			</Card>
 		</div>


### PR DESCRIPTION
## Summary

Sixth refactor of the deep-DRY series. The `rounded bg-muted font-mono` code-display block was hand-rolled across every generator / decoder route that shows a hash, key body, decoded JWT payload, or built URL — 14 call sites with three structurally distinct shapes:

| Shape | Where it shows up |
|-------|-------------------|
| `<code className="block break-all rounded bg-muted p-N font-mono text-X">` | Single-value inline displays (hashes, fingerprints, built URLs) |
| `<pre className="overflow-auto rounded bg-muted p-N font-mono text-X">` | Preserved-format payloads (decoded JWT JSON) |
| `<pre className="max-h-N overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-N font-mono text-X">` | Height-clamped preformatted blocks (full SSH / GPG key bodies) |

The mix of values (`p-2` vs `p-3`, `text-xs` vs `text-sm`, `max-h-32` vs `max-h-48`) made the duplication noisy without obvious patterning.

## Changes

### `feat(ui)`: `CodeBlock`

`src/lib/components/ui/code-block.tsx` — single primitive covering all three shapes via variant props:

```tsx
interface CodeBlockProps {
  as?: 'code' | 'pre';        // default 'code'
  padding?: 'sm' | 'md';       // p-2 / p-3, default 'sm'
  size?: 'xs' | 'sm';          // text-xs / text-sm, default 'xs'
  maxHeight?: 'sm' | 'md';     // max-h-32 / max-h-48 (pre only)
  wrap?: boolean;               // whitespace-pre-wrap break-all on pre
  className?: string;
  children?: ReactNode;
}
```

### Migrate 14 call sites

| File | Replacements |
|------|--------------|
| `routes/hash-generator.tsx` | 1 |
| `routes/jwt-decoder.tsx` | 3 |
| `routes/bcrypt-generator.tsx` | 1 |
| `routes/url-encoder.tsx` | 1 |
| `routes/ssh-key-generator.tsx` | 4 |
| `routes/gpg-key-generator.tsx` | 4 |

The four `<code>` blocks that previously lacked `break-all` now pick it up via the `CodeBlock` default — long fingerprint strings that used to overflow horizontally now wrap. A UX improvement that fell out for free.

## Out of scope

The audit also flagged the `<CardHeader flex-row + CopyButton + …>` shell ("ResultCard", 15 call sites). Its body content varies significantly per route (single code line, JSON pre, key-value lists, etc.) and needs a richer prop surface than this single primitive can clean up. Slated for a follow-up PR.

## Net change

```
7 files changed, 104 insertions(+), 32 deletions(-)
```

After subtracting the ~75-line new primitive, ~−10 lines of inline `<code>` / `<pre>` boilerplate — but the bigger win is a single source of truth for the code-display tokens (padding, size, maxHeight) across the app.

## Test plan

- [x] `bun run check` passes
- [x] `bun run test` — all 141 tests pass
- [x] Pre-commit hooks green
- [ ] Visual smoke: generate a hash on `/hash-generator` — verify hash row shows in a `text-xs p-2` code block
- [ ] Visual smoke: decode a JWT on `/jwt-decoder` — verify header / payload panes show in `text-xs p-3` pre blocks, the signature shows in a `text-xs p-3` code block
- [ ] Visual smoke: generate a BCrypt hash on `/bcrypt-generator` — verify the hash shows in a `text-sm p-3` code block
- [ ] Visual smoke: build a URL on `/url-encoder` — verify the built URL shows in a `text-sm p-3` code block
- [ ] Visual smoke: generate an SSH key pair — verify fingerprint (`code sm`) and public / private key bodies (`pre wrap max-h`) render correctly with their respective height clamps
- [ ] Visual smoke: generate a GPG key pair — same shape as SSH
