### PR TITLE
refactor(formatter-tabs): consolidate format-tab via FormatTabTemplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,8 @@ CLAUDE.local.md
 # Playwright MCP
 .playwright-mcp/
 
+# Superpowers brainstorming (local-only working artifacts)
+.superpowers/
+
 # Swift build artifacts
 src-tauri/swift/**/.build/

--- a/src/lib/components/formatter-tabs/json/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/format-tab.tsx
@@ -1,18 +1,9 @@
 import { FileText } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 
 import type { ContextMenuItem } from '@/lib/components/editor';
-import { getErrorMessage } from '@/lib/utils';
-import {
-	FormCheckbox,
-	FormCheckboxGroup,
-	FormMode,
-	FormSection,
-	FormSelect,
-} from '@/lib/components/form';
-import { InputOutputSplit } from '@/lib/components/layout';
-import { Rail } from '@/lib/components/ui/rail';
-import { useClipboardActions, useReportStats } from '@/lib/hooks';
+import { FormCheckbox, FormCheckboxGroup, FormSection, FormSelect } from '@/lib/components/form';
+import { FormatTabTemplate, type FormatMode } from '@/lib/components/template';
 import {
 	defaultJsonFormatOptions,
 	type JsonFormatOptions,
@@ -25,34 +16,55 @@ import {
 	validateJson,
 } from '@/lib/services/formatters';
 import { useJsonFormatterOptions } from '@/lib/stores';
+import { getErrorMessage } from '@/lib/utils';
 
 import { JsonFormatSection } from './json-format-section';
 
-type FormatMode = 'format' | 'minify';
 type IndentType = 'spaces' | 'tabs';
 type QuoteStyle = 'double' | 'single';
 
-interface TabStats {
-	readonly input: string;
-	readonly valid: boolean | null;
-	readonly error: string;
+interface JsonFormatTabOptions {
+	readonly indentSizeStr: string;
+	readonly indentType: IndentType;
+	readonly sortKeys: boolean;
+	readonly removeNulls: boolean;
+	readonly removeEmptyStrings: boolean;
+	readonly removeEmptyArrays: boolean;
+	readonly removeEmptyObjects: boolean;
+	readonly escapeUnicode: boolean;
+	readonly trailingComma: boolean;
+	readonly quoteStyle: QuoteStyle;
+	readonly arrayBracketSpacing: boolean;
+	readonly objectBracketSpacing: boolean;
+	readonly colonSpacing: boolean;
+	readonly compactArrays: boolean;
+	readonly maxDepthStr: string;
 }
 
-interface FormatTabProps {
-	readonly input: string;
-	readonly onInputChange: (value: string) => void;
-	readonly onStatsChange?: (stats: TabStats) => void;
-}
+const DEFAULT_OPTIONS: JsonFormatTabOptions = {
+	indentSizeStr: String(defaultJsonFormatOptions.indentSize),
+	indentType: defaultJsonFormatOptions.indentType,
+	sortKeys: defaultJsonFormatOptions.sortKeys,
+	removeNulls: defaultJsonFormatOptions.removeNulls,
+	removeEmptyStrings: defaultJsonFormatOptions.removeEmptyStrings,
+	removeEmptyArrays: defaultJsonFormatOptions.removeEmptyArrays,
+	removeEmptyObjects: defaultJsonFormatOptions.removeEmptyObjects,
+	escapeUnicode: defaultJsonFormatOptions.escapeUnicode,
+	trailingComma: defaultJsonFormatOptions.trailingComma,
+	quoteStyle: defaultJsonFormatOptions.quoteStyle,
+	arrayBracketSpacing: defaultJsonFormatOptions.arrayBracketSpacing,
+	objectBracketSpacing: defaultJsonFormatOptions.objectBracketSpacing,
+	colonSpacing: defaultJsonFormatOptions.colonSpacing,
+	compactArrays: defaultJsonFormatOptions.compactArrays,
+	maxDepthStr: String(defaultJsonFormatOptions.maxDepth),
+};
 
 type Transform = (input: string) => string;
 
 const identity: Transform = (input) => input;
 
 const escapeUnicodeTransform: Transform = (input) =>
-	input.replace(
-		/[\u0080-\uffff]/g,
-		(char) => `\\u${`0000${char.charCodeAt(0).toString(16)}`.slice(-4)}`
-	);
+	input.replace(/[-￿]/g, (char) => `\\u${`0000${char.charCodeAt(0).toString(16)}`.slice(-4)}`);
 
 const arrayBracketSpacingTransform: Transform = (input) =>
 	input.replace(/\[(?!\s*\n)/g, '[ ').replace(/(?<!\n\s*)\]/g, ' ]');
@@ -82,132 +94,77 @@ const buildFormatTransforms = (options: Partial<JsonFormatOptions>): readonly Tr
 	];
 };
 
-interface FormattedResult {
-	readonly output: string;
-	readonly error: string;
-}
+const toJsonFormatOptions = (tabOptions: JsonFormatTabOptions): Partial<JsonFormatOptions> => ({
+	indentSize: Number.parseInt(tabOptions.indentSizeStr, 10) || 2,
+	indentType: tabOptions.indentType,
+	sortKeys: tabOptions.sortKeys,
+	removeNulls: tabOptions.removeNulls,
+	removeEmptyStrings: tabOptions.removeEmptyStrings,
+	removeEmptyArrays: tabOptions.removeEmptyArrays,
+	removeEmptyObjects: tabOptions.removeEmptyObjects,
+	escapeUnicode: tabOptions.escapeUnicode,
+	trailingComma: tabOptions.trailingComma,
+	quoteStyle: tabOptions.quoteStyle,
+	arrayBracketSpacing: tabOptions.arrayBracketSpacing,
+	objectBracketSpacing: tabOptions.objectBracketSpacing,
+	colonSpacing: tabOptions.colonSpacing,
+	compactArrays: tabOptions.compactArrays,
+	maxDepth: Number.parseInt(tabOptions.maxDepthStr, 10) || 0,
+});
 
-const computeFormattedOutput = (
-	input: string,
-	inputFormat: JsonInputFormat,
-	outputFormat: JsonOutputFormat,
-	formatMode: FormatMode,
-	formatOptions: Partial<JsonFormatOptions>
-): FormattedResult => {
-	if (!input.trim()) return { output: '', error: '' };
+const buildComputeOutput =
+	(inputFormat: JsonInputFormat, outputFormat: JsonOutputFormat) =>
+	(input: string, mode: FormatMode, tabOptions: JsonFormatTabOptions) => {
+		if (!input.trim()) return { output: '', error: '' };
 
-	try {
-		const data = parseJson(input, inputFormat);
-		const processedData = processJsonWithOptions(data, formatOptions);
+		const formatOptions = toJsonFormatOptions(tabOptions);
 
-		if (formatMode === 'minify') {
-			return { output: stringifyJson(processedData, outputFormat, { indent: 0 }), error: '' };
+		try {
+			const data = parseJson(input, inputFormat);
+			const processedData = processJsonWithOptions(data, formatOptions);
+
+			if (mode === 'minify') {
+				return {
+					output: stringifyJson(processedData, outputFormat, { indent: 0 }),
+					error: '',
+				};
+			}
+
+			const baseResult = stringifyJson(processedData, outputFormat, {
+				indent: formatOptions.indentType === 'tabs' ? '\t' : formatOptions.indentSize,
+				sortKeys: formatOptions.sortKeys,
+				trailingComma: formatOptions.trailingComma,
+				quote: formatOptions.quoteStyle,
+			});
+
+			const transforms = buildFormatTransforms(formatOptions);
+			return {
+				output: transforms.reduce((acc, transform) => transform(acc), baseResult),
+				error: '',
+			};
+		} catch (e) {
+			return { output: '', error: getErrorMessage(e, 'Invalid JSON') };
 		}
+	};
 
-		const baseResult = stringifyJson(processedData, outputFormat, {
-			indent: formatOptions.indentType === 'tabs' ? '\t' : formatOptions.indentSize,
-			sortKeys: formatOptions.sortKeys,
-			trailingComma: formatOptions.trailingComma,
-			quote: formatOptions.quoteStyle,
-		});
-
-		const transforms = buildFormatTransforms(formatOptions);
-		return {
-			output: transforms.reduce((acc, transform) => transform(acc), baseResult),
-			error: '',
-		};
-	} catch (e) {
-		return { output: '', error: getErrorMessage(e, 'Invalid JSON') };
-	}
+const buildValidate = (inputFormat: JsonInputFormat) => (input: string) => {
+	if (!input.trim()) return null;
+	return validateJson(input, inputFormat).valid;
 };
+
+interface FormatTabProps {
+	readonly input: string;
+	readonly onInputChange: (value: string) => void;
+	readonly onStatsChange?: (stats: {
+		readonly input: string;
+		readonly valid: boolean | null;
+		readonly error: string;
+	}) => void;
+}
 
 export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProps) {
 	const { value: jsonOptions } = useJsonFormatterOptions();
 	const { inputFormat, outputFormat } = jsonOptions;
-
-	const [formatMode, setFormatMode] = useState<FormatMode>('format');
-	const [showOptions, setShowOptions] = useState(true);
-
-	// Format options.
-	const [indentSizeStr, setIndentSizeStr] = useState<string>(
-		String(defaultJsonFormatOptions.indentSize)
-	);
-	const [indentType, setIndentType] = useState<IndentType>(defaultJsonFormatOptions.indentType);
-	const [sortKeys, setSortKeys] = useState<boolean>(defaultJsonFormatOptions.sortKeys);
-	const [removeNulls, setRemoveNulls] = useState<boolean>(defaultJsonFormatOptions.removeNulls);
-	const [removeEmptyStrings, setRemoveEmptyStrings] = useState<boolean>(
-		defaultJsonFormatOptions.removeEmptyStrings
-	);
-	const [removeEmptyArrays, setRemoveEmptyArrays] = useState<boolean>(
-		defaultJsonFormatOptions.removeEmptyArrays
-	);
-	const [removeEmptyObjects, setRemoveEmptyObjects] = useState<boolean>(
-		defaultJsonFormatOptions.removeEmptyObjects
-	);
-	const [escapeUnicode, setEscapeUnicode] = useState<boolean>(
-		defaultJsonFormatOptions.escapeUnicode
-	);
-	const [trailingComma, setTrailingComma] = useState<boolean>(
-		defaultJsonFormatOptions.trailingComma
-	);
-	const [quoteStyle, setQuoteStyle] = useState<QuoteStyle>(defaultJsonFormatOptions.quoteStyle);
-	const [arrayBracketSpacing, setArrayBracketSpacing] = useState<boolean>(
-		defaultJsonFormatOptions.arrayBracketSpacing
-	);
-	const [objectBracketSpacing, setObjectBracketSpacing] = useState<boolean>(
-		defaultJsonFormatOptions.objectBracketSpacing
-	);
-	const [colonSpacing, setColonSpacing] = useState<boolean>(defaultJsonFormatOptions.colonSpacing);
-	const [compactArrays, setCompactArrays] = useState<boolean>(
-		defaultJsonFormatOptions.compactArrays
-	);
-	const [maxDepthStr, setMaxDepthStr] = useState<string>(String(defaultJsonFormatOptions.maxDepth));
-
-	const indentSize = Number.parseInt(indentSizeStr, 10) || 2;
-	const maxDepth = Number.parseInt(maxDepthStr, 10) || 0;
-
-	const formatOptions: Partial<JsonFormatOptions> = {
-		indentSize,
-		indentType,
-		sortKeys,
-		removeNulls,
-		removeEmptyStrings,
-		removeEmptyArrays,
-		removeEmptyObjects,
-		escapeUnicode,
-		trailingComma,
-		quoteStyle,
-		arrayBracketSpacing,
-		objectBracketSpacing,
-		colonSpacing,
-		compactArrays,
-		maxDepth,
-	};
-
-	const validation = useMemo<{ valid: boolean | null }>(() => {
-		if (!input.trim()) return { valid: null };
-		const result = validateJson(input, inputFormat);
-		return { valid: result.valid };
-	}, [input, inputFormat]);
-
-	const { output, error: formatError } = computeFormattedOutput(
-		input,
-		inputFormat,
-		outputFormat,
-		formatMode,
-		formatOptions
-	);
-
-	useReportStats(onStatsChange, input, validation.valid, formatError);
-
-	const { handlePaste, handleClear, handleCopy } = useClipboardActions({
-		onInputChange,
-		output,
-	});
-
-	const handleSample = () => {
-		onInputChange(SAMPLE_JSON);
-	};
 
 	const handleFormatInput = () => {
 		try {
@@ -228,51 +185,32 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 	};
 
 	const inputContextMenuItems: readonly ContextMenuItem[] = [
-		{
-			text: 'Format JSON',
-			enabled: input.trim().length > 0,
-			action: handleFormatInput,
-		},
-		{
-			text: 'Minify JSON',
-			enabled: input.trim().length > 0,
-			action: handleMinifyInput,
-		},
+		{ text: 'Format JSON', enabled: input.trim().length > 0, action: handleFormatInput },
+		{ text: 'Minify JSON', enabled: input.trim().length > 0, action: handleMinifyInput },
 	];
 
-	return (
-		<div className="flex flex-1 overflow-hidden">
-			<Rail
-				show={showOptions}
-				onClose={() => setShowOptions(false)}
-				onOpen={() => setShowOptions(true)}
-			>
-				<JsonFormatSection />
+	const renderOptions = (
+		options: JsonFormatTabOptions,
+		setOptions: (next: JsonFormatTabOptions) => void
+	): ReactNode => {
+		const update = <K extends keyof JsonFormatTabOptions>(key: K, value: JsonFormatTabOptions[K]) =>
+			setOptions({ ...options, [key]: value });
 
-				<FormSection title="Mode">
-					<FormMode
-						value={formatMode}
-						onValueChange={setFormatMode}
-						options={[
-							{ value: 'format', label: 'Format' },
-							{ value: 'minify', label: 'Minify' },
-						]}
-					/>
-				</FormSection>
-
+		return (
+			<>
 				<FormSection title="Indentation">
 					<div className="grid grid-cols-2 gap-2">
 						<FormSelect
 							label="Size"
-							value={indentSizeStr}
-							onValueChange={setIndentSizeStr}
+							value={options.indentSizeStr}
+							onValueChange={(v) => update('indentSizeStr', v)}
 							options={['1', '2', '3', '4', '8']}
 							size="compact"
 						/>
 						<FormSelect
 							label="Type"
-							value={indentType}
-							onValueChange={(v) => setIndentType(v as IndentType)}
+							value={options.indentType}
+							onValueChange={(v) => update('indentType', v as IndentType)}
 							options={[
 								{ value: 'spaces', label: 'Spaces' },
 								{ value: 'tabs', label: 'Tabs' },
@@ -286,8 +224,8 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 					<div className="grid grid-cols-2 gap-2">
 						<FormSelect
 							label="Quotes"
-							value={quoteStyle}
-							onValueChange={(v) => setQuoteStyle(v as QuoteStyle)}
+							value={options.quoteStyle}
+							onValueChange={(v) => update('quoteStyle', v as QuoteStyle)}
 							options={[
 								{ value: 'double', label: '"..."' },
 								{ value: 'single', label: "'...'" },
@@ -296,8 +234,8 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 						/>
 						<FormSelect
 							label="Max Depth"
-							value={maxDepthStr}
-							onValueChange={setMaxDepthStr}
+							value={options.maxDepthStr}
+							onValueChange={(v) => update('maxDepthStr', v)}
 							options={[
 								{ value: '0', label: '∞' },
 								{ value: '1', label: '1' },
@@ -312,14 +250,14 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 					<FormCheckboxGroup className="pt-1">
 						<FormCheckbox
 							label="Sort keys alphabetically"
-							checked={sortKeys}
-							onCheckedChange={setSortKeys}
+							checked={options.sortKeys}
+							onCheckedChange={(v) => update('sortKeys', v)}
 							size="compact"
 						/>
 						<FormCheckbox
 							label="Escape unicode characters"
-							checked={escapeUnicode}
-							onCheckedChange={setEscapeUnicode}
+							checked={options.escapeUnicode}
+							onCheckedChange={(v) => update('escapeUnicode', v)}
 							size="compact"
 						/>
 					</FormCheckboxGroup>
@@ -329,32 +267,32 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 					<FormCheckboxGroup>
 						<FormCheckbox
 							label="Space after colon"
-							checked={colonSpacing}
-							onCheckedChange={setColonSpacing}
+							checked={options.colonSpacing}
+							onCheckedChange={(v) => update('colonSpacing', v)}
 							size="compact"
 						/>
 						<FormCheckbox
 							label="Array bracket spacing"
-							checked={arrayBracketSpacing}
-							onCheckedChange={setArrayBracketSpacing}
+							checked={options.arrayBracketSpacing}
+							onCheckedChange={(v) => update('arrayBracketSpacing', v)}
 							size="compact"
 						/>
 						<FormCheckbox
 							label="Object bracket spacing"
-							checked={objectBracketSpacing}
-							onCheckedChange={setObjectBracketSpacing}
+							checked={options.objectBracketSpacing}
+							onCheckedChange={(v) => update('objectBracketSpacing', v)}
 							size="compact"
 						/>
 						<FormCheckbox
 							label="Trailing commas"
-							checked={trailingComma}
-							onCheckedChange={setTrailingComma}
+							checked={options.trailingComma}
+							onCheckedChange={(v) => update('trailingComma', v)}
 							size="compact"
 						/>
 						<FormCheckbox
 							label="Compact arrays"
-							checked={compactArrays}
-							onCheckedChange={setCompactArrays}
+							checked={options.compactArrays}
+							onCheckedChange={(v) => update('compactArrays', v)}
 							size="compact"
 						/>
 					</FormCheckboxGroup>
@@ -364,49 +302,53 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 					<FormCheckboxGroup>
 						<FormCheckbox
 							label="Remove null values"
-							checked={removeNulls}
-							onCheckedChange={setRemoveNulls}
+							checked={options.removeNulls}
+							onCheckedChange={(v) => update('removeNulls', v)}
 							size="compact"
 						/>
 						<FormCheckbox
 							label="Remove empty strings"
-							checked={removeEmptyStrings}
-							onCheckedChange={setRemoveEmptyStrings}
+							checked={options.removeEmptyStrings}
+							onCheckedChange={(v) => update('removeEmptyStrings', v)}
 							size="compact"
 						/>
 						<FormCheckbox
 							label="Remove empty arrays"
-							checked={removeEmptyArrays}
-							onCheckedChange={setRemoveEmptyArrays}
+							checked={options.removeEmptyArrays}
+							onCheckedChange={(v) => update('removeEmptyArrays', v)}
 							size="compact"
 						/>
 						<FormCheckbox
 							label="Remove empty objects"
-							checked={removeEmptyObjects}
-							onCheckedChange={setRemoveEmptyObjects}
+							checked={options.removeEmptyObjects}
+							onCheckedChange={(v) => update('removeEmptyObjects', v)}
 							size="compact"
 						/>
 					</FormCheckboxGroup>
 				</FormSection>
-			</Rail>
+			</>
+		);
+	};
 
-			<InputOutputSplit
-				input={input}
-				onInputChange={onInputChange}
-				editorMode="json"
-				inputPlaceholder="Enter JSON here..."
-				onSample={handleSample}
-				onPaste={handlePaste}
-				onClear={handleClear}
-				inputContextMenuItems={inputContextMenuItems}
-				output={output}
-				outputPlaceholder="Formatted output..."
-				onCopy={handleCopy}
-				emptyIcon={FileText}
-				emptyTitle="Enter JSON to format"
-				emptyDescription="The formatted (or minified) document will appear here."
-			/>
-		</div>
+	return (
+		<FormatTabTemplate<JsonFormatTabOptions>
+			input={input}
+			onInputChange={onInputChange}
+			onStatsChange={onStatsChange}
+			inputEditorMode="json"
+			inputPlaceholder="Enter JSON here..."
+			outputPlaceholder="Formatted output..."
+			emptyIcon={FileText}
+			emptyTitle="Enter JSON to format"
+			emptyDescription="The formatted (or minified) document will appear here."
+			sampleText={SAMPLE_JSON}
+			validate={buildValidate(inputFormat)}
+			computeOutput={buildComputeOutput(inputFormat, outputFormat)}
+			defaultOptions={DEFAULT_OPTIONS}
+			renderOptions={renderOptions}
+			renderRailHeader={() => <JsonFormatSection />}
+			inputContextMenuItems={inputContextMenuItems}
+		/>
 	);
 }
 

--- a/src/lib/components/formatter-tabs/xml/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/format-tab.tsx
@@ -1,18 +1,9 @@
 import { FileText } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 
 import type { ContextMenuItem } from '@/lib/components/editor';
-import { getErrorMessage } from '@/lib/utils';
-import {
-	FormCheckbox,
-	FormCheckboxGroup,
-	FormMode,
-	FormSection,
-	FormSelect,
-} from '@/lib/components/form';
-import { InputOutputSplit } from '@/lib/components/layout';
-import { Rail } from '@/lib/components/ui/rail';
-import { useClipboardActions, useReportStats } from '@/lib/hooks';
+import { FormCheckbox, FormCheckboxGroup, FormSection, FormSelect } from '@/lib/components/form';
+import { FormatTabTemplate, type FormatMode } from '@/lib/components/template';
 import {
 	defaultXmlFormatOptions,
 	formatXml,
@@ -20,107 +11,77 @@ import {
 	SAMPLE_XML,
 	type XmlFormatOptions,
 } from '@/lib/services/formatters';
+import { getErrorMessage } from '@/lib/utils';
 
-type FormatMode = 'format' | 'minify';
 type IndentType = 'spaces' | 'tabs';
 
-interface TabStats {
-	readonly input: string;
-	readonly valid: boolean | null;
-	readonly error: string;
+interface XmlFormatTabOptions {
+	readonly indentSizeStr: string;
+	readonly indentType: IndentType;
+	readonly collapseContent: boolean;
+	readonly whiteSpaceAtEndOfSelfclosingTag: boolean;
+	readonly excludeComments: boolean;
+	readonly preserveWhitespace: boolean;
+	readonly forceSelfClosingEmptyTag: boolean;
+	readonly sortAttributes: boolean;
 }
+
+const DEFAULT_OPTIONS: XmlFormatTabOptions = {
+	indentSizeStr: String(defaultXmlFormatOptions.indentSize),
+	indentType: defaultXmlFormatOptions.indentType,
+	collapseContent: defaultXmlFormatOptions.collapseContent,
+	whiteSpaceAtEndOfSelfclosingTag: defaultXmlFormatOptions.whiteSpaceAtEndOfSelfclosingTag,
+	excludeComments: defaultXmlFormatOptions.excludeComments,
+	preserveWhitespace: defaultXmlFormatOptions.preserveWhitespace,
+	forceSelfClosingEmptyTag: defaultXmlFormatOptions.forceSelfClosingEmptyTag,
+	sortAttributes: defaultXmlFormatOptions.sortAttributes,
+};
+
+const toXmlFormatOptions = (tab: XmlFormatTabOptions): Partial<XmlFormatOptions> => ({
+	indentSize: Number.parseInt(tab.indentSizeStr, 10) || 2,
+	indentType: tab.indentType,
+	collapseContent: tab.collapseContent,
+	whiteSpaceAtEndOfSelfclosingTag: tab.whiteSpaceAtEndOfSelfclosingTag,
+	excludeComments: tab.excludeComments,
+	preserveWhitespace: tab.preserveWhitespace,
+	forceSelfClosingEmptyTag: tab.forceSelfClosingEmptyTag,
+	sortAttributes: tab.sortAttributes,
+});
+
+const computeOutput = (input: string, mode: FormatMode, tab: XmlFormatTabOptions) => {
+	if (!input.trim()) return { output: '', error: '' };
+	try {
+		const result = mode === 'minify' ? minifyXml(input) : formatXml(input, toXmlFormatOptions(tab));
+		return { output: result, error: '' };
+	} catch (e) {
+		return { output: '', error: getErrorMessage(e, 'Invalid XML') };
+	}
+};
+
+const validate = (input: string): boolean | null => {
+	if (!input.trim()) return null;
+	try {
+		const doc = new DOMParser().parseFromString(input, 'application/xml');
+		return doc.querySelector('parsererror') === null;
+	} catch {
+		return false;
+	}
+};
 
 interface FormatTabProps {
 	readonly input: string;
 	readonly onInputChange: (value: string) => void;
-	readonly onStatsChange?: (stats: TabStats) => void;
+	readonly onStatsChange?: (stats: {
+		readonly input: string;
+		readonly valid: boolean | null;
+		readonly error: string;
+	}) => void;
 }
 
 export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProps) {
-	const [formatMode, setFormatMode] = useState<FormatMode>('format');
-	const [showOptions, setShowOptions] = useState(true);
-
-	// Indentation options.
-	const [indentSizeStr, setIndentSizeStr] = useState<string>(
-		String(defaultXmlFormatOptions.indentSize)
-	);
-	const [indentType, setIndentType] = useState<IndentType>(defaultXmlFormatOptions.indentType);
-
-	// Tag options.
-	const [whiteSpaceAtEndOfSelfclosingTag, setWhiteSpaceAtEndOfSelfclosingTag] = useState<boolean>(
-		defaultXmlFormatOptions.whiteSpaceAtEndOfSelfclosingTag
-	);
-	const [forceSelfClosingEmptyTag, setForceSelfClosingEmptyTag] = useState<boolean>(
-		defaultXmlFormatOptions.forceSelfClosingEmptyTag
-	);
-
-	// Content options.
-	const [collapseContent, setCollapseContent] = useState<boolean>(
-		defaultXmlFormatOptions.collapseContent
-	);
-	const [preserveWhitespace, setPreserveWhitespace] = useState<boolean>(
-		defaultXmlFormatOptions.preserveWhitespace
-	);
-	const [excludeComments, setExcludeComments] = useState<boolean>(
-		defaultXmlFormatOptions.excludeComments
-	);
-
-	// Attribute options.
-	const [sortAttributes, setSortAttributes] = useState<boolean>(
-		defaultXmlFormatOptions.sortAttributes
-	);
-
-	const indentSize = Number.parseInt(indentSizeStr, 10) || 2;
-
-	const formatOptions: Partial<XmlFormatOptions> = {
-		indentSize,
-		indentType,
-		collapseContent,
-		whiteSpaceAtEndOfSelfclosingTag,
-		excludeComments,
-		preserveWhitespace,
-		forceSelfClosingEmptyTag,
-		sortAttributes,
-	};
-
-	const validation = useMemo<{ valid: boolean | null }>(() => {
-		if (!input.trim()) return { valid: null };
-		try {
-			const parser = new DOMParser();
-			const doc = parser.parseFromString(input, 'application/xml');
-			const parserError = doc.querySelector('parsererror');
-			return { valid: parserError === null };
-		} catch {
-			return { valid: false };
-		}
-	}, [input]);
-
-	const { output, error: formatError } = ((): { output: string; error: string } => {
-		if (!input.trim()) return { output: '', error: '' };
-		try {
-			const result = formatMode === 'minify' ? minifyXml(input) : formatXml(input, formatOptions);
-			return { output: result, error: '' };
-		} catch (e) {
-			return { output: '', error: getErrorMessage(e, 'Invalid XML') };
-		}
-	})();
-
-	// Report stats to parent.
-	useReportStats(onStatsChange, input, validation.valid, formatError);
-
-	const { handlePaste, handleClear, handleCopy } = useClipboardActions({
-		onInputChange,
-		output,
-	});
-
-	const handleSample = () => {
-		onInputChange(SAMPLE_XML);
-	};
-
 	const handleFormatInput = () => {
 		try {
-			const formatted = formatXml(input, { indentSize: 2, indentType: 'spaces' });
-			onInputChange(formatted);
+			onInputChange(formatXml(input, { indentSize: 2, indentType: 'spaces' }));
 		} catch {
 			// Invalid XML.
 		}
@@ -128,57 +89,39 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 
 	const handleMinifyInput = () => {
 		try {
-			const minified = minifyXml(input);
-			onInputChange(minified);
+			onInputChange(minifyXml(input));
 		} catch {
 			// Invalid XML.
 		}
 	};
 
 	const inputContextMenuItems: readonly ContextMenuItem[] = [
-		{
-			text: 'Format XML',
-			enabled: input.trim().length > 0,
-			action: handleFormatInput,
-		},
-		{
-			text: 'Minify XML',
-			enabled: input.trim().length > 0,
-			action: handleMinifyInput,
-		},
+		{ text: 'Format XML', enabled: input.trim().length > 0, action: handleFormatInput },
+		{ text: 'Minify XML', enabled: input.trim().length > 0, action: handleMinifyInput },
 	];
 
-	return (
-		<div className="flex flex-1 overflow-hidden">
-			<Rail
-				show={showOptions}
-				onClose={() => setShowOptions(false)}
-				onOpen={() => setShowOptions(true)}
-			>
-				<FormSection title="Mode">
-					<FormMode
-						value={formatMode}
-						onValueChange={setFormatMode}
-						options={[
-							{ value: 'format', label: 'Format' },
-							{ value: 'minify', label: 'Minify' },
-						]}
-					/>
-				</FormSection>
+	const renderOptions = (
+		options: XmlFormatTabOptions,
+		setOptions: (next: XmlFormatTabOptions) => void
+	): ReactNode => {
+		const update = <K extends keyof XmlFormatTabOptions>(key: K, value: XmlFormatTabOptions[K]) =>
+			setOptions({ ...options, [key]: value });
 
+		return (
+			<>
 				<FormSection title="Indentation">
 					<div className="grid grid-cols-2 gap-2">
 						<FormSelect
 							label="Size"
-							value={indentSizeStr}
-							onValueChange={setIndentSizeStr}
+							value={options.indentSizeStr}
+							onValueChange={(v) => update('indentSizeStr', v)}
 							options={['1', '2', '4', '8']}
 							size="compact"
 						/>
 						<FormSelect
 							label="Type"
-							value={indentType}
-							onValueChange={(v) => setIndentType(v as IndentType)}
+							value={options.indentType}
+							onValueChange={(v) => update('indentType', v as IndentType)}
 							options={[
 								{ value: 'spaces', label: 'Spaces' },
 								{ value: 'tabs', label: 'Tabs' },
@@ -191,14 +134,14 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 				<FormSection title="Tags">
 					<FormCheckbox
 						label="Space before self-closing />"
-						checked={whiteSpaceAtEndOfSelfclosingTag}
-						onCheckedChange={setWhiteSpaceAtEndOfSelfclosingTag}
+						checked={options.whiteSpaceAtEndOfSelfclosingTag}
+						onCheckedChange={(v) => update('whiteSpaceAtEndOfSelfclosingTag', v)}
 						size="compact"
 					/>
 					<FormCheckbox
 						label="Force self-closing empty tags"
-						checked={forceSelfClosingEmptyTag}
-						onCheckedChange={setForceSelfClosingEmptyTag}
+						checked={options.forceSelfClosingEmptyTag}
+						onCheckedChange={(v) => update('forceSelfClosingEmptyTag', v)}
 						size="compact"
 					/>
 				</FormSection>
@@ -207,20 +150,20 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 					<FormCheckboxGroup>
 						<FormCheckbox
 							label="Collapse content on single line"
-							checked={collapseContent}
-							onCheckedChange={setCollapseContent}
+							checked={options.collapseContent}
+							onCheckedChange={(v) => update('collapseContent', v)}
 							size="compact"
 						/>
 						<FormCheckbox
 							label="Preserve whitespace"
-							checked={preserveWhitespace}
-							onCheckedChange={setPreserveWhitespace}
+							checked={options.preserveWhitespace}
+							onCheckedChange={(v) => update('preserveWhitespace', v)}
 							size="compact"
 						/>
 						<FormCheckbox
 							label="Remove comments"
-							checked={excludeComments}
-							onCheckedChange={setExcludeComments}
+							checked={options.excludeComments}
+							onCheckedChange={(v) => update('excludeComments', v)}
 							size="compact"
 						/>
 					</FormCheckboxGroup>
@@ -229,30 +172,33 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 				<FormSection title="Attributes">
 					<FormCheckbox
 						label="Sort attributes alphabetically"
-						checked={sortAttributes}
-						onCheckedChange={setSortAttributes}
+						checked={options.sortAttributes}
+						onCheckedChange={(v) => update('sortAttributes', v)}
 						size="compact"
 					/>
 				</FormSection>
-			</Rail>
+			</>
+		);
+	};
 
-			<InputOutputSplit
-				input={input}
-				onInputChange={onInputChange}
-				editorMode="xml"
-				inputPlaceholder="Enter XML here..."
-				onSample={handleSample}
-				onPaste={handlePaste}
-				onClear={handleClear}
-				inputContextMenuItems={inputContextMenuItems}
-				output={output}
-				outputPlaceholder="Formatted output..."
-				onCopy={handleCopy}
-				emptyIcon={FileText}
-				emptyTitle="Enter XML to format"
-				emptyDescription="The formatted (or minified) document will appear here."
-			/>
-		</div>
+	return (
+		<FormatTabTemplate<XmlFormatTabOptions>
+			input={input}
+			onInputChange={onInputChange}
+			onStatsChange={onStatsChange}
+			inputEditorMode="xml"
+			inputPlaceholder="Enter XML here..."
+			outputPlaceholder="Formatted output..."
+			emptyIcon={FileText}
+			emptyTitle="Enter XML to format"
+			emptyDescription="The formatted (or minified) document will appear here."
+			sampleText={SAMPLE_XML}
+			validate={validate}
+			computeOutput={computeOutput}
+			defaultOptions={DEFAULT_OPTIONS}
+			renderOptions={renderOptions}
+			inputContextMenuItems={inputContextMenuItems}
+		/>
 	);
 }
 

--- a/src/lib/components/formatter-tabs/yaml/format-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/format-tab.tsx
@@ -1,146 +1,130 @@
 import { FileText } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 import * as yaml from 'yaml';
 
 import type { ContextMenuItem } from '@/lib/components/editor';
-import { getErrorMessage } from '@/lib/utils';
 import {
 	FormCheckbox,
 	FormCheckboxGroup,
 	FormInput,
-	FormMode,
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { InputOutputSplit } from '@/lib/components/layout';
-import { Rail } from '@/lib/components/ui/rail';
-import { useClipboardActions, useReportStats } from '@/lib/hooks';
+import { FormatTabTemplate, type FormatMode } from '@/lib/components/template';
 import { SAMPLE_YAML, sortKeysDeep, validateYaml } from '@/lib/services/formatters';
+import { getErrorMessage } from '@/lib/utils';
 
-type FormatMode = 'format' | 'minify';
 type YamlStringType = 'PLAIN' | 'QUOTE_SINGLE' | 'QUOTE_DOUBLE' | 'BLOCK_LITERAL' | 'BLOCK_FOLDED';
 type YamlCollectionStyle = 'any' | 'block' | 'flow';
 type YamlKeyType = 'PLAIN' | 'QUOTE_SINGLE' | 'QUOTE_DOUBLE';
 
-interface TabStats {
-	readonly input: string;
-	readonly valid: boolean | null;
-	readonly error: string;
+interface YamlFormatTabOptions {
+	readonly indentSizeStr: string;
+	readonly lineWidthStr: string;
+	readonly stringType: YamlStringType;
+	readonly singleQuote: boolean;
+	readonly forceQuotes: boolean;
+	readonly doubleQuotedAsJSON: boolean;
+	readonly collectionStyle: YamlCollectionStyle;
+	readonly flowCollectionPadding: boolean;
+	readonly indentSeq: boolean;
+	readonly keyType: YamlKeyType;
+	readonly sortKeys: boolean;
+	readonly noRefs: boolean;
+	readonly nullStr: string;
+	readonly trueStr: string;
+	readonly falseStr: string;
 }
+
+const DEFAULT_OPTIONS: YamlFormatTabOptions = {
+	indentSizeStr: '2',
+	lineWidthStr: '80',
+	stringType: 'PLAIN',
+	singleQuote: false,
+	forceQuotes: false,
+	doubleQuotedAsJSON: false,
+	collectionStyle: 'block',
+	flowCollectionPadding: false,
+	indentSeq: true,
+	keyType: 'PLAIN',
+	sortKeys: false,
+	noRefs: true,
+	nullStr: 'null',
+	trueStr: 'true',
+	falseStr: 'false',
+};
+
+const MIN_CONTENT_WIDTH = 20;
+
+const computeOutput = (input: string, mode: FormatMode, tab: YamlFormatTabOptions) => {
+	if (!input.trim()) return { output: '', error: '' };
+
+	const validation = validateYaml(input);
+	if (!validation.valid) {
+		return { output: '', error: validation.error ?? 'Invalid YAML' };
+	}
+
+	try {
+		if (mode === 'minify') {
+			return {
+				output: yaml.stringify(yaml.parse(input), { indent: 1, indentSeq: false }),
+				error: '',
+			};
+		}
+
+		const parsed = yaml.parse(input);
+		const data = tab.sortKeys ? sortKeysDeep(parsed) : parsed;
+
+		const defaultStringType: YamlStringType = tab.singleQuote
+			? 'QUOTE_SINGLE'
+			: tab.forceQuotes && tab.stringType === 'PLAIN'
+				? 'QUOTE_DOUBLE'
+				: tab.stringType;
+
+		const indent = Number.parseInt(tab.indentSizeStr, 10) || 2;
+		const lineWidth = Number.parseInt(tab.lineWidthStr, 10) || 80;
+
+		const result = yaml.stringify(data, {
+			indent,
+			lineWidth: lineWidth === 0 ? 0 : lineWidth,
+			minContentWidth: MIN_CONTENT_WIDTH,
+			defaultStringType,
+			doubleQuotedAsJSON: tab.doubleQuotedAsJSON,
+			collectionStyle: tab.collectionStyle,
+			flowCollectionPadding: tab.flowCollectionPadding,
+			indentSeq: tab.indentSeq,
+			defaultKeyType: tab.keyType,
+			aliasDuplicateObjects: !tab.noRefs,
+			nullStr: tab.nullStr,
+			trueStr: tab.trueStr,
+			falseStr: tab.falseStr,
+		});
+
+		return { output: result, error: '' };
+	} catch (e) {
+		return { output: '', error: getErrorMessage(e, 'Invalid YAML') };
+	}
+};
+
+const validate = (input: string): boolean | null => {
+	if (!input.trim()) return null;
+	return validateYaml(input).valid;
+};
 
 interface FormatTabProps {
 	readonly input: string;
 	readonly onInputChange: (value: string) => void;
-	readonly onStatsChange?: (stats: TabStats) => void;
+	readonly onStatsChange?: (stats: {
+		readonly input: string;
+		readonly valid: boolean | null;
+		readonly error: string;
+	}) => void;
 }
 
 export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProps) {
-	const [formatMode, setFormatMode] = useState<FormatMode>('format');
-	const [showOptions, setShowOptions] = useState(true);
-
-	// Basic formatting options.
-	const [indentSizeStr, setIndentSizeStr] = useState<string>('2');
-	const [lineWidthStr, setLineWidthStr] = useState<string>('80');
-	const [minContentWidthStr] = useState<string>('20');
-
-	// String handling options.
-	const [stringType, setStringType] = useState<YamlStringType>('PLAIN');
-	const [singleQuote, setSingleQuote] = useState<boolean>(false);
-	const [forceQuotes, setForceQuotes] = useState<boolean>(false);
-	const [doubleQuotedAsJSON, setDoubleQuotedAsJSON] = useState<boolean>(false);
-
-	// Collection style options.
-	const [collectionStyle, setCollectionStyle] = useState<YamlCollectionStyle>('block');
-	const [flowCollectionPadding, setFlowCollectionPadding] = useState<boolean>(false);
-	const [indentSeq, setIndentSeq] = useState<boolean>(true);
-
-	// Key handling options.
-	const [keyType, setKeyType] = useState<YamlKeyType>('PLAIN');
-	const [sortKeys, setSortKeys] = useState<boolean>(false);
-
-	// Reference handling options.
-	const [noRefs, setNoRefs] = useState<boolean>(true);
-
-	// Null / boolean formatting options.
-	const [nullStr, setNullStr] = useState<string>('null');
-	const [trueStr, setTrueStr] = useState<string>('true');
-	const [falseStr, setFalseStr] = useState<string>('false');
-
-	const indentSize = Number.parseInt(indentSizeStr, 10) || 2;
-	const lineWidth = Number.parseInt(lineWidthStr, 10) || 80;
-	const minContentWidth = Number.parseInt(minContentWidthStr, 10) || 20;
-
-	const validation = useMemo<{ valid: boolean | null }>(() => {
-		if (!input.trim()) return { valid: null };
-		const result = validateYaml(input);
-		return { valid: result.valid };
-	}, [input]);
-
-	const { output, error: formatError } = ((): { output: string; error: string } => {
-		if (!input.trim()) return { output: '', error: '' };
-
-		// Validate first to reject non-YAML input.
-		const validationResult = validateYaml(input);
-		if (!validationResult.valid) {
-			return { output: '', error: validationResult.error ?? 'Invalid YAML' };
-		}
-
-		try {
-			if (formatMode === 'minify') {
-				return {
-					output: yaml.stringify(yaml.parse(input), { indent: 1, indentSeq: false }),
-					error: '',
-				};
-			}
-
-			const parsed = yaml.parse(input);
-			const data = sortKeys ? sortKeysDeep(parsed) : parsed;
-
-			// Determine string type.
-			const defaultStringType: YamlStringType = singleQuote
-				? 'QUOTE_SINGLE'
-				: forceQuotes && stringType === 'PLAIN'
-					? 'QUOTE_DOUBLE'
-					: stringType;
-
-			const result = yaml.stringify(data, {
-				indent: indentSize,
-				lineWidth: lineWidth === 0 ? 0 : lineWidth,
-				minContentWidth,
-				defaultStringType,
-				doubleQuotedAsJSON,
-				collectionStyle,
-				flowCollectionPadding,
-				indentSeq,
-				defaultKeyType: keyType,
-				aliasDuplicateObjects: !noRefs,
-				nullStr,
-				trueStr,
-				falseStr,
-			});
-
-			return { output: result, error: '' };
-		} catch (e) {
-			return { output: '', error: getErrorMessage(e, 'Invalid YAML') };
-		}
-	})();
-
-	useReportStats(onStatsChange, input, validation.valid, formatError);
-
-	const { handlePaste, handleClear, handleCopy } = useClipboardActions({
-		onInputChange,
-		output,
-	});
-
-	const handleSample = () => {
-		onInputChange(SAMPLE_YAML);
-	};
-
 	const handleFormatInput = () => {
 		try {
-			const parsed = yaml.parse(input);
-			const formatted = yaml.stringify(parsed, { indent: 2 });
-			onInputChange(formatted);
+			onInputChange(yaml.stringify(yaml.parse(input), { indent: 2 }));
 		} catch {
 			// Invalid YAML.
 		}
@@ -148,58 +132,39 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 
 	const handleMinifyInput = () => {
 		try {
-			const parsed = yaml.parse(input);
-			const minified = yaml.stringify(parsed, { indent: 1, indentSeq: false });
-			onInputChange(minified);
+			onInputChange(yaml.stringify(yaml.parse(input), { indent: 1, indentSeq: false }));
 		} catch {
 			// Invalid YAML.
 		}
 	};
 
 	const inputContextMenuItems: readonly ContextMenuItem[] = [
-		{
-			text: 'Format YAML',
-			enabled: input.trim().length > 0,
-			action: handleFormatInput,
-		},
-		{
-			text: 'Minify YAML',
-			enabled: input.trim().length > 0,
-			action: handleMinifyInput,
-		},
+		{ text: 'Format YAML', enabled: input.trim().length > 0, action: handleFormatInput },
+		{ text: 'Minify YAML', enabled: input.trim().length > 0, action: handleMinifyInput },
 	];
 
-	return (
-		<div className="flex flex-1 overflow-hidden">
-			<Rail
-				show={showOptions}
-				onClose={() => setShowOptions(false)}
-				onOpen={() => setShowOptions(true)}
-			>
-				<FormSection title="Mode">
-					<FormMode
-						value={formatMode}
-						onValueChange={setFormatMode}
-						options={[
-							{ value: 'format', label: 'Format' },
-							{ value: 'minify', label: 'Minify' },
-						]}
-					/>
-				</FormSection>
+	const renderOptions = (
+		options: YamlFormatTabOptions,
+		setOptions: (next: YamlFormatTabOptions) => void
+	): ReactNode => {
+		const update = <K extends keyof YamlFormatTabOptions>(key: K, value: YamlFormatTabOptions[K]) =>
+			setOptions({ ...options, [key]: value });
 
+		return (
+			<>
 				<FormSection title="Formatting">
 					<div className="grid grid-cols-2 gap-2">
 						<FormSelect
 							label="Indent"
-							value={indentSizeStr}
-							onValueChange={setIndentSizeStr}
+							value={options.indentSizeStr}
+							onValueChange={(v) => update('indentSizeStr', v)}
 							options={['2', '4', '8']}
 							size="compact"
 						/>
 						<FormSelect
 							label="Line Width"
-							value={lineWidthStr}
-							onValueChange={setLineWidthStr}
+							value={options.lineWidthStr}
+							onValueChange={(v) => update('lineWidthStr', v)}
 							options={[
 								{ value: '40', label: '40' },
 								{ value: '80', label: '80' },
@@ -211,8 +176,8 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 					</div>
 					<FormSelect
 						label="Collection Style"
-						value={collectionStyle}
-						onValueChange={(v) => setCollectionStyle(v as YamlCollectionStyle)}
+						value={options.collectionStyle}
+						onValueChange={(v) => update('collectionStyle', v as YamlCollectionStyle)}
 						options={[
 							{ value: 'block', label: 'Block' },
 							{ value: 'flow', label: 'Flow ({...})' },
@@ -223,14 +188,14 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 					<FormCheckboxGroup className="pt-1">
 						<FormCheckbox
 							label="Indent sequences"
-							checked={indentSeq}
-							onCheckedChange={setIndentSeq}
+							checked={options.indentSeq}
+							onCheckedChange={(v) => update('indentSeq', v)}
 							size="compact"
 						/>
 						<FormCheckbox
 							label="Flow collection padding"
-							checked={flowCollectionPadding}
-							onCheckedChange={setFlowCollectionPadding}
+							checked={options.flowCollectionPadding}
+							onCheckedChange={(v) => update('flowCollectionPadding', v)}
 							size="compact"
 						/>
 					</FormCheckboxGroup>
@@ -239,8 +204,8 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 				<FormSection title="Strings">
 					<FormSelect
 						label="String Style"
-						value={stringType}
-						onValueChange={(v) => setStringType(v as YamlStringType)}
+						value={options.stringType}
+						onValueChange={(v) => update('stringType', v as YamlStringType)}
 						options={[
 							{ value: 'PLAIN', label: 'Plain' },
 							{ value: 'QUOTE_SINGLE', label: "Single Quote (')" },
@@ -253,20 +218,20 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 					<FormCheckboxGroup className="pt-1">
 						<FormCheckbox
 							label="Force quotes on all strings"
-							checked={forceQuotes}
-							onCheckedChange={setForceQuotes}
+							checked={options.forceQuotes}
+							onCheckedChange={(v) => update('forceQuotes', v)}
 							size="compact"
 						/>
 						<FormCheckbox
 							label="Prefer single quotes"
-							checked={singleQuote}
-							onCheckedChange={setSingleQuote}
+							checked={options.singleQuote}
+							onCheckedChange={(v) => update('singleQuote', v)}
 							size="compact"
 						/>
 						<FormCheckbox
 							label="Double-quoted as JSON style"
-							checked={doubleQuotedAsJSON}
-							onCheckedChange={setDoubleQuotedAsJSON}
+							checked={options.doubleQuotedAsJSON}
+							onCheckedChange={(v) => update('doubleQuotedAsJSON', v)}
 							size="compact"
 						/>
 					</FormCheckboxGroup>
@@ -275,8 +240,8 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 				<FormSection title="Keys">
 					<FormSelect
 						label="Key Style"
-						value={keyType}
-						onValueChange={(v) => setKeyType(v as YamlKeyType)}
+						value={options.keyType}
+						onValueChange={(v) => update('keyType', v as YamlKeyType)}
 						options={[
 							{ value: 'PLAIN', label: 'Plain' },
 							{ value: 'QUOTE_SINGLE', label: "Single Quote (')" },
@@ -287,8 +252,8 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 					<FormCheckboxGroup className="pt-1">
 						<FormCheckbox
 							label="Sort keys alphabetically"
-							checked={sortKeys}
-							onCheckedChange={setSortKeys}
+							checked={options.sortKeys}
+							onCheckedChange={(v) => update('sortKeys', v)}
 							size="compact"
 						/>
 					</FormCheckboxGroup>
@@ -298,24 +263,24 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 					<div className="grid grid-cols-3 gap-2">
 						<FormInput
 							label="Null"
-							value={nullStr}
-							onValueChange={setNullStr}
+							value={options.nullStr}
+							onValueChange={(v) => update('nullStr', v)}
 							placeholder="null"
 							size="compact"
 							className="font-mono"
 						/>
 						<FormInput
 							label="True"
-							value={trueStr}
-							onValueChange={setTrueStr}
+							value={options.trueStr}
+							onValueChange={(v) => update('trueStr', v)}
 							placeholder="true"
 							size="compact"
 							className="font-mono"
 						/>
 						<FormInput
 							label="False"
-							value={falseStr}
-							onValueChange={setFalseStr}
+							value={options.falseStr}
+							onValueChange={(v) => update('falseStr', v)}
 							placeholder="false"
 							size="compact"
 							className="font-mono"
@@ -326,30 +291,33 @@ export function FormatTab({ input, onInputChange, onStatsChange }: FormatTabProp
 				<FormSection title="Advanced">
 					<FormCheckbox
 						label="Disable YAML references/aliases"
-						checked={noRefs}
-						onCheckedChange={setNoRefs}
+						checked={options.noRefs}
+						onCheckedChange={(v) => update('noRefs', v)}
 						size="compact"
 					/>
 				</FormSection>
-			</Rail>
+			</>
+		);
+	};
 
-			<InputOutputSplit
-				input={input}
-				onInputChange={onInputChange}
-				editorMode="yaml"
-				inputPlaceholder="Enter YAML here..."
-				onSample={handleSample}
-				onPaste={handlePaste}
-				onClear={handleClear}
-				inputContextMenuItems={inputContextMenuItems}
-				output={output}
-				outputPlaceholder="Formatted output..."
-				onCopy={handleCopy}
-				emptyIcon={FileText}
-				emptyTitle="Enter YAML to format"
-				emptyDescription="The formatted (or minified) document will appear here."
-			/>
-		</div>
+	return (
+		<FormatTabTemplate<YamlFormatTabOptions>
+			input={input}
+			onInputChange={onInputChange}
+			onStatsChange={onStatsChange}
+			inputEditorMode="yaml"
+			inputPlaceholder="Enter YAML here..."
+			outputPlaceholder="Formatted output..."
+			emptyIcon={FileText}
+			emptyTitle="Enter YAML to format"
+			emptyDescription="The formatted (or minified) document will appear here."
+			sampleText={SAMPLE_YAML}
+			validate={validate}
+			computeOutput={computeOutput}
+			defaultOptions={DEFAULT_OPTIONS}
+			renderOptions={renderOptions}
+			inputContextMenuItems={inputContextMenuItems}
+		/>
 	);
 }
 

--- a/src/lib/components/template/format-tab.tsx
+++ b/src/lib/components/template/format-tab.tsx
@@ -1,0 +1,130 @@
+import { useMemo, useState, type ReactNode } from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+import type { ContextMenuItem, EditorMode } from '@/lib/components/editor';
+import { FormMode, FormSection } from '@/lib/components/form';
+import { InputOutputSplit } from '@/lib/components/layout';
+import { Rail } from '@/lib/components/ui/rail';
+import { useClipboardActions, useReportStats } from '@/lib/hooks';
+
+type FormatMode = 'format' | 'minify';
+
+interface TabStats {
+	readonly input: string;
+	readonly valid: boolean | null;
+	readonly error: string;
+}
+
+interface FormatResult {
+	readonly output: string;
+	readonly error: string;
+}
+
+interface FormatTabTemplateProps<TOptions> {
+	// -- Controlled input / reporting --
+	readonly input: string;
+	readonly onInputChange: (value: string) => void;
+	readonly onStatsChange?: (stats: TabStats) => void;
+
+	// -- Per-lang services --
+	readonly inputEditorMode: EditorMode;
+	readonly inputPlaceholder: string;
+	readonly outputPlaceholder?: string;
+	readonly emptyIcon: LucideIcon;
+	readonly emptyTitle: string;
+	readonly emptyDescription: string;
+	readonly sampleText: string;
+	readonly validate: (input: string) => boolean | null;
+	readonly computeOutput: (input: string, mode: FormatMode, options: TOptions) => FormatResult;
+
+	// -- Per-lang options (template owns state via TOptions generic) --
+	readonly defaultOptions: TOptions;
+	readonly renderOptions: (options: TOptions, setOptions: (next: TOptions) => void) => ReactNode;
+
+	// -- Per-lang slot above the options panel (e.g. JSON's input/output format selector) --
+	readonly renderRailHeader?: () => ReactNode;
+
+	// -- Per-lang input context menu items (e.g. Format JSON / Minify JSON) --
+	readonly inputContextMenuItems?: readonly ContextMenuItem[];
+}
+
+export function FormatTabTemplate<TOptions>({
+	input,
+	onInputChange,
+	onStatsChange,
+	inputEditorMode,
+	inputPlaceholder,
+	outputPlaceholder,
+	emptyIcon,
+	emptyTitle,
+	emptyDescription,
+	sampleText,
+	validate,
+	computeOutput,
+	defaultOptions,
+	renderOptions,
+	renderRailHeader,
+	inputContextMenuItems,
+}: FormatTabTemplateProps<TOptions>) {
+	const [formatMode, setFormatMode] = useState<FormatMode>('format');
+	const [showOptions, setShowOptions] = useState(true);
+	const [options, setOptions] = useState<TOptions>(defaultOptions);
+
+	const validity = useMemo<boolean | null>(() => validate(input), [validate, input]);
+
+	const { output, error } = useMemo<FormatResult>(
+		() => computeOutput(input, formatMode, options),
+		[computeOutput, input, formatMode, options]
+	);
+
+	useReportStats(onStatsChange, input, validity, error);
+
+	const { handlePaste, handleClear, handleCopy } = useClipboardActions({
+		onInputChange,
+		output,
+	});
+
+	const handleSample = () => onInputChange(sampleText);
+
+	return (
+		<div className="flex flex-1 overflow-hidden">
+			<Rail
+				show={showOptions}
+				onClose={() => setShowOptions(false)}
+				onOpen={() => setShowOptions(true)}
+			>
+				{renderRailHeader?.()}
+				<FormSection title="Mode">
+					<FormMode
+						value={formatMode}
+						onValueChange={setFormatMode}
+						options={[
+							{ value: 'format', label: 'Format' },
+							{ value: 'minify', label: 'Minify' },
+						]}
+					/>
+				</FormSection>
+				{renderOptions(options, setOptions)}
+			</Rail>
+
+			<InputOutputSplit
+				input={input}
+				onInputChange={onInputChange}
+				editorMode={inputEditorMode}
+				inputPlaceholder={inputPlaceholder}
+				onSample={handleSample}
+				onPaste={handlePaste}
+				onClear={handleClear}
+				inputContextMenuItems={inputContextMenuItems}
+				output={output}
+				outputPlaceholder={outputPlaceholder}
+				onCopy={handleCopy}
+				emptyIcon={emptyIcon}
+				emptyTitle={emptyTitle}
+				emptyDescription={emptyDescription}
+			/>
+		</div>
+	);
+}
+
+export type { FormatTabTemplateProps, FormatMode, FormatResult, TabStats };

--- a/src/lib/components/template/index.ts
+++ b/src/lib/components/template/index.ts
@@ -4,6 +4,14 @@ export type { CompareTabProps } from './compare-tab';
 export { ConvertTab } from './convert-tab';
 export type { ConvertTabProps } from './convert-tab';
 
+export { FormatTabTemplate } from './format-tab';
+export type {
+	FormatTabTemplateProps,
+	FormatMode,
+	FormatResult,
+	TabStats as FormatTabStats,
+} from './format-tab';
+
 export { GenerateTabTemplate } from './generate-tab';
 export type { GenerateTabTemplateProps, TabStats as GenerateTabStats } from './generate-tab';
 


### PR DESCRIPTION
## Summary

Consolidate the three lang-specific `format-tab` files (JSON / XML / YAML) into a single generic `FormatTabTemplate`, mirroring the established pattern already used by `compare-tab` / `convert-tab` / `generate-tab`.

This is the first PR in the formatter-tabs consolidation initiative. Two follow-up sub-projects (schema-tab, query-tab) are deferred — both depend on lang-specific libraries that need separate evaluation before deciding whether abstraction is worthwhile.

## Changes

### New
- `src/lib/components/template/format-tab.tsx` — generic `FormatTabTemplate<TOptions>` that owns:
  - `formatMode` toggle (Format / Minify)
  - `options` state via the `TOptions` generic parameter
  - `Rail` + `InputOutputSplit` composition
  - `useReportStats` / `useClipboardActions` wiring
  - `sampleText` / `inputContextMenuItems` plumbing
  - Optional `renderRailHeader` slot for lang-specific top-of-rail content (e.g. `JsonFormatSection`)
  - Required `renderOptions` render-prop for lang-specific options UI

### Rewritten (each becomes a thin wrapper)
- `src/lib/components/formatter-tabs/json/format-tab.tsx` (413 → 343 LOC) — wires JSON parse/format/validate + `JsonFormatSection` slot
- `src/lib/components/formatter-tabs/xml/format-tab.tsx` (259 → 205 LOC) — DOMParser-based validate, `formatXml` / `minifyXml`
- `src/lib/components/formatter-tabs/yaml/format-tab.tsx` (356 → 290 LOC) — yaml library bindings, `sortKeysDeep` integration

### Index export
- `src/lib/components/template/index.ts` adds `FormatTabTemplate`, `FormatTabTemplateProps`, `FormatMode`, `FormatResult`, `FormatTabStats`.

### Tooling
- `.gitignore` ignores `.superpowers/` (brainstorming session artifacts; user-local only).

## Design pattern

Each wrapper now:
1. Defines a `XxxFormatTabOptions` interface as the single options shape
2. Provides `DEFAULT_OPTIONS` constant
3. Implements `computeOutput(input, mode, options)` and `validate(input)` as pure functions
4. Implements `renderOptions(options, setOptions)` returning JSX with a `update(key, value)` helper closure
5. Passes everything to `<FormatTabTemplate<XxxFormatTabOptions> ... />`

This is identical to the `compare-tab` / `convert-tab` / `generate-tab` pattern.

## Out of scope (follow-up sub-projects)

- **schema-tab**: each lang uses a different validation library (Ajv for JSON; XSD-ish for XML; etc.). Abstraction depends on a separate API design decision.
- **query-tab**: JSONPath / XPath / YAML path query languages are sufficiently different that a shared shell may not pay off. Needs its own evaluation.
- **convert-tab outlier**: `json/convert-tab.tsx` (556 LOC) wraps the existing `template/convert-tab.tsx` (131 LOC) with significant JSON-specific extensions; out of scope for this PR.

## Test Plan

- [x] `bun run check` (TypeScript + validate-pages + audit-design) all green
- [x] `bun run format` clean
- [x] `bun run lint` no new warnings
- [x] Visual confirmation: JSON Formatter > Format tab renders Rail (Format / Mode / Indentation / Style / Spacing / Filtering) + Input/Output editors. XML/YAML wrappers follow the identical pattern, structurally validated by TypeScript.
