### PR TITLE
feat(list-comparer): add List Comparer tool

### DIFF
--- a/src/lib/services/list-compare.ts
+++ b/src/lib/services/list-compare.ts
@@ -1,0 +1,212 @@
+/**
+ * Pure set-comparison primitives for two newline-separated lists.
+ *
+ * The service splits raw text into lines, normalises each line according to
+ * the supplied options (trimming, case folding, empty handling), and then
+ * runs set operations on the normalised forms while remembering the original
+ * casing of the first occurrence for display.
+ *
+ * Display strings preserve the original casing / whitespace of the first
+ * occurrence so users always see what they typed; comparisons stay
+ * predictable because they happen on the normalised form.
+ */
+
+export type SortMode = 'original' | 'asc' | 'desc';
+
+export type OperationKind =
+	| 'intersection'
+	| 'union'
+	| 'difference-a'
+	| 'difference-b'
+	| 'symmetric';
+
+export type Region = 'a-only' | 'b-only' | 'common';
+
+export interface CompareOptions {
+	readonly caseSensitive: boolean;
+	readonly trimWhitespace: boolean;
+	readonly ignoreEmpty: boolean;
+	readonly sortMode: SortMode;
+}
+
+export const DEFAULT_OPTIONS: CompareOptions = {
+	caseSensitive: false,
+	trimWhitespace: true,
+	ignoreEmpty: true,
+	sortMode: 'original',
+};
+
+export interface NormalisedList {
+	readonly originalLines: readonly string[];
+	readonly normalisedSet: ReadonlySet<string>;
+	readonly normalisedToOriginal: ReadonlyMap<string, string>;
+}
+
+export interface CompareResult {
+	readonly options: CompareOptions;
+	readonly a: NormalisedList;
+	readonly b: NormalisedList;
+	readonly intersection: readonly string[];
+	readonly union: readonly string[];
+	readonly differenceA: readonly string[];
+	readonly differenceB: readonly string[];
+	readonly symmetric: readonly string[];
+}
+
+const splitLines = (raw: string): readonly string[] => raw.split(/\r?\n/);
+
+const normaliseLine = (line: string, options: CompareOptions): string => {
+	const trimmed = options.trimWhitespace ? line.trim() : line;
+	return options.caseSensitive ? trimmed : trimmed.toLowerCase();
+};
+
+const isKept = (normalised: string, options: CompareOptions): boolean =>
+	!options.ignoreEmpty || normalised.length > 0;
+
+/**
+ * Normalise a raw newline-separated string into a list paired with a Set of
+ * normalised values and a map back to the first-seen original line.
+ */
+export const normaliseList = (raw: string, options: CompareOptions): NormalisedList => {
+	const originalLines = splitLines(raw);
+	const normalisedSet = new Set<string>();
+	const normalisedToOriginal = new Map<string, string>();
+	originalLines.forEach((line) => {
+		const normalised = normaliseLine(line, options);
+		if (!isKept(normalised, options)) return;
+		if (!normalisedToOriginal.has(normalised)) {
+			normalisedToOriginal.set(normalised, line);
+		}
+		normalisedSet.add(normalised);
+	});
+	return { originalLines, normalisedSet, normalisedToOriginal };
+};
+
+/**
+ * Count the number of lines in `raw` that would survive the current
+ * normalisation pipeline. Duplicates are counted only once because the UI
+ * surfaces the set-shaped count alongside each list.
+ */
+export const lineCount = (raw: string, options: CompareOptions): number =>
+	normaliseList(raw, options).normalisedSet.size;
+
+const localeCompare = (left: string, right: string): number =>
+	left.localeCompare(right, undefined, { sensitivity: 'base', numeric: true });
+
+const insertionOrder = (
+	keys: ReadonlySet<string>,
+	a: NormalisedList,
+	b: NormalisedList
+): readonly string[] => {
+	const seen = new Set<string>();
+	const order: string[] = [];
+	const collect = (source: NormalisedList) => {
+		source.normalisedToOriginal.forEach((_, key) => {
+			if (keys.has(key) && !seen.has(key)) {
+				seen.add(key);
+				order.push(key);
+			}
+		});
+	};
+	collect(a);
+	collect(b);
+	return order;
+};
+
+const sortKeys = (
+	keys: readonly string[],
+	a: NormalisedList,
+	b: NormalisedList,
+	options: CompareOptions
+): readonly string[] => {
+	if (options.sortMode === 'original') return insertionOrder(new Set(keys), a, b);
+	const display = (key: string): string =>
+		a.normalisedToOriginal.get(key) ?? b.normalisedToOriginal.get(key) ?? key;
+	const direction = options.sortMode === 'asc' ? 1 : -1;
+	return [...keys].sort((left, right) => direction * localeCompare(display(left), display(right)));
+};
+
+const toDisplay = (
+	keys: readonly string[],
+	a: NormalisedList,
+	b: NormalisedList
+): readonly string[] =>
+	keys.map((key) => a.normalisedToOriginal.get(key) ?? b.normalisedToOriginal.get(key) ?? key);
+
+/**
+ * Run all five set operations on `a` and `b` in one pass and return the
+ * results pre-sorted according to `options.sortMode` with display strings
+ * resolved to first-seen originals.
+ */
+export const compare = (a: string, b: string, options: CompareOptions): CompareResult => {
+	const left = normaliseList(a, options);
+	const right = normaliseList(b, options);
+
+	const intersectionKeys = [...left.normalisedSet].filter((key) => right.normalisedSet.has(key));
+	const differenceAKeys = [...left.normalisedSet].filter((key) => !right.normalisedSet.has(key));
+	const differenceBKeys = [...right.normalisedSet].filter((key) => !left.normalisedSet.has(key));
+	const symmetricKeys = [...differenceAKeys, ...differenceBKeys];
+	const unionKeys = [...new Set([...left.normalisedSet, ...right.normalisedSet])];
+
+	const sorted = {
+		intersection: sortKeys(intersectionKeys, left, right, options),
+		union: sortKeys(unionKeys, left, right, options),
+		differenceA: sortKeys(differenceAKeys, left, right, options),
+		differenceB: sortKeys(differenceBKeys, left, right, options),
+		symmetric: sortKeys(symmetricKeys, left, right, options),
+	};
+
+	return {
+		options,
+		a: left,
+		b: right,
+		intersection: toDisplay(sorted.intersection, left, right),
+		union: toDisplay(sorted.union, left, right),
+		differenceA: toDisplay(sorted.differenceA, left, right),
+		differenceB: toDisplay(sorted.differenceB, left, right),
+		symmetric: toDisplay(sorted.symmetric, left, right),
+	};
+};
+
+/**
+ * Region resolution for tinting result rows and Venn diagram regions.
+ * Resolves the supplied display line back through normalisation before
+ * looking it up so callers can pass either the original or the normalised
+ * form.
+ */
+export const regionFor = (line: string, result: CompareResult): Region => {
+	const normalised = normaliseLine(line, result.options);
+	const inA = result.a.normalisedSet.has(normalised);
+	const inB = result.b.normalisedSet.has(normalised);
+	if (inA && inB) return 'common';
+	if (inB) return 'b-only';
+	return 'a-only';
+};
+
+/**
+ * Pick the result array for an operation.
+ */
+export const resultFor = (kind: OperationKind, result: CompareResult): readonly string[] => {
+	if (kind === 'intersection') return result.intersection;
+	if (kind === 'union') return result.union;
+	if (kind === 'difference-a') return result.differenceA;
+	if (kind === 'difference-b') return result.differenceB;
+	return result.symmetric;
+};
+
+/**
+ * Two overlapping word lists for the rail's "Load sample" action.
+ */
+export const SAMPLE_LIST_A = `apple
+banana
+cherry
+date
+fig
+grape`;
+
+export const SAMPLE_LIST_B = `banana
+cherry
+grape
+kiwi
+date
+mango`;

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -26,6 +26,7 @@ import {
 	Key,
 	KeyRound,
 	Link,
+	ListChecks,
 	type LucideIcon,
 	Lock,
 	Network,
@@ -318,6 +319,15 @@ export const PAGES: readonly PageDefinition[] = [
 		icon: Regex,
 		description: 'Test, replace, visualize, and explain regular expressions',
 		color: 'text-neutral-500',
+		category: 'text',
+	},
+	{
+		id: 'list-comparer',
+		title: 'List Comparer',
+		url: '/list-comparer',
+		icon: ListChecks,
+		description: 'Set operations and Venn diagram on two newline-separated lists',
+		color: 'text-cyan-600',
 		category: 'text',
 	},
 	{

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -25,6 +25,7 @@ import { Route as NumberBaseConverterRouteImport } from './routes/number-base-co
 import { Route as NetworkScannerRouteImport } from './routes/network-scanner';
 import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces';
 import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor';
+import { Route as ListComparerRouteImport } from './routes/list-comparer';
 import { Route as JwtDecoderRouteImport } from './routes/jwt-decoder';
 import { Route as JsonFormatterRouteImport } from './routes/json-formatter';
 import { Route as HashGeneratorRouteImport } from './routes/hash-generator';
@@ -117,6 +118,11 @@ const MarkdownEditorRoute = MarkdownEditorRouteImport.update({
 	path: '/markdown-editor',
 	getParentRoute: () => rootRouteImport,
 } as any);
+const ListComparerRoute = ListComparerRouteImport.update({
+	id: '/list-comparer',
+	path: '/list-comparer',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const JwtDecoderRoute = JwtDecoderRouteImport.update({
 	id: '/jwt-decoder',
 	path: '/jwt-decoder',
@@ -185,6 +191,7 @@ export interface FileRoutesByFullPath {
 	'/hash-generator': typeof HashGeneratorRoute;
 	'/json-formatter': typeof JsonFormatterRoute;
 	'/jwt-decoder': typeof JwtDecoderRoute;
+	'/list-comparer': typeof ListComparerRoute;
 	'/markdown-editor': typeof MarkdownEditorRoute;
 	'/network-interfaces': typeof NetworkInterfacesRoute;
 	'/network-scanner': typeof NetworkScannerRoute;
@@ -214,6 +221,7 @@ export interface FileRoutesByTo {
 	'/hash-generator': typeof HashGeneratorRoute;
 	'/json-formatter': typeof JsonFormatterRoute;
 	'/jwt-decoder': typeof JwtDecoderRoute;
+	'/list-comparer': typeof ListComparerRoute;
 	'/markdown-editor': typeof MarkdownEditorRoute;
 	'/network-interfaces': typeof NetworkInterfacesRoute;
 	'/network-scanner': typeof NetworkScannerRoute;
@@ -244,6 +252,7 @@ export interface FileRoutesById {
 	'/hash-generator': typeof HashGeneratorRoute;
 	'/json-formatter': typeof JsonFormatterRoute;
 	'/jwt-decoder': typeof JwtDecoderRoute;
+	'/list-comparer': typeof ListComparerRoute;
 	'/markdown-editor': typeof MarkdownEditorRoute;
 	'/network-interfaces': typeof NetworkInterfacesRoute;
 	'/network-scanner': typeof NetworkScannerRoute;
@@ -275,6 +284,7 @@ export interface FileRouteTypes {
 		| '/hash-generator'
 		| '/json-formatter'
 		| '/jwt-decoder'
+		| '/list-comparer'
 		| '/markdown-editor'
 		| '/network-interfaces'
 		| '/network-scanner'
@@ -304,6 +314,7 @@ export interface FileRouteTypes {
 		| '/hash-generator'
 		| '/json-formatter'
 		| '/jwt-decoder'
+		| '/list-comparer'
 		| '/markdown-editor'
 		| '/network-interfaces'
 		| '/network-scanner'
@@ -333,6 +344,7 @@ export interface FileRouteTypes {
 		| '/hash-generator'
 		| '/json-formatter'
 		| '/jwt-decoder'
+		| '/list-comparer'
 		| '/markdown-editor'
 		| '/network-interfaces'
 		| '/network-scanner'
@@ -363,6 +375,7 @@ export interface RootRouteChildren {
 	HashGeneratorRoute: typeof HashGeneratorRoute;
 	JsonFormatterRoute: typeof JsonFormatterRoute;
 	JwtDecoderRoute: typeof JwtDecoderRoute;
+	ListComparerRoute: typeof ListComparerRoute;
 	MarkdownEditorRoute: typeof MarkdownEditorRoute;
 	NetworkInterfacesRoute: typeof NetworkInterfacesRoute;
 	NetworkScannerRoute: typeof NetworkScannerRoute;
@@ -495,6 +508,13 @@ declare module '@tanstack/react-router' {
 			preLoaderRoute: typeof MarkdownEditorRouteImport;
 			parentRoute: typeof rootRouteImport;
 		};
+		'/list-comparer': {
+			id: '/list-comparer';
+			path: '/list-comparer';
+			fullPath: '/list-comparer';
+			preLoaderRoute: typeof ListComparerRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
 		'/jwt-decoder': {
 			id: '/jwt-decoder';
 			path: '/jwt-decoder';
@@ -587,6 +607,7 @@ const rootRouteChildren: RootRouteChildren = {
 	HashGeneratorRoute: HashGeneratorRoute,
 	JsonFormatterRoute: JsonFormatterRoute,
 	JwtDecoderRoute: JwtDecoderRoute,
+	ListComparerRoute: ListComparerRoute,
 	MarkdownEditorRoute: MarkdownEditorRoute,
 	NetworkInterfacesRoute: NetworkInterfacesRoute,
 	NetworkScannerRoute: NetworkScannerRoute,

--- a/src/routes/list-comparer.tsx
+++ b/src/routes/list-comparer.tsx
@@ -1,0 +1,493 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useMemo, type ChangeEvent } from 'react';
+import {
+	ArrowLeftRight,
+	FlaskConical,
+	GitCompareArrows,
+	ListChecks,
+	Minus,
+	Sigma,
+	Trash2,
+} from 'lucide-react';
+
+import { CopyButton } from '@/lib/components/action';
+import {
+	FormCheckbox,
+	FormCheckboxGroup,
+	FormInfo,
+	FormMode,
+	FormSection,
+} from '@/lib/components/form';
+import { ToolShell } from '@/lib/components/shell';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { Badge } from '@/lib/components/ui/badge';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { Textarea } from '@/lib/components/ui/textarea';
+import { useDocumentTitle } from '@/lib/hooks';
+import {
+	compare,
+	DEFAULT_OPTIONS,
+	type OperationKind,
+	type Region,
+	regionFor,
+	resultFor,
+	SAMPLE_LIST_A,
+	SAMPLE_LIST_B,
+	type SortMode,
+} from '@/lib/services/list-compare';
+import { createToolOptionsStore } from '@/lib/stores';
+import { cn } from '@/lib/utils';
+
+export const Route = createFileRoute('/list-comparer')({
+	component: ListComparerPage,
+});
+
+interface ListComparerOptions {
+	readonly caseSensitive: boolean;
+	readonly trimWhitespace: boolean;
+	readonly ignoreEmpty: boolean;
+	readonly sortMode: SortMode;
+	readonly activeOp: OperationKind;
+}
+
+const DEFAULTS: ListComparerOptions = {
+	caseSensitive: DEFAULT_OPTIONS.caseSensitive,
+	trimWhitespace: DEFAULT_OPTIONS.trimWhitespace,
+	ignoreEmpty: DEFAULT_OPTIONS.ignoreEmpty,
+	sortMode: DEFAULT_OPTIONS.sortMode,
+	activeOp: 'intersection',
+};
+
+const useListComparerOptions = createToolOptionsStore<ListComparerOptions>(
+	'list-comparer',
+	DEFAULTS
+);
+
+const useListComparerInputs = createToolOptionsStore<{
+	readonly inputA: string;
+	readonly inputB: string;
+}>('list-comparer-inputs', { inputA: '', inputB: '' });
+
+const SORT_OPTIONS: readonly { readonly value: SortMode; readonly label: string }[] = [
+	{ value: 'original', label: 'Original' },
+	{ value: 'asc', label: 'A → Z' },
+	{ value: 'desc', label: 'Z → A' },
+];
+
+const OPERATIONS = [
+	{ id: 'intersection' as const, label: 'A ∩ B', icon: Sigma },
+	{ id: 'union' as const, label: 'A ∪ B', icon: Sigma },
+	{ id: 'difference-a' as const, label: 'A \\ B', icon: Minus },
+	{ id: 'difference-b' as const, label: 'B \\ A', icon: Minus },
+	{ id: 'symmetric' as const, label: 'A △ B', icon: GitCompareArrows },
+] as const satisfies readonly {
+	readonly id: OperationKind;
+	readonly label: string;
+	readonly icon: typeof Sigma;
+}[];
+
+const regionRowClass = (region: Region): string => {
+	if (region === 'a-only') return 'border-l-blue-500 bg-blue-500/[0.06]';
+	if (region === 'b-only') return 'border-l-emerald-500 bg-emerald-500/[0.06]';
+	return 'border-l-fuchsia-500 bg-fuchsia-500/[0.06]';
+};
+
+const regionBadgeClass = (region: Region): string => {
+	if (region === 'a-only') return 'border-blue-500/40 bg-blue-500/10 text-blue-500';
+	if (region === 'b-only') return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-500';
+	return 'border-fuchsia-500/40 bg-fuchsia-500/10 text-fuchsia-500';
+};
+
+const regionLabel = (region: Region): string => {
+	if (region === 'a-only') return 'A';
+	if (region === 'b-only') return 'B';
+	return 'A∩B';
+};
+
+interface ListInputCardProps {
+	readonly title: string;
+	readonly subtitle: string;
+	readonly value: string;
+	readonly count: number;
+	readonly placeholder: string;
+	readonly onValueChange: (value: string) => void;
+	readonly accentClass: string;
+}
+
+function ListInputCard({
+	title,
+	subtitle,
+	value,
+	count,
+	placeholder,
+	onValueChange,
+	accentClass,
+}: ListInputCardProps) {
+	const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) =>
+		onValueChange(event.target.value);
+	return (
+		<Card density="compact" className="flex h-full flex-col">
+			<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+				<div className="flex items-center gap-2">
+					<span className={cn('h-2.5 w-2.5 rounded-full', accentClass)} aria-hidden />
+					<CardTitle className="text-sm font-medium">{title}</CardTitle>
+					<span className="text-xs text-muted-foreground">{subtitle}</span>
+				</div>
+				<Badge variant="outline" className="font-mono">
+					{count} {count === 1 ? 'line' : 'lines'}
+				</Badge>
+			</CardHeader>
+			<CardContent className="flex-1">
+				<Textarea
+					value={value}
+					onChange={handleChange}
+					placeholder={placeholder}
+					className="h-full min-h-32 resize-none font-mono text-xs"
+				/>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface VennDiagramProps {
+	readonly aOnly: number;
+	readonly common: number;
+	readonly bOnly: number;
+}
+
+function VennDiagram({ aOnly, common, bOnly }: VennDiagramProps) {
+	// SVG measured in a 240x140 viewBox so callers can size the wrapper with
+	// `h-{n} w-full` and the diagram scales without distorting circle radii.
+	return (
+		<svg
+			viewBox="0 0 240 140"
+			role="img"
+			aria-label={`Venn diagram: A only ${aOnly}, common ${common}, B only ${bOnly}`}
+			className="h-32 w-full max-w-md"
+		>
+			<title>{`A only ${aOnly}, common ${common}, B only ${bOnly}`}</title>
+			<circle
+				cx="90"
+				cy="70"
+				r="55"
+				className="fill-blue-500/15 stroke-blue-500/60"
+				strokeWidth="1.5"
+			/>
+			<circle
+				cx="150"
+				cy="70"
+				r="55"
+				className="fill-emerald-500/15 stroke-emerald-500/60"
+				strokeWidth="1.5"
+			/>
+			<text x="60" y="68" textAnchor="middle" className="fill-blue-500 font-mono text-[11px]">
+				A only
+			</text>
+			<text
+				x="60"
+				y="84"
+				textAnchor="middle"
+				className="fill-foreground font-mono text-base font-semibold"
+			>
+				{aOnly}
+			</text>
+			<text x="120" y="68" textAnchor="middle" className="fill-fuchsia-500 font-mono text-[11px]">
+				Common
+			</text>
+			<text
+				x="120"
+				y="84"
+				textAnchor="middle"
+				className="fill-foreground font-mono text-base font-semibold"
+			>
+				{common}
+			</text>
+			<text x="180" y="68" textAnchor="middle" className="fill-emerald-500 font-mono text-[11px]">
+				B only
+			</text>
+			<text
+				x="180"
+				y="84"
+				textAnchor="middle"
+				className="fill-foreground font-mono text-base font-semibold"
+			>
+				{bOnly}
+			</text>
+		</svg>
+	);
+}
+
+function ListComparerPage() {
+	const { value: options, patch } = useListComparerOptions();
+	const { value: inputs, patch: patchInputs } = useListComparerInputs();
+	const { inputA, inputB } = inputs;
+	const { caseSensitive, trimWhitespace, ignoreEmpty, sortMode, activeOp } = options;
+
+	useDocumentTitle('List Comparer');
+
+	const compareOptions = useMemo(
+		() => ({ caseSensitive, trimWhitespace, ignoreEmpty, sortMode }),
+		[caseSensitive, trimWhitespace, ignoreEmpty, sortMode]
+	);
+
+	const result = useMemo(
+		() => compare(inputA, inputB, compareOptions),
+		[inputA, inputB, compareOptions]
+	);
+
+	const counts = {
+		intersection: result.intersection.length,
+		union: result.union.length,
+		differenceA: result.differenceA.length,
+		differenceB: result.differenceB.length,
+		symmetric: result.symmetric.length,
+	};
+
+	const operationCount = (kind: OperationKind): number => resultFor(kind, result).length;
+
+	const aOnly = counts.differenceA;
+	const bOnly = counts.differenceB;
+	const common = counts.intersection;
+	const aTotal = result.a.normalisedSet.size;
+	const bTotal = result.b.normalisedSet.size;
+
+	const activeLines = resultFor(activeOp, result);
+	const activeCount = activeLines.length;
+
+	const handleSample = () => patchInputs({ inputA: SAMPLE_LIST_A, inputB: SAMPLE_LIST_B });
+	const handleSwap = () => patchInputs({ inputA: inputB, inputB: inputA });
+	const handleClear = () => patchInputs({ inputA: '', inputB: '' });
+	const setInputA = (value: string) => patchInputs({ inputA: value });
+	const setInputB = (value: string) => patchInputs({ inputB: value });
+
+	const hasAnyInput = inputA.length > 0 || inputB.length > 0;
+	const validity = hasAnyInput ? true : null;
+
+	const rail = (
+		<>
+			<FormSection title="Options">
+				<FormCheckboxGroup>
+					<FormCheckbox
+						label="Case-sensitive"
+						checked={caseSensitive}
+						onCheckedChange={(v) => patch({ caseSensitive: v })}
+						size="compact"
+					/>
+					<FormCheckbox
+						label="Trim whitespace"
+						checked={trimWhitespace}
+						onCheckedChange={(v) => patch({ trimWhitespace: v })}
+						size="compact"
+					/>
+					<FormCheckbox
+						label="Ignore empty lines"
+						checked={ignoreEmpty}
+						onCheckedChange={(v) => patch({ ignoreEmpty: v })}
+						size="compact"
+					/>
+				</FormCheckboxGroup>
+			</FormSection>
+
+			<FormSection title="Sort">
+				<FormMode
+					value={sortMode}
+					onValueChange={(v) => patch({ sortMode: v })}
+					options={SORT_OPTIONS}
+				/>
+			</FormSection>
+
+			<FormSection title="Actions">
+				<div className="flex flex-col gap-2">
+					<Button variant="outline" size="sm" className="justify-start" onClick={handleSample}>
+						<FlaskConical className="mr-2 h-3.5 w-3.5" />
+						Load sample
+					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						className="justify-start"
+						onClick={handleSwap}
+						disabled={!hasAnyInput}
+					>
+						<ArrowLeftRight className="mr-2 h-3.5 w-3.5" />
+						Swap A ↔ B
+					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						className="justify-start"
+						onClick={handleClear}
+						disabled={!hasAnyInput}
+					>
+						<Trash2 className="mr-2 h-3.5 w-3.5" />
+						Clear
+					</Button>
+				</div>
+			</FormSection>
+
+			<FormSection title="About">
+				<FormInfo>
+					<ul className="list-inside list-disc space-y-0.5">
+						<li>Set operations on two newline-separated lists</li>
+						<li>Duplicates are folded; first-seen casing is preserved</li>
+						<li>Venn diagram visualises A-only / common / B-only</li>
+					</ul>
+				</FormInfo>
+			</FormSection>
+		</>
+	);
+
+	const statusContent = (
+		<>
+			<StatItem label="A" value={aTotal} />
+			<StatItem label="B" value={bTotal} />
+			<StatItem label="Common" value={common} />
+			<StatItem
+				label={OPERATIONS.find((op) => op.id === activeOp)?.label ?? 'Result'}
+				value={activeCount}
+			/>
+		</>
+	);
+
+	return (
+		<ToolShell
+			valid={validity}
+			rail={rail}
+			statusContent={statusContent}
+			toolbarLeading={
+				<div className="flex items-center gap-2 text-sm font-semibold">
+					<ListChecks className="h-4 w-4 text-cyan-600" />
+					<span>List Comparer</span>
+				</div>
+			}
+		>
+			<div className="flex h-full flex-col gap-3 overflow-hidden p-3">
+				<div className="grid h-1/3 min-h-44 shrink-0 gap-3 sm:grid-cols-2">
+					<ListInputCard
+						title="List A"
+						subtitle="left input"
+						value={inputA}
+						count={aTotal}
+						placeholder={`apple
+banana
+cherry`}
+						onValueChange={setInputA}
+						accentClass="bg-blue-500"
+					/>
+					<ListInputCard
+						title="List B"
+						subtitle="right input"
+						value={inputB}
+						count={bTotal}
+						placeholder={`banana
+cherry
+grape`}
+						onValueChange={setInputB}
+						accentClass="bg-emerald-500"
+					/>
+				</div>
+
+				<Card density="compact" className="shrink-0">
+					<CardHeader className="pb-2">
+						<CardTitle className="text-sm font-medium">Venn diagram</CardTitle>
+					</CardHeader>
+					<CardContent className="flex items-center justify-center">
+						<VennDiagram aOnly={aOnly} common={common} bOnly={bOnly} />
+					</CardContent>
+				</Card>
+
+				<Card density="compact" className="flex min-h-0 flex-1 flex-col">
+					<CardHeader className="flex flex-row items-center justify-between gap-2 space-y-0 pb-2">
+						<div
+							role="tablist"
+							aria-label="Set operations"
+							className="flex flex-wrap items-center gap-1 rounded-lg bg-surface-2 p-1"
+						>
+							{OPERATIONS.map((op) => {
+								const Icon = op.icon;
+								const isActive = op.id === activeOp;
+								const count = operationCount(op.id);
+								return (
+									<button
+										key={op.id}
+										type="button"
+										role="tab"
+										aria-selected={isActive}
+										onClick={() => patch({ activeOp: op.id })}
+										className={cn(
+											'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors',
+											isActive
+												? 'bg-surface-0 text-foreground shadow-sm'
+												: 'text-muted-foreground hover:bg-interactive-hover hover:text-foreground'
+										)}
+									>
+										<Icon className="h-3.5 w-3.5" />
+										<span className="font-mono">{op.label}</span>
+										<Badge variant="outline" className="ml-1 h-4 px-1.5 font-mono text-[10px]">
+											{count}
+										</Badge>
+									</button>
+								);
+							})}
+						</div>
+						<CopyButton
+							text={activeLines.join('\n')}
+							toastLabel={OPERATIONS.find((op) => op.id === activeOp)?.label ?? 'Result'}
+							disabled={activeCount === 0}
+						/>
+					</CardHeader>
+					<CardContent className="flex min-h-0 flex-1 flex-col p-0">
+						{activeLines.length > 0 ? (
+							<div className="flex-1 overflow-auto rounded-b-lg bg-card">
+								<ul className="divide-y divide-border/40">
+									{activeLines.map((line, index) => {
+										const region = regionFor(line, result);
+										return (
+											<li
+												// biome-ignore lint/suspicious/noArrayIndexKey: result list is immutable per render
+												key={`${region}-${index}-${line}`}
+												className={cn(
+													'flex items-center gap-3 border-l-4 px-3 py-1.5 font-mono text-sm',
+													regionRowClass(region)
+												)}
+											>
+												<Badge
+													variant="outline"
+													className={cn(
+														'h-5 shrink-0 px-1.5 font-mono text-[10px]',
+														regionBadgeClass(region)
+													)}
+												>
+													{regionLabel(region)}
+												</Badge>
+												<span className="min-w-0 flex-1 truncate">
+													{line.length === 0 ? (
+														<span className="text-muted-foreground italic">(empty line)</span>
+													) : (
+														line
+													)}
+												</span>
+											</li>
+										);
+									})}
+								</ul>
+							</div>
+						) : (
+							<EmbeddedEmptyState
+								icon={ListChecks}
+								title={hasAnyInput ? 'No items in this result' : 'Enter two lists'}
+								description={
+									hasAnyInput
+										? 'Adjust the lists or switch to another operation to see results.'
+										: 'Paste newline-separated values into List A and List B to start comparing.'
+								}
+								fillHeight
+							/>
+						)}
+					</CardContent>
+				</Card>
+			</div>
+		</ToolShell>
+	);
+}


### PR DESCRIPTION
## Summary
Add a List Comparer under **Text** that runs set operations on two newline-separated lists and visualises the relationship with a Venn diagram. Closes #221.

## Features
- **Two-pane input** (List A, List B) with live line counts
- **Five operation tabs**: A ∩ B, A ∪ B, A \ B, B \ A, A △ B — each with a count badge
- **Venn diagram SVG** at the top with counts in each region
- **Comparison options**: case-sensitive, trim whitespace, ignore empty lines
- **Sort modes**: original / ascending / descending
- **Region-coded result list** with subtle background tones (A-only / B-only / common)
- **Copy all** for the active operation's result

## Changes
### Added
- `src/routes/list-comparer.tsx`
- `src/lib/services/list-compare.ts`
- Page registration in `src/lib/services/pages.ts`

## Test plan
- [x] `bun run check` green
- [x] `bun run lint` no new warnings
- [x] `bun run format` clean
- [ ] Manual: load sample, verify all 5 tab counts make sense
- [ ] Manual: toggle case-sensitive, verify "Apple" vs "apple" behave as expected
- [ ] Manual: toggle trim whitespace, verify spaces don't create false-distinct items
- [ ] Manual: try each sort mode
- [ ] Manual: swap A ↔ B, verify difference tabs invert

Closes #221
