### PR TITLE
refactor: redesign sidebar (inline search) and top page (minimal polish)

### DIFF
--- a/src/lib/components/layout/app-sidebar.tsx
+++ b/src/lib/components/layout/app-sidebar.tsx
@@ -1,6 +1,6 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useRouterState } from '@tanstack/react-router';
-import { ChevronLeft, ChevronRight, Clock, Pin, PinOff, Settings } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Clock, Pin, PinOff, Search, Settings, X } from 'lucide-react';
 
 import {
 	Collapsible,
@@ -21,6 +21,7 @@ import {
 	SidebarGroupContent,
 	SidebarGroupLabel,
 	SidebarHeader,
+	SidebarInput,
 	SidebarMenu,
 	SidebarMenuButton,
 	SidebarMenuItem,
@@ -32,10 +33,11 @@ import {
 	getPageById,
 	getPageByUrl,
 	getPagesByCategory,
+	getToolPages,
+	type CategoryInfo,
 	type PageDefinition,
 } from '@/lib/services/pages';
 import { useRecentToolsStore, useSidebarStore, useToolPinsStore } from '@/lib/stores';
-import { cn } from '@/lib/utils';
 
 interface ToolMenuItemProps {
 	readonly tool: PageDefinition;
@@ -79,6 +81,219 @@ function ToolMenuItem({ tool, active, pinned, onTogglePin, keyPrefix }: ToolMenu
 	);
 }
 
+interface PinnedGroupProps {
+	readonly pages: readonly PageDefinition[];
+	readonly pathname: string;
+	readonly onTogglePin: (toolId: string) => void;
+}
+
+function PinnedGroup({ pages, pathname, onTogglePin }: PinnedGroupProps) {
+	return (
+		<SidebarGroup>
+			<SidebarGroupLabel className="text-sidebar-foreground">
+				<div className="flex items-center gap-2 px-2 py-1.5">
+					<Pin className="size-4 opacity-70" />
+					<span className="flex-1 text-left text-xs font-medium uppercase tracking-wider">
+						Pinned
+					</span>
+				</div>
+			</SidebarGroupLabel>
+			<SidebarGroupContent>
+				<SidebarMenu>
+					{pages.map((tool) => (
+						<ToolMenuItem
+							key={`pinned-${tool.id}`}
+							tool={tool}
+							active={pathname === tool.url}
+							pinned
+							onTogglePin={onTogglePin}
+							keyPrefix="pinned"
+						/>
+					))}
+				</SidebarMenu>
+			</SidebarGroupContent>
+		</SidebarGroup>
+	);
+}
+
+interface RecentGroupProps {
+	readonly pages: readonly PageDefinition[];
+	readonly pathname: string;
+	readonly onTogglePin: (toolId: string) => void;
+}
+
+function RecentGroup({ pages, pathname, onTogglePin }: RecentGroupProps) {
+	return (
+		<SidebarGroup>
+			<SidebarGroupLabel className="text-sidebar-foreground">
+				<div className="flex items-center gap-2 px-2 py-1.5">
+					<Clock className="size-4 opacity-70" />
+					<span className="flex-1 text-left text-xs font-medium uppercase tracking-wider">
+						Recent
+					</span>
+				</div>
+			</SidebarGroupLabel>
+			<SidebarGroupContent>
+				<SidebarMenu>
+					{pages.map((tool) => (
+						<ToolMenuItem
+							key={`recent-${tool.id}`}
+							tool={tool}
+							active={pathname === tool.url}
+							pinned={false}
+							onTogglePin={onTogglePin}
+							keyPrefix="recent"
+						/>
+					))}
+				</SidebarMenu>
+			</SidebarGroupContent>
+		</SidebarGroup>
+	);
+}
+
+interface CategoryGroupProps {
+	readonly category: CategoryInfo;
+	readonly pages: readonly PageDefinition[];
+	readonly pathname: string;
+	readonly isOpen: boolean;
+	readonly onOpenChange: (open: boolean) => void;
+	readonly pinnedSet: ReadonlySet<string>;
+	readonly onTogglePin: (toolId: string) => void;
+}
+
+function CategoryGroup({
+	category,
+	pages,
+	pathname,
+	isOpen,
+	onOpenChange,
+	pinnedSet,
+	onTogglePin,
+}: CategoryGroupProps) {
+	const CategoryIcon = category.icon;
+	return (
+		<Collapsible open={isOpen} onOpenChange={onOpenChange} className="group/collapsible">
+			<SidebarGroup>
+				<SidebarGroupLabel className="group/label p-0 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground">
+					<CollapsibleTrigger className="flex w-full items-center gap-2 px-2 py-1.5">
+						<CategoryIcon className="size-4 opacity-70" />
+						<span className="flex-1 text-left text-xs font-medium uppercase tracking-wider">
+							{category.label}
+						</span>
+						<ChevronRight className="size-4 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
+					</CollapsibleTrigger>
+				</SidebarGroupLabel>
+				<CollapsibleContent>
+					<SidebarGroupContent>
+						<SidebarMenu>
+							{pages.map((tool) => (
+								<ToolMenuItem
+									key={tool.id}
+									tool={tool}
+									active={pathname === tool.url}
+									pinned={pinnedSet.has(tool.id)}
+									onTogglePin={onTogglePin}
+								/>
+							))}
+						</SidebarMenu>
+					</SidebarGroupContent>
+				</CollapsibleContent>
+			</SidebarGroup>
+		</Collapsible>
+	);
+}
+
+interface SidebarSearchInputProps {
+	readonly inputRef: React.RefObject<HTMLInputElement | null>;
+	readonly query: string;
+	readonly onQueryChange: (value: string) => void;
+}
+
+function SidebarSearchInput({ inputRef, query, onQueryChange }: SidebarSearchInputProps) {
+	return (
+		<div className="relative px-2">
+			<Search
+				aria-hidden="true"
+				className="pointer-events-none absolute left-4 top-2 size-3.5 text-muted-foreground"
+			/>
+			<SidebarInput
+				ref={inputRef}
+				value={query}
+				onChange={(e) => onQueryChange(e.target.value)}
+				placeholder="Search tools..."
+				className="h-7 px-7 text-sm"
+				onKeyDown={(e) => {
+					if (e.key === 'Escape') {
+						e.preventDefault();
+						onQueryChange('');
+					}
+				}}
+				aria-label="Search tools"
+			/>
+			{query ? (
+				<button
+					type="button"
+					onClick={() => onQueryChange('')}
+					aria-label="Clear search"
+					className="absolute right-3 top-2 text-muted-foreground hover:text-foreground"
+				>
+					<X className="size-3.5" />
+				</button>
+			) : null}
+		</div>
+	);
+}
+
+interface SidebarSearchResultsProps {
+	readonly filtered: readonly PageDefinition[];
+	readonly query: string;
+	readonly pathname: string;
+	readonly pinnedSet: ReadonlySet<string>;
+	readonly onTogglePin: (toolId: string) => void;
+}
+
+function SidebarSearchResults({
+	filtered,
+	query,
+	pathname,
+	pinnedSet,
+	onTogglePin,
+}: SidebarSearchResultsProps) {
+	if (filtered.length === 0) {
+		return (
+			<div className="px-3 py-6 text-center text-xs text-muted-foreground">
+				No tools match <span className="font-medium text-foreground">&quot;{query}&quot;</span>
+			</div>
+		);
+	}
+	return (
+		<SidebarGroup>
+			<SidebarGroupLabel className="text-sidebar-foreground">
+				<div className="flex items-center gap-2 px-2 py-1.5">
+					<Search className="size-4 opacity-70" />
+					<span className="flex-1 text-left text-xs font-medium uppercase tracking-wider">
+						Search results ({filtered.length})
+					</span>
+				</div>
+			</SidebarGroupLabel>
+			<SidebarGroupContent>
+				<SidebarMenu>
+					{filtered.map((tool) => (
+						<ToolMenuItem
+							key={`search-${tool.id}`}
+							tool={tool}
+							active={pathname === tool.url}
+							pinned={pinnedSet.has(tool.id)}
+							onTogglePin={onTogglePin}
+							keyPrefix="search"
+						/>
+					))}
+				</SidebarMenu>
+			</SidebarGroupContent>
+		</SidebarGroup>
+	);
+}
+
 export function AppSidebar(_: AppSidebarProps = {}) {
 	const openGroups = useSidebarStore((s) => s.openGroups);
 	const setGroupOpen = useSidebarStore((s) => s.setGroupOpen);
@@ -89,22 +304,46 @@ export function AppSidebar(_: AppSidebarProps = {}) {
 
 	const pathname = useRouterState({ select: (state) => state.location.pathname });
 	const sidebar = useSidebar();
-	// Recent section shows only in collapsed (icon-only) mode. The expanded
-	// sidebar already displays every category inline, so a Recent section
-	// adds noise without value AND shifts the categorized tree downward
-	// when items get added or reordered. In icon-only mode the labels are
-	// hidden, so Recent earns its place as a quick-access shortcut row.
-	const showRecent = sidebar.state === 'collapsed';
+	const expanded = sidebar.state === 'expanded';
+	// Recent section shows only in collapsed (icon-only) mode. In expanded
+	// mode every tool is already reachable via Categories, so Recent would
+	// just add vertical noise and shift the tree when items change.
+	const showRecent = !expanded;
 
-	// Record visits to tool pages (excludes `/` and `/settings`, which are
-	// filtered out of `getToolPages`'s definition).
+	const [query, setQuery] = useState('');
+	const inputRef = useRef<HTMLInputElement | null>(null);
+
+	const handleQueryChange = useCallback((value: string) => setQuery(value), []);
+
+	// Search filter — case-insensitive substring match on title + description.
+	// Uses the existing getToolPages() helper so Dashboard / Settings are
+	// excluded automatically. Tab-level matches are intentionally not surfaced
+	// in the sidebar (those belong to the Cmd+K palette).
+	const filteredTools = useMemo<readonly PageDefinition[]>(() => {
+		const q = query.trim().toLowerCase();
+		if (!q) return [];
+		return getToolPages().filter(
+			(tool) => tool.title.toLowerCase().includes(q) || tool.description.toLowerCase().includes(q)
+		);
+	}, [query]);
+	const searchActive = query.trim().length > 0;
+
+	// Click handler for the collapsed-mode Search icon. Expands the sidebar
+	// first, then focuses the input on the next frame so the element is
+	// guaranteed mounted.
+	const expandAndFocusSearch = useCallback(() => {
+		sidebar.setOpen(true);
+		requestAnimationFrame(() => inputRef.current?.focus());
+	}, [sidebar]);
+
+	// Record visits to tool pages (excludes `/` and `/settings`).
 	useEffect(() => {
 		const page = getPageByUrl(pathname);
 		if (!page || page.id === 'dashboard' || page.id === 'settings') return;
 		recordVisit(page.id);
 	}, [pathname, recordVisit]);
 
-	const pinnedSet = new Set(pinned);
+	const pinnedSet = useMemo(() => new Set(pinned), [pinned]);
 
 	const pinnedPages = pinned
 		.map((id) => getPageById(id))
@@ -118,7 +357,7 @@ export function AppSidebar(_: AppSidebarProps = {}) {
 
 	return (
 		<Sidebar collapsible="icon">
-			<SidebarHeader className="border-b border-sidebar-border/50 pb-2">
+			<SidebarHeader className="gap-2 border-b border-sidebar-border/50 pb-2">
 				<SidebarMenu>
 					<SidebarMenuItem>
 						<SidebarMenuButton
@@ -133,100 +372,51 @@ export function AppSidebar(_: AppSidebarProps = {}) {
 						</SidebarMenuButton>
 					</SidebarMenuItem>
 				</SidebarMenu>
+				{expanded ? (
+					<SidebarSearchInput inputRef={inputRef} query={query} onQueryChange={handleQueryChange} />
+				) : (
+					<SidebarMenu>
+						<SidebarMenuItem>
+							<SidebarMenuButton tooltip="Search tools" onClick={expandAndFocusSearch}>
+								<Search />
+								<span>Search tools</span>
+							</SidebarMenuButton>
+						</SidebarMenuItem>
+					</SidebarMenu>
+				)}
 			</SidebarHeader>
 
 			<SidebarContent>
-				{pinnedPages.length > 0 ? (
-					<SidebarGroup>
-						<SidebarGroupLabel className="text-sidebar-foreground">
-							<div className="flex items-center gap-2 px-2 py-1.5">
-								<Pin className="size-4 opacity-70" />
-								<span className="flex-1 text-left text-xs font-semibold">Pinned</span>
-							</div>
-						</SidebarGroupLabel>
-						<SidebarGroupContent>
-							<SidebarMenu>
-								{pinnedPages.map((tool) => (
-									<ToolMenuItem
-										key={`pinned-${tool.id}`}
-										tool={tool}
-										active={pathname === tool.url}
-										pinned
-										onTogglePin={togglePin}
-										keyPrefix="pinned"
-									/>
-								))}
-							</SidebarMenu>
-						</SidebarGroupContent>
-					</SidebarGroup>
-				) : null}
-				{showRecent && recentPages.length > 0 ? (
-					<SidebarGroup>
-						<SidebarGroupLabel className="text-sidebar-foreground">
-							<div className="flex items-center gap-2 px-2 py-1.5">
-								<Clock className="size-4 opacity-70" />
-								<span className="flex-1 text-left text-xs font-semibold">Recent</span>
-							</div>
-						</SidebarGroupLabel>
-						<SidebarGroupContent>
-							<SidebarMenu>
-								{recentPages.map((tool) => (
-									<ToolMenuItem
-										key={`recent-${tool.id}`}
-										tool={tool}
-										active={pathname === tool.url}
-										pinned={false}
-										onTogglePin={togglePin}
-										keyPrefix="recent"
-									/>
-								))}
-							</SidebarMenu>
-						</SidebarGroupContent>
-					</SidebarGroup>
-				) : null}
-				{CATEGORIES.map((category) => {
-					const CategoryIcon = category.icon;
-					const categoryPages = getPagesByCategory(category.id);
-					const isOpen = openGroups[category.id] ?? category.defaultOpen;
-					return (
-						<Collapsible
-							key={category.id}
-							open={isOpen}
-							onOpenChange={(open) => setGroupOpen(category.id, open)}
-							className="group/collapsible"
-						>
-							<SidebarGroup>
-								<SidebarGroupLabel className="group/label p-0 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground">
-									<CollapsibleTrigger
-										className={cn(
-											'flex w-full items-center gap-2 border-l-2 px-2 py-1.5',
-											category.borderClass
-										)}
-									>
-										<CategoryIcon className="size-4 opacity-70" />
-										<span className="flex-1 text-left text-xs font-semibold">{category.label}</span>
-										<ChevronRight className="size-4 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
-									</CollapsibleTrigger>
-								</SidebarGroupLabel>
-								<CollapsibleContent>
-									<SidebarGroupContent>
-										<SidebarMenu>
-											{categoryPages.map((tool) => (
-												<ToolMenuItem
-													key={tool.id}
-													tool={tool}
-													active={pathname === tool.url}
-													pinned={pinnedSet.has(tool.id)}
-													onTogglePin={togglePin}
-												/>
-											))}
-										</SidebarMenu>
-									</SidebarGroupContent>
-								</CollapsibleContent>
-							</SidebarGroup>
-						</Collapsible>
-					);
-				})}
+				{searchActive ? (
+					<SidebarSearchResults
+						filtered={filteredTools}
+						query={query.trim()}
+						pathname={pathname}
+						pinnedSet={pinnedSet}
+						onTogglePin={togglePin}
+					/>
+				) : (
+					<>
+						{pinnedPages.length > 0 ? (
+							<PinnedGroup pages={pinnedPages} pathname={pathname} onTogglePin={togglePin} />
+						) : null}
+						{showRecent && recentPages.length > 0 ? (
+							<RecentGroup pages={recentPages} pathname={pathname} onTogglePin={togglePin} />
+						) : null}
+						{CATEGORIES.map((category) => (
+							<CategoryGroup
+								key={category.id}
+								category={category}
+								pages={getPagesByCategory(category.id)}
+								pathname={pathname}
+								isOpen={openGroups[category.id] ?? category.defaultOpen}
+								onOpenChange={(open) => setGroupOpen(category.id, open)}
+								pinnedSet={pinnedSet}
+								onTogglePin={togglePin}
+							/>
+						))}
+					</>
+				)}
 			</SidebarContent>
 
 			<SidebarFooter className="border-t border-sidebar-border py-1.5">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,7 +1,12 @@
 import { Link, createFileRoute } from '@tanstack/react-router';
 
 import { Card, CardContent } from '@/lib/components/ui/card';
-import { CATEGORIES, getPagesByCategory } from '@/lib/services/pages';
+import {
+	CATEGORIES,
+	getPagesByCategory,
+	type CategoryInfo,
+	type PageDefinition,
+} from '@/lib/services/pages';
 import { cn } from '@/lib/utils';
 
 export const Route = createFileRoute('/')({
@@ -11,79 +16,94 @@ export const Route = createFileRoute('/')({
 function HomePage() {
 	return (
 		<div className="flex h-full flex-col">
-			<main className="flex-1 overflow-y-auto p-6">
-				<div className="mx-auto max-w-5xl space-y-6">
-					{/* Welcome Section */}
-					<section className="rounded-xl border bg-gradient-to-br from-accent-brand/5 to-transparent p-6">
-						<div className="flex items-center gap-3">
-							<img src="/logo.svg" alt="" className="h-10 w-10" />
-							<div>
-								<h2 className="text-xl font-bold">Kogu</h2>
-								<p className="text-sm text-muted-foreground">
-									Developer tools suite. All processing is local.
-								</p>
-							</div>
-						</div>
-					</section>
-
-					{/* Tools by Category */}
-					{CATEGORIES.map((category) => {
-						const CategoryIcon = category.icon;
-						const tools = getPagesByCategory(category.id);
-						return (
-							<section key={category.id}>
-								<div
-									className={cn(
-										'mb-3 flex items-center gap-2 border-l-2 pl-2',
-										category.borderClass
-									)}
-								>
-									<CategoryIcon className={cn('h-4 w-4', category.iconClass)} />
-									<h3 className="text-sm font-bold text-muted-foreground">{category.label}</h3>
-								</div>
-								<div className="grid gap-4 sm:grid-cols-2">
-									{tools.map((tool) => {
-										const ToolIcon = tool.icon;
-										return (
-											<Link
-												key={tool.id}
-												to={tool.url as never}
-												className="group block rounded-xl outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/30"
-											>
-												<Card
-													density="compact"
-													className="h-full border-border/50 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-border hover:shadow-md"
-												>
-													<CardContent className="flex h-full items-center gap-3">
-														<div className="shrink-0 rounded-lg bg-accent-soft p-2">
-															<ToolIcon className={cn('h-6 w-6', tool.color)} />
-														</div>
-														<div className="min-w-0 flex-1">
-															<div className="text-sm font-semibold transition-transform duration-150 group-hover:translate-x-0.5">
-																{tool.title}
-															</div>
-															<p className="line-clamp-2 text-xs text-muted-foreground/80">
-																{tool.description}
-															</p>
-														</div>
-													</CardContent>
-												</Card>
-											</Link>
-										);
-									})}
-								</div>
-							</section>
-						);
-					})}
+			<main className="flex-1 overflow-y-auto">
+				<div className="mx-auto max-w-5xl space-y-8 px-6 py-8 sm:px-8 sm:py-10">
+					<Welcome />
+					{CATEGORIES.map((category) => (
+						<CategorySection key={category.id} category={category} />
+					))}
 				</div>
 			</main>
-
-			{/* Footer */}
-			<footer className="border-t border-border/50 px-4 py-1.5">
-				<p className="text-xs text-muted-foreground/50">
-					Built with Tauri 2 + React 19 + shadcn-ui + Tailwind CSS v4
-				</p>
-			</footer>
+			<Footer />
 		</div>
+	);
+}
+
+function Welcome() {
+	return (
+		<section className="rounded-lg border border-border/60 px-6 py-7 sm:px-8">
+			<div className="flex items-center gap-3">
+				<img src="/logo.svg" alt="" className="size-11" />
+				<div>
+					<h2 className="text-xl font-semibold tracking-tight">Kogu</h2>
+					<p className="mt-1 text-sm text-muted-foreground">
+						Developer tools suite. All processing is local.
+					</p>
+				</div>
+			</div>
+		</section>
+	);
+}
+
+interface CategorySectionProps {
+	readonly category: CategoryInfo;
+}
+
+function CategorySection({ category }: CategorySectionProps) {
+	const CategoryIcon = category.icon;
+	const tools = getPagesByCategory(category.id);
+	return (
+		<section>
+			<div className="mb-4 flex items-center gap-2">
+				<CategoryIcon className={cn('size-4', category.iconClass)} />
+				<h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground/80">
+					{category.label}
+				</h3>
+			</div>
+			<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+				{tools.map((tool) => (
+					<ToolCard key={tool.id} tool={tool} />
+				))}
+			</div>
+		</section>
+	);
+}
+
+interface ToolCardProps {
+	readonly tool: PageDefinition;
+}
+
+function ToolCard({ tool }: ToolCardProps) {
+	const ToolIcon = tool.icon;
+	return (
+		<Link
+			to={tool.url as never}
+			className="group block rounded-lg outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/30"
+		>
+			<Card
+				density="compact"
+				className="h-full border-border/60 transition-colors duration-150 hover:border-border hover:bg-surface-2/60"
+			>
+				<CardContent className="flex h-full items-center gap-3">
+					<div className="shrink-0 rounded-md bg-muted/60 p-2">
+						<ToolIcon className={cn('size-5', tool.color)} />
+					</div>
+					<div className="min-w-0 flex-1">
+						<div className="text-sm font-medium">{tool.title}</div>
+						<p className="line-clamp-2 text-xs text-muted-foreground">{tool.description}</p>
+					</div>
+				</CardContent>
+			</Card>
+		</Link>
+	);
+}
+
+function Footer() {
+	return (
+		<footer className="border-t border-border/40 px-6 py-2">
+			<p className="text-xs text-muted-foreground/50">
+				Built with Tauri 2 + React 19 + shadcn-ui + Tailwind CSS v4
+			</p>
+		</footer>
 	);
 }


### PR DESCRIPTION
## Summary

Redesign of `AppSidebar` and the home page (`/`) for a more focused, minimal-flat aesthetic.

- **Sidebar** gains an inline search input in the header and a filtered flat-list view when the query is non-empty. Existing Pinned / Recent / Category sections are preserved.
- **Home page** drops decorative gradients, shadows, and hover transforms in favor of subtle borders + neutral hovers. Internal JSX is split into named components for readability.

## Changes

### Sidebar (`src/lib/components/layout/app-sidebar.tsx`)

- `SidebarSearchInput` + `SidebarSearchResults` (new file-internal components)
- `PinnedGroup` / `RecentGroup` / `CategoryGroup` extracted from inline JSX
- Filter via existing `getToolPages()` — case-insensitive substring on title + description
- Icon-only mode replaces the input with a Search icon button that expands the sidebar and focuses the input
- ESC inside the input clears the query
- Section labels normalize to `text-xs font-medium uppercase tracking-wider muted`
- Colored decorative `border-l-2` stripe on category headers is removed

### Home page (`src/routes/index.tsx`)

- Split into `Welcome` / `CategorySection` / `ToolCard` / `Footer` named functions
- Welcome: gradient removed, single subtle border + neutral bg, title uses `tracking-tight`
- CategorySection: left stripe removed, label moves to uppercase small muted
- ToolCard: `shadow-*` and hover `translate-*` removed; hover is now `bg-surface-2/60 + border-border`; icon container switches to neutral `bg-muted/60`; title becomes `font-medium`; grid gains `lg:grid-cols-3`
- Per-tool / per-category color accents are retained (Kogu identity)

### Out of scope (intentionally not changed)

- Keyboard navigation in search (arrow keys / Enter) — YAGNI
- Fuzzy / typo-tolerant matching — YAGNI
- Sidebar variant (still `sidebar`; not switched to `inset` / `floating`)
- Cmd+K command palette (kept for global ops)

## Test Plan

- [x] `bun run check` (TypeScript + validate-pages + audit-design)
- [x] `bun run format`
- [x] `bun run lint` (no new warnings)
- [x] Visual verification in light + dark for:
  - Sidebar expanded (Pinned + Categories)
  - Sidebar search active (query "json" → 3 results)
  - Sidebar empty state ("No tools match \"zzzznotfound\"")
  - Home page (3-column grid at lg, neutral icon containers)
  - 3-tier chrome hierarchy unchanged (AppSidebar > Rail/ToolBar > Editor)
