### PR TITLE
refactor: clarify status bar semantics + switch Generate language picker to Select

### DIFF
--- a/src/lib/components/shell/status-bar.tsx
+++ b/src/lib/components/shell/status-bar.tsx
@@ -9,21 +9,48 @@ interface StatusBarProps {
 	readonly children?: ReactNode;
 }
 
+/**
+ * Tool-level status bar anchored at the bottom of every `ToolShell`.
+ *
+ * Three slots:
+ * - **Left**: error message (when `error` is set) OR `children` (stats /
+ *   microcopy supplied by the route). Mutually exclusive — an error
+ *   takes precedence so callers don't have to hide their stats manually.
+ * - **Right**: validity badge driven by the `valid` tri-state
+ *   (`true` / `false` / `null` for "unevaluated").
+ *
+ * Accessibility:
+ * - `role="status"` + `aria-live="polite"` so screen readers announce
+ *   parse errors, validation flips, and counter updates without
+ *   interrupting the user.
+ * - `aria-label="Tool status"` separates this bar from the editor's
+ *   own footer (cursor position / byte count) in the AT tree.
+ *
+ * Stat separation:
+ * - The children wrapper uses `[&>*+*]:border-l [&>*+*]:border-border/40
+ *   [&>*+*]:pl-2` so consecutive child elements grow a 1px hairline
+ *   between them — turning a row of `<StatItem>`s into a readable
+ *   segmented readout instead of a flat list. A single child has no
+ *   leading divider.
+ */
 export function StatusBar({ valid, error, children }: StatusBarProps) {
 	const hasContent = Boolean(children) || valid !== undefined || Boolean(error);
 
 	if (!hasContent) return null;
 
 	return (
-		<footer className="flex h-7 shrink-0 items-center justify-between border-t border-border/60 bg-surface-2 px-3">
-			<div className="flex items-center gap-2 text-xs">
+		<footer
+			role="status"
+			aria-live="polite"
+			aria-label="Tool status"
+			className="flex h-7 shrink-0 items-center justify-between border-t border-border/60 bg-surface-2 px-3"
+		>
+			<div className="flex items-center gap-2 text-xs [&>*+*]:border-l [&>*+*]:border-border/40 [&>*+*]:pl-2">
 				{error ? (
-					<>
-						<AlertTriangle className="h-3 w-3 shrink-0 text-destructive" />
-						<span className="max-w-md truncate text-destructive" title={error}>
-							{error}
-						</span>
-					</>
+					<span className="flex items-center gap-1.5 text-destructive" title={error}>
+						<AlertTriangle className="h-3 w-3 shrink-0" />
+						<span className="max-w-md truncate">{error}</span>
+					</span>
 				) : (
 					children
 				)}

--- a/src/lib/components/template/generate-tab.tsx
+++ b/src/lib/components/template/generate-tab.tsx
@@ -7,7 +7,6 @@ import {
 	FormCheckbox,
 	FormCheckboxGroup,
 	FormInput,
-	FormMode,
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
@@ -356,10 +355,14 @@ export function GenerateTabTemplate({
 				{extraOptions}
 
 				<FormSection title="Target Language">
-					<FormMode
+					<FormSelect
 						value={generateLanguage}
-						onValueChange={setGenerateLanguage}
-						options={LANGUAGE_OPTIONS.map((lang) => ({ value: lang.value, label: lang.label }))}
+						onValueChange={(v) => setGenerateLanguage(v as TargetLanguage)}
+						options={LANGUAGE_OPTIONS.map((lang) => ({
+							value: lang.value,
+							label: lang.label,
+							description: `.${lang.extension}`,
+						}))}
 					/>
 				</FormSection>
 


### PR DESCRIPTION
## Summary

Two small polish items from the queue: **T2-3** (status bar role clarity) and **T2-4** (Generate tab language picker UX).

## Changes

### T2-3 — Status bar

The tool-level \`StatusBar\` carried three concerns in a single left slot — error messages, route-supplied stats, and microcopy hints — without semantic markup or visual separation. Screen readers couldn't distinguish it from the editor's own footer status, and multi-stat readouts (e.g. password generator's Count / Length / Entropy) rendered as a flat gap-separated list.

* **\`role=\"status\"\` + \`aria-live=\"polite\"\`** — screen readers announce parse errors, validation flips, and counter updates without interrupting the user.
* **\`aria-label=\"Tool status\"\`** — separates this bar from the editor footer (cursor position / byte count) in the AT tree.
* **Hairline divider between stat items** via \`[&>*+*]:border-l [&>*+*]:border-border/40 [&>*+*]:pl-2\`. A single stat has no leading border (sibling selector); multiple stats now read as a segmented readout.
* **Error rendering tightens** — the previous fragment (icon + text as separate flex children) now wraps in a single span so the divider rule doesn't paint a line between the warning icon and its message.

### T2-4 — Generate tab language picker

The \"Target Language\" picker in the Generate tab used \`FormMode\` (ToggleGroup, radio-style mutual exclusion) for 10 languages. ToggleGroup is meant for 2-5 options; at 10 the buttons wrap awkwardly or compress to unreadable widths.

Switch to \`FormSelect\` (Radix Select dropdown). Each option carries the file extension as its description (\`.ts\`, \`.js\`, \`.go\`, etc.), so picking a language also surfaces the natural file-extension association.

\`\`\`diff
- <FormMode
-   value={generateLanguage}
-   onValueChange={setGenerateLanguage}
-   options={LANGUAGE_OPTIONS.map((lang) => ({ value: lang.value, label: lang.label }))}
- />
+ <FormSelect
+   value={generateLanguage}
+   onValueChange={(v) => setGenerateLanguage(v as TargetLanguage)}
+   options={LANGUAGE_OPTIONS.map((lang) => ({
+     value: lang.value,
+     label: lang.label,
+     description: \`.\${lang.extension}\`,
+   }))}
+ />
\`\`\`

The change touches only the language picker; per-language sub-options blocks (TypeScript root name, Java class style, Python style, etc.) keep their existing controls.

## Net change

\`\`\`
2 files changed, 42 insertions(+), 12 deletions(-)
\`\`\`

## Test plan

- [x] \`bun run check\` passes
- [x] \`bun run test\` — 141 tests pass
- [x] DOM probe: Generate tab renders \`[data-slot=select-trigger]\` instead of ToggleGroup
- [ ] Smoke: select each of the 10 languages from the dropdown → confirm sub-options panel switches accordingly
- [ ] Smoke: status bar with multiple StatItems shows visible 1px dividers between them
- [ ] Smoke: status bar with an error renders the icon + text without an internal divider between them
- [ ] Screen reader (VoiceOver / NVDA): focus the status bar → reads as a \"status\" region labelled \"Tool status\"