### PR TITLE
feat(tool-bar): pin/unpin toggle button beside page title

### DIFF
--- a/src/lib/components/shell/tool-bar.tsx
+++ b/src/lib/components/shell/tool-bar.tsx
@@ -1,7 +1,12 @@
 import type { ReactNode } from 'react';
 import { useRouterState } from '@tanstack/react-router';
+import { Pin } from 'lucide-react';
 
+import { Button } from '@/lib/components/ui/button';
+import { IconTooltip } from '@/lib/components/ui/icon-tooltip';
 import { getPageByUrl } from '@/lib/services/pages';
+import { useToolPinsStore } from '@/lib/stores';
+import { cn } from '@/lib/utils';
 
 interface ToolBarProps {
 	readonly title?: string;
@@ -16,11 +21,34 @@ export function ToolBar({ title: titleOverride, leading, center, trailing }: Too
 	const title = titleOverride ?? pageDefinition?.title ?? 'Untitled';
 	const PageIcon = pageDefinition?.icon;
 
+	const pinned = useToolPinsStore((s) => s.pinned);
+	const togglePin = useToolPinsStore((s) => s.togglePin);
+
+	const isToolPage =
+		pageDefinition !== undefined &&
+		pageDefinition.id !== 'dashboard' &&
+		pageDefinition.id !== 'settings';
+	const isPinned = isToolPage && pinned.includes(pageDefinition.id);
+
 	return (
 		<header className="grid h-12 shrink-0 grid-cols-[auto_1fr_auto] items-center border-b bg-surface-1 px-4">
 			<div className="flex min-w-0 shrink-0 items-center gap-2">
 				{PageIcon ? <PageIcon className="h-4 w-4 shrink-0 opacity-80" /> : null}
 				<h1 className="truncate text-sm font-bold tracking-tight">{title}</h1>
+				{isToolPage ? (
+					<IconTooltip label={isPinned ? 'Unpin from sidebar' : 'Pin to sidebar'}>
+						<Button
+							variant="ghost"
+							size="icon-sm"
+							onClick={() => togglePin(pageDefinition.id)}
+							aria-pressed={isPinned}
+							className="h-7 w-7 hover:bg-interactive-hover"
+						>
+							<Pin className={cn('h-3.5 w-3.5', isPinned && 'fill-current')} />
+							<span className="sr-only">{isPinned ? 'Unpin from sidebar' : 'Pin to sidebar'}</span>
+						</Button>
+					</IconTooltip>
+				) : null}
 				{leading}
 			</div>
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -121,11 +121,19 @@ function RootLayout() {
 			handleResetAllSettings().catch(() => {});
 		}).catch(() => null);
 
-		// Capture-phase suppression of the native context menu, except inside the
-		// code editor wrapper where the system menu (copy / paste) is desirable.
+		// Capture-phase suppression of the native context menu, with two
+		// exceptions:
+		//  - `.code-editor-wrapper`: Monaco needs the system menu for
+		//    copy / paste affordance.
+		//  - `[data-slot=context-menu-trigger]`: Radix `ContextMenu` triggers
+		//    (e.g. the sidebar tool items' Pin/Unpin menu) need the event to
+		//    reach their handler. Without this allowance the capture-phase
+		//    `preventDefault` consumes the event before Radix sees it and the
+		//    custom menu never opens.
 		const handleContextMenu = (e: MouseEvent) => {
 			const target = e.target as HTMLElement;
 			if (target.closest('.code-editor-wrapper')) return;
+			if (target.closest('[data-slot=context-menu-trigger]')) return;
 			e.preventDefault();
 			e.stopPropagation();
 		};


### PR DESCRIPTION
## Summary

User feedback: the Pin/Unpin action from #298 was only reachable via right-click on sidebar tool items — discoverable to power users, invisible to everyone else. Surface a toggle icon button immediately to the right of the page title in `ToolBar`, matching the placement pattern Linear / Notion / Cursor use for "star this page" controls.

Also fix the dormant context menu that this conversation revealed.

## Changes

### `feat(tool-bar)` — Pin button beside title

```tsx
<header>
  <div className="flex items-center gap-2">
    {PageIcon ? <PageIcon /> : null}
    <h1>{title}</h1>
    {isToolPage ? (
      <IconTooltip label={isPinned ? 'Unpin from sidebar' : 'Pin to sidebar'}>
        <Button variant="ghost" size="icon-sm" aria-pressed={isPinned} ...>
          <Pin className={cn('h-3.5 w-3.5', isPinned && 'fill-current')} />
        </Button>
      </IconTooltip>
    ) : null}
    {leading}
  </div>
  ...
</header>
```

* Reads `pathname` (already used to resolve the title), looks up the corresponding `PageDefinition`, and skips rendering for Dashboard (`/`) and Settings (`/settings`).
* **Unpinned**: outline `Pin` icon.
* **Pinned**: same icon with `fill-current` — solid pin makes the active state unmistakable at a glance.
* `IconTooltip` wraps the button (tense-matched: `Pin to sidebar` / `Unpin from sidebar`).
* `aria-pressed` + `sr-only` label for screen readers.
* Re-uses the same `ghost` + `h-7 w-7` + `hover:bg-interactive-hover` styling as the TitleBar nav buttons so the chrome ring reads consistently.

### `fix(__root)` — pass Radix context menus through the global suppressor

The capture-phase `contextmenu` handler in `__root.tsx` was allowing the native menu only inside `.code-editor-wrapper` (Monaco copy/paste). Every other element — including Radix `ContextMenuTrigger`s on sidebar tool items — had its event consumed before Radix could see it, so the Pin/Unpin context menu shipped in #298 silently never opened.

Add a second pass-through for `[data-slot=context-menu-trigger]`:

```diff
  const handleContextMenu = (e: MouseEvent) => {
    const target = e.target as HTMLElement;
    if (target.closest('.code-editor-wrapper')) return;
+   if (target.closest('[data-slot=context-menu-trigger]')) return;
    e.preventDefault();
    e.stopPropagation();
  };
```

The two surfaces now coexist:
* **Header button** — discoverable, always visible, scoped to the current page.
* **Sidebar right-click** — power-user shortcut for pinning a tool the user can see in the sidebar without navigating to it.

## Net change

```
2 files changed, 38 insertions(+), 2 deletions(-)
  src/lib/components/shell/tool-bar.tsx | 30 ++++++++++++++++++++++++
  src/routes/__root.tsx                 | 12 +++++++++--
```

## Test plan

- [x] `bun run check` passes
- [x] Pre-commit hooks green
- [ ] Smoke: every tool page header shows the Pin icon button immediately right of the title
- [ ] Smoke: click Pin → tool appears in sidebar Pinned section, button switches to filled
- [ ] Smoke: click again → tool removed from Pinned, button reverts to outline
- [ ] Smoke: Dashboard (`/`) and Settings (`/settings`) header DO NOT show the Pin button
- [ ] Smoke: right-click a sidebar tool item → Pin/Unpin context menu now opens (was silently broken)
- [ ] Smoke: right-click in the background / title bar → no context menu (suppression still works elsewhere)
- [ ] Smoke: right-click inside Monaco editor → system menu still shows (copy/paste preserved)