### PR TITLE
refactor(sidebar): show Recent only in icon-only collapsed mode

### DIFF
--- a/src/lib/components/layout/app-sidebar.tsx
+++ b/src/lib/components/layout/app-sidebar.tsx
@@ -89,6 +89,12 @@ export function AppSidebar(_: AppSidebarProps = {}) {
 
 	const pathname = useRouterState({ select: (state) => state.location.pathname });
 	const sidebar = useSidebar();
+	// Recent section shows only in collapsed (icon-only) mode. The expanded
+	// sidebar already displays every category inline, so a Recent section
+	// adds noise without value AND shifts the categorized tree downward
+	// when items get added or reordered. In icon-only mode the labels are
+	// hidden, so Recent earns its place as a quick-access shortcut row.
+	const showRecent = sidebar.state === 'collapsed';
 
 	// Record visits to tool pages (excludes `/` and `/settings`, which are
 	// filtered out of `getToolPages`'s definition).
@@ -154,7 +160,7 @@ export function AppSidebar(_: AppSidebarProps = {}) {
 						</SidebarGroupContent>
 					</SidebarGroup>
 				) : null}
-				{recentPages.length > 0 ? (
+				{showRecent && recentPages.length > 0 ? (
 					<SidebarGroup>
 						<SidebarGroupLabel className="text-sidebar-foreground">
 							<div className="flex items-center gap-2 px-2 py-1.5">


### PR DESCRIPTION
## Summary

User feedback after #297 (Recent tools): in the expanded sidebar the Recent section shifts the categorized tree downward every time a new tool is opened or a recent tool is revisited. Subsequent clicks land on the wrong row because the target moved during the previous interaction.

Fix: render Recent only when the sidebar is in icon-only (collapsed) mode.

## Rationale

| Sidebar mode | Tool labels | Best affordance |
|--------------|-------------|-----------------|
| Expanded     | Visible     | Categorized tree (~20 items, 5 groups). User locates a tool by category. |
| Collapsed (icon-only) | Hidden | A column of unlabeled icons. Recent's quick-access row at the top earns its place — same shape as the categories but ordered by usage. |

In expanded mode Recent **adds noise without value** AND **destabilizes the layout** every time the user navigates. In icon-only mode Recent **is** the navigation affordance for "where did I just have that?" — same idea as VS Code's Activity Bar.

## Implementation

```tsx
const showRecent = sidebar.state === 'collapsed';
// …
{showRecent && recentPages.length > 0 ? <SidebarGroup>…</SidebarGroup> : null}
```

The store still records visits in expanded mode (the `useEffect` on `pathname` is unchanged) — only the rendering is gated. So the Recent list accumulates while the user works in expanded mode and is ready to surface the moment they collapse the sidebar.

Pinned stays visible in both modes (user-curated, expected to stay where put). Categorized groups stay visible in both modes (they are the primary nav).

## Net change

```
1 file changed, 7 insertions(+), 1 deletion(-)
```

## Test plan

- [x] `bun run check` passes
- [x] Pre-commit hooks green
- [ ] Smoke: expanded mode — navigating between tools does not shift the categorized tree
- [ ] Smoke: collapse sidebar to icon-only — Recent row appears at top with the most-recent 5 visits
- [ ] Smoke: navigate while in icon-only mode — Recent reorders as expected (the destabilization is acceptable here because every row is the same shape)
- [ ] Smoke: re-expand sidebar — Recent disappears, categorized tree at full height