### PR TITLE
refactor(theme): drop Copper + flatten chrome to match dev-tool trend

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -91,13 +91,7 @@
 	--card-foreground: oklch(0.145 0 0);
 	--popover: oklch(1 0 0);
 	--popover-foreground: oklch(0.145 0 0);
-	/*
-	 * Brand color: Copper / Brass. Mid-luminance warm hue (60°) selected so
-	 * primary action buttons read clearly on a white background and the
-	 * sidebar active state pop visibly without overwhelming the page. Pair
-	 * with near-white foreground for WCAG AA on solid primary surfaces.
-	 */
-	--primary: oklch(0.55 0.15 60);
+	--primary: oklch(0.205 0 0);
 	--primary-foreground: oklch(0.985 0 0);
 	--secondary: oklch(0.97 0 0);
 	--secondary-foreground: oklch(0.205 0 0);
@@ -120,27 +114,26 @@
 	--info-foreground: oklch(0.98 0.01 250);
 	--border: oklch(0.93 0 0);
 	--input: oklch(0.93 0 0);
-	--ring: oklch(0.55 0.15 60);
+	--ring: oklch(0.708 0 0);
 	--chart-1: oklch(0.646 0.222 41.116);
 	--chart-2: oklch(0.6 0.118 184.704);
 	--chart-3: oklch(0.398 0.07 227.392);
 	--chart-4: oklch(0.828 0.189 84.429);
 	--chart-5: oklch(0.769 0.188 70.08);
 	/*
-	 * Sidebar (panel-style): committed to "ツール container" framing rather
-	 * than the neutral half-step the shadcn default gave (0.98). The slightly
-	 * deeper grey reads as a panel against the white main area, and the tiny
-	 * Copper chroma (0.008 at hue 60) gives the surface a warm character
-	 * without crossing into "tinted background" territory.
+	 * Sidebar (panel-style): committed to "ツール container" framing — slightly
+	 * deeper grey than the shadcn default (0.98 → 0.97) so the surface reads
+	 * as a distinct panel against the white main area instead of an
+	 * uncommitted half-step.
 	 */
-	--sidebar: oklch(0.97 0.008 60);
+	--sidebar: oklch(0.97 0 0);
 	--sidebar-foreground: oklch(0.145 0 0);
-	--sidebar-primary: oklch(0.55 0.15 60);
+	--sidebar-primary: oklch(0.205 0 0);
 	--sidebar-primary-foreground: oklch(0.985 0 0);
 	--sidebar-accent: oklch(0.97 0 0);
 	--sidebar-accent-foreground: oklch(0.205 0 0);
 	--sidebar-border: oklch(0.93 0 0);
-	--sidebar-ring: oklch(0.55 0.15 60);
+	--sidebar-ring: oklch(0.708 0 0);
 	/* Surface hierarchy (pure grayscale) */
 	--surface-0: oklch(1 0 0);
 	--surface-1: oklch(0.985 0 0);
@@ -199,14 +192,8 @@
 	--card-foreground: oklch(0.985 0 0);
 	--popover: oklch(0.205 0 0);
 	--popover-foreground: oklch(0.985 0 0);
-	/*
-	 * Brand color: Copper / Brass (dark variant). Lightness lifted to 0.70
-	 * for visibility on dark backgrounds; foreground uses a deep
-	 * Copper-tinted near-black so the contrast hue is part of the brand
-	 * family rather than a neutral grey.
-	 */
-	--primary: oklch(0.7 0.13 60);
-	--primary-foreground: oklch(0.15 0.05 60);
+	--primary: oklch(0.985 0 0);
+	--primary-foreground: oklch(0.205 0 0);
 	--secondary: oklch(0.269 0 0);
 	--secondary-foreground: oklch(0.985 0 0);
 	--muted: oklch(0.269 0 0);
@@ -229,26 +216,21 @@
 	--info-foreground: oklch(0.16 0.02 250);
 	--border: oklch(1 0 0 / 10%);
 	--input: oklch(1 0 0 / 15%);
-	--ring: oklch(0.7 0.13 60);
+	--ring: oklch(0.556 0 0);
 	--chart-1: oklch(0.488 0.243 264.376);
 	--chart-2: oklch(0.696 0.17 162.48);
 	--chart-3: oklch(0.769 0.188 70.08);
 	--chart-4: oklch(0.627 0.265 303.9);
 	--chart-5: oklch(0.645 0.246 16.439);
-	/*
-	 * Sidebar (dark, panel-style + warm tint). Dark mode is already panel-
-	 * style by default (sidebar `lighter` than background); the only change
-	 * here is the same tiny Copper chroma applied to keep the brand
-	 * character consistent across modes.
-	 */
-	--sidebar: oklch(0.205 0.008 60);
+	/* Sidebar/Rail (dark mode, panel-style — already lighter than background by default) */
+	--sidebar: oklch(0.205 0 0);
 	--sidebar-foreground: oklch(0.985 0 0);
-	--sidebar-primary: oklch(0.7 0.13 60);
-	--sidebar-primary-foreground: oklch(0.15 0.05 60);
+	--sidebar-primary: oklch(0.985 0 0);
+	--sidebar-primary-foreground: oklch(0.205 0 0);
 	--sidebar-accent: oklch(0.269 0 0);
 	--sidebar-accent-foreground: oklch(0.985 0 0);
 	--sidebar-border: oklch(1 0 0 / 10%);
-	--sidebar-ring: oklch(0.7 0.13 60);
+	--sidebar-ring: oklch(0.556 0 0);
 	/* Surface hierarchy (pure grayscale) */
 	--surface-0: oklch(0.22 0 0);
 	--surface-1: oklch(0.18 0 0);

--- a/src/app.css
+++ b/src/app.css
@@ -112,8 +112,8 @@
 	--warning-foreground: oklch(0.98 0.02 75);
 	--info: oklch(0.55 0.15 250);
 	--info-foreground: oklch(0.98 0.01 250);
-	--border: oklch(0.93 0 0);
-	--input: oklch(0.93 0 0);
+	--border: oklch(0.9 0 0);
+	--input: oklch(0.9 0 0);
 	--ring: oklch(0.708 0 0);
 	--chart-1: oklch(0.646 0.222 41.116);
 	--chart-2: oklch(0.6 0.118 184.704);
@@ -121,23 +121,32 @@
 	--chart-4: oklch(0.828 0.189 84.429);
 	--chart-5: oklch(0.769 0.188 70.08);
 	/*
-	 * Sidebar (panel-style): committed to "ツール container" framing — slightly
-	 * deeper grey than the shadcn default (0.98 → 0.97) so the surface reads
-	 * as a distinct panel against the white main area instead of an
-	 * uncommitted half-step.
+	 * Sidebar (flat / borderless): aligned with the VS Code Modern / Zed
+	 * tradition where panel surfaces share the editor background and rely
+	 * on a thin border for separation. Eliminates the tonal step between
+	 * navigation and content — every pixel of background reads as one
+	 * "work surface". The right-edge border (`group-data-[side=left]:
+	 * border-r` inside `Sidebar`) carries the visual delimiter.
 	 */
-	--sidebar: oklch(0.97 0 0);
+	--sidebar: oklch(1 0 0);
 	--sidebar-foreground: oklch(0.145 0 0);
 	--sidebar-primary: oklch(0.205 0 0);
 	--sidebar-primary-foreground: oklch(0.985 0 0);
 	--sidebar-accent: oklch(0.97 0 0);
 	--sidebar-accent-foreground: oklch(0.205 0 0);
-	--sidebar-border: oklch(0.93 0 0);
+	--sidebar-border: oklch(0.9 0 0);
 	--sidebar-ring: oklch(0.708 0 0);
-	/* Surface hierarchy (pure grayscale) */
+	/*
+	 * Surface hierarchy (flat at the outer chrome, retained for sub-panels).
+	 * Surfaces 0–2 share the editor background to keep the top toolbar,
+	 * sidebar, rail, status bar, and SectionHeader visually flush; surfaces
+	 * 3–4 keep a faint grey for true sub-panel separators (diff-results
+	 * footer, markdown-editor formatting bar, network-scanner sub-headers)
+	 * where a border alone wouldn't read as a section break.
+	 */
 	--surface-0: oklch(1 0 0);
-	--surface-1: oklch(0.985 0 0);
-	--surface-2: oklch(0.97 0 0);
+	--surface-1: oklch(1 0 0);
+	--surface-2: oklch(1 0 0);
 	--surface-3: oklch(0.95 0 0);
 	--surface-4: oklch(0.93 0 0);
 	/* Panel and accent */
@@ -214,27 +223,36 @@
 	--warning-foreground: oklch(0.16 0.02 75);
 	--info: oklch(0.68 0.15 250);
 	--info-foreground: oklch(0.16 0.02 250);
-	--border: oklch(1 0 0 / 10%);
-	--input: oklch(1 0 0 / 15%);
+	--border: oklch(1 0 0 / 15%);
+	--input: oklch(1 0 0 / 20%);
 	--ring: oklch(0.556 0 0);
 	--chart-1: oklch(0.488 0.243 264.376);
 	--chart-2: oklch(0.696 0.17 162.48);
 	--chart-3: oklch(0.769 0.188 70.08);
 	--chart-4: oklch(0.627 0.265 303.9);
 	--chart-5: oklch(0.645 0.246 16.439);
-	/* Sidebar/Rail (dark mode, panel-style — already lighter than background by default) */
-	--sidebar: oklch(0.205 0 0);
+	/*
+	 * Sidebar (flat / borderless in dark mode too). Aligned with VS Code
+	 * Modern / Zed where the sidebar shares the editor background and
+	 * relies on a thin border for the right-edge separator.
+	 */
+	--sidebar: oklch(0.145 0 0);
 	--sidebar-foreground: oklch(0.985 0 0);
 	--sidebar-primary: oklch(0.985 0 0);
 	--sidebar-primary-foreground: oklch(0.205 0 0);
 	--sidebar-accent: oklch(0.269 0 0);
 	--sidebar-accent-foreground: oklch(0.985 0 0);
-	--sidebar-border: oklch(1 0 0 / 10%);
+	--sidebar-border: oklch(1 0 0 / 15%);
 	--sidebar-ring: oklch(0.556 0 0);
-	/* Surface hierarchy (pure grayscale) */
-	--surface-0: oklch(0.22 0 0);
-	--surface-1: oklch(0.18 0 0);
-	--surface-2: oklch(0.15 0 0);
+	/*
+	 * Surface hierarchy (dark, flat at the outer chrome). Surfaces 0-2 match
+	 * the editor background; surfaces 3-4 keep recessed darkness for true
+	 * sub-panel separators (diff-results, markdown-editor toolbar, network-
+	 * scanner sub-headers).
+	 */
+	--surface-0: oklch(0.145 0 0);
+	--surface-1: oklch(0.145 0 0);
+	--surface-2: oklch(0.145 0 0);
 	--surface-3: oklch(0.12 0 0);
 	--surface-4: oklch(0.1 0 0);
 	/* Panel and accent */


### PR DESCRIPTION
## Summary

Two related theme refinements landing together:

1. **Revert the Copper brand color** introduced in #290 — the saturated hue at `oklch(0.55 0.15 60)` pushed the app toward an "earthy / craft tool" register and away from the neutral, content-forward aesthetic shared by current dev tools.
2. **Flatten the outer chrome** — sidebar / rail / toolbar / status bar share `--background` exactly, matching the VS Code Modern / Zed / Cursor pattern where panel surfaces sit flush with the editor and rely on thin borders for separation.

## Commits

| # | SHA | Theme |
|---|-----|-------|
| 1 | `cdaf204` | revert(theme): drop Copper brand color, keep structural improvements |
| 2 | `f3ee0b6` | refactor(theme): flatten sidebar / rail / toolbar to match dev-tool trend |

## Token changes

### Light mode

| Token | Was | Now |
|-------|-----|-----|
| `--primary` | `oklch(0.55 0.15 60)` Copper | `oklch(0.205 0 0)` near-black |
| `--ring` | Copper | `oklch(0.708 0 0)` neutral grey |
| `--sidebar` | `oklch(0.97 0.008 60)` warm panel | **`oklch(1 0 0)` = `--background`** |
| `--surface-1` | `oklch(0.985 0 0)` | **`oklch(1 0 0)` = `--background`** |
| `--surface-2` | `oklch(0.97 0 0)` | **`oklch(1 0 0)` = `--background`** |
| `--border` / `--input` / `--sidebar-border` | `0.93` | `0.90` |

### Dark mode

| Token | Was | Now |
|-------|-----|-----|
| `--primary` | `oklch(0.70 0.13 60)` Copper | `oklch(0.985 0 0)` near-white |
| `--primary-foreground` | Copper-tinted near-black | `oklch(0.205 0 0)` neutral |
| `--ring` | Copper | `oklch(0.556 0 0)` |
| `--sidebar` | `oklch(0.205 0.008 60)` | **`oklch(0.145 0 0)` = `--background`** |
| `--surface-0/1/2` | `0.22 / 0.18 / 0.15` | **all `0.145` = `--background`** |
| `--border` / `--input` / `--sidebar-border` | `10%` / `15%` / `10%` | `15%` / `20%` / `15%` |

`--surface-3` / `--surface-4` retained in both modes (sub-panel separators).

## Kept (structural improvements from Tier 1)

* ALL CAPS → Title Case across primitives
* Sidebar header single-line ("Kogu", no "Developer Tools" tagline)
* Sidebar active state: `bg-primary/10 + text-primary + shadow-[inset_2px_0_0_var(--primary)]` — now reads as grey wash + 2px black left-edge bar
* `ToneBadge` primitive
* `CopyButton` default `variant: outline`
* GeneratedListPanel borderless rows with hover-reveal
* Home page compact density
* Font picker `max-h-72`
* Formatter empty status microcopy

## Net effect

The app reads as a single calm work surface, with thin borders demarcating regions. Primary CTAs (Generate buttons) return to standard productivity-tool black. Sidebar active item retains its strong "you are here" affordance through structural cues (background tint + left-edge bar) rather than brand color.

## Net change

```
1 file changed, ~55 insertions(+), ~55 deletions(-)
```

## Test plan

- [x] `bun run check` passes
- [x] Pre-commit hooks green (frontend-format + frontend-lint)
- [x] Visual: sidebar / rail / top toolbar / status bar are all white, separated by thin borders
- [x] Visual: Generate button is solid black, sidebar UUID Generator active item has soft grey + 2px black left bar
- [ ] Toggle dark mode — verify sidebar / rail / status bar are all near-black (= `--background`), separated by 15% alpha borders
- [ ] Spot-check sub-panels (diff-results footer, markdown-editor formatting bar) — those should retain the `--surface-3` / `--surface-4` grey for true section separation