### PR TITLE
refactor(panel): introduce GeneratedListPanel for uuid + password routes

### DIFF
--- a/src/lib/components/panel/generated-list-panel.tsx
+++ b/src/lib/components/panel/generated-list-panel.tsx
@@ -1,0 +1,92 @@
+import type { LucideIcon } from 'lucide-react';
+
+import { CopyButton } from '@/lib/components/action';
+import { SectionHeader } from '@/lib/components/layout';
+import { EmbeddedEmptyState, LiveStatusRegion } from '@/lib/components/status';
+import { Card, CardContent } from '@/lib/components/ui/card';
+
+interface GeneratedListPanelProps {
+	// Header title (e.g. "Generated UUIDs", "Generated Passwords").
+	readonly title: string;
+	// Per-item copy toast label (e.g. "UUID", "Password").
+	readonly itemToastLabel: string;
+	// Copy-all toast label, called with the result count
+	// (e.g. `(n) => \`${n} UUID${n > 1 ? 's' : ''}\``).
+	readonly copyAllToastLabel: (count: number) => string;
+	// Empty-state slot.
+	readonly emptyIcon: LucideIcon;
+	readonly emptyTitle: string;
+	readonly emptyDescription: string;
+	// Data + the flash counter used to key the wrapper for
+	// `animate-flash-success` re-mount after each regeneration.
+	readonly results: readonly string[];
+	readonly flashCounter: number;
+}
+
+// Right-pane panel used by the simple list-of-strings generators (UUID,
+// password). Mirrors the exact JSX skeleton that was duplicated across
+// the two routes: `<SectionHeader>` with a Copy-All trailing slot, then
+// a `<LiveStatusRegion>` that renders either an `EmbeddedEmptyState`
+// (no results yet) or the keyed `animate-flash-success` list of
+// per-value cards with their own `<CopyButton>`. Per-route variation
+// is funneled through `title`, `itemToastLabel`, `copyAllToastLabel`,
+// and the three empty-state strings.
+export function GeneratedListPanel({
+	title,
+	itemToastLabel,
+	copyAllToastLabel,
+	emptyIcon,
+	emptyTitle,
+	emptyDescription,
+	results,
+	flashCounter,
+}: GeneratedListPanelProps) {
+	return (
+		<div className="flex h-full flex-col overflow-hidden">
+			<SectionHeader
+				title={title}
+				count={results.length || undefined}
+				trailing={
+					results.length > 0 ? (
+						<CopyButton
+							text={results.join('\n')}
+							label="Copy All"
+							toastLabel={copyAllToastLabel(results.length)}
+							size="sm"
+							// SectionHeader is bg-surface-2; restore visible hover affordance.
+							className="h-7 hover:bg-interactive-hover"
+						/>
+					) : null
+				}
+			/>
+			<LiveStatusRegion className="flex-1 overflow-auto p-4">
+				{results.length > 0 ? (
+					<div key={flashCounter} className="animate-flash-success space-y-2 rounded-md">
+						{results.map((value) => (
+							<Card key={value} density="compact">
+								<CardContent className="flex items-center gap-2">
+									<code className="flex-1 break-all font-mono text-sm">{value}</code>
+									<CopyButton
+										text={value}
+										toastLabel={itemToastLabel}
+										size="sm"
+										showLabel={false}
+									/>
+								</CardContent>
+							</Card>
+						))}
+					</div>
+				) : (
+					<EmbeddedEmptyState
+						icon={emptyIcon}
+						title={emptyTitle}
+						description={emptyDescription}
+						fillHeight
+					/>
+				)}
+			</LiveStatusRegion>
+		</div>
+	);
+}
+
+export type { GeneratedListPanelProps };

--- a/src/lib/components/panel/index.ts
+++ b/src/lib/components/panel/index.ts
@@ -4,5 +4,8 @@ export type { DiffLegendProps } from './diff-legend';
 export { DiffResults } from './diff-results';
 export type { DiffItem, DiffResultsProps } from './diff-results';
 
+export { GeneratedListPanel } from './generated-list-panel';
+export type { GeneratedListPanelProps } from './generated-list-panel';
+
 export { OptionsPanel } from './options-panel';
 export type { OptionsPanelProps } from './options-panel';

--- a/src/routes/password-generator.tsx
+++ b/src/routes/password-generator.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { Lock, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { ActionButton, CopyButton } from '@/lib/components/action';
+import { ActionButton } from '@/lib/components/action';
 import { getErrorMessage } from '@/lib/utils';
 import {
 	FormCheckbox,
@@ -12,10 +12,9 @@ import {
 	FormSection,
 	FormSlider,
 } from '@/lib/components/form';
-import { SectionHeader } from '@/lib/components/layout';
+import { GeneratedListPanel } from '@/lib/components/panel';
 import { ToolShell } from '@/lib/components/shell';
-import { EmbeddedEmptyState, LiveStatusRegion, StatItem } from '@/lib/components/status';
-import { Card, CardContent } from '@/lib/components/ui/card';
+import { StatItem } from '@/lib/components/status';
 import { createToolOptionsStore } from '@/lib/stores';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
@@ -247,45 +246,16 @@ function PasswordGeneratorPage() {
 				</>
 			}
 		>
-			<div className="flex h-full flex-col overflow-hidden">
-				<SectionHeader
-					title="Generated Passwords"
-					count={results.length || undefined}
-					trailing={
-						results.length > 0 ? (
-							<CopyButton
-								text={results.join('\n')}
-								label="Copy All"
-								toastLabel={`${results.length} password${results.length > 1 ? 's' : ''}`}
-								size="sm"
-								// SectionHeader is bg-surface-2; restore visible hover affordance.
-								className="h-7 hover:bg-interactive-hover"
-							/>
-						) : null
-					}
-				/>
-				<LiveStatusRegion className="flex-1 overflow-auto p-4">
-					{results.length > 0 ? (
-						<div key={flashCounter} className="animate-flash-success space-y-2 rounded-md">
-							{results.map((password) => (
-								<Card key={password} density="compact">
-									<CardContent className="flex items-center gap-2">
-										<code className="flex-1 break-all font-mono text-sm">{password}</code>
-										<CopyButton text={password} toastLabel="Password" size="sm" showLabel={false} />
-									</CardContent>
-								</Card>
-							))}
-						</div>
-					) : (
-						<EmbeddedEmptyState
-							icon={Lock}
-							title="Generate passwords"
-							description="Adjust the options on the left and click Generate to create secure passwords."
-							fillHeight
-						/>
-					)}
-				</LiveStatusRegion>
-			</div>
+			<GeneratedListPanel
+				title="Generated Passwords"
+				itemToastLabel="Password"
+				copyAllToastLabel={(n) => `${n} password${n > 1 ? 's' : ''}`}
+				emptyIcon={Lock}
+				emptyTitle="Generate passwords"
+				emptyDescription="Adjust the options on the left and click Generate to create secure passwords."
+				results={results}
+				flashCounter={flashCounter}
+			/>
 		</ToolShell>
 	);
 }

--- a/src/routes/uuid-generator.tsx
+++ b/src/routes/uuid-generator.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from 'react';
 import { Fingerprint, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { ActionButton, CopyButton } from '@/lib/components/action';
+import { ActionButton } from '@/lib/components/action';
 import { getErrorMessage } from '@/lib/utils';
 import {
 	FormCheckbox,
@@ -14,10 +14,9 @@ import {
 	FormSelect,
 	FormSlider,
 } from '@/lib/components/form';
-import { SectionHeader } from '@/lib/components/layout';
+import { GeneratedListPanel } from '@/lib/components/panel';
 import { ToolShell } from '@/lib/components/shell';
-import { EmbeddedEmptyState, LiveStatusRegion, StatItem } from '@/lib/components/status';
-import { Card, CardContent } from '@/lib/components/ui/card';
+import { StatItem } from '@/lib/components/status';
 import { createToolOptionsStore } from '@/lib/stores';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
@@ -241,45 +240,16 @@ function UuidGeneratorPage() {
 				</>
 			}
 		>
-			<div className="flex h-full flex-col overflow-hidden">
-				<SectionHeader
-					title="Generated UUIDs"
-					count={results.length || undefined}
-					trailing={
-						results.length > 0 ? (
-							<CopyButton
-								text={results.join('\n')}
-								label="Copy All"
-								toastLabel={`${results.length} UUID${results.length > 1 ? 's' : ''}`}
-								size="sm"
-								// SectionHeader is bg-surface-2; restore visible hover affordance.
-								className="h-7 hover:bg-interactive-hover"
-							/>
-						) : null
-					}
-				/>
-				<LiveStatusRegion className="flex-1 overflow-auto p-4">
-					{results.length > 0 ? (
-						<div key={flashCounter} className="animate-flash-success space-y-2 rounded-md">
-							{results.map((uuid) => (
-								<Card key={uuid} density="compact">
-									<CardContent className="flex items-center gap-2">
-										<code className="flex-1 break-all font-mono text-sm">{uuid}</code>
-										<CopyButton text={uuid} toastLabel="UUID" size="sm" showLabel={false} />
-									</CardContent>
-								</Card>
-							))}
-						</div>
-					) : (
-						<EmbeddedEmptyState
-							icon={Fingerprint}
-							title="Generate UUIDs"
-							description="Pick a version on the left and click Generate to create unique identifiers."
-							fillHeight
-						/>
-					)}
-				</LiveStatusRegion>
-			</div>
+			<GeneratedListPanel
+				title="Generated UUIDs"
+				itemToastLabel="UUID"
+				copyAllToastLabel={(n) => `${n} UUID${n > 1 ? 's' : ''}`}
+				emptyIcon={Fingerprint}
+				emptyTitle="Generate UUIDs"
+				emptyDescription="Pick a version on the left and click Generate to create unique identifiers."
+				results={results}
+				flashCounter={flashCounter}
+			/>
 		</ToolShell>
 	);
 }


### PR DESCRIPTION
## Summary

Eighth refactor of the deep-DRY series. The UUID and Password generator routes shared a 38-line right-pane JSX skeleton: `<SectionHeader>` with a Copy-All trailing slot, then a `<LiveStatusRegion>` rendering either an `EmbeddedEmptyState` when results are empty or the keyed `animate-flash-success` list of per-value `<Card>`s — each card owning its own `<CopyButton>` for the per-row copy. The only per-route variation was a handful of strings and the empty-state icon.

## Changes

### `feat(panel)`: `GeneratedListPanel`

`src/lib/components/panel/generated-list-panel.tsx` — single shell owning the entire JSX skeleton:

```tsx
interface GeneratedListPanelProps {
  title: string;                                  // "Generated UUIDs", "Generated Passwords"
  itemToastLabel: string;                          // "UUID", "Password"
  copyAllToastLabel: (count: number) => string;    // (n) => `${n} UUID${n > 1 ? 's' : ''}`
  emptyIcon: LucideIcon;
  emptyTitle: string;
  emptyDescription: string;
  results: readonly string[];
  flashCounter: number;                            // re-mount key for animate-flash-success
}
```

The `copyAllToastLabel` callback lets each route own its own pluralization (`"5 UUIDs"` vs `"5 passwords"`) without the panel hard-coding an opinion.

### Migrate two routes

| Route | Before | After | Imports dropped |
|-------|--------|-------|-----------------|
| `routes/uuid-generator.tsx` | 38-line panel | 9-line wrapper | `SectionHeader`, `CopyButton`, `EmbeddedEmptyState`, `LiveStatusRegion`, `Card`, `CardContent` |
| `routes/password-generator.tsx` | 38-line panel | 9-line wrapper | same as above |

## Out of scope

Five other routes (`ssh-key-generator`, `gpg-key-generator`, `bcrypt-generator`, `qr-code-generator`, and the generators that show a single complex result) keep their hand-rolled shells. They render a single result with a richer body (multi-line key, base64 image, kv-pair list) and don't fit the list-of-simple-strings shape this panel models.

## Net change

```
4 files changed, 121 insertions(+), 86 deletions(-)
```

The new panel adds ~93 lines; the two routes lose 76 lines of duplicated JSX. The real win is removing the maintenance hazard where a fix in one route had to be ported to the other, and giving the remaining list-style generators a clear target if they grow into this shape.

## Test plan

- [x] `bun run check` passes
- [x] `bun run test` — all 141 tests pass
- [x] Pre-commit hooks green
- [ ] Smoke: open `/uuid-generator` — verify rail Generate produces N UUID cards, each with its own copy button; Copy All shows "5 UUIDs" toast; clearing returns to the empty state
- [ ] Smoke: open `/password-generator` — verify rail Generate produces N password cards, each with its own copy button; Copy All shows "5 passwords" toast; the flash-success animation fires on each regeneration
