### PR TITLE
fix(sidebar): expand variant + CSS-var shorthand to var() form

### DIFF
--- a/src/lib/components/ui/sidebar.tsx
+++ b/src/lib/components/ui/sidebar.tsx
@@ -215,7 +215,7 @@ function Sidebar({
 					'group-data-[side=right]:rotate-180',
 					variant === 'floating' || variant === 'inset'
 						? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]'
-						: 'group-data-[collapsible=icon]:w-(--sidebar-width-icon)'
+						: 'group-data-[collapsible=icon]:w-[var(--sidebar-width-icon)]'
 				)}
 			/>
 			<div
@@ -226,7 +226,7 @@ function Sidebar({
 					// Adjust the padding for floating and inset variants.
 					variant === 'floating' || variant === 'inset'
 						? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
-						: 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l',
+						: 'group-data-[collapsible=icon]:w-[var(--sidebar-width-icon)] group-data-[side=left]:border-r group-data-[side=right]:border-l',
 					className
 				)}
 				{...props}


### PR DESCRIPTION
## Summary

Fix the middle collapse mode (T3-1 from the polish plan). The "Collapse" footer button looked like a no-op because the rail never shrank — clicking it set the right data attributes (\`data-state=\"collapsed\"\`, \`data-collapsible=\"icon\"\`) but the CSS rule that should reduce the width never matched, so the rail stayed at full \`--sidebar-width\` (16rem / 256px).

## Root cause

The shadcn \`Sidebar\` primitive (copied from the upstream React template) used Tailwind v4's CSS-variable-as-value shorthand under a variant prefix:

\`\`\`tsx
'group-data-[collapsible=icon]:w-(--sidebar-width-icon)'
\`\`\`

In our Tailwind v4.3.0 setup, that combination silently fails to compile. DOM probe confirmed:

- Container className contains the variant + shorthand classes ✓
- Parent group has \`data-collapsible=\"icon\"\` ✓
- \`--sidebar-width-icon\` CSS variable resolves to \`3rem\` ✓
- But \`getComputedStyle(container).width === \"256px\"\` ✗ — no rule matched

A query of \`document.styleSheets\` for any rule with selector containing \`collapsible=icon\` returned zero matches.

The bare shorthand \`w-(--sidebar-width)\` (no variant prefix) compiles fine throughout the same file. The issue is specifically the **variant + shorthand combo**.

## Fix

Replace both occurrences with the explicit \`var()\` form, which compiles correctly regardless of variant prefix:

\`\`\`diff
- group-data-[collapsible=icon]:w-(--sidebar-width-icon)
+ group-data-[collapsible=icon]:w-[var(--sidebar-width-icon)]
\`\`\`

(Lines 218, 229 in \`src/lib/components/ui/sidebar.tsx\`.)

The other \`w-(--sidebar-width)\` usages (lines 164, 182, 213, 225, 581) don't have a variant prefix and stay as-is — they compile correctly.

## Effect

Clicking the \"Collapse\" footer button now produces the intended **icon-only rail** (~48px width):

- All category icons stacked vertically (JSON Formatter, YAML, XML, etc.)
- Hover reveals the full label as a tooltip (via shadcn's built-in \`tooltip\` prop on \`SidebarMenuButton\`)
- The previously-merged sidebar active treatment (\`bg-primary/10\` + 2px left bar) still applies — the active tool stays clearly marked even in icon-only mode
- Matches the VS Code Activity Bar / Cursor / Cody pattern

## Net change

\`\`\`
1 file changed, 2 insertions(+), 2 deletions(-)
\`\`\`

## Test plan

- [x] \`bun run check\` passes
- [x] DOM probe: container width = 48px when state=collapsed
- [x] Visual: clicking Collapse shrinks the sidebar to icon-only, labels disappear
- [x] Visual: active tool still shows highlight in collapsed state
- [ ] Click an icon in collapsed state → navigates correctly
- [ ] Hover icon → tooltip with tool name appears
- [ ] Click Collapse again (now showing right-arrow chevron) → expands back to full width