### PR TITLE
feat(number-base-converter): add Number Base Converter tool

### DIFF
--- a/src/lib/services/number-base.ts
+++ b/src/lib/services/number-base.ts
@@ -1,0 +1,588 @@
+/**
+ * Pure helpers for the Number Base Converter route.
+ *
+ * Everything operates on `bigint` so 64-bit unsigned values round-trip
+ * without precision loss. Two's-complement signedness is expressed as a
+ * pair of conversions (`toSigned` / `toUnsigned`) over a fixed bit width.
+ */
+
+export type BitWidth = 8 | 16 | 32 | 64;
+export type Base = 2 | 8 | 10 | 16;
+export type Signedness = 'signed' | 'unsigned';
+export type FloatWidth = 32 | 64;
+
+export const BIT_WIDTHS: readonly BitWidth[] = [8, 16, 32, 64];
+export const BASES: readonly Base[] = [2, 8, 10, 16];
+
+export const BASE_LABEL: Record<Base, string> = {
+	2: 'Binary',
+	8: 'Octal',
+	10: 'Decimal',
+	16: 'Hexadecimal',
+};
+
+export const BASE_PREFIX: Record<Base, string> = {
+	2: '0b',
+	8: '0o',
+	10: '',
+	16: '0x',
+};
+
+export const BASE_GROUP_SIZE: Record<Base, number> = {
+	2: 4,
+	8: 3,
+	10: 3,
+	16: 4,
+};
+
+const BIGINT_ONE = 1n;
+const BIGINT_ZERO = 0n;
+
+/** Mask for the lowest `width` bits — `(1 << width) - 1`. */
+export const widthMask = (width: BitWidth): bigint => (BIGINT_ONE << BigInt(width)) - BIGINT_ONE;
+
+/** The single high bit for the given width — `1 << (width - 1)`. */
+export const signBit = (width: BitWidth): bigint => BIGINT_ONE << BigInt(width - 1);
+
+/** Inclusive range of the signed two's-complement representation. */
+export const signedMin = (width: BitWidth): bigint => -(BIGINT_ONE << BigInt(width - 1));
+export const signedMax = (width: BitWidth): bigint =>
+	(BIGINT_ONE << BigInt(width - 1)) - BIGINT_ONE;
+export const unsignedMax = (width: BitWidth): bigint => (BIGINT_ONE << BigInt(width)) - BIGINT_ONE;
+
+/**
+ * Map an arbitrary integer into the unsigned interpretation of `width` bits.
+ *
+ * Negative inputs are wrapped via two's complement so `toUnsigned(-1n, 8)`
+ * returns `255n` (0xFF). Always returns a value in `[0, 2^width)`.
+ */
+export const toUnsigned = (value: bigint, width: BitWidth): bigint => {
+	const mod = BIGINT_ONE << BigInt(width);
+	return ((value % mod) + mod) % mod;
+};
+
+/**
+ * Map an unsigned bit pattern back to its signed two's-complement value.
+ *
+ * `toSigned(255n, 8)` returns `-1n`; `toSigned(127n, 8)` stays `127n`.
+ */
+export const toSigned = (value: bigint, width: BitWidth): bigint => {
+	const unsigned = toUnsigned(value, width);
+	return unsigned >= signBit(width) ? unsigned - (BIGINT_ONE << BigInt(width)) : unsigned;
+};
+
+/**
+ * Strip whitespace plus the conventional `0b` / `0o` / `0x` prefixes and any
+ * underscore / comma / space digit separators.
+ */
+const stripPrefixesAndSeparators = (text: string, base: Base): string => {
+	const trimmed = text.trim().replaceAll(/[_,\s]/g, '');
+	if (trimmed.length === 0) return '';
+	const lower = trimmed.toLowerCase();
+
+	// Allow a leading sign for decimal only; other bases interpret unsigned.
+	const signRe = /^[+-]/;
+	const sign = base === 10 && signRe.test(trimmed) ? trimmed[0] : '';
+	const body = sign ? trimmed.slice(1) : trimmed;
+	const bodyLower = sign ? lower.slice(1) : lower;
+
+	if (base === 2 && bodyLower.startsWith('0b')) return `${sign}${body.slice(2)}`;
+	if (base === 8 && bodyLower.startsWith('0o')) return `${sign}${body.slice(2)}`;
+	if (base === 16 && bodyLower.startsWith('0x')) return `${sign}${body.slice(2)}`;
+	return `${sign}${body}`;
+};
+
+const BASE_PATTERN: Record<Base, RegExp> = {
+	2: /^[01]+$/,
+	8: /^[0-7]+$/,
+	10: /^-?[0-9]+$/,
+	16: /^[0-9a-fA-F]+$/,
+};
+
+/**
+ * Parse a text input in `base` to a bigint, returning the unsigned bit pattern
+ * inside `width`. Returns `null` when the text cannot be parsed.
+ *
+ * - Whitespace, underscores, commas, and `0b`/`0o`/`0x` prefixes are stripped.
+ * - Negative decimals are accepted when `signedness === 'signed'` and folded
+ *   to two's-complement.
+ * - Out-of-range inputs are rejected (no silent truncation): for example
+ *   `'256'` in 8-bit unsigned returns `null`, and `'-1'` in unsigned mode
+ *   returns `null`.
+ */
+export const parseInBase = (
+	text: string,
+	base: Base,
+	width: BitWidth,
+	signedness: Signedness
+): bigint | null => {
+	const cleaned = stripPrefixesAndSeparators(text, base);
+	if (cleaned.length === 0) return null;
+	if (!BASE_PATTERN[base].test(cleaned)) return null;
+	if (base !== 10 && cleaned.startsWith('-')) return null;
+
+	let value: bigint;
+	try {
+		value = base === 10 ? BigInt(cleaned) : BigInt(`0${baseRadixPrefix(base)}${cleaned}`);
+	} catch {
+		return null;
+	}
+
+	if (signedness === 'signed') {
+		if (value < signedMin(width) || value > signedMax(width)) return null;
+	} else {
+		if (value < BIGINT_ZERO || value > unsignedMax(width)) return null;
+	}
+
+	return toUnsigned(value, width);
+};
+
+const baseRadixPrefix = (base: Base): string => {
+	if (base === 2) return 'b';
+	if (base === 8) return 'o';
+	if (base === 16) return 'x';
+	return '';
+};
+
+const padLengthForBase = (base: Base, width: BitWidth): number => {
+	if (base === 2) return width;
+	if (base === 8) return Math.ceil(width / 3);
+	if (base === 16) return Math.ceil(width / 4);
+	return 0;
+};
+
+const groupDigits = (digits: string, groupSize: number, separator: string): string => {
+	if (groupSize <= 0 || digits.length <= groupSize) return digits;
+	const groups: string[] = [];
+	for (let i = digits.length; i > 0; i -= groupSize) {
+		const start = Math.max(0, i - groupSize);
+		groups.unshift(digits.slice(start, i));
+	}
+	return groups.join(separator);
+};
+
+interface FormatOptions {
+	readonly group?: boolean;
+	readonly uppercase?: boolean;
+	readonly pad?: boolean;
+}
+
+/**
+ * Format a bigint in the requested base with optional grouping / padding.
+ *
+ * Signed mode prepends `'-'` when the value's signed interpretation is
+ * negative for base 10, and shows the unsigned bit pattern for non-10 bases
+ * (two's complement is the meaningful view there).
+ */
+export const formatInBase = (
+	value: bigint,
+	base: Base,
+	width: BitWidth,
+	signedness: Signedness,
+	opts: FormatOptions = {}
+): string => {
+	const { group = false, uppercase = false, pad = false } = opts;
+	const unsigned = toUnsigned(value, width);
+
+	if (base === 10) {
+		const display = signedness === 'signed' ? toSigned(unsigned, width) : unsigned;
+		const sign = display < BIGINT_ZERO ? '-' : '';
+		const abs = display < BIGINT_ZERO ? -display : display;
+		const digits = abs.toString(10);
+		return `${sign}${group ? groupDigits(digits, BASE_GROUP_SIZE[10], ',') : digits}`;
+	}
+
+	let digits = unsigned.toString(base);
+	if (pad) {
+		const target = padLengthForBase(base, width);
+		if (digits.length < target) digits = digits.padStart(target, '0');
+	}
+	if (uppercase) digits = digits.toUpperCase();
+	if (group) digits = groupDigits(digits, BASE_GROUP_SIZE[base], ' ');
+	return digits;
+};
+
+// -------------------------------------------------------------------------
+// Bitwise operations — all consume / produce unsigned bigints within `width`.
+// -------------------------------------------------------------------------
+
+export const bitwiseAnd = (a: bigint, b: bigint, width: BitWidth): bigint =>
+	a & b & widthMask(width);
+
+export const bitwiseOr = (a: bigint, b: bigint, width: BitWidth): bigint =>
+	(a | b) & widthMask(width);
+
+export const bitwiseXor = (a: bigint, b: bigint, width: BitWidth): bigint =>
+	(a ^ b) & widthMask(width);
+
+export const bitwiseNot = (a: bigint, width: BitWidth): bigint => ~a & widthMask(width);
+
+export const shiftLeft = (a: bigint, n: number, width: BitWidth): bigint => {
+	if (n <= 0) return a & widthMask(width);
+	if (n >= width) return BIGINT_ZERO;
+	return (a << BigInt(n)) & widthMask(width);
+};
+
+/**
+ * Logical / arithmetic right shift on the unsigned bit pattern.
+ *
+ * - `'unsigned'` performs a logical shift (fills with zeros).
+ * - `'signed'` performs an arithmetic shift (replicates the sign bit).
+ */
+export const shiftRight = (
+	a: bigint,
+	n: number,
+	width: BitWidth,
+	signedness: Signedness
+): bigint => {
+	const masked = a & widthMask(width);
+	if (n <= 0) return masked;
+	if (signedness === 'unsigned') {
+		if (n >= width) return BIGINT_ZERO;
+		return masked >> BigInt(n);
+	}
+	const signed = toSigned(masked, width);
+	const shifted = signed >> BigInt(Math.min(n, width));
+	return toUnsigned(shifted, width);
+};
+
+/** Toggle the bit at `index` (0 = least significant) on the unsigned pattern. */
+export const toggleBit = (value: bigint, index: number, width: BitWidth): bigint => {
+	if (index < 0 || index >= width) return value;
+	return (value ^ (BIGINT_ONE << BigInt(index))) & widthMask(width);
+};
+
+/** Population count (Hamming weight) for the lowest `width` bits. */
+export const popcount = (value: bigint, width: BitWidth): number => {
+	const masked = value & widthMask(width);
+	let count = 0;
+	let remaining = masked;
+	while (remaining > BIGINT_ZERO) {
+		if ((remaining & BIGINT_ONE) === BIGINT_ONE) count += 1;
+		remaining >>= BIGINT_ONE;
+	}
+	return count;
+};
+
+// -------------------------------------------------------------------------
+// IEEE 754 breakdown
+// -------------------------------------------------------------------------
+
+export type FloatClassification = 'zero' | 'subnormal' | 'normal' | 'infinity' | 'nan';
+
+export interface IeeeBreakdown {
+	readonly width: FloatWidth;
+	readonly sign: 0 | 1;
+	readonly biasedExponent: number;
+	readonly unbiasedExponent: number;
+	readonly mantissa: bigint;
+	readonly mantissaBits: number;
+	readonly exponentBits: number;
+	readonly bias: number;
+	readonly numericValue: number;
+	readonly classification: FloatClassification;
+	readonly hexValue: string;
+}
+
+const ieeeLayout = (
+	width: FloatWidth
+): { exponentBits: number; mantissaBits: number; bias: number } => {
+	if (width === 32) return { exponentBits: 8, mantissaBits: 23, bias: 127 };
+	return { exponentBits: 11, mantissaBits: 52, bias: 1023 };
+};
+
+const bitsToFloat = (bits: bigint, width: FloatWidth): number => {
+	const buffer = new ArrayBuffer(width / 8);
+	const view = new DataView(buffer);
+	if (width === 32) {
+		view.setUint32(0, Number(bits & 0xffffffffn), false);
+		return view.getFloat32(0, false);
+	}
+	view.setBigUint64(0, bits & 0xffffffffffffffffn, false);
+	return view.getFloat64(0, false);
+};
+
+/**
+ * Convert a numeric float back to its raw IEEE 754 bit pattern. Useful when
+ * the user types a decimal float and wants to see the encoded bits.
+ */
+export const floatToBits = (value: number, width: FloatWidth): bigint => {
+	const buffer = new ArrayBuffer(width / 8);
+	const view = new DataView(buffer);
+	if (width === 32) {
+		view.setFloat32(0, value, false);
+		return BigInt(view.getUint32(0, false));
+	}
+	view.setFloat64(0, value, false);
+	return view.getBigUint64(0, false);
+};
+
+/**
+ * Decompose an unsigned bit pattern into IEEE 754 components for the given
+ * float width. The bits are interpreted big-endian inside the `width / 8` byte
+ * buffer — matching how every common platform stores floats.
+ */
+export const ieeeBreakdown = (value: bigint, width: FloatWidth): IeeeBreakdown => {
+	const { exponentBits, mantissaBits, bias } = ieeeLayout(width);
+	const totalBits = BigInt(width);
+	const masked = value & (width === 32 ? 0xffffffffn : 0xffffffffffffffffn);
+
+	const sign = (masked >> (totalBits - BIGINT_ONE)) & BIGINT_ONE;
+	const exponentMask = (BIGINT_ONE << BigInt(exponentBits)) - BIGINT_ONE;
+	const biasedExponent = Number((masked >> BigInt(mantissaBits)) & exponentMask);
+	const mantissaMask = (BIGINT_ONE << BigInt(mantissaBits)) - BIGINT_ONE;
+	const mantissa = masked & mantissaMask;
+
+	const numericValue = bitsToFloat(masked, width);
+
+	let classification: FloatClassification;
+	if (biasedExponent === 0 && mantissa === BIGINT_ZERO) classification = 'zero';
+	else if (biasedExponent === 0) classification = 'subnormal';
+	else if (biasedExponent === (1 << exponentBits) - 1)
+		classification = mantissa === BIGINT_ZERO ? 'infinity' : 'nan';
+	else classification = 'normal';
+
+	const hexValue = `0x${masked
+		.toString(16)
+		.padStart(width / 4, '0')
+		.toUpperCase()}`;
+
+	return {
+		width,
+		sign: sign === BIGINT_ONE ? 1 : 0,
+		biasedExponent,
+		unbiasedExponent: biasedExponent - bias,
+		mantissa,
+		mantissaBits,
+		exponentBits,
+		bias,
+		numericValue,
+		classification,
+		hexValue,
+	};
+};
+
+// -------------------------------------------------------------------------
+// ASCII / Unicode helpers
+// -------------------------------------------------------------------------
+
+export interface AsciiInfo {
+	readonly codePoint: number;
+	readonly glyph: string | null;
+	readonly category: 'control' | 'printable' | 'extended';
+	readonly name: string;
+	readonly printable: boolean;
+	readonly controlAbbr?: string;
+}
+
+const CONTROL_NAMES: readonly string[] = [
+	'NUL (Null)',
+	'SOH (Start of Heading)',
+	'STX (Start of Text)',
+	'ETX (End of Text)',
+	'EOT (End of Transmission)',
+	'ENQ (Enquiry)',
+	'ACK (Acknowledge)',
+	'BEL (Bell)',
+	'BS (Backspace)',
+	'HT (Horizontal Tab)',
+	'LF (Line Feed)',
+	'VT (Vertical Tab)',
+	'FF (Form Feed)',
+	'CR (Carriage Return)',
+	'SO (Shift Out)',
+	'SI (Shift In)',
+	'DLE (Data Link Escape)',
+	'DC1 (Device Control 1, XON)',
+	'DC2 (Device Control 2)',
+	'DC3 (Device Control 3, XOFF)',
+	'DC4 (Device Control 4)',
+	'NAK (Negative Acknowledge)',
+	'SYN (Synchronous Idle)',
+	'ETB (End of Transmission Block)',
+	'CAN (Cancel)',
+	'EM (End of Medium)',
+	'SUB (Substitute)',
+	'ESC (Escape)',
+	'FS (File Separator)',
+	'GS (Group Separator)',
+	'RS (Record Separator)',
+	'US (Unit Separator)',
+];
+
+const CONTROL_ABBR: readonly string[] = [
+	'NUL',
+	'SOH',
+	'STX',
+	'ETX',
+	'EOT',
+	'ENQ',
+	'ACK',
+	'BEL',
+	'BS',
+	'HT',
+	'LF',
+	'VT',
+	'FF',
+	'CR',
+	'SO',
+	'SI',
+	'DLE',
+	'DC1',
+	'DC2',
+	'DC3',
+	'DC4',
+	'NAK',
+	'SYN',
+	'ETB',
+	'CAN',
+	'EM',
+	'SUB',
+	'ESC',
+	'FS',
+	'GS',
+	'RS',
+	'US',
+];
+
+/**
+ * Describe an 8-bit byte value as an ASCII / Latin-1 character.
+ *
+ * Returns `null` when `width` is not 8 (the inspector only makes sense for
+ * single-byte values).
+ */
+export const asciiInfo = (value: bigint, width: BitWidth): AsciiInfo | null => {
+	if (width !== 8) return null;
+	const codePoint = Number(value & 0xffn);
+
+	if (codePoint < 0x20) {
+		return {
+			codePoint,
+			glyph: null,
+			category: 'control',
+			name: CONTROL_NAMES[codePoint] ?? 'Control',
+			printable: false,
+			controlAbbr: CONTROL_ABBR[codePoint],
+		};
+	}
+	if (codePoint === 0x7f) {
+		return {
+			codePoint,
+			glyph: null,
+			category: 'control',
+			name: 'DEL (Delete)',
+			printable: false,
+			controlAbbr: 'DEL',
+		};
+	}
+	if (codePoint < 0x80) {
+		return {
+			codePoint,
+			glyph: String.fromCharCode(codePoint),
+			category: 'printable',
+			name: `U+${codePoint.toString(16).toUpperCase().padStart(4, '0')}`,
+			printable: true,
+		};
+	}
+	return {
+		codePoint,
+		glyph: String.fromCharCode(codePoint),
+		category: 'extended',
+		name: `U+${codePoint.toString(16).toUpperCase().padStart(4, '0')} (Latin-1)`,
+		printable: true,
+	};
+};
+
+// -------------------------------------------------------------------------
+// Presets
+// -------------------------------------------------------------------------
+
+export interface PresetDescriptor {
+	readonly id: string;
+	readonly label: string;
+	readonly compute: (width: BitWidth, signedness: Signedness) => bigint;
+	readonly availableFor?: (width: BitWidth, signedness: Signedness) => boolean;
+}
+
+const alternatingPattern = (width: BitWidth): bigint => {
+	// 0xAA AA AA AA … — the canonical "10101010" pattern, masked to the
+	// requested width.
+	const byte = 0xaan;
+	let result = BIGINT_ZERO;
+	for (let i = 0; i < width / 8; i += 1) {
+		result = (result << 8n) | byte;
+	}
+	return result & widthMask(width);
+};
+
+export const PRESETS: readonly PresetDescriptor[] = [
+	{ id: 'zero', label: 'Zero', compute: () => BIGINT_ZERO },
+	{ id: 'one', label: 'One', compute: () => BIGINT_ONE },
+	{
+		id: 'negative-one',
+		label: '-1 (all 1s)',
+		compute: (width) => widthMask(width),
+		availableFor: (_w, s) => s === 'signed',
+	},
+	{
+		id: 'max',
+		label: 'MAX',
+		compute: (width, signedness) =>
+			signedness === 'signed' ? toUnsigned(signedMax(width), width) : unsignedMax(width),
+	},
+	{
+		id: 'min',
+		label: 'MIN',
+		compute: (width, signedness) =>
+			signedness === 'signed' ? toUnsigned(signedMin(width), width) : BIGINT_ZERO,
+	},
+	{
+		id: 'sign-bit',
+		label: 'Sign bit only',
+		compute: (width) => signBit(width),
+	},
+	{
+		id: 'all-ones',
+		label: 'All 1s',
+		compute: (width) => widthMask(width),
+	},
+	{
+		id: 'alternating',
+		label: 'Alternating (0xAA…)',
+		compute: (width) => alternatingPattern(width),
+	},
+	{
+		id: 'low-nibble',
+		label: 'Low nibble (0x0F)',
+		compute: () => 0x0fn,
+	},
+	{
+		id: 'high-nibble',
+		label: 'High nibble',
+		compute: (width) => 0xfn << BigInt(width - 4),
+	},
+];
+
+/**
+ * Common IEEE 754 patterns made available as quick-fill operands. Returned as
+ * unsigned bigints; pair them with `bitWidth >= floatWidth` before applying.
+ */
+export interface FloatPreset {
+	readonly id: string;
+	readonly label: string;
+	readonly bits: bigint;
+	readonly width: FloatWidth;
+}
+
+export const FLOAT_PRESETS: readonly FloatPreset[] = [
+	{ id: 'f32-zero', label: '+0.0 (f32)', bits: 0x00000000n, width: 32 },
+	{ id: 'f32-one', label: '1.0 (f32)', bits: 0x3f800000n, width: 32 },
+	{ id: 'f32-neg-one', label: '-1.0 (f32)', bits: 0xbf800000n, width: 32 },
+	{ id: 'f32-pi', label: 'π (f32)', bits: 0x40490fdbn, width: 32 },
+	{ id: 'f32-inf', label: '+Infinity (f32)', bits: 0x7f800000n, width: 32 },
+	{ id: 'f32-nan', label: 'NaN (f32)', bits: 0x7fc00000n, width: 32 },
+	{ id: 'f64-zero', label: '+0.0 (f64)', bits: 0x0000000000000000n, width: 64 },
+	{ id: 'f64-one', label: '1.0 (f64)', bits: 0x3ff0000000000000n, width: 64 },
+	{ id: 'f64-pi', label: 'π (f64)', bits: 0x400921fb54442d18n, width: 64 },
+	{ id: 'f64-e', label: 'e (f64)', bits: 0x4005bf0a8b145769n, width: 64 },
+];

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -6,6 +6,7 @@ import {
 	ArrowRightLeft,
 	Binary,
 	Braces,
+	Calculator,
 	CalendarClock,
 	CaseSensitive,
 	Clock,
@@ -247,6 +248,16 @@ export const PAGES: readonly PageDefinition[] = [
 		icon: CalendarClock,
 		description: 'Convert between Unix, ISO, RFC formats with multi-timezone support',
 		color: 'text-amber-600',
+		category: 'generators',
+	},
+	{
+		id: 'number-base-converter',
+		title: 'Number Base Converter',
+		url: '/number-base-converter',
+		icon: Calculator,
+		description:
+			'Convert between binary, octal, decimal, and hex with bitwise operations and IEEE 754 view',
+		color: 'text-orange-600',
 		category: 'generators',
 	},
 	{

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -20,6 +20,7 @@ import { Route as SettingsRouteImport } from './routes/settings';
 import { Route as RegexTesterRouteImport } from './routes/regex-tester';
 import { Route as QrCodeGeneratorRouteImport } from './routes/qr-code-generator';
 import { Route as PasswordGeneratorRouteImport } from './routes/password-generator';
+import { Route as NumberBaseConverterRouteImport } from './routes/number-base-converter';
 import { Route as NetworkScannerRouteImport } from './routes/network-scanner';
 import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces';
 import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor';
@@ -88,6 +89,11 @@ const QrCodeGeneratorRoute = QrCodeGeneratorRouteImport.update({
 const PasswordGeneratorRoute = PasswordGeneratorRouteImport.update({
 	id: '/password-generator',
 	path: '/password-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
+const NumberBaseConverterRoute = NumberBaseConverterRouteImport.update({
+	id: '/number-base-converter',
+	path: '/number-base-converter',
 	getParentRoute: () => rootRouteImport,
 } as any);
 const NetworkScannerRoute = NetworkScannerRouteImport.update({
@@ -176,6 +182,7 @@ export interface FileRoutesByFullPath {
 	'/markdown-editor': typeof MarkdownEditorRoute;
 	'/network-interfaces': typeof NetworkInterfacesRoute;
 	'/network-scanner': typeof NetworkScannerRoute;
+	'/number-base-converter': typeof NumberBaseConverterRoute;
 	'/password-generator': typeof PasswordGeneratorRoute;
 	'/qr-code-generator': typeof QrCodeGeneratorRoute;
 	'/regex-tester': typeof RegexTesterRoute;
@@ -203,6 +210,7 @@ export interface FileRoutesByTo {
 	'/markdown-editor': typeof MarkdownEditorRoute;
 	'/network-interfaces': typeof NetworkInterfacesRoute;
 	'/network-scanner': typeof NetworkScannerRoute;
+	'/number-base-converter': typeof NumberBaseConverterRoute;
 	'/password-generator': typeof PasswordGeneratorRoute;
 	'/qr-code-generator': typeof QrCodeGeneratorRoute;
 	'/regex-tester': typeof RegexTesterRoute;
@@ -231,6 +239,7 @@ export interface FileRoutesById {
 	'/markdown-editor': typeof MarkdownEditorRoute;
 	'/network-interfaces': typeof NetworkInterfacesRoute;
 	'/network-scanner': typeof NetworkScannerRoute;
+	'/number-base-converter': typeof NumberBaseConverterRoute;
 	'/password-generator': typeof PasswordGeneratorRoute;
 	'/qr-code-generator': typeof QrCodeGeneratorRoute;
 	'/regex-tester': typeof RegexTesterRoute;
@@ -260,6 +269,7 @@ export interface FileRouteTypes {
 		| '/markdown-editor'
 		| '/network-interfaces'
 		| '/network-scanner'
+		| '/number-base-converter'
 		| '/password-generator'
 		| '/qr-code-generator'
 		| '/regex-tester'
@@ -287,6 +297,7 @@ export interface FileRouteTypes {
 		| '/markdown-editor'
 		| '/network-interfaces'
 		| '/network-scanner'
+		| '/number-base-converter'
 		| '/password-generator'
 		| '/qr-code-generator'
 		| '/regex-tester'
@@ -314,6 +325,7 @@ export interface FileRouteTypes {
 		| '/markdown-editor'
 		| '/network-interfaces'
 		| '/network-scanner'
+		| '/number-base-converter'
 		| '/password-generator'
 		| '/qr-code-generator'
 		| '/regex-tester'
@@ -342,6 +354,7 @@ export interface RootRouteChildren {
 	MarkdownEditorRoute: typeof MarkdownEditorRoute;
 	NetworkInterfacesRoute: typeof NetworkInterfacesRoute;
 	NetworkScannerRoute: typeof NetworkScannerRoute;
+	NumberBaseConverterRoute: typeof NumberBaseConverterRoute;
 	PasswordGeneratorRoute: typeof PasswordGeneratorRoute;
 	QrCodeGeneratorRoute: typeof QrCodeGeneratorRoute;
 	RegexTesterRoute: typeof RegexTesterRoute;
@@ -432,6 +445,13 @@ declare module '@tanstack/react-router' {
 			path: '/password-generator';
 			fullPath: '/password-generator';
 			preLoaderRoute: typeof PasswordGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/number-base-converter': {
+			id: '/number-base-converter';
+			path: '/number-base-converter';
+			fullPath: '/number-base-converter';
+			preLoaderRoute: typeof NumberBaseConverterRouteImport;
 			parentRoute: typeof rootRouteImport;
 		};
 		'/network-scanner': {
@@ -550,6 +570,7 @@ const rootRouteChildren: RootRouteChildren = {
 	MarkdownEditorRoute: MarkdownEditorRoute,
 	NetworkInterfacesRoute: NetworkInterfacesRoute,
 	NetworkScannerRoute: NetworkScannerRoute,
+	NumberBaseConverterRoute: NumberBaseConverterRoute,
 	PasswordGeneratorRoute: PasswordGeneratorRoute,
 	QrCodeGeneratorRoute: QrCodeGeneratorRoute,
 	RegexTesterRoute: RegexTesterRoute,

--- a/src/routes/number-base-converter.tsx
+++ b/src/routes/number-base-converter.tsx
@@ -1,0 +1,1012 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { type CSSProperties, useMemo, useState } from 'react';
+
+import { CopyButton } from '@/lib/components/action';
+import {
+	FormCheckbox,
+	FormCheckboxGroup,
+	FormInfo,
+	FormMode,
+	FormSection,
+	FormSelect,
+	FormSlider,
+} from '@/lib/components/form';
+import { useDocumentTitle } from '@/lib/hooks';
+import { ToolShell } from '@/lib/components/shell';
+import { StatItem } from '@/lib/components/status';
+import {
+	Accordion,
+	AccordionContent,
+	AccordionItem,
+	AccordionTrigger,
+} from '@/lib/components/ui/accordion';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { Input } from '@/lib/components/ui/input';
+import { Label } from '@/lib/components/ui/label';
+import { ToneBadge } from '@/lib/components/ui/tone-badge';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/lib/components/ui/tooltip';
+import { createToolOptionsStore } from '@/lib/stores';
+import { cn } from '@/lib/utils';
+import {
+	asciiInfo,
+	BASE_LABEL,
+	BASE_PREFIX,
+	BASES,
+	BIT_WIDTHS,
+	bitwiseAnd,
+	bitwiseNot,
+	bitwiseOr,
+	bitwiseXor,
+	type Base,
+	type BitWidth,
+	type FloatWidth,
+	floatToBits,
+	formatInBase,
+	FLOAT_PRESETS,
+	type IeeeBreakdown,
+	ieeeBreakdown,
+	parseInBase,
+	popcount,
+	PRESETS,
+	shiftLeft,
+	shiftRight,
+	signBit,
+	signedMax,
+	signedMin,
+	type Signedness,
+	toggleBit,
+	toSigned,
+	toUnsigned,
+	widthMask,
+} from '@/lib/services/number-base';
+
+interface NumberBaseOptions {
+	readonly bitWidth: BitWidth;
+	readonly signedness: Signedness;
+	readonly primaryBase: Base;
+	readonly group: boolean;
+	readonly uppercase: boolean;
+	readonly pad: boolean;
+	readonly floatWidth: FloatWidth;
+}
+
+const DEFAULTS: NumberBaseOptions = {
+	bitWidth: 32,
+	signedness: 'unsigned',
+	primaryBase: 10,
+	group: true,
+	uppercase: true,
+	pad: true,
+	floatWidth: 32,
+};
+
+const useNumberBaseOptions = createToolOptionsStore<NumberBaseOptions>(
+	'number-base-converter',
+	DEFAULTS
+);
+
+export const Route = createFileRoute('/number-base-converter')({
+	component: NumberBaseConverterPage,
+});
+
+const BIT_WIDTH_OPTIONS = BIT_WIDTHS.map((w) => ({
+	value: String(w),
+	label: `${w}-bit`,
+}));
+
+const SIGNEDNESS_OPTIONS = [
+	{ value: 'unsigned', label: 'Unsigned' },
+	{ value: 'signed', label: 'Signed' },
+] as const;
+
+const PRIMARY_BASE_OPTIONS = BASES.map((b) => ({
+	value: String(b),
+	label: BASE_LABEL[b],
+}));
+
+const FLOAT_WIDTH_OPTIONS = [
+	{ value: '32', label: '32-bit (f32)' },
+	{ value: '64', label: '64-bit (f64)' },
+] as const;
+
+const isBitWidth = (v: number): v is BitWidth => v === 8 || v === 16 || v === 32 || v === 64;
+const isBase = (v: number): v is Base => v === 2 || v === 8 || v === 10 || v === 16;
+const isFloatWidth = (v: number): v is FloatWidth => v === 32 || v === 64;
+
+function NumberBaseConverterPage() {
+	const { value: options, patch } = useNumberBaseOptions();
+	const { bitWidth, signedness, primaryBase, group, uppercase, pad, floatWidth } = options;
+
+	useDocumentTitle('Number Base Converter');
+
+	const [showRail, setShowRail] = useState(true);
+
+	// Canonical state: unsigned bit pattern within the current bit width.
+	const [valueA, setValueA] = useState<bigint>(0n);
+	const [valueB, setValueB] = useState<bigint>(0n);
+	const [shiftN, setShiftN] = useState<number>(1);
+
+	// Per-base text drafts: when the user is mid-typing, the formatted
+	// representation should not steal focus. Each field's raw text is preserved
+	// here until the input is reformatted (clear button, preset, etc.).
+	const [drafts, setDrafts] = useState<Record<Base, string | null>>({
+		2: null,
+		8: null,
+		10: null,
+		16: null,
+	});
+	const [draftsB, setDraftsB] = useState<string | null>(null);
+
+	const formatOpts = useMemo(() => ({ group, uppercase, pad }), [group, uppercase, pad]);
+
+	// Clamp shift amount to the current width whenever width changes.
+	const maxShift = bitWidth;
+	const clampedShift = Math.min(shiftN, maxShift);
+
+	// Whenever bit width changes, re-mask the operands so we do not silently
+	// retain bits outside the new range.
+	const maskedA = toUnsigned(valueA, bitWidth);
+	const maskedB = toUnsigned(valueB, bitWidth);
+
+	const signedA = toSigned(maskedA, bitWidth);
+	const isNegative = signedness === 'signed' && signedA < 0n;
+
+	const resultAnd = bitwiseAnd(maskedA, maskedB, bitWidth);
+	const resultOr = bitwiseOr(maskedA, maskedB, bitWidth);
+	const resultXor = bitwiseXor(maskedA, maskedB, bitWidth);
+	const resultNot = bitwiseNot(maskedA, bitWidth);
+	const resultShl = shiftLeft(maskedA, clampedShift, bitWidth);
+	const resultShr = shiftRight(maskedA, clampedShift, bitWidth, signedness);
+
+	const hammingWeight = popcount(maskedA, bitWidth);
+
+	const baseFormatted = (value: bigint, base: Base): string =>
+		formatInBase(value, base, bitWidth, signedness, formatOpts);
+
+	const handleBaseChange = (base: Base, text: string) => {
+		setDrafts((prev) => ({ ...prev, [base]: text }));
+		const parsed = parseInBase(text, base, bitWidth, signedness);
+		if (parsed !== null) setValueA(parsed);
+	};
+
+	const handleBaseBlur = (base: Base) => {
+		setDrafts((prev) => ({ ...prev, [base]: null }));
+	};
+
+	const handleOperandBChange = (text: string) => {
+		setDraftsB(text);
+		const parsed = parseInBase(text, primaryBase, bitWidth, signedness);
+		if (parsed !== null) setValueB(parsed);
+	};
+
+	const handleBitWidthChange = (raw: string) => {
+		const next = Number(raw);
+		if (!isBitWidth(next)) return;
+		patch({ bitWidth: next });
+		// Re-mask both operands to the new width.
+		setValueA((current) => toUnsigned(current, next));
+		setValueB((current) => toUnsigned(current, next));
+		setShiftN((current) => Math.min(current, next));
+		setDrafts({ 2: null, 8: null, 10: null, 16: null });
+		setDraftsB(null);
+	};
+
+	const handleSignednessChange = (next: string) => {
+		if (next !== 'signed' && next !== 'unsigned') return;
+		patch({ signedness: next });
+		setDrafts({ 2: null, 8: null, 10: null, 16: null });
+		setDraftsB(null);
+	};
+
+	const handlePrimaryBaseChange = (raw: string) => {
+		const next = Number(raw);
+		if (!isBase(next)) return;
+		patch({ primaryBase: next });
+		setDraftsB(null);
+	};
+
+	const handleFloatWidthChange = (raw: string) => {
+		const next = Number(raw);
+		if (!isFloatWidth(next)) return;
+		patch({ floatWidth: next });
+	};
+
+	const handleToggleBit = (index: number) => {
+		setValueA((current) => toggleBit(toUnsigned(current, bitWidth), index, bitWidth));
+		setDrafts({ 2: null, 8: null, 10: null, 16: null });
+	};
+
+	const handleApplyPresetToA = (compute: (w: BitWidth, s: Signedness) => bigint) => {
+		setValueA(compute(bitWidth, signedness));
+		setDrafts({ 2: null, 8: null, 10: null, 16: null });
+	};
+
+	const handleApplyPresetToB = (compute: (w: BitWidth, s: Signedness) => bigint) => {
+		setValueB(compute(bitWidth, signedness));
+		setDraftsB(null);
+	};
+
+	const handleSwapAB = () => {
+		setValueA(maskedB);
+		setValueB(maskedA);
+		setDrafts({ 2: null, 8: null, 10: null, 16: null });
+		setDraftsB(null);
+	};
+
+	const handleApplyFloatPreset = (bits: bigint) => {
+		setValueA(toUnsigned(bits, bitWidth));
+		setDrafts({ 2: null, 8: null, 10: null, 16: null });
+	};
+
+	const handleInterpretFloatInput = (text: string) => {
+		const numeric = Number(text);
+		if (
+			!Number.isFinite(numeric) &&
+			text.trim().toLowerCase() !== 'nan' &&
+			text.trim().toLowerCase() !== 'infinity' &&
+			text.trim().toLowerCase() !== '-infinity'
+		) {
+			return;
+		}
+		const parsed = Number.parseFloat(text);
+		const bits = floatToBits(parsed, floatWidth);
+		setValueA(toUnsigned(bits, bitWidth));
+		setDrafts({ 2: null, 8: null, 10: null, 16: null });
+	};
+
+	const presetButtons = useMemo(
+		() => PRESETS.filter((p) => !p.availableFor || p.availableFor(bitWidth, signedness)),
+		[bitWidth, signedness]
+	);
+
+	const supportsIeee =
+		bitWidth >= 32 && (floatWidth === 32 || floatWidth === 64) && floatWidth <= bitWidth;
+	const ieee = supportsIeee ? ieeeBreakdown(maskedA, floatWidth) : null;
+
+	const showAscii = bitWidth === 8;
+	const asciiData = showAscii ? asciiInfo(maskedA, 8) : null;
+
+	const rangeText = useMemo(() => {
+		if (signedness === 'signed') {
+			return `${signedMin(bitWidth)} … ${signedMax(bitWidth)}`;
+		}
+		return `0 … ${widthMask(bitWidth)}`;
+	}, [bitWidth, signedness]);
+
+	const operandBPlaceholder = `Operand B in ${BASE_LABEL[primaryBase].toLowerCase()}…`;
+
+	return (
+		<ToolShell
+			valid={null}
+			showRail={showRail}
+			onShowRailChange={setShowRail}
+			statusContent={
+				<>
+					<StatItem label="Bits" value={bitWidth} />
+					<StatItem label="Bytes" value={bitWidth / 8} />
+					<StatItem label="Mode" value={signedness === 'signed' ? 'Signed' : 'Unsigned'} />
+					<StatItem label="Pop" value={hammingWeight} />
+					{isNegative ? <StatItem label="Sign" value="-" variant="error" /> : null}
+				</>
+			}
+			rail={
+				<>
+					<FormSection title="Format">
+						<FormSelect
+							label="Bit Width"
+							value={String(bitWidth)}
+							options={BIT_WIDTH_OPTIONS}
+							onValueChange={handleBitWidthChange}
+							size="compact"
+						/>
+						<FormMode<Signedness>
+							label="Signedness"
+							value={signedness}
+							options={
+								SIGNEDNESS_OPTIONS as unknown as readonly { value: Signedness; label: string }[]
+							}
+							onValueChange={(v) => handleSignednessChange(v)}
+						/>
+						<FormSelect
+							label="Primary Base (for operand B)"
+							value={String(primaryBase)}
+							options={PRIMARY_BASE_OPTIONS}
+							onValueChange={handlePrimaryBaseChange}
+							size="compact"
+						/>
+						<FormCheckboxGroup>
+							<FormCheckbox
+								label="Group digits"
+								checked={group}
+								onCheckedChange={(v) => patch({ group: v })}
+								size="compact"
+							/>
+							<FormCheckbox
+								label="Uppercase hex"
+								checked={uppercase}
+								onCheckedChange={(v) => patch({ uppercase: v })}
+								size="compact"
+							/>
+							<FormCheckbox
+								label="Pad to width"
+								checked={pad}
+								onCheckedChange={(v) => patch({ pad: v })}
+								size="compact"
+							/>
+						</FormCheckboxGroup>
+					</FormSection>
+
+					<FormSection title="Bitwise Operand B">
+						<div className="space-y-1">
+							<Label htmlFor="operand-b" className="text-xs text-muted-foreground">
+								Operand B ({BASE_LABEL[primaryBase].toLowerCase()})
+							</Label>
+							<Input
+								id="operand-b"
+								value={draftsB ?? baseFormatted(maskedB, primaryBase)}
+								placeholder={operandBPlaceholder}
+								onChange={(e) => handleOperandBChange(e.target.value)}
+								onBlur={() => setDraftsB(null)}
+								className="h-7 font-mono text-xs"
+							/>
+						</div>
+						<FormSlider
+							label="Shift amount (n)"
+							value={clampedShift}
+							onValueChange={setShiftN}
+							min={0}
+							max={maxShift}
+							step={1}
+							valueLabel={String(clampedShift)}
+							size="compact"
+						/>
+						<div className="flex gap-1">
+							<Button variant="outline" size="sm" className="flex-1" onClick={handleSwapAB}>
+								Swap A ↔ B
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								className="flex-1"
+								onClick={() => handleApplyPresetToB(() => 0n)}
+							>
+								B = 0
+							</Button>
+						</div>
+					</FormSection>
+
+					<FormSection title="IEEE 754">
+						<FormSelect
+							label="Float width"
+							value={String(floatWidth)}
+							options={
+								FLOAT_WIDTH_OPTIONS as unknown as readonly { value: string; label: string }[]
+							}
+							onValueChange={handleFloatWidthChange}
+							size="compact"
+						/>
+						<FormInfo>
+							{bitWidth < 32
+								? 'Switch bit width to 32 or 64 to enable IEEE 754 inspection.'
+								: floatWidth > bitWidth
+									? `Increase bit width to ${floatWidth} or shrink float width.`
+									: 'Float bits are read from the high bits of A.'}
+						</FormInfo>
+					</FormSection>
+
+					<FormSection title="Presets">
+						<div className="grid grid-cols-2 gap-1">
+							{presetButtons.map((preset) => (
+								<Button
+									key={preset.id}
+									variant="outline"
+									size="sm"
+									className="h-7 justify-start truncate px-2 text-xs"
+									onClick={() => handleApplyPresetToA(preset.compute)}
+								>
+									{preset.label}
+								</Button>
+							))}
+						</div>
+					</FormSection>
+
+					<FormSection title="About">
+						<FormInfo>
+							<ul className="list-inside list-disc space-y-0.5">
+								<li>Edit any base to update the rest</li>
+								<li>Click bits in the grid to toggle them</li>
+								<li>Signed mode renders two's complement</li>
+								<li>Range: {rangeText}</li>
+							</ul>
+						</FormInfo>
+					</FormSection>
+				</>
+			}
+		>
+			<div className="flex h-full flex-col overflow-auto p-3">
+				<div className="space-y-3">
+					<BasesGrid
+						value={maskedA}
+						drafts={drafts}
+						bitWidth={bitWidth}
+						signedness={signedness}
+						formatOpts={formatOpts}
+						onBaseChange={handleBaseChange}
+						onBaseBlur={handleBaseBlur}
+					/>
+					<BitGridCard
+						value={maskedA}
+						bitWidth={bitWidth}
+						signedness={signedness}
+						onToggleBit={handleToggleBit}
+					/>
+					<BitwiseTable
+						a={maskedA}
+						b={maskedB}
+						resultAnd={resultAnd}
+						resultOr={resultOr}
+						resultXor={resultXor}
+						resultNot={resultNot}
+						resultShl={resultShl}
+						resultShr={resultShr}
+						shiftN={clampedShift}
+						bitWidth={bitWidth}
+						signedness={signedness}
+						formatOpts={formatOpts}
+					/>
+					{showAscii && asciiData ? <AsciiCard info={asciiData} /> : null}
+					<Card density="compact">
+						<Accordion type="single" collapsible>
+							<AccordionItem value="ieee">
+								<CardHeader className="pb-0">
+									<AccordionTrigger className="py-0">
+										<CardTitle>IEEE 754 ({floatWidth}-bit)</CardTitle>
+									</AccordionTrigger>
+								</CardHeader>
+								<AccordionContent>
+									<CardContent>
+										{ieee ? (
+											<IeeeSection
+												breakdown={ieee}
+												maskedA={maskedA}
+												bitWidth={bitWidth}
+												floatWidth={floatWidth}
+												onApplyFloatPreset={handleApplyFloatPreset}
+												onInterpretFloatInput={handleInterpretFloatInput}
+											/>
+										) : (
+											<p className="text-xs text-muted-foreground">
+												Increase bit width to {floatWidth} bits to inspect IEEE 754 components.
+											</p>
+										)}
+									</CardContent>
+								</AccordionContent>
+							</AccordionItem>
+						</Accordion>
+					</Card>
+				</div>
+			</div>
+		</ToolShell>
+	);
+}
+
+interface BasesGridProps {
+	readonly value: bigint;
+	readonly drafts: Record<Base, string | null>;
+	readonly bitWidth: BitWidth;
+	readonly signedness: Signedness;
+	readonly formatOpts: {
+		readonly group: boolean;
+		readonly uppercase: boolean;
+		readonly pad: boolean;
+	};
+	readonly onBaseChange: (base: Base, text: string) => void;
+	readonly onBaseBlur: (base: Base) => void;
+}
+
+function BasesGrid({
+	value,
+	drafts,
+	bitWidth,
+	signedness,
+	formatOpts,
+	onBaseChange,
+	onBaseBlur,
+}: BasesGridProps) {
+	return (
+		<div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+			{BASES.map((base) => {
+				const draft = drafts[base];
+				const formatted = formatInBase(value, base, bitWidth, signedness, formatOpts);
+				const display = draft ?? formatted;
+				return (
+					<Card key={base} density="compact">
+						<CardHeader className="flex flex-row items-center justify-between gap-2 pb-2">
+							<div className="flex min-w-0 items-center gap-2">
+								<CardTitle className="truncate">{BASE_LABEL[base]}</CardTitle>
+								{BASE_PREFIX[base] ? (
+									<span className="rounded-sm bg-muted px-1 py-0.5 font-mono text-2xs text-muted-foreground">
+										{BASE_PREFIX[base]}
+									</span>
+								) : null}
+								<span className="ml-1 text-2xs text-muted-foreground/70">base {base}</span>
+							</div>
+							<CopyButton
+								text={formatted}
+								toastLabel={BASE_LABEL[base]}
+								size="sm"
+								showLabel={false}
+							/>
+						</CardHeader>
+						<CardContent>
+							<Input
+								value={display}
+								onChange={(e) => onBaseChange(base, e.target.value)}
+								onBlur={() => onBaseBlur(base)}
+								spellCheck={false}
+								autoCorrect="off"
+								autoCapitalize="off"
+								className="h-8 font-mono text-sm tabular-nums"
+							/>
+						</CardContent>
+					</Card>
+				);
+			})}
+		</div>
+	);
+}
+
+interface BitGridCardProps {
+	readonly value: bigint;
+	readonly bitWidth: BitWidth;
+	readonly signedness: Signedness;
+	readonly onToggleBit: (index: number) => void;
+}
+
+function BitGridCard({ value, bitWidth, signedness, onToggleBit }: BitGridCardProps) {
+	// Render most-significant-bit on the left.
+	const indices = useMemo(() => {
+		const out: number[] = [];
+		for (let i = bitWidth - 1; i >= 0; i -= 1) out.push(i);
+		return out;
+	}, [bitWidth]);
+
+	const signBitIndex = bitWidth - 1;
+	const signBitMask = signBit(bitWidth);
+	const isSignBitSet = (value & signBitMask) === signBitMask;
+	const signActive = signedness === 'signed' && isSignBitSet;
+
+	return (
+		<Card density="compact">
+			<CardHeader className="pb-2">
+				<div className="flex items-center justify-between gap-2">
+					<CardTitle>Bit Grid</CardTitle>
+					<div className="flex items-center gap-1 text-2xs text-muted-foreground">
+						<span className="inline-block size-2 rounded-sm bg-primary" />
+						<span>set</span>
+						<span className="ml-2 inline-block size-2 rounded-sm border border-border bg-background" />
+						<span>clear</span>
+						{signedness === 'signed' ? (
+							<>
+								<span className="ml-2 inline-block size-2 rounded-sm bg-destructive" />
+								<span>sign bit</span>
+							</>
+						) : null}
+					</div>
+				</div>
+			</CardHeader>
+			<CardContent>
+				<div
+					className="grid w-full gap-y-1.5 overflow-x-auto"
+					style={{ '--bit-cols': bitWidth } as CSSProperties}
+				>
+					<div
+						className="grid gap-x-0.5"
+						style={{ gridTemplateColumns: `repeat(${bitWidth}, minmax(1.25rem, 1fr))` }}
+					>
+						{indices.map((idx) => {
+							const isByteStart = idx % 8 === 7;
+							return (
+								<span
+									key={`label-${idx}`}
+									className={cn(
+										'text-center font-mono text-[10px] leading-none text-muted-foreground tabular-nums',
+										isByteStart && 'text-foreground/70'
+									)}
+								>
+									{idx}
+								</span>
+							);
+						})}
+					</div>
+					<div
+						className="grid gap-x-0.5"
+						style={{ gridTemplateColumns: `repeat(${bitWidth}, minmax(1.25rem, 1fr))` }}
+					>
+						{indices.map((idx) => {
+							const bit = (value >> BigInt(idx)) & 1n;
+							const isSet = bit === 1n;
+							const isSignBit = idx === signBitIndex && signedness === 'signed';
+							const isByteBoundary = idx % 8 === 0;
+							const placeValue = 1n << BigInt(idx);
+							return (
+								<Tooltip key={`bit-${idx}`}>
+									<TooltipTrigger asChild>
+										<button
+											type="button"
+											aria-label={`Toggle bit ${idx}`}
+											aria-pressed={isSet}
+											onClick={() => onToggleBit(idx)}
+											className={cn(
+												'flex h-6 items-center justify-center rounded-sm border font-mono text-xs leading-none tabular-nums transition-colors',
+												isByteBoundary && 'mr-1',
+												isSet
+													? signActive && isSignBit
+														? 'border-destructive bg-destructive text-destructive-foreground'
+														: 'border-primary bg-primary text-primary-foreground'
+													: signActive && isSignBit
+														? 'border-destructive/60 bg-destructive/10 text-destructive'
+														: 'border-border bg-background text-muted-foreground hover:bg-muted'
+											)}
+										>
+											{isSet ? '1' : '0'}
+										</button>
+									</TooltipTrigger>
+									<TooltipContent>
+										<span className="font-mono text-2xs">
+											bit {idx} · 2^{idx} = {placeValue.toString(10)}
+										</span>
+									</TooltipContent>
+								</Tooltip>
+							);
+						})}
+					</div>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface BitwiseTableProps {
+	readonly a: bigint;
+	readonly b: bigint;
+	readonly resultAnd: bigint;
+	readonly resultOr: bigint;
+	readonly resultXor: bigint;
+	readonly resultNot: bigint;
+	readonly resultShl: bigint;
+	readonly resultShr: bigint;
+	readonly shiftN: number;
+	readonly bitWidth: BitWidth;
+	readonly signedness: Signedness;
+	readonly formatOpts: {
+		readonly group: boolean;
+		readonly uppercase: boolean;
+		readonly pad: boolean;
+	};
+}
+
+function BitwiseTable({
+	a,
+	b,
+	resultAnd,
+	resultOr,
+	resultXor,
+	resultNot,
+	resultShl,
+	resultShr,
+	shiftN,
+	bitWidth,
+	signedness,
+	formatOpts,
+}: BitwiseTableProps) {
+	const rows: readonly { readonly label: string; readonly value: bigint }[] = [
+		{ label: 'A', value: a },
+		{ label: 'B', value: b },
+		{ label: 'A & B', value: resultAnd },
+		{ label: 'A | B', value: resultOr },
+		{ label: 'A ^ B', value: resultXor },
+		{ label: '~A', value: resultNot },
+		{ label: `A << ${shiftN}`, value: resultShl },
+		{ label: `A >> ${shiftN}`, value: resultShr },
+	];
+
+	return (
+		<Card density="compact">
+			<CardHeader className="pb-2">
+				<CardTitle>Bitwise Operations</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<div className="overflow-x-auto">
+					<table className="w-full min-w-max border-collapse text-xs">
+						<thead>
+							<tr className="border-b border-border/60 text-left text-2xs uppercase tracking-wide text-muted-foreground">
+								<th className="py-1.5 pr-3 font-semibold">Expression</th>
+								{BASES.map((base) => (
+									<th key={base} className="py-1.5 pr-3 font-semibold">
+										{BASE_LABEL[base]}
+									</th>
+								))}
+								<th className="py-1.5 pr-1 text-right" />
+							</tr>
+						</thead>
+						<tbody>
+							{rows.map((row) => (
+								<tr key={row.label} className="border-b border-border/30 last:border-b-0">
+									<td className="py-1.5 pr-3 font-mono text-foreground/90">{row.label}</td>
+									{BASES.map((base) => {
+										const text = formatInBase(row.value, base, bitWidth, signedness, formatOpts);
+										return (
+											<td
+												key={base}
+												className="py-1.5 pr-3 font-mono tabular-nums text-foreground/80"
+											>
+												{text}
+											</td>
+										);
+									})}
+									<td className="py-1.5 pr-1 text-right">
+										<CopyButton
+											text={formatInBase(row.value, 10, bitWidth, signedness, formatOpts)}
+											toastLabel={`${row.label} (decimal)`}
+											size="sm"
+											showLabel={false}
+											variant="ghost"
+										/>
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface AsciiCardProps {
+	readonly info: NonNullable<ReturnType<typeof asciiInfo>>;
+}
+
+function AsciiCard({ info }: AsciiCardProps) {
+	const codeHex = `0x${info.codePoint.toString(16).toUpperCase().padStart(2, '0')}`;
+	const codeDec = info.codePoint.toString(10);
+
+	return (
+		<Card density="compact">
+			<CardHeader className="pb-2">
+				<div className="flex items-center justify-between gap-2">
+					<CardTitle>ASCII / Latin-1</CardTitle>
+					<ToneBadge
+						tone={
+							info.category === 'printable'
+								? 'success'
+								: info.category === 'extended'
+									? 'info'
+									: 'warning'
+						}
+					>
+						{info.category}
+					</ToneBadge>
+				</div>
+			</CardHeader>
+			<CardContent>
+				<div className="flex items-center gap-4">
+					<div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-md border bg-muted font-mono text-3xl tabular-nums">
+						{info.glyph ?? info.controlAbbr ?? '?'}
+					</div>
+					<div className="flex flex-col gap-1 text-sm">
+						<div className="flex items-center gap-2">
+							<span className="text-muted-foreground">Name:</span>
+							<span className="font-medium">{info.name}</span>
+						</div>
+						<div className="flex items-center gap-2">
+							<span className="text-muted-foreground">Hex:</span>
+							<span className="font-mono">{codeHex}</span>
+						</div>
+						<div className="flex items-center gap-2">
+							<span className="text-muted-foreground">Decimal:</span>
+							<span className="font-mono">{codeDec}</span>
+						</div>
+						<div className="flex items-center gap-2">
+							<span className="text-muted-foreground">Printable:</span>
+							<span>{info.printable ? 'yes' : 'no'}</span>
+						</div>
+					</div>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface IeeeSectionProps {
+	readonly breakdown: IeeeBreakdown;
+	readonly maskedA: bigint;
+	readonly bitWidth: BitWidth;
+	readonly floatWidth: FloatWidth;
+	readonly onApplyFloatPreset: (bits: bigint) => void;
+	readonly onInterpretFloatInput: (text: string) => void;
+}
+
+function IeeeSection({
+	breakdown,
+	maskedA,
+	bitWidth,
+	floatWidth,
+	onApplyFloatPreset,
+	onInterpretFloatInput,
+}: IeeeSectionProps) {
+	const {
+		sign,
+		biasedExponent,
+		unbiasedExponent,
+		mantissa,
+		exponentBits,
+		mantissaBits,
+		bias,
+		numericValue,
+		classification,
+		hexValue,
+	} = breakdown;
+	const [floatInput, setFloatInput] = useState<string>('');
+
+	// When the bit width exceeds the float width, the float bits live in the
+	// lower `floatWidth` bits. (DataView round-trip ignores higher bits.)
+	const floatBits = maskedA & ((1n << BigInt(floatWidth)) - 1n);
+	const totalBits = floatWidth;
+
+	const cellWidthClass = totalBits === 32 ? 'min-w-6' : 'min-w-4';
+
+	const bitCells: readonly {
+		readonly bit: 0 | 1;
+		readonly zone: 'sign' | 'exponent' | 'mantissa';
+		readonly index: number;
+	}[] = useMemo(() => {
+		const cells: { bit: 0 | 1; zone: 'sign' | 'exponent' | 'mantissa'; index: number }[] = [];
+		for (let i = totalBits - 1; i >= 0; i -= 1) {
+			const bit = ((floatBits >> BigInt(i)) & 1n) === 1n ? 1 : 0;
+			let zone: 'sign' | 'exponent' | 'mantissa';
+			if (i === totalBits - 1) zone = 'sign';
+			else if (i >= mantissaBits) zone = 'exponent';
+			else zone = 'mantissa';
+			cells.push({ bit, zone, index: i });
+		}
+		return cells;
+	}, [floatBits, totalBits, mantissaBits]);
+
+	const zoneClass = (zone: 'sign' | 'exponent' | 'mantissa', bit: 0 | 1): string => {
+		const base =
+			'flex h-6 items-center justify-center rounded-sm border font-mono text-xs leading-none tabular-nums';
+		if (zone === 'sign') {
+			return cn(
+				base,
+				bit === 1
+					? 'border-destructive bg-destructive text-destructive-foreground'
+					: 'border-destructive/40 bg-destructive/10 text-destructive'
+			);
+		}
+		if (zone === 'exponent') {
+			return cn(
+				base,
+				bit === 1
+					? 'border-warning bg-warning/80 text-warning-foreground'
+					: 'border-warning/30 bg-warning/10 text-warning'
+			);
+		}
+		return cn(
+			base,
+			bit === 1
+				? 'border-info bg-info/80 text-info-foreground'
+				: 'border-info/30 bg-info/10 text-info'
+		);
+	};
+
+	const classificationTone =
+		classification === 'normal' || classification === 'zero'
+			? 'success'
+			: classification === 'subnormal'
+				? 'info'
+				: 'warning';
+
+	const numericDisplay = Number.isNaN(numericValue)
+		? 'NaN'
+		: !Number.isFinite(numericValue)
+			? numericValue > 0
+				? '+Infinity'
+				: '-Infinity'
+			: numericValue.toString();
+
+	return (
+		<div className="space-y-3">
+			<div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+				<span>
+					Bit width <span className="font-mono text-foreground">{bitWidth}</span> · float width{' '}
+					<span className="font-mono text-foreground">{floatWidth}</span>
+				</span>
+				<ToneBadge tone={classificationTone}>{classification}</ToneBadge>
+				<span className="font-mono text-foreground">{hexValue}</span>
+			</div>
+			<div className="overflow-x-auto">
+				<div
+					className="grid gap-x-0.5"
+					style={{ gridTemplateColumns: `repeat(${totalBits}, minmax(1rem, 1fr))` }}
+				>
+					{bitCells.map(({ bit, zone, index }) => (
+						<Tooltip key={`f-${index}`}>
+							<TooltipTrigger asChild>
+								<span className={cn(zoneClass(zone, bit), cellWidthClass)}>{bit}</span>
+							</TooltipTrigger>
+							<TooltipContent>
+								<span className="font-mono text-2xs">
+									bit {index} · {zone}
+								</span>
+							</TooltipContent>
+						</Tooltip>
+					))}
+				</div>
+			</div>
+			<div className="grid gap-3 sm:grid-cols-3">
+				<div className="space-y-1 rounded-md border border-destructive/30 bg-destructive/5 p-2 text-xs">
+					<div className="font-semibold text-destructive">Sign (1 bit)</div>
+					<div className="font-mono text-sm">{sign}</div>
+					<div className="text-muted-foreground">{sign === 1 ? 'negative' : 'positive'}</div>
+				</div>
+				<div className="space-y-1 rounded-md border border-warning/30 bg-warning/5 p-2 text-xs">
+					<div className="font-semibold text-warning">Exponent ({exponentBits} bits)</div>
+					<div className="font-mono text-sm">
+						raw {biasedExponent} − bias {bias} = {unbiasedExponent}
+					</div>
+				</div>
+				<div className="space-y-1 rounded-md border border-info/30 bg-info/5 p-2 text-xs">
+					<div className="font-semibold text-info">Mantissa ({mantissaBits} bits)</div>
+					<div className="font-mono text-sm break-all">
+						0x
+						{mantissa
+							.toString(16)
+							.toUpperCase()
+							.padStart(Math.ceil(mantissaBits / 4), '0')}
+					</div>
+				</div>
+			</div>
+			<div className="space-y-1 text-sm">
+				<div className="flex items-center gap-2">
+					<span className="text-muted-foreground">Numeric value:</span>
+					<span className="font-mono">{numericDisplay}</span>
+				</div>
+			</div>
+			<div className="space-y-2 rounded-md border bg-muted/30 p-2">
+				<div className="text-xs font-semibold text-muted-foreground">Interpret a float</div>
+				<div className="flex gap-2">
+					<Input
+						value={floatInput}
+						placeholder="e.g. 3.14159 or -1.5e-3"
+						onChange={(e) => setFloatInput(e.target.value)}
+						className="h-7 flex-1 font-mono text-xs"
+					/>
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => onInterpretFloatInput(floatInput)}
+						disabled={floatInput.trim().length === 0}
+					>
+						To bits
+					</Button>
+				</div>
+				<div className="flex flex-wrap gap-1">
+					{FLOAT_PRESETS.filter((p) => p.width === floatWidth).map((preset) => (
+						<Button
+							key={preset.id}
+							variant="outline"
+							size="sm"
+							className="h-6 px-2 text-2xs"
+							onClick={() => onApplyFloatPreset(preset.bits)}
+						>
+							{preset.label}
+						</Button>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Add a Number Base Converter under **Generators** that displays binary / octal / decimal / hexadecimal representations simultaneously, with a bit-grid visualization, bitwise operations panel, IEEE 754 view, and ASCII column. Closes #219.

## Features

- **4 bases at once** (bin / oct / dec / hex) — edit any one, others update
- **Bit width selector**: 8 / 16 / 32 / 64-bit
- **Signed / unsigned toggle** with two's-complement view (sign bit highlighted in red when negative)
- **Bit grid** with byte boundaries, per-bit click-to-toggle, hover tooltip with place value
- **Bitwise operations**: AND / OR / XOR / NOT / shift-left / shift-right, all four bases shown for each result
- **IEEE 754 view** (32-bit and 64-bit): sign / exponent / mantissa breakdown with color coding, plus a "decimal to bits" interpreter
- **ASCII / Latin-1 column** for 8-bit byte values (glyph, name, hex / decimal codepoint)
- **Presets**: 0, 1, -1, MAX, MIN, sign-bit-only, all-1s, alternating-bits (0xAA…), low / high nibble, plus IEEE 754 quick patterns (pi, e, +Inf, NaN, …)
- **Live status bar**: bit count, byte count, signed/unsigned mode, Hamming weight, negative-sign indicator
- **Persisted options** via `createToolOptionsStore('number-base-converter', …)` — bit width, signedness, format flags survive reloads

## Changes

### Added

- `src/routes/number-base-converter.tsx` — page component with rail + main pane
- `src/lib/services/number-base.ts` — pure parse / format / bitwise / IEEE 754 / ASCII logic (BigInt end-to-end so 64-bit values round-trip cleanly)
- Page registration entry in `src/lib/services/pages.ts`

## Test plan

- [x] `bun run check` (TS + validate-pages + audit-design) green
- [x] `bun run lint` no new warnings in the touched files
- [x] `bun run format` clean
- [x] `bun test` 141 tests pass
- [x] `bun run build` succeeds
- [ ] Manual: enter values in each of the four bases, verify others update
- [ ] Manual: toggle 8 / 16 / 32 / 64 width, confirm two's-complement view flips sign bit color
- [ ] Manual: click bits in the bit grid, verify decimal updates
- [ ] Manual: enter operand B, verify all bitwise results
- [ ] Manual: switch to 32-bit, enter a known IEEE 754 pattern (e.g., 0x40490FDB = pi), verify breakdown
- [ ] Manual: switch to 8-bit, enter 65, verify ASCII shows 'A'

Closes #219
