### PR TITLE
feat(sidebar): add Pinned tools + right-click context menu (Pin/Unpin)

### DIFF
--- a/src/lib/components/layout/app-sidebar.tsx
+++ b/src/lib/components/layout/app-sidebar.tsx
@@ -1,12 +1,18 @@
 import { useEffect } from 'react';
 import { Link, useRouterState } from '@tanstack/react-router';
-import { ChevronLeft, ChevronRight, Clock, Settings } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Clock, Pin, PinOff, Settings } from 'lucide-react';
 
 import {
 	Collapsible,
 	CollapsibleContent,
 	CollapsibleTrigger,
 } from '@/lib/components/ui/collapsible';
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuTrigger,
+} from '@/lib/components/ui/context-menu';
 import {
 	Sidebar,
 	SidebarContent,
@@ -21,15 +27,65 @@ import {
 	SidebarRail,
 	useSidebar,
 } from '@/lib/components/ui/sidebar';
-import { CATEGORIES, getPageById, getPageByUrl, getPagesByCategory } from '@/lib/services/pages';
-import { useRecentToolsStore, useSidebarStore } from '@/lib/stores';
+import {
+	CATEGORIES,
+	getPageById,
+	getPageByUrl,
+	getPagesByCategory,
+	type PageDefinition,
+} from '@/lib/services/pages';
+import { useRecentToolsStore, useSidebarStore, useToolPinsStore } from '@/lib/stores';
 import { cn } from '@/lib/utils';
+
+interface ToolMenuItemProps {
+	readonly tool: PageDefinition;
+	readonly active: boolean;
+	readonly pinned: boolean;
+	readonly onTogglePin: (toolId: string) => void;
+	/** Optional key prefix when the same tool may appear in multiple groups (e.g. Recent vs Categorized). */
+	readonly keyPrefix?: string;
+}
+
+function ToolMenuItem({ tool, active, pinned, onTogglePin, keyPrefix }: ToolMenuItemProps) {
+	const ToolIcon = tool.icon;
+	return (
+		<ContextMenu>
+			<ContextMenuTrigger asChild>
+				<SidebarMenuItem key={keyPrefix ? `${keyPrefix}-${tool.id}` : tool.id}>
+					<SidebarMenuButton isActive={active} tooltip={tool.title} asChild>
+						<Link to={tool.url as never}>
+							<ToolIcon />
+							<span>{tool.title}</span>
+						</Link>
+					</SidebarMenuButton>
+				</SidebarMenuItem>
+			</ContextMenuTrigger>
+			<ContextMenuContent className="w-44">
+				<ContextMenuItem onSelect={() => onTogglePin(tool.id)}>
+					{pinned ? (
+						<>
+							<PinOff className="size-4" />
+							<span>Unpin</span>
+						</>
+					) : (
+						<>
+							<Pin className="size-4" />
+							<span>Pin to top</span>
+						</>
+					)}
+				</ContextMenuItem>
+			</ContextMenuContent>
+		</ContextMenu>
+	);
+}
 
 export function AppSidebar(_: AppSidebarProps = {}) {
 	const openGroups = useSidebarStore((s) => s.openGroups);
 	const setGroupOpen = useSidebarStore((s) => s.setGroupOpen);
 	const recent = useRecentToolsStore((s) => s.recent);
 	const recordVisit = useRecentToolsStore((s) => s.recordVisit);
+	const pinned = useToolPinsStore((s) => s.pinned);
+	const togglePin = useToolPinsStore((s) => s.togglePin);
 
 	const pathname = useRouterState({ select: (state) => state.location.pathname });
 	const sidebar = useSidebar();
@@ -42,9 +98,17 @@ export function AppSidebar(_: AppSidebarProps = {}) {
 		recordVisit(page.id);
 	}, [pathname, recordVisit]);
 
+	const pinnedSet = new Set(pinned);
+
+	const pinnedPages = pinned
+		.map((id) => getPageById(id))
+		.filter((page): page is NonNullable<typeof page> => page !== undefined);
+
+	// Hide pinned tools from Recent — they're already prominent at the top.
 	const recentPages = recent
 		.map((entry) => getPageById(entry.toolId))
-		.filter((page): page is NonNullable<typeof page> => page !== undefined);
+		.filter((page): page is NonNullable<typeof page> => page !== undefined)
+		.filter((page) => !pinnedSet.has(page.id));
 
 	return (
 		<Sidebar collapsible="icon">
@@ -66,6 +130,30 @@ export function AppSidebar(_: AppSidebarProps = {}) {
 			</SidebarHeader>
 
 			<SidebarContent>
+				{pinnedPages.length > 0 ? (
+					<SidebarGroup>
+						<SidebarGroupLabel className="text-sidebar-foreground">
+							<div className="flex items-center gap-2 px-2 py-1.5">
+								<Pin className="size-4 opacity-70" />
+								<span className="flex-1 text-left text-xs font-semibold">Pinned</span>
+							</div>
+						</SidebarGroupLabel>
+						<SidebarGroupContent>
+							<SidebarMenu>
+								{pinnedPages.map((tool) => (
+									<ToolMenuItem
+										key={`pinned-${tool.id}`}
+										tool={tool}
+										active={pathname === tool.url}
+										pinned
+										onTogglePin={togglePin}
+										keyPrefix="pinned"
+									/>
+								))}
+							</SidebarMenu>
+						</SidebarGroupContent>
+					</SidebarGroup>
+				) : null}
 				{recentPages.length > 0 ? (
 					<SidebarGroup>
 						<SidebarGroupLabel className="text-sidebar-foreground">
@@ -76,23 +164,16 @@ export function AppSidebar(_: AppSidebarProps = {}) {
 						</SidebarGroupLabel>
 						<SidebarGroupContent>
 							<SidebarMenu>
-								{recentPages.map((tool) => {
-									const ToolIcon = tool.icon;
-									return (
-										<SidebarMenuItem key={`recent-${tool.id}`}>
-											<SidebarMenuButton
-												isActive={pathname === tool.url}
-												tooltip={tool.title}
-												asChild
-											>
-												<Link to={tool.url as never}>
-													<ToolIcon />
-													<span>{tool.title}</span>
-												</Link>
-											</SidebarMenuButton>
-										</SidebarMenuItem>
-									);
-								})}
+								{recentPages.map((tool) => (
+									<ToolMenuItem
+										key={`recent-${tool.id}`}
+										tool={tool}
+										active={pathname === tool.url}
+										pinned={false}
+										onTogglePin={togglePin}
+										keyPrefix="recent"
+									/>
+								))}
 							</SidebarMenu>
 						</SidebarGroupContent>
 					</SidebarGroup>
@@ -124,23 +205,15 @@ export function AppSidebar(_: AppSidebarProps = {}) {
 								<CollapsibleContent>
 									<SidebarGroupContent>
 										<SidebarMenu>
-											{categoryPages.map((tool) => {
-												const ToolIcon = tool.icon;
-												return (
-													<SidebarMenuItem key={tool.id}>
-														<SidebarMenuButton
-															isActive={pathname === tool.url}
-															tooltip={tool.title}
-															asChild
-														>
-															<Link to={tool.url as never}>
-																<ToolIcon />
-																<span>{tool.title}</span>
-															</Link>
-														</SidebarMenuButton>
-													</SidebarMenuItem>
-												);
-											})}
+											{categoryPages.map((tool) => (
+												<ToolMenuItem
+													key={tool.id}
+													tool={tool}
+													active={pathname === tool.url}
+													pinned={pinnedSet.has(tool.id)}
+													onTogglePin={togglePin}
+												/>
+											))}
 										</SidebarMenu>
 									</SidebarGroupContent>
 								</CollapsibleContent>

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -3,3 +3,4 @@ export { MAX_RECENT_TOOLS, useRecentToolsStore } from './recent-tools';
 export { useSidebarStore } from './sidebar';
 export { useTabStore, useActiveTab } from './tabs';
 export { createToolOptionsStore } from './tool-options';
+export { useToolPinsStore } from './tool-pins';

--- a/src/lib/stores/tool-pins.ts
+++ b/src/lib/stores/tool-pins.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+interface ToolPinsState {
+	readonly pinned: readonly string[];
+	/** Add `toolId` to the pinned list. No-op if already pinned. */
+	pin: (toolId: string) => void;
+	/** Remove `toolId` from the pinned list. No-op if not pinned. */
+	unpin: (toolId: string) => void;
+	/** Toggle pin state. Returns the new state. */
+	togglePin: (toolId: string) => void;
+	/** True iff `toolId` is currently pinned. Pure derive helper for selectors. */
+	isPinned: (toolId: string) => boolean;
+}
+
+export const useToolPinsStore = create<ToolPinsState>()(
+	persist(
+		(set, get) => ({
+			pinned: [],
+			pin: (toolId) =>
+				set((state) =>
+					state.pinned.includes(toolId) ? state : { pinned: [...state.pinned, toolId] }
+				),
+			unpin: (toolId) => set((state) => ({ pinned: state.pinned.filter((id) => id !== toolId) })),
+			togglePin: (toolId) =>
+				set((state) =>
+					state.pinned.includes(toolId)
+						? { pinned: state.pinned.filter((id) => id !== toolId) }
+						: { pinned: [...state.pinned, toolId] }
+				),
+			isPinned: (toolId) => get().pinned.includes(toolId),
+		}),
+		{ name: 'kogu:tool-pins', storage: createJSONStorage(() => localStorage) }
+	)
+);


### PR DESCRIPTION
## Summary

Complete the second half of **T3-3** (Pinned tools) and ship the most useful slice of **T3-2** (context menu) at the same time: every tool item in the sidebar now exposes a right-click menu with a single Pin / Unpin action, and pinned tools surface in a dedicated section above Recent.

## Changes

### `src/lib/stores/tool-pins.ts`

New Zustand persist store, keyed by \`kogu:tool-pins\` in \`localStorage\`.

\`\`\`ts
interface ToolPinsState {
  readonly pinned: readonly string[];
  pin: (toolId: string) => void;
  unpin: (toolId: string) => void;
  togglePin: (toolId: string) => void;
  isPinned: (toolId: string) => boolean;
}
\`\`\`

Pin operations are idempotent — pinning an already-pinned tool is a no-op; same for unpinning.

### \`src/lib/components/layout/app-sidebar.tsx\`

* Internal **\`ToolMenuItem\`** component wraps a \`SidebarMenuItem\` with a Radix \`ContextMenu\`. The single menu item flips between **Pin to top** (with \`Pin\` icon) and **Unpin** (with \`PinOff\` icon) based on the tool's current pinned state.
* Replaces the hand-rolled \`SidebarMenuItem\` + \`SidebarMenuButton\` triplet at every tool-item call site — Recent, Pinned, and the categorized groups. One source of truth for tool rendering across all three sections.
* Render a **Pinned** \`SidebarGroup\` at the very top of \`SidebarContent\`, above Recent. Uses the \`Pin\` icon as the group's leading mark.
* Recent list filters out tools that are currently pinned (\`!pinnedSet.has(page.id)\`) — they're already prominent at the top, no need for duplication.

## Behavior

| Action | Result |
|--------|--------|
| Right-click any tool in sidebar | Menu shows \`Pin to top\` / \`Unpin\` based on current state |
| Click \`Pin to top\` on JSON Formatter | Tool appears at top under **Pinned** section; disappears from **Recent** if it was there |
| Click \`Unpin\` on a pinned tool | Removed from Pinned; reappears in Recent if it was a recent visit |
| Reload / restart | Pinned list persists via \`localStorage\` |
| Collapse sidebar to icon-only | Pinned section renders as icons; right-click still works |
| Hover icon-only pinned tool | Tooltip shows the tool name (existing primitive behavior) |

## Out of scope

App-wide context-menu work (editor area, status bar, code blocks, etc.) is reserved for follow-ups where the surface actually has an action to offer. This PR scopes T3-2 to the sidebar tool items because that's where the action surface (Pin/Unpin) is concrete.

## Net change

\`\`\`
3 files changed, 147 insertions(+), 38 deletions(-)
  src/lib/stores/tool-pins.ts                | 38 +++++ (new)
  src/lib/stores/index.ts                    |  1 +
  src/lib/components/layout/app-sidebar.tsx  | 108 ++++++++++++++++ (refactor)
\`\`\`

## Test plan

- [x] \`bun run check\` passes
- [x] \`bun run test\` — 141 tests pass
- [x] Pre-commit hooks green
- [x] DOM probe confirms \`ContextMenu\` trigger wraps every tool item (Pinned, Recent, Categories)
- [ ] Smoke (manual): right-click JSON Formatter → \`Pin to top\` → confirm it appears under Pinned section
- [ ] Smoke (manual): right-click pinned tool → \`Unpin\` → confirm removal from Pinned
- [ ] Smoke (manual): collapse sidebar → right-click an icon → context menu opens
- [ ] Smoke (manual): reload app → pinned set persists