### PR TITLE
feat(sidebar): add Recent tools section driven by route navigation

### DIFF
--- a/src/lib/components/layout/app-sidebar.tsx
+++ b/src/lib/components/layout/app-sidebar.tsx
@@ -1,5 +1,6 @@
+import { useEffect } from 'react';
 import { Link, useRouterState } from '@tanstack/react-router';
-import { ChevronLeft, ChevronRight, Settings } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Clock, Settings } from 'lucide-react';
 
 import {
 	Collapsible,
@@ -20,16 +21,30 @@ import {
 	SidebarRail,
 	useSidebar,
 } from '@/lib/components/ui/sidebar';
-import { CATEGORIES, getPagesByCategory } from '@/lib/services/pages';
-import { useSidebarStore } from '@/lib/stores';
+import { CATEGORIES, getPageById, getPageByUrl, getPagesByCategory } from '@/lib/services/pages';
+import { useRecentToolsStore, useSidebarStore } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 
 export function AppSidebar(_: AppSidebarProps = {}) {
 	const openGroups = useSidebarStore((s) => s.openGroups);
 	const setGroupOpen = useSidebarStore((s) => s.setGroupOpen);
+	const recent = useRecentToolsStore((s) => s.recent);
+	const recordVisit = useRecentToolsStore((s) => s.recordVisit);
 
 	const pathname = useRouterState({ select: (state) => state.location.pathname });
 	const sidebar = useSidebar();
+
+	// Record visits to tool pages (excludes `/` and `/settings`, which are
+	// filtered out of `getToolPages`'s definition).
+	useEffect(() => {
+		const page = getPageByUrl(pathname);
+		if (!page || page.id === 'dashboard' || page.id === 'settings') return;
+		recordVisit(page.id);
+	}, [pathname, recordVisit]);
+
+	const recentPages = recent
+		.map((entry) => getPageById(entry.toolId))
+		.filter((page): page is NonNullable<typeof page> => page !== undefined);
 
 	return (
 		<Sidebar collapsible="icon">
@@ -51,6 +66,37 @@ export function AppSidebar(_: AppSidebarProps = {}) {
 			</SidebarHeader>
 
 			<SidebarContent>
+				{recentPages.length > 0 ? (
+					<SidebarGroup>
+						<SidebarGroupLabel className="text-sidebar-foreground">
+							<div className="flex items-center gap-2 px-2 py-1.5">
+								<Clock className="size-4 opacity-70" />
+								<span className="flex-1 text-left text-xs font-semibold">Recent</span>
+							</div>
+						</SidebarGroupLabel>
+						<SidebarGroupContent>
+							<SidebarMenu>
+								{recentPages.map((tool) => {
+									const ToolIcon = tool.icon;
+									return (
+										<SidebarMenuItem key={`recent-${tool.id}`}>
+											<SidebarMenuButton
+												isActive={pathname === tool.url}
+												tooltip={tool.title}
+												asChild
+											>
+												<Link to={tool.url as never}>
+													<ToolIcon />
+													<span>{tool.title}</span>
+												</Link>
+											</SidebarMenuButton>
+										</SidebarMenuItem>
+									);
+								})}
+							</SidebarMenu>
+						</SidebarGroupContent>
+					</SidebarGroup>
+				) : null}
 				{CATEGORIES.map((category) => {
 					const CategoryIcon = category.icon;
 					const categoryPages = getPagesByCategory(category.id);

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -1,4 +1,5 @@
 export { useJsonFormatterOptions, type JsonFormatterOptions } from './json-formatter-options';
+export { MAX_RECENT_TOOLS, useRecentToolsStore } from './recent-tools';
 export { useSidebarStore } from './sidebar';
 export { useTabStore, useActiveTab } from './tabs';
 export { createToolOptionsStore } from './tool-options';

--- a/src/lib/stores/recent-tools.ts
+++ b/src/lib/stores/recent-tools.ts
@@ -1,0 +1,43 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+interface RecentToolEntry {
+	readonly toolId: string;
+	/** Wall-clock timestamp (ms) of last visit — used for ordering. */
+	readonly lastUsedAt: number;
+}
+
+interface RecentToolsState {
+	readonly recent: readonly RecentToolEntry[];
+	/**
+	 * Record a visit to `toolId`. Bumps it to the head of the list (most
+	 * recent first) and trims to `MAX_RECENT_TOOLS` entries.
+	 */
+	recordVisit: (toolId: string) => void;
+	/** Clear the entire recent list (e.g. from a Settings → Reset). */
+	clear: () => void;
+}
+
+/**
+ * Cap on the recent list. Five items fit naturally above the categorized
+ * tool groups without dominating the sidebar; older visits drop off the
+ * tail as new ones come in.
+ */
+export const MAX_RECENT_TOOLS = 5;
+
+export const useRecentToolsStore = create<RecentToolsState>()(
+	persist(
+		(set) => ({
+			recent: [],
+			recordVisit: (toolId) =>
+				set((state) => {
+					const now = Date.now();
+					const filtered = state.recent.filter((entry) => entry.toolId !== toolId);
+					const next = [{ toolId, lastUsedAt: now }, ...filtered].slice(0, MAX_RECENT_TOOLS);
+					return { recent: next };
+				}),
+			clear: () => set({ recent: [] }),
+		}),
+		{ name: 'kogu:recent-tools', storage: createJSONStorage(() => localStorage) }
+	)
+);


### PR DESCRIPTION
## Summary

Add a "Recent" section at the top of the sidebar that tracks the most-recently-visited tools, so the user's last few work surfaces stay one click away. This is the **Recent** half of queue item T3-3 (the Pinned half intentionally ships with the context menu work in a follow-up).

## Changes

### `src/lib/stores/recent-tools.ts`

New Zustand persist store, keyed by `kogu:recent-tools` in `localStorage`.

```ts
interface RecentToolEntry {
  readonly toolId: string;
  readonly lastUsedAt: number;
}

export const MAX_RECENT_TOOLS = 5;
```

* `recordVisit(toolId)` — bumps the tool to the head of the list (most-recent-first) and trims to `MAX_RECENT_TOOLS`. Re-visiting an already-tracked tool refreshes its position; the list never grows beyond 5.
* `clear()` — empties the list (reserved for a Settings → Reset surface that can read `MAX_RECENT_TOOLS` for confirmation copy).

### `src/lib/components/layout/app-sidebar.tsx`

* Subscribe to the store's `recent` and `recordVisit`.
* `useEffect` watches the current `pathname` and calls `recordVisit(page.id)` for valid tool pages. Dashboard (`/`) and Settings (`/settings`) are excluded — they're filtered out of `getToolPages` in the page registry, so they would clutter the list without being "tools."
* Render a `SidebarGroup` labelled "Recent" with a `Clock` icon at the top of `SidebarContent`, above the categorized groups. The group is hidden when the list is empty (first launch / after `clear()`).
* Each Recent item reuses the same `SidebarMenuItem` + `SidebarMenuButton` shape as the categorized items, so the active-state highlight (`bg-primary/10` + 2px left bar, from #290) and the icon-only collapsed mode (with tooltip on hover, from #296) both work without extra wiring.

## Behavior

| Action | Result |
|--------|--------|
| Visit A, B, C | Recent shows `[C, B, A]` |
| Visit A again | Recent becomes `[A, C, B]` — A floats to the top |
| Visit a 6th tool | Oldest entry drops off the tail |
| Visit `/` or `/settings` | List unchanged (filtered out) |
| Reload / restart | List persists via `localStorage` |
| Collapse sidebar to icon-only | Recent items render as icons; tooltip on hover shows the tool name |

## Out of scope

Pinned tools (the other half of T3-3) needs a context menu to **Pin / Unpin**. That depends on the T3-2 context-menu work, so they ship together in a follow-up PR.

## Net change

```
3 files changed, 93 insertions(+), 3 deletions(-)
  src/lib/stores/recent-tools.ts                | 43 +++++++++++++ (new)
  src/lib/stores/index.ts                       |  1 +
  src/lib/components/layout/app-sidebar.tsx     | 52 ++++++++++++++++++-
```

## Test plan

- [x] `bun run check` passes
- [x] Pre-commit hooks green
- [x] Visual: navigate to 5 different tools; sidebar shows them at top in most-recent-first order
- [x] Visual: revisiting an already-tracked tool floats it to the top
- [x] Visual: collapsed icon-only mode shows recent icons above category icons
- [ ] localStorage smoke: reload app → recent list persists
- [ ] Click a recent item → navigates to the correct tool