### PR TITLE
refactor(ui): Tier 1 visual polish + Copper brand color

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -91,7 +91,13 @@
 	--card-foreground: oklch(0.145 0 0);
 	--popover: oklch(1 0 0);
 	--popover-foreground: oklch(0.145 0 0);
-	--primary: oklch(0.205 0 0);
+	/*
+	 * Brand color: Copper / Brass. Mid-luminance warm hue (60°) selected so
+	 * primary action buttons read clearly on a white background and the
+	 * sidebar active state pop visibly without overwhelming the page. Pair
+	 * with near-white foreground for WCAG AA on solid primary surfaces.
+	 */
+	--primary: oklch(0.55 0.15 60);
 	--primary-foreground: oklch(0.985 0 0);
 	--secondary: oklch(0.97 0 0);
 	--secondary-foreground: oklch(0.205 0 0);
@@ -114,7 +120,7 @@
 	--info-foreground: oklch(0.98 0.01 250);
 	--border: oklch(0.922 0 0);
 	--input: oklch(0.922 0 0);
-	--ring: oklch(0.708 0 0);
+	--ring: oklch(0.55 0.15 60);
 	--chart-1: oklch(0.646 0.222 41.116);
 	--chart-2: oklch(0.6 0.118 184.704);
 	--chart-3: oklch(0.398 0.07 227.392);
@@ -123,12 +129,12 @@
 	/* Sidebar/Rail (shadcn/ui Sidebar standard) */
 	--sidebar: oklch(0.98 0 0);
 	--sidebar-foreground: oklch(0.145 0 0);
-	--sidebar-primary: oklch(0.205 0 0);
+	--sidebar-primary: oklch(0.55 0.15 60);
 	--sidebar-primary-foreground: oklch(0.985 0 0);
 	--sidebar-accent: oklch(0.97 0 0);
 	--sidebar-accent-foreground: oklch(0.205 0 0);
 	--sidebar-border: oklch(0.922 0 0);
-	--sidebar-ring: oklch(0.708 0 0);
+	--sidebar-ring: oklch(0.55 0.15 60);
 	/* Surface hierarchy (pure grayscale) */
 	--surface-0: oklch(1 0 0);
 	--surface-1: oklch(0.985 0 0);
@@ -187,8 +193,14 @@
 	--card-foreground: oklch(0.985 0 0);
 	--popover: oklch(0.205 0 0);
 	--popover-foreground: oklch(0.985 0 0);
-	--primary: oklch(0.985 0 0);
-	--primary-foreground: oklch(0.205 0 0);
+	/*
+	 * Brand color: Copper / Brass (dark variant). Lightness lifted to 0.70
+	 * for visibility on dark backgrounds; foreground uses a deep
+	 * Copper-tinted near-black so the contrast hue is part of the brand
+	 * family rather than a neutral grey.
+	 */
+	--primary: oklch(0.7 0.13 60);
+	--primary-foreground: oklch(0.15 0.05 60);
 	--secondary: oklch(0.269 0 0);
 	--secondary-foreground: oklch(0.985 0 0);
 	--muted: oklch(0.269 0 0);
@@ -211,7 +223,7 @@
 	--info-foreground: oklch(0.16 0.02 250);
 	--border: oklch(1 0 0 / 10%);
 	--input: oklch(1 0 0 / 15%);
-	--ring: oklch(0.556 0 0);
+	--ring: oklch(0.7 0.13 60);
 	--chart-1: oklch(0.488 0.243 264.376);
 	--chart-2: oklch(0.696 0.17 162.48);
 	--chart-3: oklch(0.769 0.188 70.08);
@@ -220,12 +232,12 @@
 	/* Sidebar/Rail (dark mode) */
 	--sidebar: oklch(0.205 0 0);
 	--sidebar-foreground: oklch(0.985 0 0);
-	--sidebar-primary: oklch(0.985 0 0);
-	--sidebar-primary-foreground: oklch(0.205 0 0);
+	--sidebar-primary: oklch(0.7 0.13 60);
+	--sidebar-primary-foreground: oklch(0.15 0.05 60);
 	--sidebar-accent: oklch(0.269 0 0);
 	--sidebar-accent-foreground: oklch(0.985 0 0);
 	--sidebar-border: oklch(1 0 0 / 10%);
-	--sidebar-ring: oklch(0.556 0 0);
+	--sidebar-ring: oklch(0.7 0.13 60);
 	/* Surface hierarchy (pure grayscale) */
 	--surface-0: oklch(0.22 0 0);
 	--surface-1: oklch(0.18 0 0);

--- a/src/app.css
+++ b/src/app.css
@@ -118,22 +118,28 @@
 	--warning-foreground: oklch(0.98 0.02 75);
 	--info: oklch(0.55 0.15 250);
 	--info-foreground: oklch(0.98 0.01 250);
-	--border: oklch(0.922 0 0);
-	--input: oklch(0.922 0 0);
+	--border: oklch(0.93 0 0);
+	--input: oklch(0.93 0 0);
 	--ring: oklch(0.55 0.15 60);
 	--chart-1: oklch(0.646 0.222 41.116);
 	--chart-2: oklch(0.6 0.118 184.704);
 	--chart-3: oklch(0.398 0.07 227.392);
 	--chart-4: oklch(0.828 0.189 84.429);
 	--chart-5: oklch(0.769 0.188 70.08);
-	/* Sidebar/Rail (shadcn/ui Sidebar standard) */
-	--sidebar: oklch(0.98 0 0);
+	/*
+	 * Sidebar (panel-style): committed to "ツール container" framing rather
+	 * than the neutral half-step the shadcn default gave (0.98). The slightly
+	 * deeper grey reads as a panel against the white main area, and the tiny
+	 * Copper chroma (0.008 at hue 60) gives the surface a warm character
+	 * without crossing into "tinted background" territory.
+	 */
+	--sidebar: oklch(0.97 0.008 60);
 	--sidebar-foreground: oklch(0.145 0 0);
 	--sidebar-primary: oklch(0.55 0.15 60);
 	--sidebar-primary-foreground: oklch(0.985 0 0);
 	--sidebar-accent: oklch(0.97 0 0);
 	--sidebar-accent-foreground: oklch(0.205 0 0);
-	--sidebar-border: oklch(0.922 0 0);
+	--sidebar-border: oklch(0.93 0 0);
 	--sidebar-ring: oklch(0.55 0.15 60);
 	/* Surface hierarchy (pure grayscale) */
 	--surface-0: oklch(1 0 0);
@@ -229,8 +235,13 @@
 	--chart-3: oklch(0.769 0.188 70.08);
 	--chart-4: oklch(0.627 0.265 303.9);
 	--chart-5: oklch(0.645 0.246 16.439);
-	/* Sidebar/Rail (dark mode) */
-	--sidebar: oklch(0.205 0 0);
+	/*
+	 * Sidebar (dark, panel-style + warm tint). Dark mode is already panel-
+	 * style by default (sidebar `lighter` than background); the only change
+	 * here is the same tiny Copper chroma applied to keep the brand
+	 * character consistent across modes.
+	 */
+	--sidebar: oklch(0.205 0.008 60);
 	--sidebar-foreground: oklch(0.985 0 0);
 	--sidebar-primary: oklch(0.7 0.13 60);
 	--sidebar-primary-foreground: oklch(0.15 0.05 60);

--- a/src/lib/components/action/copy-button.tsx
+++ b/src/lib/components/action/copy-button.tsx
@@ -19,7 +19,12 @@ export function CopyButton({
 	text,
 	label = 'Copy',
 	toastLabel,
-	variant = 'ghost',
+	// Default `outline` gives every CopyButton a visible border + subtle hover
+	// fill so it reads as an interactive control in Card headers / list section
+	// headers without competing with surrounding text. Per-row icon-only callers
+	// (`showLabel={false}` in generated lists, network-interfaces rows) opt back
+	// into `ghost` explicitly to stay subtle.
+	variant = 'outline',
 	size = 'sm',
 	className,
 	showLabel = true,

--- a/src/lib/components/editor/code/code-editor.tsx
+++ b/src/lib/components/editor/code/code-editor.tsx
@@ -375,9 +375,7 @@ function Header({
 		>
 			<div className="flex items-center gap-2">
 				{title ? (
-					<span className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
-						{title}
-					</span>
+					<span className="text-xs font-semibold text-muted-foreground">{title}</span>
 				) : null}
 				{isInput ? (
 					<InputActions

--- a/src/lib/components/form/form-input.tsx
+++ b/src/lib/components/form/form-input.tsx
@@ -46,10 +46,7 @@ export function FormInput({
 		onValueChange?.(e.target.value);
 	};
 
-	const labelClass =
-		size === 'compact'
-			? 'text-xs uppercase tracking-wide text-muted-foreground'
-			: 'text-sm font-medium';
+	const labelClass = size === 'compact' ? 'text-xs text-muted-foreground' : 'text-sm font-medium';
 
 	const inputClass = cn(
 		'bg-background',

--- a/src/lib/components/form/form-section.tsx
+++ b/src/lib/components/form/form-section.tsx
@@ -36,7 +36,7 @@ export function FormSection({
 			onOpenChange={handleOpenChange}
 			className="group border-b border-border/30 last:border-b-0"
 		>
-			<CollapsibleTrigger className="flex h-9 w-full items-center justify-between px-4 text-sm font-semibold uppercase tracking-wide text-foreground/70 transition-colors hover:bg-interactive-hover">
+			<CollapsibleTrigger className="flex h-9 w-full items-center justify-between px-4 text-sm font-semibold text-foreground/70 transition-colors hover:bg-interactive-hover">
 				{title}
 				<ChevronDown className="h-4 w-4 text-muted-foreground/50 transition-transform group-data-[state=closed]:-rotate-90" />
 			</CollapsibleTrigger>

--- a/src/lib/components/form/form-select.tsx
+++ b/src/lib/components/form/form-select.tsx
@@ -51,10 +51,7 @@ export function FormSelect({
 		}
 	};
 
-	const labelClass =
-		size === 'compact'
-			? 'text-xs uppercase tracking-wide text-muted-foreground'
-			: 'text-sm font-medium';
+	const labelClass = size === 'compact' ? 'text-xs text-muted-foreground' : 'text-sm font-medium';
 
 	const triggerClass = cn(
 		'w-full bg-background',

--- a/src/lib/components/form/form-slider.tsx
+++ b/src/lib/components/form/form-slider.tsx
@@ -38,7 +38,7 @@ export function FormSlider({
 
 	const labelClass =
 		size === 'compact'
-			? 'min-w-0 truncate text-xs uppercase tracking-wide text-muted-foreground'
+			? 'min-w-0 truncate text-xs text-muted-foreground'
 			: 'min-w-0 truncate text-sm font-medium';
 
 	const valueClass =

--- a/src/lib/components/form/form-textarea.tsx
+++ b/src/lib/components/form/form-textarea.tsx
@@ -25,10 +25,7 @@ export function FormTextarea({
 	className,
 	onValueChange,
 }: FormTextareaProps) {
-	const labelClass =
-		size === 'compact'
-			? 'text-xs uppercase tracking-wide text-muted-foreground'
-			: 'text-sm font-medium';
+	const labelClass = size === 'compact' ? 'text-xs text-muted-foreground' : 'text-sm font-medium';
 
 	const textareaClass = cn(
 		'bg-background',

--- a/src/lib/components/layout/app-sidebar.tsx
+++ b/src/lib/components/layout/app-sidebar.tsx
@@ -61,10 +61,7 @@ export function AppSidebar(_: AppSidebarProps = {}) {
 						>
 							<Link to="/">
 								<img src="/logo.svg" alt="Kogu" className="size-8 rounded-lg" />
-								<div className="grid flex-1 text-left text-sm leading-tight">
-									<span className="truncate font-semibold">Kogu</span>
-									<span className="truncate text-xs text-muted-foreground">Developer Tools</span>
-								</div>
+								<span className="flex-1 truncate text-sm font-semibold">Kogu</span>
 							</Link>
 						</SidebarMenuButton>
 					</SidebarMenuItem>

--- a/src/lib/components/layout/app-sidebar.tsx
+++ b/src/lib/components/layout/app-sidebar.tsx
@@ -92,9 +92,7 @@ export function AppSidebar(_: AppSidebarProps = {}) {
 										)}
 									>
 										<CategoryIcon className="size-4 opacity-70" />
-										<span className="flex-1 text-left text-xs font-semibold uppercase tracking-wider">
-											{category.label}
-										</span>
+										<span className="flex-1 text-left text-xs font-semibold">{category.label}</span>
 										<ChevronRight className="size-4 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
 									</CollapsibleTrigger>
 								</SidebarGroupLabel>

--- a/src/lib/components/layout/keyboard-shortcuts-dialog.tsx
+++ b/src/lib/components/layout/keyboard-shortcuts-dialog.tsx
@@ -115,9 +115,7 @@ export function KeyboardShortcutsDialog({
 				<div className="max-h-[60vh] space-y-4 overflow-y-auto py-2">
 					{filteredGroups.map((group) => (
 						<div key={group.title}>
-							<h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-								{group.title}
-							</h3>
+							<h3 className="mb-2 text-xs font-semibold text-muted-foreground">{group.title}</h3>
 							<div className="space-y-1">
 								{group.shortcuts.map((shortcut) => (
 									<div

--- a/src/lib/components/layout/section-header.tsx
+++ b/src/lib/components/layout/section-header.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 export function SectionHeader({ title, count, trailing }: SectionHeaderProps) {
 	return (
 		<div className="flex h-8 shrink-0 items-center justify-between border-b border-border/60 bg-surface-2 px-3">
-			<span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+			<span className="text-xs font-semibold text-muted-foreground">
 				{title}
 				{count !== undefined && <span className="ml-1 tabular-nums">({count})</span>}
 			</span>

--- a/src/lib/components/panel/generated-list-panel.tsx
+++ b/src/lib/components/panel/generated-list-panel.tsx
@@ -69,6 +69,7 @@ export function GeneratedListPanel({
 									<CopyButton
 										text={value}
 										toastLabel={itemToastLabel}
+										variant="ghost"
 										size="sm"
 										showLabel={false}
 									/>

--- a/src/lib/components/panel/generated-list-panel.tsx
+++ b/src/lib/components/panel/generated-list-panel.tsx
@@ -3,7 +3,6 @@ import type { LucideIcon } from 'lucide-react';
 import { CopyButton } from '@/lib/components/action';
 import { SectionHeader } from '@/lib/components/layout';
 import { EmbeddedEmptyState, LiveStatusRegion } from '@/lib/components/status';
-import { Card, CardContent } from '@/lib/components/ui/card';
 
 interface GeneratedListPanelProps {
 	// Header title (e.g. "Generated UUIDs", "Generated Passwords").
@@ -61,20 +60,22 @@ export function GeneratedListPanel({
 			/>
 			<LiveStatusRegion className="flex-1 overflow-auto p-4">
 				{results.length > 0 ? (
-					<div key={flashCounter} className="animate-flash-success space-y-2 rounded-md">
+					<div key={flashCounter} className="animate-flash-success rounded-md">
 						{results.map((value) => (
-							<Card key={value} density="compact">
-								<CardContent className="flex items-center gap-2">
-									<code className="flex-1 break-all font-mono text-sm">{value}</code>
-									<CopyButton
-										text={value}
-										toastLabel={itemToastLabel}
-										variant="ghost"
-										size="sm"
-										showLabel={false}
-									/>
-								</CardContent>
-							</Card>
+							<div
+								key={value}
+								className="group/row flex items-center gap-2 rounded-md px-3 py-1.5 transition-colors hover:bg-accent"
+							>
+								<code className="flex-1 break-all font-mono text-sm">{value}</code>
+								<CopyButton
+									text={value}
+									toastLabel={itemToastLabel}
+									variant="ghost"
+									size="sm"
+									showLabel={false}
+									className="opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100"
+								/>
+							</div>
 						))}
 					</div>
 				) : (

--- a/src/lib/components/ui/sidebar.tsx
+++ b/src/lib/components/ui/sidebar.tsx
@@ -446,7 +446,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
 }
 
 const sidebarMenuButtonVariants = cva(
-	'peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate',
+	'peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-primary/10 data-active:font-medium data-active:text-primary data-active:shadow-[inset_2px_0_0_var(--primary)] [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate',
 	{
 		variants: {
 			variant: {
@@ -635,7 +635,7 @@ function SidebarMenuSubButton({
 			data-size={size}
 			data-active={isActive}
 			className={cn(
-				'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
+				'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-primary/10 data-active:text-primary data-active:shadow-[inset_2px_0_0_var(--primary)] [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
 				className
 			)}
 			{...props}

--- a/src/lib/components/ui/tone-badge.tsx
+++ b/src/lib/components/ui/tone-badge.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+import { Badge } from '@/lib/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+type Tone = 'success' | 'warning' | 'info' | 'destructive';
+
+interface ToneBadgeProps {
+	// Semantic tone — maps to one of the four sRGB-coordinated palette pairs
+	// declared in `app.css` (`--success`, `--warning`, `--info`, `--destructive`).
+	readonly tone: Tone;
+	// Optional leading icon (e.g. `ShieldCheck` for "Secure", `ShieldAlert` for
+	// "Weak"). Renders at 12px on the left of the label.
+	readonly icon?: LucideIcon;
+	readonly className?: string;
+	readonly children: ReactNode;
+}
+
+const TONE_CLASS: Record<Tone, string> = {
+	success: 'bg-success/10 text-success',
+	warning: 'bg-warning/10 text-warning',
+	info: 'bg-info/10 text-info',
+	destructive: 'bg-destructive/10 text-destructive',
+};
+
+// Tone-colored pill that pairs the semantic `bg-{tone}/10` + `text-{tone}`
+// surface convention used across the app. Replaces the inline pattern
+// `<Badge variant="outline" className="gap-1 bg-success/10 text-success">…`
+// that appeared verbatim across the hash / ssh / gpg result panes — a single
+// place to evolve tone treatment going forward.
+export function ToneBadge({ tone, icon: Icon, className, children }: ToneBadgeProps) {
+	return (
+		<Badge variant="outline" className={cn('gap-1', TONE_CLASS[tone], className)}>
+			{Icon ? <Icon className="h-3 w-3" /> : null}
+			{children}
+		</Badge>
+	);
+}
+
+export type { ToneBadgeProps, Tone as ToneBadgeTone };

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -8,539 +8,539 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root';
-import { Route as YamlFormatterRouteImport } from './routes/yaml-formatter';
-import { Route as XmlFormatterRouteImport } from './routes/xml-formatter';
-import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator';
-import { Route as UrlEncoderRouteImport } from './routes/url-encoder';
-import { Route as StringCaseConverterRouteImport } from './routes/string-case-converter';
-import { Route as SshKeyGeneratorRouteImport } from './routes/ssh-key-generator';
-import { Route as SqlFormatterRouteImport } from './routes/sql-formatter';
-import { Route as SettingsRouteImport } from './routes/settings';
-import { Route as RegexTesterRouteImport } from './routes/regex-tester';
-import { Route as QrCodeGeneratorRouteImport } from './routes/qr-code-generator';
-import { Route as PasswordGeneratorRouteImport } from './routes/password-generator';
-import { Route as NetworkScannerRouteImport } from './routes/network-scanner';
-import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces';
-import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor';
-import { Route as JwtDecoderRouteImport } from './routes/jwt-decoder';
-import { Route as JsonFormatterRouteImport } from './routes/json-formatter';
-import { Route as HashGeneratorRouteImport } from './routes/hash-generator';
-import { Route as GpgKeyGeneratorRouteImport } from './routes/gpg-key-generator';
-import { Route as DiffViewerRouteImport } from './routes/diff-viewer';
-import { Route as CurlBuilderRouteImport } from './routes/curl-builder';
-import { Route as CronExpressionBuilderRouteImport } from './routes/cron-expression-builder';
-import { Route as BcryptGeneratorRouteImport } from './routes/bcrypt-generator';
-import { Route as Base64EncoderRouteImport } from './routes/base64-encoder';
-import { Route as IndexRouteImport } from './routes/index';
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as YamlFormatterRouteImport } from './routes/yaml-formatter'
+import { Route as XmlFormatterRouteImport } from './routes/xml-formatter'
+import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator'
+import { Route as UrlEncoderRouteImport } from './routes/url-encoder'
+import { Route as StringCaseConverterRouteImport } from './routes/string-case-converter'
+import { Route as SshKeyGeneratorRouteImport } from './routes/ssh-key-generator'
+import { Route as SqlFormatterRouteImport } from './routes/sql-formatter'
+import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as RegexTesterRouteImport } from './routes/regex-tester'
+import { Route as QrCodeGeneratorRouteImport } from './routes/qr-code-generator'
+import { Route as PasswordGeneratorRouteImport } from './routes/password-generator'
+import { Route as NetworkScannerRouteImport } from './routes/network-scanner'
+import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces'
+import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor'
+import { Route as JwtDecoderRouteImport } from './routes/jwt-decoder'
+import { Route as JsonFormatterRouteImport } from './routes/json-formatter'
+import { Route as HashGeneratorRouteImport } from './routes/hash-generator'
+import { Route as GpgKeyGeneratorRouteImport } from './routes/gpg-key-generator'
+import { Route as DiffViewerRouteImport } from './routes/diff-viewer'
+import { Route as CurlBuilderRouteImport } from './routes/curl-builder'
+import { Route as CronExpressionBuilderRouteImport } from './routes/cron-expression-builder'
+import { Route as BcryptGeneratorRouteImport } from './routes/bcrypt-generator'
+import { Route as Base64EncoderRouteImport } from './routes/base64-encoder'
+import { Route as IndexRouteImport } from './routes/index'
 
 const YamlFormatterRoute = YamlFormatterRouteImport.update({
-	id: '/yaml-formatter',
-	path: '/yaml-formatter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/yaml-formatter',
+  path: '/yaml-formatter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const XmlFormatterRoute = XmlFormatterRouteImport.update({
-	id: '/xml-formatter',
-	path: '/xml-formatter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/xml-formatter',
+  path: '/xml-formatter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const UuidGeneratorRoute = UuidGeneratorRouteImport.update({
-	id: '/uuid-generator',
-	path: '/uuid-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/uuid-generator',
+  path: '/uuid-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const UrlEncoderRoute = UrlEncoderRouteImport.update({
-	id: '/url-encoder',
-	path: '/url-encoder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/url-encoder',
+  path: '/url-encoder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const StringCaseConverterRoute = StringCaseConverterRouteImport.update({
-	id: '/string-case-converter',
-	path: '/string-case-converter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/string-case-converter',
+  path: '/string-case-converter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SshKeyGeneratorRoute = SshKeyGeneratorRouteImport.update({
-	id: '/ssh-key-generator',
-	path: '/ssh-key-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/ssh-key-generator',
+  path: '/ssh-key-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SqlFormatterRoute = SqlFormatterRouteImport.update({
-	id: '/sql-formatter',
-	path: '/sql-formatter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/sql-formatter',
+  path: '/sql-formatter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SettingsRoute = SettingsRouteImport.update({
-	id: '/settings',
-	path: '/settings',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const RegexTesterRoute = RegexTesterRouteImport.update({
-	id: '/regex-tester',
-	path: '/regex-tester',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/regex-tester',
+  path: '/regex-tester',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const QrCodeGeneratorRoute = QrCodeGeneratorRouteImport.update({
-	id: '/qr-code-generator',
-	path: '/qr-code-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/qr-code-generator',
+  path: '/qr-code-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const PasswordGeneratorRoute = PasswordGeneratorRouteImport.update({
-	id: '/password-generator',
-	path: '/password-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/password-generator',
+  path: '/password-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const NetworkScannerRoute = NetworkScannerRouteImport.update({
-	id: '/network-scanner',
-	path: '/network-scanner',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/network-scanner',
+  path: '/network-scanner',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const NetworkInterfacesRoute = NetworkInterfacesRouteImport.update({
-	id: '/network-interfaces',
-	path: '/network-interfaces',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/network-interfaces',
+  path: '/network-interfaces',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MarkdownEditorRoute = MarkdownEditorRouteImport.update({
-	id: '/markdown-editor',
-	path: '/markdown-editor',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/markdown-editor',
+  path: '/markdown-editor',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const JwtDecoderRoute = JwtDecoderRouteImport.update({
-	id: '/jwt-decoder',
-	path: '/jwt-decoder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/jwt-decoder',
+  path: '/jwt-decoder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const JsonFormatterRoute = JsonFormatterRouteImport.update({
-	id: '/json-formatter',
-	path: '/json-formatter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/json-formatter',
+  path: '/json-formatter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const HashGeneratorRoute = HashGeneratorRouteImport.update({
-	id: '/hash-generator',
-	path: '/hash-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/hash-generator',
+  path: '/hash-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const GpgKeyGeneratorRoute = GpgKeyGeneratorRouteImport.update({
-	id: '/gpg-key-generator',
-	path: '/gpg-key-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/gpg-key-generator',
+  path: '/gpg-key-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DiffViewerRoute = DiffViewerRouteImport.update({
-	id: '/diff-viewer',
-	path: '/diff-viewer',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/diff-viewer',
+  path: '/diff-viewer',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CurlBuilderRoute = CurlBuilderRouteImport.update({
-	id: '/curl-builder',
-	path: '/curl-builder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/curl-builder',
+  path: '/curl-builder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CronExpressionBuilderRoute = CronExpressionBuilderRouteImport.update({
-	id: '/cron-expression-builder',
-	path: '/cron-expression-builder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/cron-expression-builder',
+  path: '/cron-expression-builder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const BcryptGeneratorRoute = BcryptGeneratorRouteImport.update({
-	id: '/bcrypt-generator',
-	path: '/bcrypt-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/bcrypt-generator',
+  path: '/bcrypt-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const Base64EncoderRoute = Base64EncoderRouteImport.update({
-	id: '/base64-encoder',
-	path: '/base64-encoder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/base64-encoder',
+  path: '/base64-encoder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
-	id: '/',
-	path: '/',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
-	'/': typeof IndexRoute;
-	'/base64-encoder': typeof Base64EncoderRoute;
-	'/bcrypt-generator': typeof BcryptGeneratorRoute;
-	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
-	'/curl-builder': typeof CurlBuilderRoute;
-	'/diff-viewer': typeof DiffViewerRoute;
-	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
-	'/hash-generator': typeof HashGeneratorRoute;
-	'/json-formatter': typeof JsonFormatterRoute;
-	'/jwt-decoder': typeof JwtDecoderRoute;
-	'/markdown-editor': typeof MarkdownEditorRoute;
-	'/network-interfaces': typeof NetworkInterfacesRoute;
-	'/network-scanner': typeof NetworkScannerRoute;
-	'/password-generator': typeof PasswordGeneratorRoute;
-	'/qr-code-generator': typeof QrCodeGeneratorRoute;
-	'/regex-tester': typeof RegexTesterRoute;
-	'/settings': typeof SettingsRoute;
-	'/sql-formatter': typeof SqlFormatterRoute;
-	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
-	'/string-case-converter': typeof StringCaseConverterRoute;
-	'/url-encoder': typeof UrlEncoderRoute;
-	'/uuid-generator': typeof UuidGeneratorRoute;
-	'/xml-formatter': typeof XmlFormatterRoute;
-	'/yaml-formatter': typeof YamlFormatterRoute;
+  '/': typeof IndexRoute
+  '/base64-encoder': typeof Base64EncoderRoute
+  '/bcrypt-generator': typeof BcryptGeneratorRoute
+  '/cron-expression-builder': typeof CronExpressionBuilderRoute
+  '/curl-builder': typeof CurlBuilderRoute
+  '/diff-viewer': typeof DiffViewerRoute
+  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
+  '/hash-generator': typeof HashGeneratorRoute
+  '/json-formatter': typeof JsonFormatterRoute
+  '/jwt-decoder': typeof JwtDecoderRoute
+  '/markdown-editor': typeof MarkdownEditorRoute
+  '/network-interfaces': typeof NetworkInterfacesRoute
+  '/network-scanner': typeof NetworkScannerRoute
+  '/password-generator': typeof PasswordGeneratorRoute
+  '/qr-code-generator': typeof QrCodeGeneratorRoute
+  '/regex-tester': typeof RegexTesterRoute
+  '/settings': typeof SettingsRoute
+  '/sql-formatter': typeof SqlFormatterRoute
+  '/ssh-key-generator': typeof SshKeyGeneratorRoute
+  '/string-case-converter': typeof StringCaseConverterRoute
+  '/url-encoder': typeof UrlEncoderRoute
+  '/uuid-generator': typeof UuidGeneratorRoute
+  '/xml-formatter': typeof XmlFormatterRoute
+  '/yaml-formatter': typeof YamlFormatterRoute
 }
 export interface FileRoutesByTo {
-	'/': typeof IndexRoute;
-	'/base64-encoder': typeof Base64EncoderRoute;
-	'/bcrypt-generator': typeof BcryptGeneratorRoute;
-	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
-	'/curl-builder': typeof CurlBuilderRoute;
-	'/diff-viewer': typeof DiffViewerRoute;
-	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
-	'/hash-generator': typeof HashGeneratorRoute;
-	'/json-formatter': typeof JsonFormatterRoute;
-	'/jwt-decoder': typeof JwtDecoderRoute;
-	'/markdown-editor': typeof MarkdownEditorRoute;
-	'/network-interfaces': typeof NetworkInterfacesRoute;
-	'/network-scanner': typeof NetworkScannerRoute;
-	'/password-generator': typeof PasswordGeneratorRoute;
-	'/qr-code-generator': typeof QrCodeGeneratorRoute;
-	'/regex-tester': typeof RegexTesterRoute;
-	'/settings': typeof SettingsRoute;
-	'/sql-formatter': typeof SqlFormatterRoute;
-	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
-	'/string-case-converter': typeof StringCaseConverterRoute;
-	'/url-encoder': typeof UrlEncoderRoute;
-	'/uuid-generator': typeof UuidGeneratorRoute;
-	'/xml-formatter': typeof XmlFormatterRoute;
-	'/yaml-formatter': typeof YamlFormatterRoute;
+  '/': typeof IndexRoute
+  '/base64-encoder': typeof Base64EncoderRoute
+  '/bcrypt-generator': typeof BcryptGeneratorRoute
+  '/cron-expression-builder': typeof CronExpressionBuilderRoute
+  '/curl-builder': typeof CurlBuilderRoute
+  '/diff-viewer': typeof DiffViewerRoute
+  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
+  '/hash-generator': typeof HashGeneratorRoute
+  '/json-formatter': typeof JsonFormatterRoute
+  '/jwt-decoder': typeof JwtDecoderRoute
+  '/markdown-editor': typeof MarkdownEditorRoute
+  '/network-interfaces': typeof NetworkInterfacesRoute
+  '/network-scanner': typeof NetworkScannerRoute
+  '/password-generator': typeof PasswordGeneratorRoute
+  '/qr-code-generator': typeof QrCodeGeneratorRoute
+  '/regex-tester': typeof RegexTesterRoute
+  '/settings': typeof SettingsRoute
+  '/sql-formatter': typeof SqlFormatterRoute
+  '/ssh-key-generator': typeof SshKeyGeneratorRoute
+  '/string-case-converter': typeof StringCaseConverterRoute
+  '/url-encoder': typeof UrlEncoderRoute
+  '/uuid-generator': typeof UuidGeneratorRoute
+  '/xml-formatter': typeof XmlFormatterRoute
+  '/yaml-formatter': typeof YamlFormatterRoute
 }
 export interface FileRoutesById {
-	__root__: typeof rootRouteImport;
-	'/': typeof IndexRoute;
-	'/base64-encoder': typeof Base64EncoderRoute;
-	'/bcrypt-generator': typeof BcryptGeneratorRoute;
-	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
-	'/curl-builder': typeof CurlBuilderRoute;
-	'/diff-viewer': typeof DiffViewerRoute;
-	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
-	'/hash-generator': typeof HashGeneratorRoute;
-	'/json-formatter': typeof JsonFormatterRoute;
-	'/jwt-decoder': typeof JwtDecoderRoute;
-	'/markdown-editor': typeof MarkdownEditorRoute;
-	'/network-interfaces': typeof NetworkInterfacesRoute;
-	'/network-scanner': typeof NetworkScannerRoute;
-	'/password-generator': typeof PasswordGeneratorRoute;
-	'/qr-code-generator': typeof QrCodeGeneratorRoute;
-	'/regex-tester': typeof RegexTesterRoute;
-	'/settings': typeof SettingsRoute;
-	'/sql-formatter': typeof SqlFormatterRoute;
-	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
-	'/string-case-converter': typeof StringCaseConverterRoute;
-	'/url-encoder': typeof UrlEncoderRoute;
-	'/uuid-generator': typeof UuidGeneratorRoute;
-	'/xml-formatter': typeof XmlFormatterRoute;
-	'/yaml-formatter': typeof YamlFormatterRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/base64-encoder': typeof Base64EncoderRoute
+  '/bcrypt-generator': typeof BcryptGeneratorRoute
+  '/cron-expression-builder': typeof CronExpressionBuilderRoute
+  '/curl-builder': typeof CurlBuilderRoute
+  '/diff-viewer': typeof DiffViewerRoute
+  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
+  '/hash-generator': typeof HashGeneratorRoute
+  '/json-formatter': typeof JsonFormatterRoute
+  '/jwt-decoder': typeof JwtDecoderRoute
+  '/markdown-editor': typeof MarkdownEditorRoute
+  '/network-interfaces': typeof NetworkInterfacesRoute
+  '/network-scanner': typeof NetworkScannerRoute
+  '/password-generator': typeof PasswordGeneratorRoute
+  '/qr-code-generator': typeof QrCodeGeneratorRoute
+  '/regex-tester': typeof RegexTesterRoute
+  '/settings': typeof SettingsRoute
+  '/sql-formatter': typeof SqlFormatterRoute
+  '/ssh-key-generator': typeof SshKeyGeneratorRoute
+  '/string-case-converter': typeof StringCaseConverterRoute
+  '/url-encoder': typeof UrlEncoderRoute
+  '/uuid-generator': typeof UuidGeneratorRoute
+  '/xml-formatter': typeof XmlFormatterRoute
+  '/yaml-formatter': typeof YamlFormatterRoute
 }
 export interface FileRouteTypes {
-	fileRoutesByFullPath: FileRoutesByFullPath;
-	fullPaths:
-		| '/'
-		| '/base64-encoder'
-		| '/bcrypt-generator'
-		| '/cron-expression-builder'
-		| '/curl-builder'
-		| '/diff-viewer'
-		| '/gpg-key-generator'
-		| '/hash-generator'
-		| '/json-formatter'
-		| '/jwt-decoder'
-		| '/markdown-editor'
-		| '/network-interfaces'
-		| '/network-scanner'
-		| '/password-generator'
-		| '/qr-code-generator'
-		| '/regex-tester'
-		| '/settings'
-		| '/sql-formatter'
-		| '/ssh-key-generator'
-		| '/string-case-converter'
-		| '/url-encoder'
-		| '/uuid-generator'
-		| '/xml-formatter'
-		| '/yaml-formatter';
-	fileRoutesByTo: FileRoutesByTo;
-	to:
-		| '/'
-		| '/base64-encoder'
-		| '/bcrypt-generator'
-		| '/cron-expression-builder'
-		| '/curl-builder'
-		| '/diff-viewer'
-		| '/gpg-key-generator'
-		| '/hash-generator'
-		| '/json-formatter'
-		| '/jwt-decoder'
-		| '/markdown-editor'
-		| '/network-interfaces'
-		| '/network-scanner'
-		| '/password-generator'
-		| '/qr-code-generator'
-		| '/regex-tester'
-		| '/settings'
-		| '/sql-formatter'
-		| '/ssh-key-generator'
-		| '/string-case-converter'
-		| '/url-encoder'
-		| '/uuid-generator'
-		| '/xml-formatter'
-		| '/yaml-formatter';
-	id:
-		| '__root__'
-		| '/'
-		| '/base64-encoder'
-		| '/bcrypt-generator'
-		| '/cron-expression-builder'
-		| '/curl-builder'
-		| '/diff-viewer'
-		| '/gpg-key-generator'
-		| '/hash-generator'
-		| '/json-formatter'
-		| '/jwt-decoder'
-		| '/markdown-editor'
-		| '/network-interfaces'
-		| '/network-scanner'
-		| '/password-generator'
-		| '/qr-code-generator'
-		| '/regex-tester'
-		| '/settings'
-		| '/sql-formatter'
-		| '/ssh-key-generator'
-		| '/string-case-converter'
-		| '/url-encoder'
-		| '/uuid-generator'
-		| '/xml-formatter'
-		| '/yaml-formatter';
-	fileRoutesById: FileRoutesById;
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/base64-encoder'
+    | '/bcrypt-generator'
+    | '/cron-expression-builder'
+    | '/curl-builder'
+    | '/diff-viewer'
+    | '/gpg-key-generator'
+    | '/hash-generator'
+    | '/json-formatter'
+    | '/jwt-decoder'
+    | '/markdown-editor'
+    | '/network-interfaces'
+    | '/network-scanner'
+    | '/password-generator'
+    | '/qr-code-generator'
+    | '/regex-tester'
+    | '/settings'
+    | '/sql-formatter'
+    | '/ssh-key-generator'
+    | '/string-case-converter'
+    | '/url-encoder'
+    | '/uuid-generator'
+    | '/xml-formatter'
+    | '/yaml-formatter'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/base64-encoder'
+    | '/bcrypt-generator'
+    | '/cron-expression-builder'
+    | '/curl-builder'
+    | '/diff-viewer'
+    | '/gpg-key-generator'
+    | '/hash-generator'
+    | '/json-formatter'
+    | '/jwt-decoder'
+    | '/markdown-editor'
+    | '/network-interfaces'
+    | '/network-scanner'
+    | '/password-generator'
+    | '/qr-code-generator'
+    | '/regex-tester'
+    | '/settings'
+    | '/sql-formatter'
+    | '/ssh-key-generator'
+    | '/string-case-converter'
+    | '/url-encoder'
+    | '/uuid-generator'
+    | '/xml-formatter'
+    | '/yaml-formatter'
+  id:
+    | '__root__'
+    | '/'
+    | '/base64-encoder'
+    | '/bcrypt-generator'
+    | '/cron-expression-builder'
+    | '/curl-builder'
+    | '/diff-viewer'
+    | '/gpg-key-generator'
+    | '/hash-generator'
+    | '/json-formatter'
+    | '/jwt-decoder'
+    | '/markdown-editor'
+    | '/network-interfaces'
+    | '/network-scanner'
+    | '/password-generator'
+    | '/qr-code-generator'
+    | '/regex-tester'
+    | '/settings'
+    | '/sql-formatter'
+    | '/ssh-key-generator'
+    | '/string-case-converter'
+    | '/url-encoder'
+    | '/uuid-generator'
+    | '/xml-formatter'
+    | '/yaml-formatter'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-	IndexRoute: typeof IndexRoute;
-	Base64EncoderRoute: typeof Base64EncoderRoute;
-	BcryptGeneratorRoute: typeof BcryptGeneratorRoute;
-	CronExpressionBuilderRoute: typeof CronExpressionBuilderRoute;
-	CurlBuilderRoute: typeof CurlBuilderRoute;
-	DiffViewerRoute: typeof DiffViewerRoute;
-	GpgKeyGeneratorRoute: typeof GpgKeyGeneratorRoute;
-	HashGeneratorRoute: typeof HashGeneratorRoute;
-	JsonFormatterRoute: typeof JsonFormatterRoute;
-	JwtDecoderRoute: typeof JwtDecoderRoute;
-	MarkdownEditorRoute: typeof MarkdownEditorRoute;
-	NetworkInterfacesRoute: typeof NetworkInterfacesRoute;
-	NetworkScannerRoute: typeof NetworkScannerRoute;
-	PasswordGeneratorRoute: typeof PasswordGeneratorRoute;
-	QrCodeGeneratorRoute: typeof QrCodeGeneratorRoute;
-	RegexTesterRoute: typeof RegexTesterRoute;
-	SettingsRoute: typeof SettingsRoute;
-	SqlFormatterRoute: typeof SqlFormatterRoute;
-	SshKeyGeneratorRoute: typeof SshKeyGeneratorRoute;
-	StringCaseConverterRoute: typeof StringCaseConverterRoute;
-	UrlEncoderRoute: typeof UrlEncoderRoute;
-	UuidGeneratorRoute: typeof UuidGeneratorRoute;
-	XmlFormatterRoute: typeof XmlFormatterRoute;
-	YamlFormatterRoute: typeof YamlFormatterRoute;
+  IndexRoute: typeof IndexRoute
+  Base64EncoderRoute: typeof Base64EncoderRoute
+  BcryptGeneratorRoute: typeof BcryptGeneratorRoute
+  CronExpressionBuilderRoute: typeof CronExpressionBuilderRoute
+  CurlBuilderRoute: typeof CurlBuilderRoute
+  DiffViewerRoute: typeof DiffViewerRoute
+  GpgKeyGeneratorRoute: typeof GpgKeyGeneratorRoute
+  HashGeneratorRoute: typeof HashGeneratorRoute
+  JsonFormatterRoute: typeof JsonFormatterRoute
+  JwtDecoderRoute: typeof JwtDecoderRoute
+  MarkdownEditorRoute: typeof MarkdownEditorRoute
+  NetworkInterfacesRoute: typeof NetworkInterfacesRoute
+  NetworkScannerRoute: typeof NetworkScannerRoute
+  PasswordGeneratorRoute: typeof PasswordGeneratorRoute
+  QrCodeGeneratorRoute: typeof QrCodeGeneratorRoute
+  RegexTesterRoute: typeof RegexTesterRoute
+  SettingsRoute: typeof SettingsRoute
+  SqlFormatterRoute: typeof SqlFormatterRoute
+  SshKeyGeneratorRoute: typeof SshKeyGeneratorRoute
+  StringCaseConverterRoute: typeof StringCaseConverterRoute
+  UrlEncoderRoute: typeof UrlEncoderRoute
+  UuidGeneratorRoute: typeof UuidGeneratorRoute
+  XmlFormatterRoute: typeof XmlFormatterRoute
+  YamlFormatterRoute: typeof YamlFormatterRoute
 }
 
 declare module '@tanstack/react-router' {
-	interface FileRoutesByPath {
-		'/yaml-formatter': {
-			id: '/yaml-formatter';
-			path: '/yaml-formatter';
-			fullPath: '/yaml-formatter';
-			preLoaderRoute: typeof YamlFormatterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/xml-formatter': {
-			id: '/xml-formatter';
-			path: '/xml-formatter';
-			fullPath: '/xml-formatter';
-			preLoaderRoute: typeof XmlFormatterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/uuid-generator': {
-			id: '/uuid-generator';
-			path: '/uuid-generator';
-			fullPath: '/uuid-generator';
-			preLoaderRoute: typeof UuidGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/url-encoder': {
-			id: '/url-encoder';
-			path: '/url-encoder';
-			fullPath: '/url-encoder';
-			preLoaderRoute: typeof UrlEncoderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/string-case-converter': {
-			id: '/string-case-converter';
-			path: '/string-case-converter';
-			fullPath: '/string-case-converter';
-			preLoaderRoute: typeof StringCaseConverterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/ssh-key-generator': {
-			id: '/ssh-key-generator';
-			path: '/ssh-key-generator';
-			fullPath: '/ssh-key-generator';
-			preLoaderRoute: typeof SshKeyGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/sql-formatter': {
-			id: '/sql-formatter';
-			path: '/sql-formatter';
-			fullPath: '/sql-formatter';
-			preLoaderRoute: typeof SqlFormatterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/settings': {
-			id: '/settings';
-			path: '/settings';
-			fullPath: '/settings';
-			preLoaderRoute: typeof SettingsRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/regex-tester': {
-			id: '/regex-tester';
-			path: '/regex-tester';
-			fullPath: '/regex-tester';
-			preLoaderRoute: typeof RegexTesterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/qr-code-generator': {
-			id: '/qr-code-generator';
-			path: '/qr-code-generator';
-			fullPath: '/qr-code-generator';
-			preLoaderRoute: typeof QrCodeGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/password-generator': {
-			id: '/password-generator';
-			path: '/password-generator';
-			fullPath: '/password-generator';
-			preLoaderRoute: typeof PasswordGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/network-scanner': {
-			id: '/network-scanner';
-			path: '/network-scanner';
-			fullPath: '/network-scanner';
-			preLoaderRoute: typeof NetworkScannerRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/network-interfaces': {
-			id: '/network-interfaces';
-			path: '/network-interfaces';
-			fullPath: '/network-interfaces';
-			preLoaderRoute: typeof NetworkInterfacesRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/markdown-editor': {
-			id: '/markdown-editor';
-			path: '/markdown-editor';
-			fullPath: '/markdown-editor';
-			preLoaderRoute: typeof MarkdownEditorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/jwt-decoder': {
-			id: '/jwt-decoder';
-			path: '/jwt-decoder';
-			fullPath: '/jwt-decoder';
-			preLoaderRoute: typeof JwtDecoderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/json-formatter': {
-			id: '/json-formatter';
-			path: '/json-formatter';
-			fullPath: '/json-formatter';
-			preLoaderRoute: typeof JsonFormatterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/hash-generator': {
-			id: '/hash-generator';
-			path: '/hash-generator';
-			fullPath: '/hash-generator';
-			preLoaderRoute: typeof HashGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/gpg-key-generator': {
-			id: '/gpg-key-generator';
-			path: '/gpg-key-generator';
-			fullPath: '/gpg-key-generator';
-			preLoaderRoute: typeof GpgKeyGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/diff-viewer': {
-			id: '/diff-viewer';
-			path: '/diff-viewer';
-			fullPath: '/diff-viewer';
-			preLoaderRoute: typeof DiffViewerRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/curl-builder': {
-			id: '/curl-builder';
-			path: '/curl-builder';
-			fullPath: '/curl-builder';
-			preLoaderRoute: typeof CurlBuilderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/cron-expression-builder': {
-			id: '/cron-expression-builder';
-			path: '/cron-expression-builder';
-			fullPath: '/cron-expression-builder';
-			preLoaderRoute: typeof CronExpressionBuilderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/bcrypt-generator': {
-			id: '/bcrypt-generator';
-			path: '/bcrypt-generator';
-			fullPath: '/bcrypt-generator';
-			preLoaderRoute: typeof BcryptGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/base64-encoder': {
-			id: '/base64-encoder';
-			path: '/base64-encoder';
-			fullPath: '/base64-encoder';
-			preLoaderRoute: typeof Base64EncoderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/': {
-			id: '/';
-			path: '/';
-			fullPath: '/';
-			preLoaderRoute: typeof IndexRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-	}
+  interface FileRoutesByPath {
+    '/yaml-formatter': {
+      id: '/yaml-formatter'
+      path: '/yaml-formatter'
+      fullPath: '/yaml-formatter'
+      preLoaderRoute: typeof YamlFormatterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/xml-formatter': {
+      id: '/xml-formatter'
+      path: '/xml-formatter'
+      fullPath: '/xml-formatter'
+      preLoaderRoute: typeof XmlFormatterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/uuid-generator': {
+      id: '/uuid-generator'
+      path: '/uuid-generator'
+      fullPath: '/uuid-generator'
+      preLoaderRoute: typeof UuidGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/url-encoder': {
+      id: '/url-encoder'
+      path: '/url-encoder'
+      fullPath: '/url-encoder'
+      preLoaderRoute: typeof UrlEncoderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/string-case-converter': {
+      id: '/string-case-converter'
+      path: '/string-case-converter'
+      fullPath: '/string-case-converter'
+      preLoaderRoute: typeof StringCaseConverterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/ssh-key-generator': {
+      id: '/ssh-key-generator'
+      path: '/ssh-key-generator'
+      fullPath: '/ssh-key-generator'
+      preLoaderRoute: typeof SshKeyGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sql-formatter': {
+      id: '/sql-formatter'
+      path: '/sql-formatter'
+      fullPath: '/sql-formatter'
+      preLoaderRoute: typeof SqlFormatterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/regex-tester': {
+      id: '/regex-tester'
+      path: '/regex-tester'
+      fullPath: '/regex-tester'
+      preLoaderRoute: typeof RegexTesterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/qr-code-generator': {
+      id: '/qr-code-generator'
+      path: '/qr-code-generator'
+      fullPath: '/qr-code-generator'
+      preLoaderRoute: typeof QrCodeGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/password-generator': {
+      id: '/password-generator'
+      path: '/password-generator'
+      fullPath: '/password-generator'
+      preLoaderRoute: typeof PasswordGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/network-scanner': {
+      id: '/network-scanner'
+      path: '/network-scanner'
+      fullPath: '/network-scanner'
+      preLoaderRoute: typeof NetworkScannerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/network-interfaces': {
+      id: '/network-interfaces'
+      path: '/network-interfaces'
+      fullPath: '/network-interfaces'
+      preLoaderRoute: typeof NetworkInterfacesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/markdown-editor': {
+      id: '/markdown-editor'
+      path: '/markdown-editor'
+      fullPath: '/markdown-editor'
+      preLoaderRoute: typeof MarkdownEditorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/jwt-decoder': {
+      id: '/jwt-decoder'
+      path: '/jwt-decoder'
+      fullPath: '/jwt-decoder'
+      preLoaderRoute: typeof JwtDecoderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/json-formatter': {
+      id: '/json-formatter'
+      path: '/json-formatter'
+      fullPath: '/json-formatter'
+      preLoaderRoute: typeof JsonFormatterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/hash-generator': {
+      id: '/hash-generator'
+      path: '/hash-generator'
+      fullPath: '/hash-generator'
+      preLoaderRoute: typeof HashGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/gpg-key-generator': {
+      id: '/gpg-key-generator'
+      path: '/gpg-key-generator'
+      fullPath: '/gpg-key-generator'
+      preLoaderRoute: typeof GpgKeyGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/diff-viewer': {
+      id: '/diff-viewer'
+      path: '/diff-viewer'
+      fullPath: '/diff-viewer'
+      preLoaderRoute: typeof DiffViewerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/curl-builder': {
+      id: '/curl-builder'
+      path: '/curl-builder'
+      fullPath: '/curl-builder'
+      preLoaderRoute: typeof CurlBuilderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/cron-expression-builder': {
+      id: '/cron-expression-builder'
+      path: '/cron-expression-builder'
+      fullPath: '/cron-expression-builder'
+      preLoaderRoute: typeof CronExpressionBuilderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/bcrypt-generator': {
+      id: '/bcrypt-generator'
+      path: '/bcrypt-generator'
+      fullPath: '/bcrypt-generator'
+      preLoaderRoute: typeof BcryptGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/base64-encoder': {
+      id: '/base64-encoder'
+      path: '/base64-encoder'
+      fullPath: '/base64-encoder'
+      preLoaderRoute: typeof Base64EncoderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+  }
 }
 
 const rootRouteChildren: RootRouteChildren = {
-	IndexRoute: IndexRoute,
-	Base64EncoderRoute: Base64EncoderRoute,
-	BcryptGeneratorRoute: BcryptGeneratorRoute,
-	CronExpressionBuilderRoute: CronExpressionBuilderRoute,
-	CurlBuilderRoute: CurlBuilderRoute,
-	DiffViewerRoute: DiffViewerRoute,
-	GpgKeyGeneratorRoute: GpgKeyGeneratorRoute,
-	HashGeneratorRoute: HashGeneratorRoute,
-	JsonFormatterRoute: JsonFormatterRoute,
-	JwtDecoderRoute: JwtDecoderRoute,
-	MarkdownEditorRoute: MarkdownEditorRoute,
-	NetworkInterfacesRoute: NetworkInterfacesRoute,
-	NetworkScannerRoute: NetworkScannerRoute,
-	PasswordGeneratorRoute: PasswordGeneratorRoute,
-	QrCodeGeneratorRoute: QrCodeGeneratorRoute,
-	RegexTesterRoute: RegexTesterRoute,
-	SettingsRoute: SettingsRoute,
-	SqlFormatterRoute: SqlFormatterRoute,
-	SshKeyGeneratorRoute: SshKeyGeneratorRoute,
-	StringCaseConverterRoute: StringCaseConverterRoute,
-	UrlEncoderRoute: UrlEncoderRoute,
-	UuidGeneratorRoute: UuidGeneratorRoute,
-	XmlFormatterRoute: XmlFormatterRoute,
-	YamlFormatterRoute: YamlFormatterRoute,
-};
+  IndexRoute: IndexRoute,
+  Base64EncoderRoute: Base64EncoderRoute,
+  BcryptGeneratorRoute: BcryptGeneratorRoute,
+  CronExpressionBuilderRoute: CronExpressionBuilderRoute,
+  CurlBuilderRoute: CurlBuilderRoute,
+  DiffViewerRoute: DiffViewerRoute,
+  GpgKeyGeneratorRoute: GpgKeyGeneratorRoute,
+  HashGeneratorRoute: HashGeneratorRoute,
+  JsonFormatterRoute: JsonFormatterRoute,
+  JwtDecoderRoute: JwtDecoderRoute,
+  MarkdownEditorRoute: MarkdownEditorRoute,
+  NetworkInterfacesRoute: NetworkInterfacesRoute,
+  NetworkScannerRoute: NetworkScannerRoute,
+  PasswordGeneratorRoute: PasswordGeneratorRoute,
+  QrCodeGeneratorRoute: QrCodeGeneratorRoute,
+  RegexTesterRoute: RegexTesterRoute,
+  SettingsRoute: SettingsRoute,
+  SqlFormatterRoute: SqlFormatterRoute,
+  SshKeyGeneratorRoute: SshKeyGeneratorRoute,
+  StringCaseConverterRoute: StringCaseConverterRoute,
+  UrlEncoderRoute: UrlEncoderRoute,
+  UuidGeneratorRoute: UuidGeneratorRoute,
+  XmlFormatterRoute: XmlFormatterRoute,
+  YamlFormatterRoute: YamlFormatterRoute,
+}
 export const routeTree = rootRouteImport
-	._addFileChildren(rootRouteChildren)
-	._addFileTypes<FileRouteTypes>();
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()

--- a/src/routes/hash-generator.tsx
+++ b/src/routes/hash-generator.tsx
@@ -9,7 +9,7 @@ import { useDocumentTitle } from '@/lib/hooks';
 import { SectionHeader } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, LiveStatusRegion, StatItem } from '@/lib/components/status';
-import { Badge } from '@/lib/components/ui/badge';
+import { ToneBadge } from '@/lib/components/ui/tone-badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { CodeBlock } from '@/lib/components/ui/code-block';
 import {
@@ -133,15 +133,13 @@ function HashGeneratorPage() {
 													({result.bits} bits)
 												</span>
 												{isSecure(result.algorithm) ? (
-													<Badge variant="outline" className="gap-1 bg-success/10 text-success">
-														<ShieldCheck className="h-3 w-3" />
+													<ToneBadge tone="success" icon={ShieldCheck}>
 														Secure
-													</Badge>
+													</ToneBadge>
 												) : (
-													<Badge variant="outline" className="gap-1 bg-warning/10 text-warning">
-														<ShieldAlert className="h-3 w-3" />
+													<ToneBadge tone="warning" icon={ShieldAlert}>
 														Weak
-													</Badge>
+													</ToneBadge>
 												)}
 											</div>
 											<CopyButton

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -50,13 +50,16 @@ function HomePage() {
 												to={tool.url as never}
 												className="group block rounded-xl outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/30"
 											>
-												<Card className="h-full border-border/50 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-border hover:shadow-md">
-													<CardContent className="flex h-full items-center gap-4 p-5">
-														<div className="shrink-0 rounded-lg bg-accent-soft p-2.5">
-															<ToolIcon className={cn('h-7 w-7', tool.color)} />
+												<Card
+													density="compact"
+													className="h-full border-border/50 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-border hover:shadow-md"
+												>
+													<CardContent className="flex h-full items-center gap-3">
+														<div className="shrink-0 rounded-lg bg-accent-soft p-2">
+															<ToolIcon className={cn('h-6 w-6', tool.color)} />
 														</div>
 														<div className="min-w-0 flex-1">
-															<div className="font-semibold transition-transform duration-150 group-hover:translate-x-0.5">
+															<div className="text-sm font-semibold transition-transform duration-150 group-hover:translate-x-0.5">
 																{tool.title}
 															</div>
 															<p className="line-clamp-2 text-xs text-muted-foreground/80">

--- a/src/routes/json-formatter.tsx
+++ b/src/routes/json-formatter.tsx
@@ -38,7 +38,11 @@ function JsonFormatterPage() {
 						<StatItem label="Depth" value={liveStats.depth} />
 						<StatItem label="Size" value={liveStats.size} />
 					</>
-				) : null
+				) : (
+					<span className="text-xs text-muted-foreground/70">
+						Paste, drop, or load sample to get started
+					</span>
+				)
 			}
 			renderTabContent={({ tab, input, onInputChange, onStatsChange }) => {
 				switch (tab) {

--- a/src/routes/network-interfaces.tsx
+++ b/src/routes/network-interfaces.tsx
@@ -419,6 +419,7 @@ function NetworkInterfacesPage() {
 																		</span>
 																		<code className="font-mono text-xs">{iface.macAddress}</code>
 																		<CopyButton
+																			variant="ghost"
 																			text={iface.macAddress}
 																			toastLabel="MAC address"
 																			size="icon"
@@ -440,6 +441,7 @@ function NetworkInterfacesPage() {
 																			{addr.address}/{addr.prefixLen}
 																		</code>
 																		<CopyButton
+																			variant="ghost"
 																			text={addr.address}
 																			toastLabel="IPv4 address"
 																			size="icon"
@@ -476,6 +478,7 @@ function NetworkInterfacesPage() {
 																				</span>
 																			) : null}
 																			<CopyButton
+																				variant="ghost"
 																				text={addr.address}
 																				toastLabel="IPv6 address"
 																				size="icon"

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -212,7 +212,7 @@ function SettingsPage() {
 									>
 										<Command>
 											<CommandInput placeholder="Search fonts..." />
-											<CommandList className="max-h-48">
+											<CommandList className="max-h-72">
 												<CommandEmpty>No fonts found.</CommandEmpty>
 												<CommandGroup heading="System Fonts">
 													<FontPickerItem
@@ -297,7 +297,7 @@ function SettingsPage() {
 									>
 										<Command>
 											<CommandInput placeholder="Search fonts..." />
-											<CommandList className="max-h-48">
+											<CommandList className="max-h-72">
 												<CommandEmpty>No fonts found.</CommandEmpty>
 												<CommandGroup heading="System Monospace Fonts">
 													<FontPickerItem

--- a/src/routes/sql-formatter.tsx
+++ b/src/routes/sql-formatter.tsx
@@ -141,7 +141,11 @@ function SqlFormatterPage() {
 						<StatItem label="Statements" value={stats.statements} />
 						<StatItem label="Size" value={stats.size} />
 					</>
-				) : null
+				) : (
+					<span className="text-xs text-muted-foreground/70">
+						Paste, drop, or load sample to get started
+					</span>
+				)
 			}
 			rail={
 				<>

--- a/src/routes/xml-formatter.tsx
+++ b/src/routes/xml-formatter.tsx
@@ -30,7 +30,11 @@ function XmlFormatterPage() {
 						<StatItem label="Depth" value={liveStats.depth} />
 						<StatItem label="Size" value={liveStats.size} />
 					</>
-				) : null
+				) : (
+					<span className="text-xs text-muted-foreground/70">
+						Paste, drop, or load sample to get started
+					</span>
+				)
 			}
 			renderTabContent={({ tab, input, onInputChange, onStatsChange }) => {
 				switch (tab) {

--- a/src/routes/yaml-formatter.tsx
+++ b/src/routes/yaml-formatter.tsx
@@ -30,7 +30,11 @@ function YamlFormatterPage() {
 						<StatItem label="Depth" value={liveStats.depth} />
 						<StatItem label="Size" value={liveStats.size} />
 					</>
-				) : null
+				) : (
+					<span className="text-xs text-muted-foreground/70">
+						Paste, drop, or load sample to get started
+					</span>
+				)
 			}
 			renderTabContent={({ tab, input, onInputChange, onStatsChange }) => {
 				switch (tab) {


### PR DESCRIPTION
## Summary

Tier 1 visual polish + brand color introduction. 10 commits, no behavior changes — purely visual / token / primitive-level work that establishes the design system baseline for further Tier 2-4 work.

## Commits (in order)

| # | Commit | Theme |
|---|--------|-------|
| 1 | `599ba0d` refactor(ui): drop ALL CAPS from section labels across primitives | T1-1 Typography |
| 2 | `7709de6` feat(theme): adopt Copper/Brass as brand color across primary tokens | T4-1a Brand color |
| 3 | `5ae81e4` feat(theme): commit sidebar to panel-style + soften borders + warm tint | T4-1b Background |
| 4 | `63d9da8` refactor(sidebar): strengthen active state + collapse header to single line | T1-2 Sidebar |
| 5 | `a20eceb` refactor(ui): introduce ToneBadge primitive for tone-colored pills | T1-3 DRY |
| 6 | `0a12839` refactor(home): adopt compact density for tool cards | T1-4 Density |
| 7 | `ad0434e` refactor(settings): widen font picker scroll area from h-48 to h-72 | T1-5 Font picker |
| 8 | `d368dfb` refactor(copy-button): default to outline variant for visible affordance | T1-6 Copy |
| 9 | `94d3805` refactor(panel): swap per-item Cards for borderless rows in GeneratedListPanel | T1-7 List density |
| 10 | `c69077e` refactor(formatter): surface "paste / sample" hint in empty status bar | T1-8 Microcopy |

## Key changes

### Brand color: Copper / Brass

* Light mode: `--primary: oklch(0.55 0.15 60)`
* Dark mode: `--primary: oklch(0.70 0.13 60)` (lifted lightness + tighter chroma for visibility on dark bg)
* `--ring`, `--sidebar-primary`, `--sidebar-ring` all share the brand hue
* Dark `--primary-foreground` is now Copper-tinted near-black (`oklch(0.15 0.05 60)`) so contrast color stays in the brand family

### Background tuning

* Light sidebar: `oklch(0.98 0 0)` → `oklch(0.97 0.008 60)` (committed panel-style + barely-visible warm tint)
* Light borders: `0.922` → `0.93` (softer)
* Dark sidebar: `oklch(0.205 0 0)` → `oklch(0.205 0.008 60)` (warm tint, dark mode is already panel-style)

### Typography

* Dropped `uppercase tracking-wide` from 9 primitives: form-section, form-input/select/slider/textarea (compact label), app-sidebar (group labels), section-header, keyboard-shortcuts-dialog, code-editor toolbar. Callsite text was already Title Case, so no per-callsite changes.
* Badge-style caps (network-scanner protocol tags, tree-view type badges) intentionally retained — different semantic.

### Sidebar active state

`SidebarMenuButton` + `SidebarMenuSubButton`:

```diff
- data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground
+ data-active:bg-primary/10 data-active:font-medium data-active:text-primary data-active:shadow-[inset_2px_0_0_var(--primary)]
```

Linear/VS Code-style: Copper text + Copper-tinted background + 2px Copper left-edge bar via inset box-shadow.

### Other primitives / patterns

* `<ToneBadge tone="success|warning|info|destructive" icon?>` — collapses the `<Badge variant="outline" className="gap-1 bg-{tone}/10 text-{tone}">` recipe. Two callsites migrated (hash-generator Secure / Weak).
* `CopyButton` default `variant: 'ghost' → 'outline'`. Per-row icon-only callers (`showLabel={false}`) explicitly opt back into `ghost`.
* `GeneratedListPanel` inner rows: per-item `<Card density="compact">` → `<div hover:bg-accent>`. Per-row CopyButton reveals on `group-hover/row:opacity-100 focus-visible:opacity-100`.
* Home page tool cards: `density="default"` (manual `p-5`) → `density="compact"`. Closes the home → tool density step gap.
* Settings font picker: `CommandList max-h-48` → `max-h-72` (~9 rows visible instead of ~5).
* Formatter empty status bar: `null` → muted hint `"Paste, drop, or load sample to get started"` across json/xml/yaml/sql.

## Net change

```
17 files changed, ~95 insertions(+), ~75 deletions(-) (excluding new primitive file)
```

## Test plan

- [x] `bun run check` passes
- [x] `bun run test` — all 141 tests pass
- [x] Pre-commit hooks green (frontend-lint + frontend-format)
- [ ] Smoke: open home — verify tool cards are compact density, sidebar header is single-line "Kogu", sidebar group labels are Title Case
- [ ] Smoke: navigate to any tool — verify active sidebar item has Copper background + left bar, rail FormSection titles are Title Case
- [ ] Smoke: open `/uuid-generator`, generate — verify result rows are borderless with hover affordance, per-row copy reveals on hover
- [ ] Smoke: open `/hash-generator`, hash text — verify "Secure" / "Weak" badges still tone-colored correctly (now via ToneBadge)
- [ ] Smoke: open `/ssh-key-generator`, generate — verify Card header Copy buttons are now visibly outlined
- [ ] Smoke: open `/settings`, open font picker — verify ~9 rows fit in viewport
- [ ] Smoke: open `/json-formatter`, empty input — verify status bar shows "Paste, drop, or load sample to get started" hint
- [ ] Smoke: toggle dark mode — verify Copper still reads against dark bg, sidebar warm tint still present, all states still legible
