### PR TITLE
refactor(chrome): simplify sidebar footer + shrink Cmd+K palette

### DIFF
--- a/src/lib/components/layout/app-sidebar.tsx
+++ b/src/lib/components/layout/app-sidebar.tsx
@@ -1,6 +1,5 @@
 import { Link, useRouterState } from '@tanstack/react-router';
-import { useTheme } from 'next-themes';
-import { ChevronLeft, ChevronRight, Monitor, Moon, Settings, Sun } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Settings } from 'lucide-react';
 
 import {
 	Collapsible,
@@ -25,29 +24,12 @@ import { CATEGORIES, getPagesByCategory } from '@/lib/services/pages';
 import { useSidebarStore } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 
-type ThemeName = 'light' | 'dark' | 'system';
-
-const cycleTheme = (current: ThemeName): ThemeName => {
-	if (current === 'light') return 'dark';
-	if (current === 'dark') return 'system';
-	return 'light';
-};
-
-const isThemeName = (value: string | undefined): value is ThemeName =>
-	value === 'light' || value === 'dark' || value === 'system';
-
 export function AppSidebar(_: AppSidebarProps = {}) {
 	const openGroups = useSidebarStore((s) => s.openGroups);
 	const setGroupOpen = useSidebarStore((s) => s.setGroupOpen);
 
 	const pathname = useRouterState({ select: (state) => state.location.pathname });
 	const sidebar = useSidebar();
-	const { theme, setTheme } = useTheme();
-	const activeTheme: ThemeName = isThemeName(theme) ? theme : 'system';
-
-	const handleToggleTheme = () => {
-		setTheme(cycleTheme(activeTheme));
-	};
 
 	return (
 		<Sidebar collapsible="icon">
@@ -133,27 +115,11 @@ export function AppSidebar(_: AppSidebarProps = {}) {
 						</SidebarMenuButton>
 					</SidebarMenuItem>
 					<SidebarMenuItem>
-						<SidebarMenuButton onClick={handleToggleTheme} tooltip="Toggle theme">
-							{activeTheme === 'dark' ? (
-								<>
-									<Moon className="size-4" />
-									<span>Dark Mode</span>
-								</>
-							) : activeTheme === 'light' ? (
-								<>
-									<Sun className="size-4" />
-									<span>Light Mode</span>
-								</>
-							) : (
-								<>
-									<Monitor className="size-4" />
-									<span>System</span>
-								</>
-							)}
-						</SidebarMenuButton>
-					</SidebarMenuItem>
-					<SidebarMenuItem>
-						<SidebarMenuButton onClick={sidebar.toggleSidebar} tooltip="Toggle sidebar">
+						<SidebarMenuButton
+							onClick={sidebar.toggleSidebar}
+							tooltip="Toggle sidebar"
+							className="text-muted-foreground"
+						>
 							<ChevronLeft className="size-4 transition-transform duration-200 group-data-[state=collapsed]:rotate-180" />
 							<span>Collapse</span>
 						</SidebarMenuButton>

--- a/src/lib/components/layout/title-bar-command.tsx
+++ b/src/lib/components/layout/title-bar-command.tsx
@@ -87,7 +87,13 @@ export const TitleBarCommand = forwardRef<TitleBarCommandHandle, TitleBarCommand
 		}, [open, close]);
 
 		return (
-			<div ref={containerRef} className="relative w-full max-w-md">
+			<div
+				ref={containerRef}
+				className={cn(
+					'relative transition-[max-width] duration-150',
+					open ? 'w-full max-w-md' : 'w-fit max-w-[240px]'
+				)}
+			>
 				<CommandPrimitive
 					loop
 					shouldFilter
@@ -96,10 +102,10 @@ export const TitleBarCommand = forwardRef<TitleBarCommandHandle, TitleBarCommand
 				>
 					<div
 						className={cn(
-							'flex h-6 items-center gap-2 rounded-md border px-3 transition-colors',
+							'flex h-6 items-center gap-2 rounded-md border transition-colors',
 							open
-								? 'border-ring bg-background ring-2 ring-ring/30'
-								: 'border-border/60 bg-background hover:bg-accent/50'
+								? 'border-ring bg-background px-3 ring-2 ring-ring/30'
+								: 'border-border/60 bg-background px-2 hover:bg-accent/50'
 						)}
 					>
 						<Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
@@ -107,10 +113,13 @@ export const TitleBarCommand = forwardRef<TitleBarCommandHandle, TitleBarCommand
 							ref={inputRef}
 							value={query}
 							onValueChange={setQuery}
-							placeholder="Search pages..."
+							placeholder="Search…"
 							onFocus={() => setOpen(true)}
 							onKeyDown={handleInputKeydown}
-							className="h-full flex-1 bg-transparent text-xs font-normal text-foreground outline-none placeholder:text-muted-foreground"
+							className={cn(
+								'h-full bg-transparent text-xs font-normal text-foreground outline-none placeholder:text-muted-foreground',
+								open ? 'flex-1' : 'w-32'
+							)}
 						/>
 						<kbd className="pointer-events-none hidden shrink-0 rounded border border-border/40 bg-card px-1.5 py-0.5 font-mono text-2xs text-muted-foreground sm:inline">
 							{formatShortcut('K', true)}


### PR DESCRIPTION
## Summary

Two small cleanups in the chrome ring around the workspace, matching the queue items **T2-5** (sidebar bottom utility separation) and **T2-6** (Cmd+K palette shrink) from the earlier polish plan.

## Commits

| # | SHA | Theme |
|---|-----|-------|
| 1 | `9534a21` | refactor(sidebar): drop theme cycle button, demote Collapse to muted utility |
| 2 | `d866945` | refactor(title-bar): shrink Cmd+K palette to compact closed state |

## Changes

### T2-5 — Sidebar footer

`AppSidebar` previously held three controls in identical visual weight:

* **Settings** (route)
* **Theme cycle** (UI control with three-state icon: Sun → Moon → Monitor)
* **Collapse** (UI control)

The Theme cycle has been redundant since #292 added an explicit Theme picker to the Settings page. Drop the cycle button and its supporting bindings (`cycleTheme`, `isThemeName`, `handleToggleTheme`, `activeTheme`, the `next-themes` import). Demote the Collapse button with `text-muted-foreground` so it reads as a tertiary utility control rather than a nav peer.

Footer now holds two items in the right semantic tier:

* **Settings** (primary — full opacity, route)
* **Collapse** (tertiary — muted, ephemeral UI control)

### T2-6 — Cmd+K palette compact closed state

`TitleBarCommand` previously occupied the full center span of the title bar (`w-full max-w-md` ≈ 448px) with a wide "Search pages..." placeholder. The persistent wide bar was unusual for a dev tool — VS Code, Cursor, and Zed all use a compact trigger that expands on focus / shortcut.

Compact the closed state:

```diff
- 'relative w-full max-w-md'
+ 'relative transition-[max-width] duration-150',
+ open ? 'w-full max-w-md' : 'w-fit max-w-[240px]'
```

* Container animates via `transition-[max-width]` so the focus expansion stays smooth.
* Inner padding: `px-3` (always) → `px-2` (closed) / `px-3` (open).
* Input: `flex-1` (always) → `w-32` (closed) / `flex-1` (open).
* Placeholder: `"Search pages..."` → `"Search…"` (fits the compact width without truncating).

Cmd+K still focuses the input via the existing `focusInput` imperative handle; on focus the wide open state animates in, so keyboard-driven use is unchanged. The persistent wide bar release ~200px of horizontal space, leaving room for future breadcrumb / current-tool indicators.

## Net change

```
2 files changed, ~21 insertions(+), ~46 deletions(-)
```

## Test plan

- [x] `bun run check` passes
- [x] `bun run test` — 141 tests pass
- [x] Pre-commit hooks green
- [x] Sidebar footer renders Settings + Collapse only; Collapse uses muted color
- [x] Title bar center shows compact `Search… ⌘K` button (~240px wide closed)
- [x] Click / focus / Cmd+K expands to `~448px` wide input, dropdown opens beneath
- [x] Click outside or Esc collapses back to compact state
- [ ] Smoke: confirm sidebar collapsed icon-only state still toggles via Collapse
- [ ] Smoke: confirm Settings page Theme picker remains the canonical theme switch path
