### PR TITLE
chore(deps): drop direct rand_core, route OsRng through ssh_key re-export

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3290,7 +3290,6 @@ dependencies = [
  "pgp",
  "quick-xml 0.40.1",
  "rand 0.10.1",
- "rand_core 0.6.4",
  "reqwest",
  "roxmltree",
  "rustls",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -83,5 +83,18 @@ x509-parser = "0.18"
 # DNS PTR Reverse Lookup
 hickory-resolver = { version = "0.26", features = ["tokio", "system-config"] }
 csnmp = "0.6.0"
-rand_core = { version = "0.6", features = ["getrandom"] }
+
+# Note: no direct `rand_core` dependency.
+#
+# The codebase only needs `OsRng` for `ssh-key` and `pgp` key generation,
+# both of which transitively pin `rand_core` 0.6 (via the RustCrypto 0.13
+# cohort). We re-export through `ssh_key::rand_core::OsRng` rather than
+# declaring `rand_core` here, which prevents Renovate from proposing the
+# 0.6 → 0.10 jump that would mismatch the transitive bound (tracked at
+# PR #260, closed).
+#
+# When `pgp` advances to a release that uses the newer RustCrypto cohort
+# (0.14+, which speaks `rand_core` 0.10), all three callers can switch to
+# the new trait at once and we can revisit whether to add `rand_core`
+# back as a direct dep on the consolidated version.
 

--- a/src-tauri/src/bin/worker.rs
+++ b/src-tauri/src/bin/worker.rs
@@ -445,7 +445,10 @@ fn handle_gpg_keygen(req: GpgRequest) -> String {
         _ => format!("{} <{}>", req.name, req.email),
     };
 
-    let rng = rand_core::OsRng;
+    // `pgp` 0.19 and `ssh-key` 0.6 both pin `rand_core` 0.6 transitively, so
+    // borrowing the `OsRng` re-export from `ssh-key` keeps a single direct
+    // path to that type without declaring `rand_core` ourselves.
+    let rng = ssh_key::rand_core::OsRng;
 
     let key_type = match req.algorithm {
         GpgKeyAlgorithm::Rsa2048 => KeyType::Rsa(2048),

--- a/src-tauri/src/generators/gpg.rs
+++ b/src-tauri/src/generators/gpg.rs
@@ -231,7 +231,10 @@ fn generate_with_library(options: GpgKeyOptions) -> Result<GpgKeyResult, Generat
     // Build user_id string
     let user_id = build_user_id(&name, &email, comment.as_deref());
 
-    let rng = rand_core::OsRng;
+    // `pgp` 0.19 and `ssh-key` 0.6 both pin `rand_core` 0.6 transitively, so
+    // borrowing the `OsRng` re-export from `ssh-key` keeps a single direct
+    // path to that type without declaring `rand_core` ourselves.
+    let rng = ssh_key::rand_core::OsRng;
 
     let key_type = match algorithm {
         GpgKeyAlgorithm::Rsa2048 => KeyType::Rsa(2048),

--- a/src-tauri/src/generators/ssh.rs
+++ b/src-tauri/src/generators/ssh.rs
@@ -222,7 +222,7 @@ fn generate_with_library(options: SshKeyOptions) -> Result<SshKeyResult, Generat
         method: _,
     } = options;
 
-    let mut rng = rand_core::OsRng;
+    let mut rng = ssh_key::rand_core::OsRng;
     let comment_str = comment.as_deref().unwrap_or("");
 
     let private_key: PrivateKey = match algorithm {


### PR DESCRIPTION
## Summary

Closes #260 by addressing the root cause rather than excluding `rand_core` from Renovate.

Three `rand_core` versions currently co-exist in `Cargo.lock` (0.6.4, 0.9.5, 0.10.1). Renovate PR #260 attempts to bump our direct `rand_core 0.6 → 0.10`, but consolidation to a single version is **not feasible right now** due to upstream constraints across the dependency graph.

## Investigation

| Layer | What pins `rand_core` |
|-------|----------------------|
| `pgp 0.19` (latest) | RustCrypto 0.13 cohort → `rand_core 0.6` (anchors ~20 crates: `elliptic-curve 0.13`, `ecdsa 0.16`, `crypto-bigint 0.5`, `dsa`, `rsa`, `k256`, `p256`, `p384`, etc.). No `pgp 0.20+` published. |
| `ssh-key 0.6` (latest stable) | Same RustCrypto 0.13 cohort → `rand_core 0.6`. `ssh-key 0.7.0-rc.10` exists but is a release candidate (MSRV 1.85). |
| `tauri-plugin-mcp-bridge 0.11.1` | `tungstenite 0.28` → `rand 0.9.4` → `rand_core 0.9.5`. |
| `rand 0.10` (our direct dep + `hickory-resolver 0.26`) | `rand_core 0.10.1`. |

Forcing our direct `rand_core` to 0.10 while `ssh-key 0.6` and `pgp 0.19` still bind 0.6 would create a `CryptoRng` trait mismatch at every call site that passes `OsRng` into either crate.

## Changes

What we *can* clean up without waiting on upstream:

### `chore(deps)`: drop direct `rand_core` from `Cargo.toml`

`src-tauri/Cargo.toml` — remove the `rand_core = { version = "0.6", … }` line. Replace it with a comment block documenting the upstream blockers so future readers know why three versions live in `Cargo.lock` and what needs to advance before consolidation is feasible.

### Route the 3 `OsRng` call sites through `ssh_key::rand_core`

```rust
- let rng = rand_core::OsRng;
+ let rng = ssh_key::rand_core::OsRng;
```

Touches:
- `src-tauri/src/generators/ssh.rs:225` — naturally `ssh-key`-bound, no comment needed.
- `src-tauri/src/generators/gpg.rs:234` — used by `pgp`. Inline comment explains the cohort-share rationale.
- `src-tauri/src/bin/worker.rs:448` — same.

The `worker.rs:244` call site already used `ssh_key::rand_core::OsRng` before this PR — this just normalizes the remaining three to match.

## Effect

- Renovate PR #260 is **moot** (there is no `rand_core` dependency to bump) and will be closed with the same explanation referenced.
- `Cargo.lock` still resolves the three `rand_core` versions because transitive bounds are unchanged, but the project's **direct dep surface** is one entry smaller.
- When `pgp` ships its next major (post-0.19, on RustCrypto 0.14 cohort) we can switch all three call sites to the new `Rng` trait in one motion and add `rand_core` back as a direct dep on the consolidated version.

## Verification

- [x] `cargo check` passes
- [x] `cargo clippy -- -W clippy::all` clean
- [x] `cargo build` succeeds
- [ ] Smoke: generate an SSH key on `/ssh-key-generator` — verify the operation still produces a valid key pair
- [ ] Smoke: generate a GPG key on `/gpg-key-generator` — same
