### PR TITLE
refactor(hooks): introduce useReportStats and useValidation, migrate 11 tabs

### DIFF
--- a/src/lib/components/formatter-tabs/json/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/format-tab.tsx
@@ -1,5 +1,5 @@
 import { FileText } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import type { ContextMenuItem } from '@/lib/components/editor';
 import { getErrorMessage } from '@/lib/utils';
@@ -12,7 +12,7 @@ import {
 } from '@/lib/components/form';
 import { InputOutputSplit } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { useClipboardActions } from '@/lib/hooks';
+import { useClipboardActions, useReportStats } from '@/lib/hooks';
 import {
 	defaultJsonFormatOptions,
 	type JsonFormatOptions,
@@ -198,13 +198,7 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 		formatOptions
 	);
 
-	useEffect(() => {
-		onStatsChange?.({
-			input,
-			valid: validation.valid,
-			error: formatError,
-		});
-	}, [input, validation.valid, formatError, onStatsChange]);
+	useReportStats(onStatsChange, input, validation.valid, formatError);
 
 	const { handlePaste, handleClear, handleCopy } = useClipboardActions({
 		onInputChange,

--- a/src/lib/components/formatter-tabs/json/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/query-tab.tsx
@@ -1,5 +1,5 @@
 import { Search } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import {
 	FormCheckbox,
@@ -11,7 +11,7 @@ import {
 import { getErrorMessage } from '@/lib/utils';
 import { InputOutputSplit } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { useClipboardActions } from '@/lib/hooks';
+import { useClipboardActions, useReportStats, useValidation } from '@/lib/hooks';
 import { executeJsonPath, validateJson } from '@/lib/services/formatters';
 import { useJsonFormatterOptions } from '@/lib/stores';
 
@@ -73,11 +73,7 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 	const [queryFlattenArrays, setQueryFlattenArrays] = useState<boolean>(false);
 	const [queryWrapResults, setQueryWrapResults] = useState<boolean>(true);
 
-	const inputValidation = useMemo<{ valid: boolean | null }>(() => {
-		if (!input.trim()) return { valid: null };
-		const result = validateJson(input, inputFormat);
-		return { valid: result.valid };
-	}, [input, inputFormat]);
+	const inputValid = useValidation(input, (s) => validateJson(s, inputFormat).valid);
 
 	const queryMaxResults = Number.parseInt(queryMaxResultsStr, 10) || 0;
 
@@ -106,13 +102,7 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 	const queryResult = queryResultData.result;
 	const queryError = queryResultData.error;
 
-	useEffect(() => {
-		onStatsChange?.({
-			input,
-			valid: inputValidation.valid,
-			error: queryError,
-		});
-	}, [input, inputValidation.valid, queryError, onStatsChange]);
+	useReportStats(onStatsChange, input, inputValid, queryError);
 
 	const { handlePaste, handleCopy } = useClipboardActions({
 		onInputChange,

--- a/src/lib/components/formatter-tabs/json/schema-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/schema-tab.tsx
@@ -1,9 +1,10 @@
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import { FileCheck, Wand2 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
+import { useReportStats, useValidation } from '@/lib/hooks';
 import { CodeEditor } from '@/lib/components/editor';
 import { FormCheckbox, FormCheckboxGroup, FormSection } from '@/lib/components/form';
 import { SplitPane } from '@/lib/components/layout';
@@ -53,11 +54,7 @@ export function SchemaTab({ input, onInputChange, onStatsChange }: SchemaTabProp
 	const [schemaValidateFormats, setSchemaValidateFormats] = useState<boolean>(true);
 	const [schemaVerboseErrors, setSchemaVerboseErrors] = useState<boolean>(false);
 
-	const inputValidation = useMemo<{ valid: boolean | null }>(() => {
-		if (!input.trim()) return { valid: null };
-		const result = validateJson(input, inputFormat);
-		return { valid: result.valid };
-	}, [input, inputFormat]);
+	const inputValid = useValidation(input, (s) => validateJson(s, inputFormat).valid);
 
 	const inferredSchema = useMemo<string>(() => {
 		if (!input.trim() || input.trim() === '{}') return '';
@@ -74,13 +71,7 @@ export function SchemaTab({ input, onInputChange, onStatsChange }: SchemaTabProp
 			? `${schemaValidationResult.errors.length} validation error(s)`
 			: '');
 
-	useEffect(() => {
-		onStatsChange?.({
-			input,
-			valid: inputValidation.valid,
-			error: combinedError,
-		});
-	}, [input, inputValidation.valid, combinedError, onStatsChange]);
+	useReportStats(onStatsChange, input, inputValid, combinedError);
 
 	const handleValidateSchema = useCallback(() => {
 		if (!input.trim() || !schemaDefinition.trim()) {

--- a/src/lib/components/formatter-tabs/xml/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/format-tab.tsx
@@ -1,5 +1,5 @@
 import { FileText } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import type { ContextMenuItem } from '@/lib/components/editor';
 import { getErrorMessage } from '@/lib/utils';
@@ -12,7 +12,7 @@ import {
 } from '@/lib/components/form';
 import { InputOutputSplit } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { useClipboardActions } from '@/lib/hooks';
+import { useClipboardActions, useReportStats } from '@/lib/hooks';
 import {
 	defaultXmlFormatOptions,
 	formatXml,
@@ -106,13 +106,7 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 	})();
 
 	// Report stats to parent.
-	useEffect(() => {
-		onStatsChange?.({
-			input,
-			valid: validation.valid,
-			error: formatError,
-		});
-	}, [input, validation.valid, formatError, onStatsChange]);
+	useReportStats(onStatsChange, input, validation.valid, formatError);
 
 	const { handlePaste, handleClear, handleCopy } = useClipboardActions({
 		onInputChange,

--- a/src/lib/components/formatter-tabs/xml/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/query-tab.tsx
@@ -1,11 +1,11 @@
 import { Search } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { FormInput, FormSection } from '@/lib/components/form';
 import { getErrorMessage } from '@/lib/utils';
 import { InputOutputSplit } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { useClipboardActions } from '@/lib/hooks';
+import { useClipboardActions, useReportStats, useValidation } from '@/lib/hooks';
 import { executeXPath, formatXml } from '@/lib/services/formatters';
 
 interface TabStats {
@@ -24,17 +24,15 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 	const [xpathExpression, setXpathExpression] = useState('//');
 	const [showOptions, setShowOptions] = useState(true);
 
-	const inputValidation = useMemo<{ valid: boolean | null }>(() => {
-		if (!input.trim()) return { valid: null };
+	const inputValid = useValidation(input, (s) => {
 		try {
 			const parser = new DOMParser();
-			const doc = parser.parseFromString(input, 'application/xml');
-			const parserError = doc.querySelector('parsererror');
-			return { valid: parserError === null };
+			const doc = parser.parseFromString(s, 'application/xml');
+			return doc.querySelector('parsererror') === null;
 		} catch {
-			return { valid: false };
+			return false;
 		}
-	}, [input]);
+	});
 
 	const queryResultData = useMemo<{ output: string; error: string; count: number }>(() => {
 		if (!input.trim() || xpathExpression.trim() === '' || xpathExpression.trim() === '//') {
@@ -70,13 +68,7 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 	const queryError = queryResultData.error;
 	const resultCount = queryResultData.count;
 
-	useEffect(() => {
-		onStatsChange?.({
-			input,
-			valid: inputValidation.valid,
-			error: queryError,
-		});
-	}, [input, inputValidation.valid, queryError, onStatsChange]);
+	useReportStats(onStatsChange, input, inputValid, queryError);
 
 	const { handlePaste, handleCopy } = useClipboardActions({
 		onInputChange,

--- a/src/lib/components/formatter-tabs/xml/schema-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/schema-tab.tsx
@@ -1,7 +1,8 @@
 import { FileCheck, Wand2 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
+import { useReportStats, useValidation } from '@/lib/hooks';
 import { CodeEditor } from '@/lib/components/editor';
 import { FormCheckbox, FormCheckboxGroup, FormSection } from '@/lib/components/form';
 import { SplitPane } from '@/lib/components/layout';
@@ -124,17 +125,15 @@ export function SchemaTab({ input, onInputChange, onStatsChange }: SchemaTabProp
 	const [validateNamespaces, setValidateNamespaces] = useState<boolean>(true);
 	const [validateDtd, setValidateDtd] = useState<boolean>(false);
 
-	const inputValidation = useMemo<{ valid: boolean | null }>(() => {
-		if (!input.trim()) return { valid: null };
+	const inputValid = useValidation(input, (s) => {
 		try {
 			const parser = new DOMParser();
-			const doc = parser.parseFromString(input, 'application/xml');
-			const parserError = doc.querySelector('parsererror');
-			return { valid: parserError === null };
+			const doc = parser.parseFromString(s, 'application/xml');
+			return doc.querySelector('parsererror') === null;
 		} catch {
-			return { valid: false };
+			return false;
 		}
-	}, [input]);
+	});
 
 	const inferredSchema = useMemo<string>(() => {
 		if (!input.trim()) return '';
@@ -151,13 +150,7 @@ export function SchemaTab({ input, onInputChange, onStatsChange }: SchemaTabProp
 			? `${schemaValidationResult.errors.length} validation error(s)`
 			: '');
 
-	useEffect(() => {
-		onStatsChange?.({
-			input,
-			valid: inputValidation.valid,
-			error: combinedError,
-		});
-	}, [input, inputValidation.valid, combinedError, onStatsChange]);
+	useReportStats(onStatsChange, input, inputValid, combinedError);
 
 	const handleValidateSchema = useCallback(() => {
 		if (!input.trim() || !schemaDefinition.trim()) {

--- a/src/lib/components/formatter-tabs/yaml/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/format-tab.tsx
@@ -1,5 +1,5 @@
 import { FileText } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import * as yaml from 'yaml';
 
 import type { ContextMenuItem } from '@/lib/components/editor';
@@ -14,7 +14,7 @@ import {
 } from '@/lib/components/form';
 import { InputOutputSplit } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { useClipboardActions } from '@/lib/hooks';
+import { useClipboardActions, useReportStats } from '@/lib/hooks';
 import { SAMPLE_YAML, sortKeysDeep, validateYaml } from '@/lib/services/formatters';
 
 type FormatMode = 'format' | 'minify';
@@ -125,13 +125,7 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 		}
 	})();
 
-	useEffect(() => {
-		onStatsChange?.({
-			input,
-			valid: validation.valid,
-			error: formatError,
-		});
-	}, [input, validation.valid, formatError, onStatsChange]);
+	useReportStats(onStatsChange, input, validation.valid, formatError);
 
 	const { handlePaste, handleClear, handleCopy } = useClipboardActions({
 		onInputChange,

--- a/src/lib/components/formatter-tabs/yaml/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/query-tab.tsx
@@ -1,5 +1,5 @@
 import { Search } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useState } from 'react';
 import * as yaml from 'yaml';
 
 import {
@@ -12,7 +12,7 @@ import {
 import { getErrorMessage } from '@/lib/utils';
 import { InputOutputSplit } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { useClipboardActions } from '@/lib/hooks';
+import { useClipboardActions, useReportStats, useValidation } from '@/lib/hooks';
 import { executeJsonPath } from '@/lib/services/formatters';
 
 type QueryOutputFormat = 'yaml' | 'json';
@@ -69,15 +69,14 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 	const [queryFlattenArrays, setQueryFlattenArrays] = useState<boolean>(false);
 	const [queryWrapResults, setQueryWrapResults] = useState<boolean>(true);
 
-	const inputValidation = useMemo<{ valid: boolean | null }>(() => {
-		if (!input.trim()) return { valid: null };
+	const inputValid = useValidation(input, (s) => {
 		try {
-			yaml.parse(input);
-			return { valid: true };
+			yaml.parse(s);
+			return true;
 		} catch {
-			return { valid: false };
+			return false;
 		}
-	}, [input]);
+	});
 
 	const queryMaxResults = Number.parseInt(queryMaxResultsStr, 10) || 0;
 
@@ -110,13 +109,7 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 	const queryResult = queryResultData.result;
 	const queryError = queryResultData.error;
 
-	useEffect(() => {
-		onStatsChange?.({
-			input,
-			valid: inputValidation.valid,
-			error: queryError,
-		});
-	}, [input, inputValidation.valid, queryError, onStatsChange]);
+	useReportStats(onStatsChange, input, inputValid, queryError);
 
 	const { handlePaste, handleCopy } = useClipboardActions({
 		onInputChange,

--- a/src/lib/components/formatter-tabs/yaml/schema-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/schema-tab.tsx
@@ -1,10 +1,11 @@
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import { FileCheck, Wand2 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import * as yaml from 'yaml';
 
+import { useReportStats, useValidation } from '@/lib/hooks';
 import { CodeEditor } from '@/lib/components/editor';
 import { FormCheckbox, FormCheckboxGroup, FormMode, FormSection } from '@/lib/components/form';
 import { SplitPane } from '@/lib/components/layout';
@@ -51,15 +52,14 @@ export function SchemaTab({ input, onInputChange, onStatsChange }: SchemaTabProp
 	const [schemaVerboseErrors, setSchemaVerboseErrors] = useState<boolean>(false);
 	const [outputSchemaFormat, setOutputSchemaFormat] = useState<SchemaFormat>('yaml');
 
-	const inputValidation = useMemo<{ valid: boolean | null }>(() => {
-		if (!input.trim()) return { valid: null };
+	const inputValid = useValidation(input, (s) => {
 		try {
-			yaml.parse(input);
-			return { valid: true };
+			yaml.parse(s);
+			return true;
 		} catch {
-			return { valid: false };
+			return false;
 		}
-	}, [input]);
+	});
 
 	const inferredSchema = useMemo<string>(() => {
 		if (!input.trim()) return '';
@@ -82,13 +82,7 @@ export function SchemaTab({ input, onInputChange, onStatsChange }: SchemaTabProp
 			? `${schemaValidationResult.errors.length} validation error(s)`
 			: '');
 
-	useEffect(() => {
-		onStatsChange?.({
-			input,
-			valid: inputValidation.valid,
-			error: combinedError,
-		});
-	}, [input, inputValidation.valid, combinedError, onStatsChange]);
+	useReportStats(onStatsChange, input, inputValid, combinedError);
 
 	const handleValidateSchema = useCallback(() => {
 		if (!input.trim() || !schemaDefinition.trim()) {

--- a/src/lib/components/template/compare-tab.tsx
+++ b/src/lib/components/template/compare-tab.tsx
@@ -1,6 +1,7 @@
 import { ArrowRightLeft } from 'lucide-react';
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 
+import { useReportStats } from '@/lib/hooks';
 import { CodeEditor } from '@/lib/components/editor';
 import { getErrorMessage } from '@/lib/utils';
 import { FormSection } from '@/lib/components/form';
@@ -132,13 +133,7 @@ export function CompareTab({
 	};
 
 	// Report stats to parent.
-	useEffect(() => {
-		onStatsChange?.({
-			input,
-			valid: combinedValidity,
-			error: compareError,
-		});
-	}, [input, combinedValidity, compareError, onStatsChange]);
+	useReportStats(onStatsChange, input, combinedValidity, compareError);
 
 	const handleSwap = () => {
 		const temp = input;

--- a/src/lib/components/template/generate-tab.tsx
+++ b/src/lib/components/template/generate-tab.tsx
@@ -1,5 +1,5 @@
 import { Code } from 'lucide-react';
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 
 import type { EditorMode } from '@/lib/components/editor';
 import { getErrorMessage } from '@/lib/utils';
@@ -13,7 +13,7 @@ import {
 } from '@/lib/components/form';
 import { InputOutputSplit } from '@/lib/components/layout';
 import { OptionsPanel } from '@/lib/components/panel';
-import { useClipboardActions } from '@/lib/hooks';
+import { useClipboardActions, useReportStats } from '@/lib/hooks';
 import {
 	type CSharpOptions,
 	generateCode,
@@ -338,13 +338,7 @@ export function GenerateTabTemplate({
 
 	const generateEditorMode = LANGUAGE_INFO[generateLanguage].editorMode;
 
-	useEffect(() => {
-		onStatsChange?.({
-			input,
-			valid: inputValidation.valid,
-			error: generateError,
-		});
-	}, [input, inputValidation.valid, generateError, onStatsChange]);
+	useReportStats(onStatsChange, input, inputValidation.valid, generateError);
 
 	const { handlePaste, handleClear, handleCopy } = useClipboardActions({
 		onInputChange,

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -9,3 +9,5 @@ export {
 	type UseFormatterPageReturn,
 } from './use-formatter-page';
 export { useIsMobile } from './use-mobile';
+export { useReportStats } from './use-report-stats';
+export { useValidation } from './use-validation';

--- a/src/lib/hooks/use-report-stats.ts
+++ b/src/lib/hooks/use-report-stats.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+
+import type { TabStats } from './use-formatter-page';
+
+// Re-runs `onStatsChange` whenever any of the three fields changes.
+// Replaces the inline `useEffect(() => onStatsChange?.({input, valid, error}),
+// [input, valid, error, onStatsChange])` ladder that appeared at 11 formatter
+// tab call sites (json/xml/yaml × format/query/schema plus the shared
+// template/convert-tab and template/generate-tab).
+//
+// The three values are passed positionally rather than as a single `stats`
+// object so callers don't have to memoize the object on every render — React's
+// referential equality on the primitive deps does the right thing.
+export function useReportStats(
+	onStatsChange: ((stats: TabStats) => void) | undefined,
+	input: string,
+	valid: boolean | null,
+	error: string
+): void {
+	useEffect(() => {
+		onStatsChange?.({ input, valid, error });
+	}, [input, valid, error, onStatsChange]);
+}

--- a/src/lib/hooks/use-validation.ts
+++ b/src/lib/hooks/use-validation.ts
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+
+// Returns `null` when `input` is empty (whitespace-only counts as empty),
+// otherwise delegates to `validate` and returns its boolean verdict.
+//
+// Replaces the `useMemo<{ valid: boolean | null }>(() => !input.trim() ?
+// { valid: null } : { valid: validateXxx(input).valid }, [input])` pattern
+// that appeared at 6 formatter tab call sites (json / xml / yaml ×
+// query / schema). The `validate` callback owns its own try / catch so
+// the hook stays format-agnostic — `yaml.parse` throws, `validateJson`
+// returns a result object, and `DOMParser` reports via `parsererror` —
+// each caller wraps the appropriate semantics inside the callback.
+export function useValidation(input: string, validate: (input: string) => boolean): boolean | null {
+	return useMemo(() => {
+		if (!input.trim()) return null;
+		return validate(input);
+	}, [input, validate]);
+}


### PR DESCRIPTION
## Summary

Closes out the "small utilities" cluster from the deep-DRY audit. Two small hooks replace inline `useEffect` / `useMemo` ladders that appeared verbatim across every formatter tab.

## Changes

### `feat(hooks)`: `useReportStats`

`src/lib/hooks/use-report-stats.ts`:

```ts
export function useReportStats(
  onStatsChange: ((stats: TabStats) => void) | undefined,
  input: string,
  valid: boolean | null,
  error: string
): void {
  useEffect(() => {
    onStatsChange?.({ input, valid, error });
  }, [input, valid, error, onStatsChange]);
}
```

Replaces the 6-line `useEffect` that appeared at **11 call sites** (json/xml/yaml × format/query/schema plus `template/compare-tab` + `template/generate-tab`). The three fields are passed positionally so callers don't need to memoize the stats object.

### `feat(hooks)`: `useValidation`

`src/lib/hooks/use-validation.ts`:

```ts
export function useValidation(
  input: string,
  validate: (input: string) => boolean
): boolean | null {
  return useMemo(() => {
    if (!input.trim()) return null;
    return validate(input);
  }, [input, validate]);
}
```

Replaces the 5-line `useMemo<{valid: boolean | null}>` ladder at **6 call sites** (json / xml / yaml × query / schema). The `validate` callback returns plain `boolean` and owns its own `try / catch` semantics — keeps the hook format-agnostic.

### Migrations

| File | Removed | Replaced with |
|------|---------|--------------|
| `formatter-tabs/json/format-tab.tsx` | 6-line useEffect | 1-line `useReportStats(...)` |
| `formatter-tabs/json/query-tab.tsx` | 5-line useMemo + 6-line useEffect | 1-line `useValidation` + 1-line `useReportStats` |
| `formatter-tabs/json/schema-tab.tsx` | same | same |
| `formatter-tabs/xml/*-tab.tsx` | same shape | same |
| `formatter-tabs/yaml/*-tab.tsx` | same shape | same |
| `template/compare-tab.tsx` | 6-line useEffect | 1-line `useReportStats` |
| `template/generate-tab.tsx` | 6-line useEffect | 1-line `useReportStats` |

Each migrated tab also drops `useEffect` / `useMemo` from its `react` import line since those become the only consumers.

## Out of scope

`template/convert-tab` and `template/generate-tab` keep their own bespoke validation flow because they receive `validate` as a prop with slightly different return shapes and don't benefit from the wrapper.

## Net change

```
14 files changed, 98 insertions(+), 131 deletions(-)
```

After subtracting the ~30-line new hook files, real net reduction is about **−65 lines** of duplicated `useEffect` / `useMemo` ladders. Smaller win than earlier phases but closes out the audit's small-utilities cluster.

## Test plan

- [x] `bun run check` passes
- [x] `bun run test` — all 141 tests pass
- [x] Pre-commit hooks green
- [ ] Smoke: open any formatter route, switch tabs — verify the status bar still reports valid / invalid / char count correctly as you edit input
- [ ] Smoke: paste invalid JSON / XML / YAML on `/json-formatter`, `/xml-formatter`, `/yaml-formatter` Query and Schema tabs — verify the validity badge flips from null (empty) → false (invalid) → true (valid) as expected
