### PR TITLE
fix(settings): unfreeze font picker open + improve item readability

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -431,6 +431,12 @@ pub fn run() {
             let settings_state = settings::SettingsState::load(&config_dir);
             app.manage(settings_state);
 
+            // Warm the system font caches from a background task so the
+            // first Settings open returns instantly. font-kit's `all_families`
+            // + per-family `is_monospace` walk would otherwise block the UI
+            // thread for several seconds on macOS at the cold path.
+            settings::prewarm_font_cache();
+
             // macOS: set up native app menu with "Reset All Settings..."
             #[cfg(target_os = "macos")]
             {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -238,16 +238,41 @@ pub fn reset_settings(
     Ok(defaults)
 }
 
-/// Get all available system font families (sorted, cached)
+/// Get all available system font families (sorted, cached).
+///
+/// `font_kit` enumeration touches `CoreText` on macOS and walks ~300+ font
+/// files, which can take seconds on the cold path. Wrap the work in
+/// `spawn_blocking` so the Tauri command runtime can yield the UI thread
+/// while the `OnceLock` primes — subsequent invocations are instant.
 #[tauri::command]
-pub fn get_system_fonts() -> Vec<String> {
-    enumerate_system_fonts().to_vec()
+pub async fn get_system_fonts() -> Vec<String> {
+    tauri::async_runtime::spawn_blocking(|| enumerate_system_fonts().to_vec())
+        .await
+        .unwrap_or_default()
 }
 
-/// Get monospace system font families only (sorted, cached)
+/// Get monospace system font families only (sorted, cached).
+///
+/// Costlier than `get_system_fonts` because every family needs `load()` +
+/// `is_monospace()` to check the metric — same `spawn_blocking` treatment.
 #[tauri::command]
-pub fn get_monospace_system_fonts() -> Vec<String> {
-    enumerate_monospace_fonts().to_vec()
+pub async fn get_monospace_system_fonts() -> Vec<String> {
+    tauri::async_runtime::spawn_blocking(|| enumerate_monospace_fonts().to_vec())
+        .await
+        .unwrap_or_default()
+}
+
+/// Warm the system font caches from a background task at app startup.
+///
+/// Called from `lib::run`'s `setup` hook so the first `get_system_fonts` /
+/// `get_monospace_system_fonts` invocation from the Settings page returns
+/// instantly instead of paying the cold-cache cost. Failure is ignored —
+/// the worst case degrades to the on-demand path that already exists.
+pub fn prewarm_font_cache() {
+    tauri::async_runtime::spawn_blocking(|| {
+        let _ = enumerate_system_fonts();
+        let _ = enumerate_monospace_fonts();
+    });
 }
 
 /// Get the settings file path (for display in the settings page)

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -42,6 +42,60 @@ export const Route = createFileRoute('/settings')({
 	component: SettingsPage,
 });
 
+interface FontPickerItemProps {
+	// Filter key passed to cmdk so search works on the human-readable name.
+	readonly searchValue: string;
+	// CSS `font-family` token. Empty string flags the "System Default" row.
+	readonly fontName: string;
+	// Optional override (e.g. "System Default"). Defaults to `fontName`.
+	readonly displayName?: string;
+	// Optional leading icon (e.g. Globe for Google Fonts).
+	readonly icon?: typeof Check;
+	readonly isSelected: boolean;
+	// Preview rendered in the target font on the right (e.g. "AaBb あア 123"
+	// for UI, "Aa Bb {} = 123" for code). Skipped when `fontName` is empty.
+	readonly sampleText: string;
+	readonly onSelect: () => void;
+}
+
+// Per-row renderer for the font picker. Three columns: leading check slot
+// (always 16px reserved so selected and unselected rows align), label in
+// the page's default UI font (stays legible for symbol / non-Latin
+// families that would render their own name as glyphs), and a trailing
+// preview in the target font that conveys the typeface's shape without
+// hiding the name.
+function FontPickerItem({
+	searchValue,
+	fontName,
+	displayName,
+	icon: Icon,
+	isSelected,
+	sampleText,
+	onSelect,
+}: FontPickerItemProps) {
+	const label = displayName ?? fontName;
+	return (
+		<CommandItem value={searchValue} onSelect={onSelect}>
+			<span className="flex h-4 w-4 shrink-0 items-center justify-center">
+				{isSelected ? <Check className="h-4 w-4" /> : null}
+			</span>
+			{Icon ? <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" /> : null}
+			<span className="flex-1 truncate">{label}</span>
+			{fontName ? (
+				<span
+					className="ml-2 shrink-0 text-xs text-muted-foreground"
+					style={{ fontFamily: `"${fontName}"` }}
+				>
+					{sampleText}
+				</span>
+			) : null}
+		</CommandItem>
+	);
+}
+
+const UI_SAMPLE_TEXT = 'AaBb あア 123';
+const CODE_SAMPLE_TEXT = 'Aa Bb {} = 123';
+
 function SettingsPage() {
 	const [fontSettings, setFontSettings] = useState<FontSettings>({ ...DEFAULT_SETTINGS.font });
 	const [systemFonts, setSystemFonts] = useState<readonly string[]>([]);
@@ -161,48 +215,45 @@ function SettingsPage() {
 											<CommandList className="max-h-48">
 												<CommandEmpty>No fonts found.</CommandEmpty>
 												<CommandGroup heading="System Fonts">
-													<CommandItem
-														value="System Default"
+													<FontPickerItem
+														searchValue="System Default"
+														fontName=""
+														displayName="System Default"
+														isSelected={!fontSettings.ui_family}
+														sampleText=""
 														onSelect={() => {
 															setFontSettings((prev) => ({ ...prev, ui_family: '' }));
 															setUiFontOpen(false);
 														}}
-													>
-														<span>System Default</span>
-														{!fontSettings.ui_family ? <Check className="ml-auto h-4 w-4" /> : null}
-													</CommandItem>
+													/>
 													{systemFonts.map((font) => (
-														<CommandItem
+														<FontPickerItem
 															key={font}
-															value={font}
+															searchValue={font}
+															fontName={font}
+															isSelected={fontSettings.ui_family === font}
+															sampleText={UI_SAMPLE_TEXT}
 															onSelect={() => {
 																setFontSettings((prev) => ({ ...prev, ui_family: font }));
 																setUiFontOpen(false);
 															}}
-														>
-															<span style={{ fontFamily: `"${font}"` }}>{font}</span>
-															{fontSettings.ui_family === font ? (
-																<Check className="ml-auto h-4 w-4" />
-															) : null}
-														</CommandItem>
+														/>
 													))}
 												</CommandGroup>
 												{fontSettings.google_fonts_enabled ? (
 													<CommandGroup heading="Google Fonts">
 														{googleUiFonts.map((gf) => (
-															<CommandItem
+															<FontPickerItem
 																key={gf.name}
-																value={`Google: ${gf.name}`}
+																searchValue={`Google: ${gf.name}`}
+																fontName={gf.name}
+																icon={Globe}
+																isSelected={fontSettings.ui_family === gf.name}
+																sampleText={UI_SAMPLE_TEXT}
 																onSelect={() =>
 																	selectGoogleFont('ui_family', gf.name, () => setUiFontOpen(false))
 																}
-															>
-																<Globe className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-																<span style={{ fontFamily: `"${gf.name}"` }}>{gf.name}</span>
-																{fontSettings.ui_family === gf.name ? (
-																	<Check className="ml-auto h-4 w-4" />
-																) : null}
-															</CommandItem>
+															/>
 														))}
 													</CommandGroup>
 												) : null}
@@ -249,52 +300,47 @@ function SettingsPage() {
 											<CommandList className="max-h-48">
 												<CommandEmpty>No fonts found.</CommandEmpty>
 												<CommandGroup heading="System Monospace Fonts">
-													<CommandItem
-														value="System Default"
+													<FontPickerItem
+														searchValue="System Default"
+														fontName=""
+														displayName="System Default"
+														isSelected={!fontSettings.code_family}
+														sampleText=""
 														onSelect={() => {
 															setFontSettings((prev) => ({ ...prev, code_family: '' }));
 															setCodeFontOpen(false);
 														}}
-													>
-														<span>System Default</span>
-														{!fontSettings.code_family ? (
-															<Check className="ml-auto h-4 w-4" />
-														) : null}
-													</CommandItem>
+													/>
 													{monospaceFonts.map((font) => (
-														<CommandItem
+														<FontPickerItem
 															key={font}
-															value={font}
+															searchValue={font}
+															fontName={font}
+															isSelected={fontSettings.code_family === font}
+															sampleText={CODE_SAMPLE_TEXT}
 															onSelect={() => {
 																setFontSettings((prev) => ({ ...prev, code_family: font }));
 																setCodeFontOpen(false);
 															}}
-														>
-															<span style={{ fontFamily: `"${font}"` }}>{font}</span>
-															{fontSettings.code_family === font ? (
-																<Check className="ml-auto h-4 w-4" />
-															) : null}
-														</CommandItem>
+														/>
 													))}
 												</CommandGroup>
 												{fontSettings.google_fonts_enabled ? (
 													<CommandGroup heading="Google Fonts">
 														{googleCodeFonts.map((gf) => (
-															<CommandItem
+															<FontPickerItem
 																key={gf.name}
-																value={`Google: ${gf.name}`}
+																searchValue={`Google: ${gf.name}`}
+																fontName={gf.name}
+																icon={Globe}
+																isSelected={fontSettings.code_family === gf.name}
+																sampleText={CODE_SAMPLE_TEXT}
 																onSelect={() =>
 																	selectGoogleFont('code_family', gf.name, () =>
 																		setCodeFontOpen(false)
 																	)
 																}
-															>
-																<Globe className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-																<span style={{ fontFamily: `"${gf.name}"` }}>{gf.name}</span>
-																{fontSettings.code_family === gf.name ? (
-																	<Check className="ml-auto h-4 w-4" />
-																) : null}
-															</CommandItem>
+															/>
 														))}
 													</CommandGroup>
 												) : null}


### PR DESCRIPTION
## Summary

Two related problems on the Settings page font picker, fixed in one PR.

1. **First open of Settings froze the UI for several seconds** (beachball on macOS).
2. **Font names were rendered in the font itself** (so symbol / non-Latin families became unreadable), and the selection check sat on the right with no reserved width on unselected rows.

## Root cause

### Freeze

`get_system_fonts` and `get_monospace_system_fonts` were declared as synchronous Tauri commands (`pub fn`), which **run on the main thread** in Tauri 2.x.

`font_kit::SystemSource::new()` + `all_families()` walks ~300+ font files via Core Text on the cold path. The monospace variant additionally `load()`s every family to read the `is_monospace()` metric, multiplying the wall time. On macOS this routinely takes 1–5 seconds — a full beachball.

`OnceLock` already cached the result so the second open was instant, but the first open paid the full cost on the UI thread.

### Readability

Each `<CommandItem>` in the font picker rendered the name in its own typeface:

```tsx
<span style={{ fontFamily: `"${font}"` }}>{font}</span>
```

For symbol fonts (Wingdings) and most non-Latin-script families the **name itself was unreadable** — there was no readable label anywhere. The `<Check>` indicator used `ml-auto h-4 w-4`, which means unselected rows had no reserved width on the right, so the eye had to sweep the full row to spot the active item.

## Changes

### Backend (`src-tauri/src/settings.rs` + `src-tauri/src/lib.rs`)

```rust
- pub fn get_system_fonts() -> Vec<String> { ... }
+ pub async fn get_system_fonts() -> Vec<String> {
+     tauri::async_runtime::spawn_blocking(|| enumerate_system_fonts().to_vec())
+         .await
+         .unwrap_or_default()
+ }
```

Same treatment for `get_monospace_system_fonts`. Tauri's command runtime now schedules these on a worker thread, freeing the UI thread on the cold path.

New `pub fn prewarm_font_cache()` fires both enumerations inside `spawn_blocking` at app startup. Called from `lib.rs::setup` so the `OnceLock` cache is hot by the time the user opens Settings. Failure is silently ignored — the worst case degrades to the on-demand path that already runs off the main thread.

### Frontend (`src/routes/settings.tsx`)

New `FontPickerItem` component with three columns:

| Slot | Purpose |
|------|---------|
| Leading 16px | `<Check />` when selected, empty spacer otherwise — rows align |
| Label (flex-1) | Family name in the page's **default UI font** — always legible regardless of which family is picked |
| Trailing (`text-xs text-muted-foreground`) | Preview rendered in the **target font** — conveys the typeface's shape without hiding the name |

Sample strings per role:

```ts
const UI_SAMPLE_TEXT = 'AaBb あア 123';   // English + kana + digits at a glance
const CODE_SAMPLE_TEXT = 'Aa Bb {} = 123'; // Programming glyphs
```

All six `<CommandItem>` call sites migrate (System Fonts + Google Fonts × UI / Code, plus the two "System Default" rows). "System Default" passes `sampleText=""` and an empty `fontName` so the preview column is omitted.

## Net change

```
3 files changed, 131 insertions(+), 54 deletions(-)
```

## Test plan

- [x] `bun run check` passes
- [x] `bun run test` — all 141 tests pass
- [x] `cargo check` clean
- [x] Pre-commit hooks green
- [ ] Smoke: cold start app, open Settings — verify no beachball / no UI freeze (prewarm should have populated the cache by then)
- [ ] Smoke: open the UI Font picker — verify rows show `[ ] Family Name    AaBb あア 123` layout, with the check landing on the left when selected
- [ ] Smoke: scroll past Wingdings / Apple Symbols / other symbol fonts — verify their family names are now readable in the default UI font (preview on the right shows the symbols)
- [ ] Smoke: open the Code Font picker — verify samples render with `{} = 123` to show how each monospace handles brackets / equals
