### PR TITLE
feat(x509-decoder): add X.509 Certificate Decoder tool

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@hpcc-js/wasm-graphviz": "^1.21.5",
+        "@peculiar/x509": "^2.0.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "4.3.0",
         "@tauri-apps/api": "^2.11.0",
@@ -37,6 +38,7 @@
         "crypto-js": "^4.2.0",
         "date-fns": "^4.3.0",
         "fuse.js": "^7.3.0",
+        "js-md5": "^0.8.3",
         "json5": "^2.2.3",
         "jsonc-parser": "^3.3.1",
         "katex": "^0.17.0",
@@ -342,6 +344,30 @@
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.130.0", "", {}, "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q=="],
+
+    "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "@peculiar/asn1-x509-attr": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ=="],
+
+    "@peculiar/asn1-csr": ["@peculiar/asn1-csr@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA=="],
+
+    "@peculiar/asn1-ecc": ["@peculiar/asn1-ecc@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw=="],
+
+    "@peculiar/asn1-pfx": ["@peculiar/asn1-pfx@2.7.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.7.0", "@peculiar/asn1-pkcs8": "^2.7.0", "@peculiar/asn1-rsa": "^2.7.0", "@peculiar/asn1-schema": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA=="],
+
+    "@peculiar/asn1-pkcs8": ["@peculiar/asn1-pkcs8@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw=="],
+
+    "@peculiar/asn1-pkcs9": ["@peculiar/asn1-pkcs9@2.7.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.7.0", "@peculiar/asn1-pfx": "^2.7.0", "@peculiar/asn1-pkcs8": "^2.7.0", "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "@peculiar/asn1-x509-attr": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew=="],
+
+    "@peculiar/asn1-rsa": ["@peculiar/asn1-rsa@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ=="],
+
+    "@peculiar/asn1-schema": ["@peculiar/asn1-schema@2.7.0", "", { "dependencies": { "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg=="],
+
+    "@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g=="],
+
+    "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.7.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/asn1-x509": "^2.7.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w=="],
+
+    "@peculiar/utils": ["@peculiar/utils@2.0.3", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ=="],
+
+    "@peculiar/x509": ["@peculiar/x509@2.0.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-r10lkuy6BNfRmyYdRAfgu6dq0HOmyIV2OLhXWE3gDEPBdX1b8miztJVyX/UxWhLwemNyDP3CLZHpDxDwSY0xaA=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -865,6 +891,8 @@
 
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
+    "asn1js": ["asn1js@3.0.10", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.5", "tslib": "^2.8.1" } }, "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg=="],
+
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
@@ -1289,6 +1317,8 @@
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
+    "js-md5": ["js-md5@0.8.3", "", {}, "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
@@ -1569,6 +1599,10 @@
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
+    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
+
+    "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
+
     "qr-code-styling": ["qr-code-styling@1.9.2", "", { "dependencies": { "qrcode-generator": "^1.4.4" } }, "sha512-RgJaZJ1/RrXJ6N0j7a+pdw3zMBmzZU4VN2dtAZf8ZggCfRB5stEQ3IoDNGaNhYY3nnZKYlYSLl5YkfWN5dPutg=="],
 
     "qrcode-generator": ["qrcode-generator@1.5.2", "", {}, "sha512-pItrW0Z9HnDBnFmgiNrY1uxRdri32Uh9EjNYLPVC2zZ3ZRIIEqBoDgm4DkvDwNNDHTK7FNkmr8zAa77BYc9xNw=="],
@@ -1754,6 +1788,8 @@
     "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
@@ -1954,6 +1990,8 @@
     "shadcn/postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
 
     "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 	"dependencies": {
 		"@fontsource-variable/geist": "^5.2.8",
 		"@hpcc-js/wasm-graphviz": "^1.21.5",
+		"@peculiar/x509": "^2.0.0",
 		"@tailwindcss/typography": "^0.5.19",
 		"@tailwindcss/vite": "4.3.0",
 		"@tauri-apps/api": "^2.11.0",
@@ -77,6 +78,7 @@
 		"crypto-js": "^4.2.0",
 		"date-fns": "^4.3.0",
 		"fuse.js": "^7.3.0",
+		"js-md5": "^0.8.3",
 		"json5": "^2.2.3",
 		"jsonc-parser": "^3.3.1",
 		"katex": "^0.17.0",

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -4,6 +4,7 @@
  */
 import {
 	ArrowRightLeft,
+	BadgeCheck,
 	Binary,
 	Braces,
 	Calculator,
@@ -163,6 +164,15 @@ export const PAGES: readonly PageDefinition[] = [
 		icon: Key,
 		description: 'Decode and inspect JWT tokens',
 		color: 'text-purple-500',
+		category: 'encoders',
+	},
+	{
+		id: 'x509-decoder',
+		title: 'X.509 Certificate Decoder',
+		url: '/x509-decoder',
+		icon: BadgeCheck,
+		description: 'Decode X.509 / PEM certificates with chain visualization and fingerprints',
+		color: 'text-teal-600',
 		category: 'encoders',
 	},
 	{

--- a/src/lib/services/x509-samples.ts
+++ b/src/lib/services/x509-samples.ts
@@ -1,0 +1,119 @@
+/**
+ * Sample certificate generator for the X.509 Certificate Decoder tool.
+ *
+ * Generates fresh, self-signed certificates at runtime via Web Crypto and
+ * `@peculiar/x509`. Avoids shipping any hard-coded PEM / DER blobs in the
+ * source tree (which would otherwise grow stale and bloat the bundle).
+ */
+
+import {
+	BasicConstraintsExtension,
+	cryptoProvider,
+	ExtendedKeyUsageExtension,
+	KeyUsageFlags,
+	KeyUsagesExtension,
+	SubjectAlternativeNameExtension,
+	SubjectKeyIdentifierExtension,
+	X509CertificateGenerator,
+} from '@peculiar/x509';
+
+cryptoProvider.set(crypto);
+
+const RSA_ALG: RsaHashedKeyGenParams = {
+	name: 'RSASSA-PKCS1-v1_5',
+	modulusLength: 2048,
+	publicExponent: new Uint8Array([1, 0, 1]),
+	hash: 'SHA-256',
+};
+
+const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+
+const newSerial = (): string => {
+	const bytes = new Uint8Array(8);
+	crypto.getRandomValues(bytes);
+	return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+};
+
+/**
+ * Generate a fresh self-signed leaf certificate (TLS server + client usage,
+ * valid for one year from now).
+ */
+export const generateSampleLeafCertificate = async (): Promise<string> => {
+	const keys = await crypto.subtle.generateKey(RSA_ALG, true, ['sign', 'verify']);
+	const now = new Date();
+	const ski = await SubjectKeyIdentifierExtension.create(keys.publicKey);
+	const san = new SubjectAlternativeNameExtension([
+		{ type: 'dns', value: 'sample.kogu.local' },
+		{ type: 'dns', value: '*.sample.kogu.local' },
+		{ type: 'ip', value: '127.0.0.1' },
+		{ type: 'email', value: 'sample@kogu.local' },
+	]);
+	const cert = await X509CertificateGenerator.createSelfSigned({
+		serialNumber: newSerial(),
+		name: 'CN=sample.kogu.local, O=Kogu Sample, OU=Engineering, C=US, ST=California, L=San Francisco',
+		notBefore: now,
+		notAfter: new Date(now.getTime() + YEAR_MS),
+		signingAlgorithm: RSA_ALG,
+		keys,
+		extensions: [
+			new BasicConstraintsExtension(false, undefined, true),
+			new KeyUsagesExtension(KeyUsageFlags.digitalSignature | KeyUsageFlags.keyEncipherment, true),
+			new ExtendedKeyUsageExtension(['1.3.6.1.5.5.7.3.1', '1.3.6.1.5.5.7.3.2'], false),
+			san,
+			ski,
+		],
+	});
+	return cert.toString('pem');
+};
+
+/**
+ * Generate a fresh two-cert chain: a CA root and a leaf signed by the CA.
+ * The returned string concatenates both PEMs (CA first, then leaf) and is
+ * the canonical "chain bundle" format consumed by parseCertificates().
+ */
+export const generateSampleChain = async (): Promise<string> => {
+	const caKeys = await crypto.subtle.generateKey(RSA_ALG, true, ['sign', 'verify']);
+	const leafKeys = await crypto.subtle.generateKey(RSA_ALG, true, ['sign', 'verify']);
+	const now = new Date();
+	const caNotAfter = new Date(now.getTime() + YEAR_MS * 5);
+	const leafNotAfter = new Date(now.getTime() + YEAR_MS);
+
+	const caSki = await SubjectKeyIdentifierExtension.create(caKeys.publicKey);
+	const ca = await X509CertificateGenerator.createSelfSigned({
+		serialNumber: newSerial(),
+		name: 'CN=Kogu Sample Root CA, O=Kogu Sample, C=US',
+		notBefore: now,
+		notAfter: caNotAfter,
+		signingAlgorithm: RSA_ALG,
+		keys: caKeys,
+		extensions: [
+			new BasicConstraintsExtension(true, 1, true),
+			new KeyUsagesExtension(KeyUsageFlags.keyCertSign | KeyUsageFlags.cRLSign, true),
+			caSki,
+		],
+	});
+
+	const leafSki = await SubjectKeyIdentifierExtension.create(leafKeys.publicKey);
+	const leaf = await X509CertificateGenerator.create({
+		serialNumber: newSerial(),
+		subject: 'CN=sample.kogu.local, O=Kogu Sample, C=US',
+		issuer: ca.subject,
+		notBefore: now,
+		notAfter: leafNotAfter,
+		signingAlgorithm: RSA_ALG,
+		publicKey: leafKeys.publicKey,
+		signingKey: caKeys.privateKey,
+		extensions: [
+			new BasicConstraintsExtension(false, undefined, true),
+			new KeyUsagesExtension(KeyUsageFlags.digitalSignature | KeyUsageFlags.keyEncipherment, true),
+			new ExtendedKeyUsageExtension(['1.3.6.1.5.5.7.3.1'], false),
+			new SubjectAlternativeNameExtension([
+				{ type: 'dns', value: 'sample.kogu.local' },
+				{ type: 'dns', value: 'api.sample.kogu.local' },
+			]),
+			leafSki,
+		],
+	});
+
+	return `${ca.toString('pem')}\n${leaf.toString('pem')}`;
+};

--- a/src/lib/services/x509.ts
+++ b/src/lib/services/x509.ts
@@ -1,0 +1,691 @@
+/**
+ * X.509 certificate parsing service.
+ *
+ * Wraps `@peculiar/x509` (ASN.1 + X.509 v3 parsing) and the Web Crypto API
+ * (SHA-256 / SHA-1 digests) plus `js-md5` (MD5 digest, not exposed via
+ * `crypto.subtle`) to produce a fully structured representation of one or
+ * more pasted certificates. All parsing happens client-side; the service
+ * never performs network I/O.
+ */
+
+import {
+	AuthorityInfoAccessExtension,
+	AuthorityKeyIdentifierExtension,
+	BasicConstraintsExtension,
+	CRLDistributionPointsExtension,
+	cryptoProvider,
+	ExtendedKeyUsageExtension,
+	KeyUsageFlags,
+	KeyUsagesExtension,
+	PemConverter,
+	SubjectAlternativeNameExtension,
+	SubjectKeyIdentifierExtension,
+	X509Certificate,
+} from '@peculiar/x509';
+import type { GeneralName } from '@peculiar/x509';
+import { md5 } from 'js-md5';
+
+import { getErrorMessage } from '@/lib/utils';
+
+// Register the platform Web Crypto so @peculiar/x509 can compute thumbprints
+// and digests without an explicit `crypto` argument at every call site.
+cryptoProvider.set(crypto);
+
+// Friendly display names for the standard certificate extensions surfaced
+// in the UI. Unknown extensions fall back to their OID.
+const EXT_NAMES: Readonly<Record<string, string>> = {
+	'2.5.29.15': 'Key Usage',
+	'2.5.29.37': 'Extended Key Usage',
+	'2.5.29.17': 'Subject Alternative Name',
+	'2.5.29.18': 'Issuer Alternative Name',
+	'2.5.29.19': 'Basic Constraints',
+	'2.5.29.14': 'Subject Key Identifier',
+	'2.5.29.35': 'Authority Key Identifier',
+	'2.5.29.31': 'CRL Distribution Points',
+	'2.5.29.32': 'Certificate Policies',
+	'1.3.6.1.5.5.7.1.1': 'Authority Information Access',
+};
+
+// Human-readable names for the bit positions of the KeyUsage extension.
+// Order matches RFC 5280 §4.2.1.3.
+const KEY_USAGE_LABELS: readonly { readonly flag: KeyUsageFlags; readonly label: string }[] = [
+	{ flag: KeyUsageFlags.digitalSignature, label: 'Digital Signature' },
+	{ flag: KeyUsageFlags.nonRepudiation, label: 'Non Repudiation' },
+	{ flag: KeyUsageFlags.keyEncipherment, label: 'Key Encipherment' },
+	{ flag: KeyUsageFlags.dataEncipherment, label: 'Data Encipherment' },
+	{ flag: KeyUsageFlags.keyAgreement, label: 'Key Agreement' },
+	{ flag: KeyUsageFlags.keyCertSign, label: 'Certificate Sign' },
+	{ flag: KeyUsageFlags.cRLSign, label: 'CRL Sign' },
+	{ flag: KeyUsageFlags.encipherOnly, label: 'Encipher Only' },
+	{ flag: KeyUsageFlags.decipherOnly, label: 'Decipher Only' },
+];
+
+// Common Extended Key Usage OIDs to human-readable purposes. Anything else
+// is rendered as its raw OID.
+const EXTENDED_KEY_USAGE_NAMES: Readonly<Record<string, string>> = {
+	'1.3.6.1.5.5.7.3.1': 'TLS Server Authentication',
+	'1.3.6.1.5.5.7.3.2': 'TLS Client Authentication',
+	'1.3.6.1.5.5.7.3.3': 'Code Signing',
+	'1.3.6.1.5.5.7.3.4': 'Email Protection',
+	'1.3.6.1.5.5.7.3.8': 'Time Stamping',
+	'1.3.6.1.5.5.7.3.9': 'OCSP Signing',
+};
+
+// Short labels for the DN component OIDs the UI surfaces directly. Anything
+// else falls back to the raw OID string.
+const DN_SHORT_NAMES: Readonly<Record<string, string>> = {
+	'2.5.4.3': 'CN',
+	'2.5.4.6': 'C',
+	'2.5.4.7': 'L',
+	'2.5.4.8': 'ST',
+	'2.5.4.10': 'O',
+	'2.5.4.11': 'OU',
+	'2.5.4.5': 'serialNumber',
+	'1.2.840.113549.1.9.1': 'emailAddress',
+	'0.9.2342.19200300.100.1.25': 'DC',
+	'2.5.4.4': 'SN',
+	'2.5.4.42': 'GN',
+	'2.5.4.12': 'title',
+};
+
+export type CertInputFormat = 'pem' | 'base64' | 'der';
+
+export interface DnComponent {
+	readonly oid: string;
+	readonly shortName: string;
+	readonly value: string;
+}
+
+export interface DistinguishedName {
+	readonly raw: string;
+	readonly components: readonly DnComponent[];
+}
+
+export type SanType = 'dns' | 'ip' | 'uri' | 'email' | 'dirName' | 'other';
+
+export interface SanEntry {
+	readonly type: SanType;
+	readonly value: string;
+}
+
+export interface PublicKeyInfo {
+	readonly algorithm: string;
+	readonly bitLength?: number;
+	readonly curve?: string;
+	readonly modulusPreview?: string;
+	readonly exponent?: string;
+	readonly raw: string;
+}
+
+export interface KeyUsageExt {
+	readonly kind: 'keyUsage';
+	readonly usages: readonly string[];
+}
+
+export interface ExtendedKeyUsageExt {
+	readonly kind: 'extendedKeyUsage';
+	readonly purposes: readonly { readonly oid: string; readonly name: string }[];
+}
+
+export interface BasicConstraintsExt {
+	readonly kind: 'basicConstraints';
+	readonly ca: boolean;
+	readonly pathLenConstraint?: number;
+}
+
+export interface SubjectAltNameExt {
+	readonly kind: 'subjectAltName';
+	readonly entries: readonly SanEntry[];
+}
+
+export interface CrlDistributionExt {
+	readonly kind: 'crlDistributionPoints';
+	readonly urls: readonly string[];
+}
+
+export interface AuthorityInfoAccessExt {
+	readonly kind: 'authorityInfoAccess';
+	readonly ocspUrls: readonly string[];
+	readonly caIssuerUrls: readonly string[];
+}
+
+export interface SubjectKeyIdExt {
+	readonly kind: 'subjectKeyId';
+	readonly keyId: string;
+}
+
+export interface AuthorityKeyIdExt {
+	readonly kind: 'authorityKeyId';
+	readonly keyId?: string;
+	readonly issuerSerial?: string;
+}
+
+export interface RawExt {
+	readonly kind: 'raw';
+	readonly value: string;
+}
+
+export type ParsedExtensionData =
+	| KeyUsageExt
+	| ExtendedKeyUsageExt
+	| BasicConstraintsExt
+	| SubjectAltNameExt
+	| CrlDistributionExt
+	| AuthorityInfoAccessExt
+	| SubjectKeyIdExt
+	| AuthorityKeyIdExt
+	| RawExt;
+
+export interface ParsedExtension {
+	readonly oid: string;
+	readonly name: string;
+	readonly critical: boolean;
+	readonly parsed: ParsedExtensionData;
+}
+
+export interface Fingerprints {
+	readonly sha256: string;
+	readonly sha1: string;
+	readonly md5: string;
+}
+
+export interface ParsedCertificate {
+	readonly version: number;
+	readonly serialNumber: string;
+	readonly signatureAlgorithm: string;
+	readonly subject: DistinguishedName;
+	readonly issuer: DistinguishedName;
+	readonly notBefore: Date;
+	readonly notAfter: Date;
+	readonly publicKey: PublicKeyInfo;
+	readonly subjectAlternativeNames: readonly SanEntry[];
+	readonly extensions: readonly ParsedExtension[];
+	readonly fingerprints: Fingerprints;
+	readonly pem: string;
+	readonly derBase64: string;
+	readonly selfSigned: boolean;
+}
+
+export interface ParseError {
+	readonly index: number;
+	readonly message: string;
+}
+
+export interface ParseResult {
+	readonly certificates: readonly ParsedCertificate[];
+	readonly errors: readonly ParseError[];
+}
+
+// Format DER bytes as colon-separated uppercase hex (e.g. `AB:CD:EF`).
+const bytesToColonHex = (bytes: Uint8Array): string =>
+	Array.from(bytes, (b) => b.toString(16).padStart(2, '0').toUpperCase()).join(':');
+
+// Format bytes as space-separated lowercase hex with no separators in the
+// preview; used for the modulus snippet.
+const bytesToSpacedHex = (bytes: Uint8Array): string =>
+	Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join(' ');
+
+const hexStringToBytes = (hex: string): Uint8Array => {
+	const clean = hex.replace(/[^0-9a-fA-F]/g, '');
+	const out = new Uint8Array(Math.floor(clean.length / 2));
+	for (let i = 0; i < out.length; i += 1) {
+		out[i] = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+	}
+	return out;
+};
+
+const arrayBufferToUint8 = (buffer: ArrayBuffer): Uint8Array => new Uint8Array(buffer);
+
+const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
+	const bytes = arrayBufferToUint8(buffer);
+	let binary = '';
+	for (let i = 0; i < bytes.length; i += 1) {
+		binary += String.fromCharCode(bytes[i] ?? 0);
+	}
+	return btoa(binary);
+};
+
+const base64ToBytes = (input: string): Uint8Array => {
+	const cleaned = input.replace(/\s+/g, '');
+	const binary = atob(cleaned);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i += 1) {
+		bytes[i] = binary.charCodeAt(i);
+	}
+	return bytes;
+};
+
+// Detect a PEM blob without committing to a specific tag (CERTIFICATE,
+// TRUSTED CERTIFICATE, etc.).
+const looksLikePem = (text: string): boolean => /-----BEGIN [^-]+-----/.test(text);
+
+// Extract individual PEM blocks from a multi-cert bundle. Falls back to a
+// single-entry array when only one BEGIN marker is present.
+const splitPemBlocks = (pem: string): readonly string[] => {
+	const matches = pem.match(/-----BEGIN [^-]+-----[\s\S]*?-----END [^-]+-----/g);
+	return matches ?? [];
+};
+
+// Re-pack a Uint8Array onto a fresh ArrayBuffer so the resulting view
+// satisfies `BufferSource` even when the source is `Uint8Array<ArrayBufferLike>`
+// (TypeScript 7's stricter generic on TypedArray surfaces this distinction).
+const toArrayBufferView = (bytes: Uint8Array): ArrayBuffer => {
+	const out = new ArrayBuffer(bytes.byteLength);
+	new Uint8Array(out).set(bytes);
+	return out;
+};
+
+const computeDigest = async (
+	algorithm: 'SHA-256' | 'SHA-1',
+	bytes: Uint8Array
+): Promise<string> => {
+	const buf = await crypto.subtle.digest(algorithm, toArrayBufferView(bytes));
+	return bytesToColonHex(arrayBufferToUint8(buf));
+};
+
+const computeMd5 = (bytes: Uint8Array): string => {
+	const hex = md5(bytes);
+	const upper = hex.toUpperCase();
+	return upper.match(/.{2}/g)?.join(':') ?? upper;
+};
+
+const computeFingerprints = async (derBytes: Uint8Array): Promise<Fingerprints> => {
+	const [sha256, sha1] = await Promise.all([
+		computeDigest('SHA-256', derBytes),
+		computeDigest('SHA-1', derBytes),
+	]);
+	return { sha256, sha1, md5: computeMd5(derBytes) };
+};
+
+const parseDistinguishedName = (raw: string): DistinguishedName => {
+	// `@peculiar/x509` returns the DN as a string `CN=foo, O=bar, C=US`. Split
+	// on commas that are not preceded by an escape, then on `=` keeping the
+	// first occurrence so values with `=` survive.
+	const parts = raw.split(/,(?![^"]*"(?:(?:[^"]*"){2})*[^"]*$)/).map((p) => p.trim());
+	const components = parts
+		.map((part): DnComponent | null => {
+			const eq = part.indexOf('=');
+			if (eq <= 0) return null;
+			const rawKey = part.slice(0, eq).trim();
+			const value = part.slice(eq + 1).trim();
+			// Keys can arrive as either OIDs (`2.5.4.3`) or shortnames (`CN`).
+			const oid = /^[0-9.]+$/.test(rawKey)
+				? rawKey
+				: (Object.entries(DN_SHORT_NAMES).find(([, short]) => short === rawKey)?.[0] ?? rawKey);
+			const shortName = DN_SHORT_NAMES[oid] ?? rawKey;
+			return { oid, shortName, value };
+		})
+		.filter((c): c is DnComponent => c !== null);
+	return { raw, components };
+};
+
+const mapGeneralNameType = (name: GeneralName): SanType => {
+	switch (name.type) {
+		case 'dns':
+			return 'dns';
+		case 'ip':
+			return 'ip';
+		case 'url':
+			return 'uri';
+		case 'email':
+			return 'email';
+		case 'dn':
+			return 'dirName';
+		default:
+			return 'other';
+	}
+};
+
+const extractSubjectAltNames = (cert: X509Certificate): readonly SanEntry[] => {
+	const ext = cert.getExtension(SubjectAlternativeNameExtension);
+	if (!ext) return [];
+	return ext.names.items.map((n) => ({ type: mapGeneralNameType(n), value: n.value }));
+};
+
+const decodePublicKey = async (cert: X509Certificate): Promise<PublicKeyInfo> => {
+	const pk = cert.publicKey;
+	const raw = pk.rawData;
+	const rawB64 = arrayBufferToBase64(raw);
+	const algorithm = pk.algorithm.name;
+	const rsa = pk.algorithm as RsaHashedKeyGenParams & { modulusLength?: number };
+	const ec = pk.algorithm as EcKeyAlgorithm & { namedCurve?: string };
+
+	// Try Web Crypto import to extract modulus / exponent details. We only
+	// care about the algorithm metadata, so importKey failure falls back to
+	// the algorithm name from the SPKI.
+	const bitLength = typeof rsa.modulusLength === 'number' ? rsa.modulusLength : undefined;
+	const curve = typeof ec.namedCurve === 'string' ? ec.namedCurve : undefined;
+
+	if (algorithm.toLowerCase().includes('rsa')) {
+		try {
+			const cryptoKey = await pk.export(
+				{ name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+				['verify'],
+				crypto
+			);
+			const jwk = await crypto.subtle.exportKey('jwk', cryptoKey);
+			const modulusB64 = jwk.n ?? '';
+			const exponentB64 = jwk.e ?? '';
+			const modulusBytes = base64UrlToBytes(modulusB64);
+			const exponentBytes = base64UrlToBytes(exponentB64);
+			const previewBytes = modulusBytes.slice(0, 16);
+			const exponent =
+				exponentBytes.length > 0
+					? `0x${Array.from(exponentBytes, (b) => b.toString(16)).join('')}`
+					: undefined;
+			return {
+				algorithm: 'RSA',
+				bitLength: bitLength ?? modulusBytes.length * 8,
+				modulusPreview: `${bytesToSpacedHex(previewBytes)} ...`,
+				exponent,
+				raw: rawB64,
+			};
+		} catch {
+			return { algorithm: 'RSA', bitLength, raw: rawB64 };
+		}
+	}
+
+	if (algorithm.toLowerCase().includes('ec')) {
+		return { algorithm: 'EC', curve, raw: rawB64 };
+	}
+
+	return { algorithm, bitLength, curve, raw: rawB64 };
+};
+
+const base64UrlToBytes = (input: string): Uint8Array => {
+	const padded = input.replace(/-/g, '+').replace(/_/g, '/');
+	const padding = padded.length % 4 === 0 ? '' : '='.repeat(4 - (padded.length % 4));
+	return base64ToBytes(padded + padding);
+};
+
+const parseKeyUsage = (cert: X509Certificate): ParsedExtensionData => {
+	const ext = cert.getExtension(KeyUsagesExtension);
+	const usages = ext
+		? KEY_USAGE_LABELS.filter((info) => (ext.usages & info.flag) === info.flag).map(
+				(info) => info.label
+			)
+		: [];
+	return { kind: 'keyUsage', usages };
+};
+
+const parseExtendedKeyUsage = (cert: X509Certificate): ParsedExtensionData => {
+	const ext = cert.getExtension(ExtendedKeyUsageExtension);
+	const purposes = ext
+		? ext.usages.map((u) => {
+				const oidString = String(u);
+				return { oid: oidString, name: EXTENDED_KEY_USAGE_NAMES[oidString] ?? oidString };
+			})
+		: [];
+	return { kind: 'extendedKeyUsage', purposes };
+};
+
+const parseBasicConstraints = (cert: X509Certificate): ParsedExtensionData => {
+	const ext = cert.getExtension(BasicConstraintsExtension);
+	return {
+		kind: 'basicConstraints',
+		ca: ext?.ca ?? false,
+		pathLenConstraint: ext?.pathLength,
+	};
+};
+
+const parseSubjectAltName = (cert: X509Certificate): ParsedExtensionData => {
+	const ext = cert.getExtension(SubjectAlternativeNameExtension);
+	const entries = ext
+		? ext.names.items.map((n) => ({ type: mapGeneralNameType(n), value: n.value }))
+		: [];
+	return { kind: 'subjectAltName', entries };
+};
+
+const parseSubjectKeyId = (cert: X509Certificate): ParsedExtensionData => {
+	const ext = cert.getExtension(SubjectKeyIdentifierExtension);
+	return { kind: 'subjectKeyId', keyId: ext?.keyId ?? '' };
+};
+
+const parseAuthorityKeyId = (cert: X509Certificate): ParsedExtensionData => {
+	const ext = cert.getExtension(AuthorityKeyIdentifierExtension);
+	return {
+		kind: 'authorityKeyId',
+		keyId: ext?.keyId,
+		issuerSerial: ext?.certId?.serialNumber,
+	};
+};
+
+const parseCrlDistribution = (cert: X509Certificate): ParsedExtensionData => {
+	const ext = cert.getExtension(CRLDistributionPointsExtension);
+	const urls = ext
+		? ext.distributionPoints
+				.flatMap((dp) => dp.distributionPoint?.fullName ?? [])
+				.flatMap((gn) => {
+					const url = gn.uniformResourceIdentifier;
+					return typeof url === 'string' ? [url] : [];
+				})
+		: [];
+	return { kind: 'crlDistributionPoints', urls };
+};
+
+const parseAuthorityInfo = (cert: X509Certificate): ParsedExtensionData => {
+	const ext = cert.getExtension(AuthorityInfoAccessExtension);
+	const ocspUrls = ext ? ext.ocsp.map((g) => g.value) : [];
+	const caIssuerUrls = ext ? ext.caIssuers.map((g) => g.value) : [];
+	return { kind: 'authorityInfoAccess', ocspUrls, caIssuerUrls };
+};
+
+// Dispatch table mapping standard extension OIDs to dedicated decoders.
+// Unknown OIDs fall through to the raw-bytes preview.
+const EXTENSION_DECODERS: Readonly<Record<string, (cert: X509Certificate) => ParsedExtensionData>> =
+	{
+		'2.5.29.15': parseKeyUsage,
+		'2.5.29.37': parseExtendedKeyUsage,
+		'2.5.29.19': parseBasicConstraints,
+		'2.5.29.17': parseSubjectAltName,
+		'2.5.29.14': parseSubjectKeyId,
+		'2.5.29.35': parseAuthorityKeyId,
+		'2.5.29.31': parseCrlDistribution,
+		'1.3.6.1.5.5.7.1.1': parseAuthorityInfo,
+	};
+
+const parseExtension = (cert: X509Certificate, oid: string): ParsedExtension => {
+	const name = EXT_NAMES[oid] ?? oid;
+	const rawExt = cert.extensions.find((e) => e.type === oid);
+	const critical = rawExt?.critical ?? false;
+	const decoder = EXTENSION_DECODERS[oid];
+	if (decoder) {
+		return { oid, name, critical, parsed: decoder(cert) };
+	}
+	return {
+		oid,
+		name,
+		critical,
+		parsed: {
+			kind: 'raw',
+			value: rawExt
+				? bytesToColonHex(arrayBufferToUint8(rawExt.value)).slice(0, 96)
+				: '(no payload)',
+		},
+	};
+};
+
+const buildParsedCertificate = async (derBytes: Uint8Array): Promise<ParsedCertificate> => {
+	const cert = new X509Certificate(toArrayBufferView(derBytes));
+	const subject = parseDistinguishedName(cert.subject);
+	const issuer = parseDistinguishedName(cert.issuer);
+	const publicKey = await decodePublicKey(cert);
+	const fingerprints = await computeFingerprints(derBytes);
+	const subjectAlternativeNames = extractSubjectAltNames(cert);
+	const extensions = cert.extensions.map((e) => parseExtension(cert, e.type));
+	const serialNumber = cert.serialNumber.replace(/(.{2})(?=.)/g, '$1:').toUpperCase();
+	let selfSigned = false;
+	try {
+		selfSigned = await cert.isSelfSigned();
+	} catch {
+		selfSigned = subject.raw === issuer.raw;
+	}
+
+	return {
+		// `@peculiar/x509` exposes the certificate version implicitly through
+		// the underlying ASN. For X.509 v3 (the only version this tool targets)
+		// the version field is always 3 when extensions are present, so we
+		// derive it from extension presence.
+		version: extensions.length > 0 ? 3 : 1,
+		serialNumber,
+		signatureAlgorithm: cert.signatureAlgorithm.name,
+		subject,
+		issuer,
+		notBefore: cert.notBefore,
+		notAfter: cert.notAfter,
+		publicKey,
+		subjectAlternativeNames,
+		extensions,
+		fingerprints,
+		pem: cert.toString('pem'),
+		derBase64: arrayBufferToBase64(cert.rawData),
+		selfSigned,
+	};
+};
+
+// Determine input format and decode to a list of DER byte arrays. PEM input
+// may contain several blocks; binary / base64 input is always a single
+// certificate.
+const decodeInput = (input: string | Uint8Array): readonly Uint8Array[] => {
+	if (input instanceof Uint8Array) return [input];
+
+	const trimmed = input.trim();
+	if (trimmed.length === 0) return [];
+
+	if (looksLikePem(trimmed)) {
+		const blocks = splitPemBlocks(trimmed);
+		const buffers = blocks.flatMap((block) => {
+			try {
+				return [arrayBufferToUint8(PemConverter.decodeFirst(block))];
+			} catch {
+				return [];
+			}
+		});
+		if (buffers.length > 0) return buffers;
+	}
+
+	// Treat as raw base64 (no headers) — strip whitespace and decode.
+	if (/^[A-Za-z0-9+/=\s-]+$/.test(trimmed)) {
+		try {
+			const noWhitespace = trimmed.replace(/\s+/g, '');
+			// Some sources paste base64url; normalise.
+			const normalised = noWhitespace.replace(/-/g, '+').replace(/_/g, '/');
+			return [base64ToBytes(normalised)];
+		} catch {
+			// fall through
+		}
+	}
+
+	// Treat as space- or colon-delimited hex (rare but cheap to support).
+	if (/^[0-9a-fA-F:\s]+$/.test(trimmed)) {
+		try {
+			return [hexStringToBytes(trimmed)];
+		} catch {
+			// fall through
+		}
+	}
+
+	throw new Error('Input is not PEM, base64, or hex DER.');
+};
+
+/**
+ * Parse one or more certificates from a string (PEM / base64 / hex) or a
+ * raw DER byte array. Per-certificate parse errors are returned alongside
+ * any successfully-parsed certificates rather than thrown.
+ */
+export const parseCertificates = async (input: string | Uint8Array): Promise<ParseResult> => {
+	const certificates: ParsedCertificate[] = [];
+	const errors: ParseError[] = [];
+
+	let buffers: readonly Uint8Array[];
+	try {
+		buffers = decodeInput(input);
+	} catch (e) {
+		return { certificates: [], errors: [{ index: 0, message: getErrorMessage(e) }] };
+	}
+
+	for (let i = 0; i < buffers.length; i += 1) {
+		const der = buffers[i];
+		if (!der) continue;
+		try {
+			const parsed = await buildParsedCertificate(der);
+			certificates.push(parsed);
+		} catch (e) {
+			errors.push({ index: i, message: getErrorMessage(e) });
+		}
+	}
+
+	return { certificates, errors };
+};
+
+/**
+ * Order a flat list of certificates as `[root, intermediates..., leaf]` by
+ * walking issuer/subject links. Certificates that cannot be linked into any
+ * chain are returned as orphans so the UI can still display them.
+ */
+export const buildChain = (
+	certs: readonly ParsedCertificate[]
+): {
+	readonly chain: readonly ParsedCertificate[];
+	readonly orphans: readonly ParsedCertificate[];
+} => {
+	if (certs.length === 0) return { chain: [], orphans: [] };
+	if (certs.length === 1) {
+		const only = certs[0];
+		if (!only) return { chain: [], orphans: [] };
+		return { chain: [only], orphans: [] };
+	}
+
+	// Leaf: a cert whose subject is not the issuer of any other cert.
+	const subjects = new Set(certs.map((c) => c.subject.raw));
+	const issuers = new Set(certs.map((c) => c.issuer.raw));
+	const leaf = certs.find((c) => !issuers.has(c.subject.raw));
+
+	if (!leaf) {
+		// Cannot determine a leaf — treat the whole list as orphans so the UI
+		// still renders each certificate card.
+		return { chain: [], orphans: certs };
+	}
+
+	const chain: ParsedCertificate[] = [leaf];
+	const used = new Set<ParsedCertificate>([leaf]);
+	let current = leaf;
+	while (current.issuer.raw !== current.subject.raw) {
+		const next = certs.find((c) => c.subject.raw === current.issuer.raw && !used.has(c));
+		if (!next) break;
+		chain.unshift(next);
+		used.add(next);
+		current = next;
+	}
+
+	const orphans = certs.filter((c) => !used.has(c) && subjects.has(c.subject.raw));
+	return { chain, orphans };
+};
+
+export const isExpired = (cert: ParsedCertificate, now: Date = new Date()): boolean =>
+	now.getTime() > cert.notAfter.getTime();
+
+export const isNotYetValid = (cert: ParsedCertificate, now: Date = new Date()): boolean =>
+	now.getTime() < cert.notBefore.getTime();
+
+export const daysUntilExpiry = (cert: ParsedCertificate, now: Date = new Date()): number => {
+	const msPerDay = 1000 * 60 * 60 * 24;
+	const diff = cert.notAfter.getTime() - now.getTime();
+	return Math.floor(diff / msPerDay);
+};
+
+export const daysSinceStart = (cert: ParsedCertificate, now: Date = new Date()): number => {
+	const msPerDay = 1000 * 60 * 60 * 24;
+	const diff = now.getTime() - cert.notBefore.getTime();
+	return Math.floor(diff / msPerDay);
+};
+
+// Extract a friendly subject label for cards/timelines: prefer CN, then O,
+// then the full raw DN.
+export const getSubjectLabel = (cert: ParsedCertificate): string => {
+	const cn = cert.subject.components.find((c) => c.shortName === 'CN')?.value;
+	if (cn) return cn;
+	const o = cert.subject.components.find((c) => c.shortName === 'O')?.value;
+	if (o) return o;
+	return cert.subject.raw;
+};

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root';
 import { Route as YamlFormatterRouteImport } from './routes/yaml-formatter';
 import { Route as XmlFormatterRouteImport } from './routes/xml-formatter';
+import { Route as X509DecoderRouteImport } from './routes/x509-decoder';
 import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator';
 import { Route as UrlEncoderRouteImport } from './routes/url-encoder';
 import { Route as StringCaseConverterRouteImport } from './routes/string-case-converter';
@@ -44,6 +45,11 @@ const YamlFormatterRoute = YamlFormatterRouteImport.update({
 const XmlFormatterRoute = XmlFormatterRouteImport.update({
 	id: '/xml-formatter',
 	path: '/xml-formatter',
+	getParentRoute: () => rootRouteImport,
+} as any);
+const X509DecoderRoute = X509DecoderRouteImport.update({
+	id: '/x509-decoder',
+	path: '/x509-decoder',
 	getParentRoute: () => rootRouteImport,
 } as any);
 const UuidGeneratorRoute = UuidGeneratorRouteImport.update({
@@ -192,6 +198,7 @@ export interface FileRoutesByFullPath {
 	'/string-case-converter': typeof StringCaseConverterRoute;
 	'/url-encoder': typeof UrlEncoderRoute;
 	'/uuid-generator': typeof UuidGeneratorRoute;
+	'/x509-decoder': typeof X509DecoderRoute;
 	'/xml-formatter': typeof XmlFormatterRoute;
 	'/yaml-formatter': typeof YamlFormatterRoute;
 }
@@ -220,6 +227,7 @@ export interface FileRoutesByTo {
 	'/string-case-converter': typeof StringCaseConverterRoute;
 	'/url-encoder': typeof UrlEncoderRoute;
 	'/uuid-generator': typeof UuidGeneratorRoute;
+	'/x509-decoder': typeof X509DecoderRoute;
 	'/xml-formatter': typeof XmlFormatterRoute;
 	'/yaml-formatter': typeof YamlFormatterRoute;
 }
@@ -249,6 +257,7 @@ export interface FileRoutesById {
 	'/string-case-converter': typeof StringCaseConverterRoute;
 	'/url-encoder': typeof UrlEncoderRoute;
 	'/uuid-generator': typeof UuidGeneratorRoute;
+	'/x509-decoder': typeof X509DecoderRoute;
 	'/xml-formatter': typeof XmlFormatterRoute;
 	'/yaml-formatter': typeof YamlFormatterRoute;
 }
@@ -279,6 +288,7 @@ export interface FileRouteTypes {
 		| '/string-case-converter'
 		| '/url-encoder'
 		| '/uuid-generator'
+		| '/x509-decoder'
 		| '/xml-formatter'
 		| '/yaml-formatter';
 	fileRoutesByTo: FileRoutesByTo;
@@ -307,6 +317,7 @@ export interface FileRouteTypes {
 		| '/string-case-converter'
 		| '/url-encoder'
 		| '/uuid-generator'
+		| '/x509-decoder'
 		| '/xml-formatter'
 		| '/yaml-formatter';
 	id:
@@ -335,6 +346,7 @@ export interface FileRouteTypes {
 		| '/string-case-converter'
 		| '/url-encoder'
 		| '/uuid-generator'
+		| '/x509-decoder'
 		| '/xml-formatter'
 		| '/yaml-formatter';
 	fileRoutesById: FileRoutesById;
@@ -364,6 +376,7 @@ export interface RootRouteChildren {
 	StringCaseConverterRoute: typeof StringCaseConverterRoute;
 	UrlEncoderRoute: typeof UrlEncoderRoute;
 	UuidGeneratorRoute: typeof UuidGeneratorRoute;
+	X509DecoderRoute: typeof X509DecoderRoute;
 	XmlFormatterRoute: typeof XmlFormatterRoute;
 	YamlFormatterRoute: typeof YamlFormatterRoute;
 }
@@ -382,6 +395,13 @@ declare module '@tanstack/react-router' {
 			path: '/xml-formatter';
 			fullPath: '/xml-formatter';
 			preLoaderRoute: typeof XmlFormatterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/x509-decoder': {
+			id: '/x509-decoder';
+			path: '/x509-decoder';
+			fullPath: '/x509-decoder';
+			preLoaderRoute: typeof X509DecoderRouteImport;
 			parentRoute: typeof rootRouteImport;
 		};
 		'/uuid-generator': {
@@ -580,6 +600,7 @@ const rootRouteChildren: RootRouteChildren = {
 	StringCaseConverterRoute: StringCaseConverterRoute,
 	UrlEncoderRoute: UrlEncoderRoute,
 	UuidGeneratorRoute: UuidGeneratorRoute,
+	X509DecoderRoute: X509DecoderRoute,
 	XmlFormatterRoute: XmlFormatterRoute,
 	YamlFormatterRoute: YamlFormatterRoute,
 };

--- a/src/routes/x509-decoder.tsx
+++ b/src/routes/x509-decoder.tsx
@@ -1,0 +1,910 @@
+import { createFileRoute } from '@tanstack/react-router';
+import {
+	BadgeCheck,
+	FlaskConical,
+	KeyRound,
+	Layers,
+	ShieldAlert,
+	ShieldCheck,
+	Trash2,
+} from 'lucide-react';
+import { useEffect, useMemo, useState, type CSSProperties, type DragEvent } from 'react';
+
+import { CopyButton } from '@/lib/components/action';
+import {
+	FormCheckbox,
+	FormCheckboxGroup,
+	FormError,
+	FormInfo,
+	FormSection,
+	FormSlider,
+	FormTextarea,
+} from '@/lib/components/form';
+import { SectionLabel } from '@/lib/components/layout';
+import { ToolShell } from '@/lib/components/shell';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import {
+	Accordion,
+	AccordionContent,
+	AccordionItem,
+	AccordionTrigger,
+} from '@/lib/components/ui/accordion';
+import { Badge } from '@/lib/components/ui/badge';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { useDocumentTitle } from '@/lib/hooks';
+import { createToolOptionsStore } from '@/lib/stores';
+import {
+	buildChain,
+	daysSinceStart,
+	daysUntilExpiry,
+	getSubjectLabel,
+	isExpired,
+	isNotYetValid,
+	parseCertificates,
+	type ParsedCertificate,
+	type ParsedExtension,
+	type ParseResult,
+	type SanEntry,
+	type SanType,
+} from '@/lib/services/x509';
+import { generateSampleChain, generateSampleLeafCertificate } from '@/lib/services/x509-samples';
+import { cn } from '@/lib/utils';
+
+interface X509Prefs {
+	readonly warnDays: number;
+	readonly severeDays: number;
+	readonly showSha256: boolean;
+	readonly showSha1: boolean;
+	readonly showMd5: boolean;
+}
+
+const DEFAULT_PREFS: X509Prefs = {
+	warnDays: 30,
+	severeDays: 7,
+	showSha256: true,
+	showSha1: true,
+	showMd5: true,
+};
+
+const useX509Prefs = createToolOptionsStore<X509Prefs>('x509-decoder', DEFAULT_PREFS);
+
+const SAN_TYPE_TONE: Readonly<
+	Record<SanType, { readonly label: string; readonly className: string }>
+> = {
+	dns: { label: 'DNS', className: 'bg-success/10 text-success border-success/30' },
+	ip: { label: 'IP', className: 'bg-info/10 text-info border-info/30' },
+	uri: { label: 'URI', className: 'bg-warning/10 text-warning border-warning/30' },
+	email: { label: 'Email', className: 'bg-primary/10 text-primary border-primary/30' },
+	dirName: { label: 'DirName', className: 'bg-muted text-foreground' },
+	other: { label: 'Other', className: 'bg-muted text-muted-foreground' },
+};
+
+const formatDate = (date: Date): string => date.toLocaleString();
+
+type ExpiryTone = 'success' | 'info' | 'warning' | 'destructive';
+
+interface ExpiryBadge {
+	readonly label: string;
+	readonly tone: ExpiryTone;
+}
+
+const buildExpiryBadge = (
+	cert: ParsedCertificate,
+	now: Date,
+	warnDays: number,
+	severeDays: number
+): ExpiryBadge => {
+	if (isNotYetValid(cert, now)) {
+		const days = Math.abs(daysSinceStart(cert, now));
+		return { label: `Not yet valid (in ${days} days)`, tone: 'info' };
+	}
+	if (isExpired(cert, now)) {
+		const days = Math.abs(daysUntilExpiry(cert, now));
+		return { label: `Expired ${days} days ago`, tone: 'destructive' };
+	}
+	const days = daysUntilExpiry(cert, now);
+	if (days <= severeDays) return { label: `Expires in ${days} days`, tone: 'destructive' };
+	if (days <= warnDays) return { label: `Expires in ${days} days`, tone: 'warning' };
+	return { label: `Valid (${days} days left)`, tone: 'success' };
+};
+
+const TONE_BADGE_CLASS: Readonly<Record<ExpiryTone, string>> = {
+	success: 'bg-success/10 text-success border-success/30',
+	info: 'bg-info/10 text-info border-info/30',
+	warning: 'bg-warning/10 text-warning border-warning/30',
+	destructive: 'bg-destructive/10 text-destructive border-destructive/30',
+};
+
+const TONE_TIMELINE_CLASS: Readonly<Record<ExpiryTone, string>> = {
+	success: 'fill-success/30 stroke-success',
+	info: 'fill-info/30 stroke-info',
+	warning: 'fill-warning/30 stroke-warning',
+	destructive: 'fill-destructive/30 stroke-destructive',
+};
+
+export const Route = createFileRoute('/x509-decoder')({
+	component: X509DecoderPage,
+});
+
+function X509DecoderPage() {
+	useDocumentTitle('X.509 Certificate Decoder');
+
+	const { value: prefs, patch } = useX509Prefs();
+
+	const [input, setInput] = useState('');
+	const [parseResult, setParseResult] = useState<ParseResult | null>(null);
+	const [parsing, setParsing] = useState(false);
+	const [now, setNow] = useState<Date>(() => new Date());
+	const [showRail, setShowRail] = useState(true);
+	const [isDragOver, setIsDragOver] = useState(false);
+
+	// Re-parse whenever the textual input changes. Debounce so a long paste
+	// (multi-cert PEM bundles) does not run the parser on each keystroke.
+	useEffect(() => {
+		if (input.trim().length === 0) {
+			setParseResult(null);
+			return;
+		}
+		const id = window.setTimeout(() => {
+			setParsing(true);
+			parseCertificates(input).then((res) => {
+				setParseResult(res);
+				setParsing(false);
+			});
+		}, 200);
+		return () => window.clearTimeout(id);
+	}, [input]);
+
+	// Live countdown — re-evaluate expiry banners every minute.
+	useEffect(() => {
+		const id = window.setInterval(() => setNow(new Date()), 60_000);
+		return () => window.clearInterval(id);
+	}, []);
+
+	const chain = useMemo(() => buildChain(parseResult?.certificates ?? []), [parseResult]);
+
+	const handleGenerateLeaf = async () => {
+		const pem = await generateSampleLeafCertificate();
+		setInput(pem);
+	};
+
+	const handleGenerateChain = async () => {
+		const pem = await generateSampleChain();
+		setInput(pem);
+	};
+
+	const handleClear = () => setInput('');
+
+	const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		setIsDragOver(false);
+		const file = e.dataTransfer.files[0];
+		if (!file) return;
+		file.arrayBuffer().then((buf) => {
+			const bytes = new Uint8Array(buf);
+			// Prefer text decoding when the file looks ASCII (PEM bundles); fall
+			// back to raw DER bytes otherwise so binary .cer / .der files parse.
+			const text = new TextDecoder('utf-8').decode(bytes);
+			if (/-----BEGIN [^-]+-----/.test(text)) {
+				setInput(text);
+				return;
+			}
+			setParsing(true);
+			parseCertificates(bytes).then((res) => {
+				setParseResult(res);
+				setParsing(false);
+			});
+		});
+	};
+
+	const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		setIsDragOver(true);
+	};
+
+	const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		setIsDragOver(false);
+	};
+
+	const certificates = parseResult?.certificates ?? [];
+	const errors = parseResult?.errors ?? [];
+
+	const soonestExpiry = useMemo(() => {
+		if (certificates.length === 0) return null;
+		const min = certificates.reduce(
+			(acc, c) => (c.notAfter.getTime() < acc.getTime() ? c.notAfter : acc),
+			certificates[0]?.notAfter ?? new Date()
+		);
+		return min;
+	}, [certificates]);
+
+	return (
+		<ToolShell
+			showRail={showRail}
+			onShowRailChange={setShowRail}
+			statusContent={
+				<>
+					<StatItem label="Certs" value={certificates.length} />
+					<StatItem label="Errors" value={errors.length} />
+					<StatItem
+						label="Soonest expiry"
+						value={soonestExpiry ? soonestExpiry.toLocaleDateString() : '—'}
+					/>
+				</>
+			}
+			rail={
+				<>
+					<FormSection title="Input">
+						<FormInfo>
+							Accepts PEM, raw base64 (no headers), and binary DER. Multi-PEM bundles are split
+							automatically into chain order.
+						</FormInfo>
+						<div className="flex flex-col gap-2">
+							<Button variant="outline" size="sm" onClick={handleGenerateLeaf}>
+								<FlaskConical className="h-3.5 w-3.5" />
+								Generate sample cert
+							</Button>
+							<Button variant="outline" size="sm" onClick={handleGenerateChain}>
+								<Layers className="h-3.5 w-3.5" />
+								Generate sample chain
+							</Button>
+							<Button variant="outline" size="sm" onClick={handleClear}>
+								<Trash2 className="h-3.5 w-3.5" />
+								Clear
+							</Button>
+						</div>
+					</FormSection>
+
+					<FormSection title="Expiry Thresholds">
+						<FormSlider
+							label="Warning at (days)"
+							value={prefs.warnDays}
+							min={1}
+							max={365}
+							step={1}
+							onValueChange={(v) =>
+								patch({ warnDays: v, severeDays: Math.min(prefs.severeDays, v) })
+							}
+						/>
+						<FormSlider
+							label="Severe at (days)"
+							value={prefs.severeDays}
+							min={1}
+							max={prefs.warnDays}
+							step={1}
+							onValueChange={(v) => patch({ severeDays: v })}
+						/>
+					</FormSection>
+
+					<FormSection title="Fingerprints">
+						<FormCheckboxGroup>
+							<FormCheckbox
+								label="SHA-256"
+								checked={prefs.showSha256}
+								onCheckedChange={(c) => patch({ showSha256: c })}
+							/>
+							<FormCheckbox
+								label="SHA-1"
+								checked={prefs.showSha1}
+								onCheckedChange={(c) => patch({ showSha1: c })}
+							/>
+							<FormCheckbox
+								label="MD5"
+								checked={prefs.showMd5}
+								onCheckedChange={(c) => patch({ showMd5: c })}
+							/>
+						</FormCheckboxGroup>
+					</FormSection>
+
+					<FormSection title="About">
+						<FormInfo>
+							All parsing happens in your browser. Nothing is uploaded. Sample certificates are
+							generated locally with fresh keys each time.
+						</FormInfo>
+					</FormSection>
+				</>
+			}
+		>
+			<div className="flex h-full flex-col overflow-hidden">
+				<div className="shrink-0 border-b bg-surface-2 p-4">
+					{/* Dropzone wrapper around the textarea. Marked as a region so
+					    screen readers can navigate it and the drag handlers attach to
+					    a recognised interactive surface. */}
+					<section
+						aria-label="Certificate input drop zone"
+						onDrop={handleDrop}
+						onDragOver={handleDragOver}
+						onDragLeave={handleDragLeave}
+						className={cn(
+							'rounded-md border-2 border-dashed border-border/60 p-2 transition-colors',
+							isDragOver && 'border-primary bg-primary/5'
+						)}
+					>
+						<FormTextarea
+							label="Certificate input"
+							value={input}
+							onValueChange={setInput}
+							placeholder="Paste PEM, base64, or hex-encoded DER. Drop a .crt / .cer / .pem / .der file here."
+							rows={6}
+							className="font-mono text-xs"
+						/>
+					</section>
+				</div>
+
+				<div className="flex-1 overflow-auto">
+					{certificates.length === 0 && errors.length === 0 ? (
+						<div className="flex h-full items-center justify-center p-4">
+							<EmbeddedEmptyState
+								icon={BadgeCheck}
+								title="Paste a certificate"
+								description="PEM, base64, or DER. Drag a .crt / .cer / .pem / .der file into the input area, or use Generate sample on the left."
+							/>
+						</div>
+					) : (
+						<div className="space-y-4 p-4">
+							{parsing ? <p className="text-xs text-muted-foreground">Parsing…</p> : null}
+
+							{errors.length > 0 ? (
+								<Card density="compact">
+									<CardHeader>
+										<CardTitle className="flex items-center gap-2 text-sm">
+											<ShieldAlert className="h-4 w-4 text-destructive" />
+											Parse errors
+										</CardTitle>
+									</CardHeader>
+									<CardContent className="space-y-1">
+										{errors.map((err) => (
+											<FormError
+												key={`${err.index}-${err.message}`}
+												message={`Certificate #${err.index + 1}: ${err.message}`}
+											/>
+										))}
+									</CardContent>
+								</Card>
+							) : null}
+
+							{chain.chain.length >= 2 ? <ChainVisualization chain={chain.chain} /> : null}
+
+							{certificates.map((cert) => (
+								<CertificateCard
+									key={`${cert.fingerprints.sha256}-${cert.serialNumber}`}
+									cert={cert}
+									now={now}
+									prefs={prefs}
+								/>
+							))}
+						</div>
+					)}
+				</div>
+			</div>
+		</ToolShell>
+	);
+}
+
+interface CertificateCardProps {
+	readonly cert: ParsedCertificate;
+	readonly now: Date;
+	readonly prefs: X509Prefs;
+}
+
+function CertificateCard({ cert, now, prefs }: CertificateCardProps) {
+	const badge = buildExpiryBadge(cert, now, prefs.warnDays, prefs.severeDays);
+	const subjectLabel = getSubjectLabel(cert);
+	const serialPreview = `${cert.serialNumber.replace(/:/g, '').slice(0, 8)}…`;
+
+	return (
+		<Card density="compact">
+			<CardHeader>
+				<div className="flex flex-wrap items-center justify-between gap-2">
+					<div className="flex min-w-0 items-center gap-2">
+						<CardTitle className="truncate text-sm font-medium">{subjectLabel}</CardTitle>
+						{cert.selfSigned ? (
+							<Badge variant="outline" className="font-mono text-2xs">
+								Self-signed
+							</Badge>
+						) : null}
+						<Badge variant="outline" className="font-mono text-2xs">
+							SN {serialPreview}
+						</Badge>
+					</div>
+					<Badge className={cn('font-medium', TONE_BADGE_CLASS[badge.tone])}>{badge.label}</Badge>
+				</div>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				<ValidityTimeline cert={cert} now={now} tone={badge.tone} />
+				<DnGrid cert={cert} />
+				<PublicKeySummary cert={cert} />
+				{cert.subjectAlternativeNames.length > 0 ? (
+					<SubjectAlternativeNames entries={cert.subjectAlternativeNames} />
+				) : null}
+				<FingerprintList cert={cert} prefs={prefs} />
+				<ExtensionsAccordion cert={cert} />
+				<RawAccordion cert={cert} />
+			</CardContent>
+		</Card>
+	);
+}
+
+interface ValidityTimelineProps {
+	readonly cert: ParsedCertificate;
+	readonly now: Date;
+	readonly tone: ExpiryTone;
+}
+
+function ValidityTimeline({ cert, now, tone }: ValidityTimelineProps) {
+	const start = cert.notBefore.getTime();
+	const end = cert.notAfter.getTime();
+	const total = Math.max(1, end - start);
+	const nowMs = now.getTime();
+	const positionRatio = Math.min(1, Math.max(0, (nowMs - start) / total));
+	const nowX = positionRatio * 100;
+
+	return (
+		<div>
+			<SectionLabel>Validity</SectionLabel>
+			<svg
+				viewBox="0 0 100 12"
+				preserveAspectRatio="none"
+				role="img"
+				aria-label={`Validity timeline from ${formatDate(cert.notBefore)} to ${formatDate(
+					cert.notAfter
+				)}, now at ${Math.round(positionRatio * 100)}%`}
+				className={cn('h-10 w-full overflow-visible', TONE_TIMELINE_CLASS[tone])}
+			>
+				<rect x="0" y="4" width="100" height="4" rx="1.5" className="opacity-40" />
+				<line
+					x1={nowX}
+					y1="0"
+					x2={nowX}
+					y2="12"
+					strokeWidth="0.6"
+					strokeLinecap="round"
+					className="stroke-foreground"
+					vectorEffect="non-scaling-stroke"
+				/>
+				<circle cx="0" cy="6" r="1" className="fill-foreground" />
+				<circle cx="100" cy="6" r="1" className="fill-foreground" />
+			</svg>
+			<div className="mt-1 flex justify-between text-2xs text-muted-foreground">
+				<span>{formatDate(cert.notBefore)}</span>
+				<span className="text-foreground">now</span>
+				<span>{formatDate(cert.notAfter)}</span>
+			</div>
+		</div>
+	);
+}
+
+interface DnGridProps {
+	readonly cert: ParsedCertificate;
+}
+
+function DnGrid({ cert }: DnGridProps) {
+	return (
+		<div className="grid gap-3 md:grid-cols-2">
+			<DnPanel title="Subject" components={cert.subject.components} />
+			<DnPanel title="Issuer" components={cert.issuer.components} />
+		</div>
+	);
+}
+
+interface DnPanelProps {
+	readonly title: string;
+	readonly components: readonly { readonly shortName: string; readonly value: string }[];
+}
+
+function DnPanel({ title, components }: DnPanelProps) {
+	return (
+		<Card density="compact">
+			<CardHeader>
+				<CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+					{title}
+				</CardTitle>
+			</CardHeader>
+			<CardContent>
+				{components.length === 0 ? (
+					<p className="text-xs text-muted-foreground">(empty)</p>
+				) : (
+					<dl className="grid grid-cols-[80px_1fr] gap-x-3 gap-y-1 text-xs">
+						{components.map((c) => (
+							<DnRow key={`${c.shortName}-${c.value}`} shortName={c.shortName} value={c.value} />
+						))}
+					</dl>
+				)}
+			</CardContent>
+		</Card>
+	);
+}
+
+interface DnRowProps {
+	readonly shortName: string;
+	readonly value: string;
+}
+
+function DnRow({ shortName, value }: DnRowProps) {
+	return (
+		<>
+			<dt className="font-mono text-muted-foreground">{shortName}</dt>
+			<dd className="break-all font-mono">{value}</dd>
+		</>
+	);
+}
+
+interface PublicKeySummaryProps {
+	readonly cert: ParsedCertificate;
+}
+
+function PublicKeySummary({ cert }: PublicKeySummaryProps) {
+	const pk = cert.publicKey;
+	return (
+		<Card density="compact">
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+					<KeyRound className="h-3.5 w-3.5" />
+					Public Key
+				</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<dl className="grid grid-cols-[120px_1fr] gap-x-3 gap-y-1 text-xs">
+					<DnRow shortName="Algorithm" value={pk.algorithm} />
+					{pk.bitLength ? <DnRow shortName="Bit length" value={`${pk.bitLength} bit`} /> : null}
+					{pk.curve ? <DnRow shortName="Curve" value={pk.curve} /> : null}
+					{pk.modulusPreview ? <DnRow shortName="Modulus" value={pk.modulusPreview} /> : null}
+					{pk.exponent ? <DnRow shortName="Exponent" value={pk.exponent} /> : null}
+					<DnRow shortName="Signature" value={cert.signatureAlgorithm} />
+				</dl>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface SubjectAlternativeNamesProps {
+	readonly entries: readonly SanEntry[];
+}
+
+function SubjectAlternativeNames({ entries }: SubjectAlternativeNamesProps) {
+	return (
+		<div>
+			<SectionLabel>Subject Alternative Names ({entries.length})</SectionLabel>
+			<div className="flex flex-wrap gap-1.5">
+				{entries.map((entry) => {
+					const tone = SAN_TYPE_TONE[entry.type];
+					return (
+						<Badge
+							key={`${entry.type}-${entry.value}`}
+							variant="outline"
+							className={cn('font-mono text-2xs', tone.className)}
+						>
+							{tone.label}: {entry.value}
+						</Badge>
+					);
+				})}
+			</div>
+		</div>
+	);
+}
+
+interface FingerprintListProps {
+	readonly cert: ParsedCertificate;
+	readonly prefs: X509Prefs;
+}
+
+function FingerprintList({ cert, prefs }: FingerprintListProps) {
+	const rows: readonly {
+		readonly label: string;
+		readonly value: string;
+		readonly show: boolean;
+	}[] = [
+		{ label: 'SHA-256', value: cert.fingerprints.sha256, show: prefs.showSha256 },
+		{ label: 'SHA-1', value: cert.fingerprints.sha1, show: prefs.showSha1 },
+		{ label: 'MD5', value: cert.fingerprints.md5, show: prefs.showMd5 },
+	];
+	const visible = rows.filter((r) => r.show);
+	if (visible.length === 0) return null;
+	return (
+		<Card density="compact">
+			<CardHeader>
+				<CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+					Fingerprints
+				</CardTitle>
+			</CardHeader>
+			<CardContent className="space-y-1.5">
+				{visible.map((row) => (
+					<div key={row.label} className="flex items-start gap-2 text-xs">
+						<span className="w-16 shrink-0 font-mono text-muted-foreground">{row.label}</span>
+						<code className="flex-1 break-all font-mono">{row.value}</code>
+						<CopyButton text={row.value} toastLabel={`${row.label} fingerprint`} size="sm" />
+					</div>
+				))}
+			</CardContent>
+		</Card>
+	);
+}
+
+interface ExtensionsAccordionProps {
+	readonly cert: ParsedCertificate;
+}
+
+function ExtensionsAccordion({ cert }: ExtensionsAccordionProps) {
+	if (cert.extensions.length === 0) return null;
+	return (
+		<Accordion type="multiple" className="w-full">
+			<AccordionItem value="extensions">
+				<AccordionTrigger>
+					<span className="flex items-center gap-2 text-sm font-medium">
+						<ShieldCheck className="h-4 w-4 text-muted-foreground" />
+						Extensions
+						<Badge variant="outline" className="font-mono text-2xs">
+							{cert.extensions.length}
+						</Badge>
+					</span>
+				</AccordionTrigger>
+				<AccordionContent>
+					<div className="space-y-2">
+						{cert.extensions.map((ext) => (
+							<ExtensionRow key={ext.oid} extension={ext} />
+						))}
+					</div>
+				</AccordionContent>
+			</AccordionItem>
+		</Accordion>
+	);
+}
+
+interface ExtensionRowProps {
+	readonly extension: ParsedExtension;
+}
+
+function ExtensionRow({ extension }: ExtensionRowProps) {
+	return (
+		<Card density="compact">
+			<CardContent className="space-y-1.5">
+				<div className="flex flex-wrap items-center gap-2">
+					<span className="text-xs font-medium">{extension.name}</span>
+					<span className="font-mono text-2xs text-muted-foreground">{extension.oid}</span>
+					{extension.critical ? (
+						<Badge className={cn('font-mono text-2xs', TONE_BADGE_CLASS.destructive)}>
+							Critical
+						</Badge>
+					) : null}
+				</div>
+				<ExtensionBody extension={extension} />
+			</CardContent>
+		</Card>
+	);
+}
+
+interface ExtensionBodyProps {
+	readonly extension: ParsedExtension;
+}
+
+function KeyUsageBody({ usages }: { readonly usages: readonly string[] }) {
+	if (usages.length === 0)
+		return <p className="text-2xs text-muted-foreground">(no usages declared)</p>;
+	return (
+		<div className="flex flex-wrap gap-1">
+			{usages.map((u) => (
+				<Badge key={u} variant="outline" className="font-mono text-2xs">
+					{u}
+				</Badge>
+			))}
+		</div>
+	);
+}
+
+function ExtendedKeyUsageBody({
+	purposes,
+}: {
+	readonly purposes: readonly { readonly oid: string; readonly name: string }[];
+}) {
+	return (
+		<div className="flex flex-wrap gap-1">
+			{purposes.map((p) => (
+				<Badge key={p.oid} variant="outline" className="font-mono text-2xs" title={p.oid}>
+					{p.name}
+				</Badge>
+			))}
+		</div>
+	);
+}
+
+function BasicConstraintsBody({
+	ca,
+	pathLenConstraint,
+}: {
+	readonly ca: boolean;
+	readonly pathLenConstraint?: number;
+}) {
+	return (
+		<dl className="grid grid-cols-[100px_1fr] gap-x-3 gap-y-1 text-2xs">
+			<DnRow shortName="CA" value={ca ? 'true' : 'false'} />
+			{typeof pathLenConstraint === 'number' ? (
+				<DnRow shortName="Path length" value={String(pathLenConstraint)} />
+			) : null}
+		</dl>
+	);
+}
+
+function AuthorityKeyIdBody({
+	keyId,
+	issuerSerial,
+}: {
+	readonly keyId?: string;
+	readonly issuerSerial?: string;
+}) {
+	return (
+		<dl className="grid grid-cols-[100px_1fr] gap-x-3 gap-y-1 text-2xs">
+			{keyId ? <DnRow shortName="Key ID" value={keyId} /> : null}
+			{issuerSerial ? <DnRow shortName="Serial" value={issuerSerial} /> : null}
+		</dl>
+	);
+}
+
+function CrlUrlsBody({ urls }: { readonly urls: readonly string[] }) {
+	if (urls.length === 0) {
+		return <p className="text-2xs text-muted-foreground">(no URLs)</p>;
+	}
+	return (
+		<ul className="space-y-1 text-2xs">
+			{urls.map((url) => (
+				<li key={url} className="break-all font-mono text-muted-foreground">
+					{url}
+				</li>
+			))}
+		</ul>
+	);
+}
+
+function AuthorityInfoBody({
+	ocspUrls,
+	caIssuerUrls,
+}: {
+	readonly ocspUrls: readonly string[];
+	readonly caIssuerUrls: readonly string[];
+}) {
+	return (
+		<dl className="grid grid-cols-[80px_1fr] gap-x-3 gap-y-1 text-2xs">
+			{ocspUrls.length > 0 ? <DnRow shortName="OCSP" value={ocspUrls.join(', ')} /> : null}
+			{caIssuerUrls.length > 0 ? (
+				<DnRow shortName="CA Issuer" value={caIssuerUrls.join(', ')} />
+			) : null}
+		</dl>
+	);
+}
+
+function ExtensionBody({ extension }: ExtensionBodyProps) {
+	const data = extension.parsed;
+	switch (data.kind) {
+		case 'keyUsage':
+			return <KeyUsageBody usages={data.usages} />;
+		case 'extendedKeyUsage':
+			return <ExtendedKeyUsageBody purposes={data.purposes} />;
+		case 'basicConstraints':
+			return <BasicConstraintsBody ca={data.ca} pathLenConstraint={data.pathLenConstraint} />;
+		case 'subjectAltName':
+			return <SubjectAlternativeNames entries={data.entries} />;
+		case 'subjectKeyId':
+			return (
+				<code className="block break-all font-mono text-2xs text-muted-foreground">
+					{data.keyId}
+				</code>
+			);
+		case 'authorityKeyId':
+			return <AuthorityKeyIdBody keyId={data.keyId} issuerSerial={data.issuerSerial} />;
+		case 'crlDistributionPoints':
+			return <CrlUrlsBody urls={data.urls} />;
+		case 'authorityInfoAccess':
+			return <AuthorityInfoBody ocspUrls={data.ocspUrls} caIssuerUrls={data.caIssuerUrls} />;
+		default:
+			return (
+				<code className="block break-all font-mono text-2xs text-muted-foreground">
+					{data.value}
+				</code>
+			);
+	}
+}
+
+interface RawAccordionProps {
+	readonly cert: ParsedCertificate;
+}
+
+function RawAccordion({ cert }: RawAccordionProps) {
+	return (
+		<Accordion type="single" collapsible className="w-full">
+			<AccordionItem value="raw">
+				<AccordionTrigger>
+					<span className="text-sm font-medium">Raw</span>
+				</AccordionTrigger>
+				<AccordionContent>
+					<div className="space-y-3">
+						<div>
+							<div className="mb-1.5 flex items-center justify-between">
+								<span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+									PEM
+								</span>
+								<CopyButton text={cert.pem} toastLabel="PEM" size="sm" />
+							</div>
+							<pre className="max-h-64 overflow-auto rounded-md border bg-muted p-3 font-mono text-2xs">
+								{cert.pem}
+							</pre>
+						</div>
+						<div>
+							<div className="mb-1.5 flex items-center justify-between">
+								<span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+									DER (base64)
+								</span>
+								<CopyButton text={cert.derBase64} toastLabel="DER base64" size="sm" />
+							</div>
+							<code className="block max-h-32 overflow-auto break-all rounded-md border bg-muted p-3 font-mono text-2xs">
+								{cert.derBase64}
+							</code>
+						</div>
+					</div>
+				</AccordionContent>
+			</AccordionItem>
+		</Accordion>
+	);
+}
+
+interface ChainVisualizationProps {
+	readonly chain: readonly ParsedCertificate[];
+}
+
+function ChainVisualization({ chain }: ChainVisualizationProps) {
+	const ordered = chain;
+	return (
+		<Card density="compact">
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2 text-sm font-medium">
+					<Layers className="h-4 w-4 text-muted-foreground" />
+					Trust chain
+					<Badge variant="outline" className="font-mono text-2xs">
+						{ordered.length} certs
+					</Badge>
+				</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<div
+					className="flex flex-wrap items-center gap-2"
+					style={{ '--chain-arrow': '"→"' } as CSSProperties}
+				>
+					{ordered.map((cert, idx) => (
+						<ChainNode
+							key={cert.fingerprints.sha256}
+							cert={cert}
+							role={idx === 0 ? 'root' : idx === ordered.length - 1 ? 'leaf' : 'intermediate'}
+							showArrow={idx < ordered.length - 1}
+						/>
+					))}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface ChainNodeProps {
+	readonly cert: ParsedCertificate;
+	readonly role: 'root' | 'intermediate' | 'leaf';
+	readonly showArrow: boolean;
+}
+
+function ChainNode({ cert, role, showArrow }: ChainNodeProps) {
+	const label = getSubjectLabel(cert);
+	const roleClass: Record<typeof role, string> = {
+		root: 'border-info/40 bg-info/5',
+		intermediate: 'border-warning/40 bg-warning/5',
+		leaf: 'border-success/40 bg-success/5',
+	};
+	return (
+		<div className="flex items-center gap-2">
+			<div
+				className={cn('min-w-32 max-w-56 rounded-md border px-3 py-1.5 text-xs', roleClass[role])}
+			>
+				<div className="text-2xs uppercase tracking-wide text-muted-foreground">{role}</div>
+				<div className="truncate font-medium">{label}</div>
+			</div>
+			{showArrow ? <span className="font-mono text-muted-foreground">→</span> : null}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
Add an X.509 / PEM Certificate Decoder under **Encoders** that fully parses pasted certificates and presents every field, extension, and validity property in a structured, scannable layout. Closes #220.

## Features
- **Full X.509 v3 parsing** via `@peculiar/x509`: subject / issuer / serial / signature algorithm / public key info
- **Distinguished Name breakdown** — each DN component on its own row
- **Subject Alternative Names** typed by category (DNS / IP / URI / email / DirName) with badges
- **Extensions** parsed with friendly labels: KeyUsage / ExtKeyUsage / BasicConstraints / SKI / AKI / CRLDP / AIA
- **SVG validity timeline** with severity-based "expires in N days" badge
- **Three fingerprints simultaneously** — SHA-256, SHA-1, MD5
- **Multi-certificate chain** support with leaf → intermediate → root visualization
- **Input formats**: PEM, base64 (no headers), DER (drag-and-drop binary)
- **Privacy**: 100% browser-side parsing; nothing leaves the device
- **Generate-sample buttons** create fresh self-signed test certs at runtime

## Changes
### Added
- `src/routes/x509-decoder.tsx`
- `src/lib/services/x509.ts`
- `src/lib/services/x509-samples.ts`
- Page registration in `src/lib/services/pages.ts`

### Dependencies
- `@peculiar/x509` (ASN.1 + X.509 parsing)
- `js-md5` (MD5 fingerprint — not in Web Crypto)

## Test plan
- [x] `bun run check` green
- [x] `bun run lint` no new warnings
- [x] `bun run format:check` clean
- [x] `vite build` succeeds
- [ ] Manual: click "Generate sample cert", verify all fields render
- [ ] Manual: click "Generate sample chain", verify chain visualization
- [ ] Manual: paste a real PEM, verify Subject / Issuer breakdown
- [ ] Manual: drag-drop a `.cer` (DER binary), verify parsing
- [ ] Manual: paste cert with SANs, verify typed badges

Closes #220
