### PR TITLE
feat(escape-tool): add multi-flavor Escape / Unescape tool

### DIFF
--- a/src/lib/services/escape.ts
+++ b/src/lib/services/escape.ts
@@ -1,0 +1,674 @@
+/**
+ * Multi-flavor escape / unescape service.
+ *
+ * Pure functions per flavor (JSON / JavaScript / HTML / XML / CSV / Shell).
+ * Each `escape*` produces both a plain string and a segment list so consumers
+ * can highlight characters that needed escaping. Each `unescape*` is fault
+ * tolerant — on malformed input it returns the original string unchanged.
+ */
+
+export type EscapeFlavor = 'json' | 'javascript' | 'html' | 'xml' | 'csv' | 'shell';
+
+export interface JsonEscapeOptions {
+	readonly escapeUnicode: boolean;
+	readonly preserveForwardSlash: boolean;
+}
+
+export interface JsEscapeOptions {
+	readonly quoteStyle: 'single' | 'double';
+	readonly escapeUnicode: boolean;
+}
+
+export interface HtmlEscapeOptions {
+	readonly entityForm: 'named' | 'numeric';
+	readonly encodeNonAscii: boolean;
+}
+
+export interface XmlEscapeOptions {
+	readonly amp: boolean;
+	readonly lt: boolean;
+	readonly gt: boolean;
+	readonly quot: boolean;
+	readonly apos: boolean;
+}
+
+export type CsvSeparator = ',' | ';' | '\t';
+
+export interface CsvEscapeOptions {
+	readonly separator: CsvSeparator;
+	readonly quoteStyle: 'always' | 'minimal';
+}
+
+export type ShellDialect = 'bash' | 'powershell' | 'cmd';
+
+export interface ShellEscapeOptions {
+	readonly dialect: ShellDialect;
+}
+
+export interface FlavorOptions {
+	readonly json: JsonEscapeOptions;
+	readonly javascript: JsEscapeOptions;
+	readonly html: HtmlEscapeOptions;
+	readonly xml: XmlEscapeOptions;
+	readonly csv: CsvEscapeOptions;
+	readonly shell: ShellEscapeOptions;
+}
+
+export const DEFAULT_FLAVOR_OPTIONS: FlavorOptions = {
+	json: { escapeUnicode: false, preserveForwardSlash: true },
+	javascript: { quoteStyle: 'single', escapeUnicode: false },
+	html: { entityForm: 'named', encodeNonAscii: false },
+	xml: { amp: true, lt: true, gt: true, quot: true, apos: true },
+	csv: { separator: ',', quoteStyle: 'minimal' },
+	shell: { dialect: 'bash' },
+};
+
+export interface EscapedSegment {
+	readonly text: string;
+	readonly changed: boolean;
+}
+
+const concatSegments = (segments: readonly EscapedSegment[]): string =>
+	segments.map((seg) => seg.text).join('');
+
+// ---------------------------------------------------------------------------
+// JSON
+// ---------------------------------------------------------------------------
+
+const toHexCodePoint = (code: number, width: number): string =>
+	code.toString(16).toUpperCase().padStart(width, '0');
+
+const escapeJsonChar = (char: string, opts: JsonEscapeOptions): string | null => {
+	switch (char) {
+		case '\\':
+			return '\\\\';
+		case '"':
+			return '\\"';
+		case '\b':
+			return '\\b';
+		case '\f':
+			return '\\f';
+		case '\n':
+			return '\\n';
+		case '\r':
+			return '\\r';
+		case '\t':
+			return '\\t';
+		case '/':
+			return opts.preserveForwardSlash ? null : '\\/';
+		default: {
+			const code = char.charCodeAt(0);
+			if (code < 0x20) return `\\u${toHexCodePoint(code, 4)}`;
+			if (opts.escapeUnicode && code > 0x7e) return `\\u${toHexCodePoint(code, 4)}`;
+			return null;
+		}
+	}
+};
+
+export const escapeJsonSegments = (
+	raw: string,
+	opts: JsonEscapeOptions
+): readonly EscapedSegment[] =>
+	Array.from(raw).map((char) => {
+		const escaped = escapeJsonChar(char, opts);
+		return escaped === null ? { text: char, changed: false } : { text: escaped, changed: true };
+	});
+
+export const escapeJson = (raw: string, opts: JsonEscapeOptions): string =>
+	concatSegments(escapeJsonSegments(raw, opts));
+
+export const unescapeJson = (esc: string, _opts: JsonEscapeOptions): string => {
+	if (!esc) return esc;
+	// JSON.parse only accepts a quoted string. Strip outermost quotes if present
+	// before attempting to parse so users can paste either form.
+	const wrapped = esc.startsWith('"') && esc.endsWith('"') && esc.length >= 2 ? esc : `"${esc}"`;
+	try {
+		const parsed = JSON.parse(wrapped) as unknown;
+		return typeof parsed === 'string' ? parsed : esc;
+	} catch {
+		return esc;
+	}
+};
+
+// ---------------------------------------------------------------------------
+// JavaScript
+// ---------------------------------------------------------------------------
+
+const escapeJsChar = (char: string, opts: JsEscapeOptions): string | null => {
+	const quoteChar = opts.quoteStyle === 'single' ? "'" : '"';
+	switch (char) {
+		case '\\':
+			return '\\\\';
+		case '\b':
+			return '\\b';
+		case '\f':
+			return '\\f';
+		case '\n':
+			return '\\n';
+		case '\r':
+			return '\\r';
+		case '\t':
+			return '\\t';
+		case '\v':
+			return '\\v';
+		case '\0':
+			return '\\0';
+		default: {
+			if (char === quoteChar) return `\\${char}`;
+			const code = char.charCodeAt(0);
+			if (code < 0x20) return `\\x${toHexCodePoint(code, 2)}`;
+			if (opts.escapeUnicode && code > 0x7e) {
+				if (code > 0xff) return `\\u${toHexCodePoint(code, 4)}`;
+				return `\\x${toHexCodePoint(code, 2)}`;
+			}
+			return null;
+		}
+	}
+};
+
+export const escapeJsSegments = (raw: string, opts: JsEscapeOptions): readonly EscapedSegment[] =>
+	Array.from(raw).map((char) => {
+		const escaped = escapeJsChar(char, opts);
+		return escaped === null ? { text: char, changed: false } : { text: escaped, changed: true };
+	});
+
+export const escapeJs = (raw: string, opts: JsEscapeOptions): string =>
+	concatSegments(escapeJsSegments(raw, opts));
+
+const JS_UNESCAPE_SIMPLE: Record<string, string> = {
+	'\\': '\\',
+	"'": "'",
+	'"': '"',
+	'`': '`',
+	b: '\b',
+	f: '\f',
+	n: '\n',
+	r: '\r',
+	t: '\t',
+	v: '\v',
+	'0': '\0',
+};
+
+export const unescapeJs = (esc: string, _opts: JsEscapeOptions): string => {
+	if (!esc) return esc;
+	const chars = Array.from(esc);
+	const out: string[] = [];
+	let i = 0;
+	while (i < chars.length) {
+		const ch = chars[i];
+		if (ch === undefined) break;
+		if (ch !== '\\' || i === chars.length - 1) {
+			out.push(ch);
+			i += 1;
+			continue;
+		}
+		const next = chars[i + 1];
+		if (next === undefined) {
+			out.push(ch);
+			i += 1;
+			continue;
+		}
+		if (next === 'x') {
+			const hex = esc.slice(i + 2, i + 4);
+			if (/^[0-9a-fA-F]{2}$/.test(hex)) {
+				out.push(String.fromCharCode(Number.parseInt(hex, 16)));
+				i += 4;
+				continue;
+			}
+		}
+		if (next === 'u') {
+			if (esc[i + 2] === '{') {
+				const end = esc.indexOf('}', i + 3);
+				const hex = end > -1 ? esc.slice(i + 3, end) : '';
+				if (/^[0-9a-fA-F]+$/.test(hex)) {
+					out.push(String.fromCodePoint(Number.parseInt(hex, 16)));
+					i = end + 1;
+					continue;
+				}
+			}
+			const hex = esc.slice(i + 2, i + 6);
+			if (/^[0-9a-fA-F]{4}$/.test(hex)) {
+				out.push(String.fromCharCode(Number.parseInt(hex, 16)));
+				i += 6;
+				continue;
+			}
+		}
+		const simple = JS_UNESCAPE_SIMPLE[next];
+		if (simple !== undefined) {
+			out.push(simple);
+			i += 2;
+			continue;
+		}
+		// Unknown escape — preserve the trailing char (mirrors JS semantics).
+		out.push(next);
+		i += 2;
+	}
+	return out.join('');
+};
+
+// ---------------------------------------------------------------------------
+// HTML
+// ---------------------------------------------------------------------------
+
+const HTML_NAMED_ENTITIES: Record<string, string> = {
+	'&': '&amp;',
+	'<': '&lt;',
+	'>': '&gt;',
+	'"': '&quot;',
+	"'": '&#39;',
+};
+
+const HTML_NUMERIC_ENTITIES: Record<string, string> = {
+	'&': '&#38;',
+	'<': '&#60;',
+	'>': '&#62;',
+	'"': '&#34;',
+	"'": '&#39;',
+};
+
+const escapeHtmlChar = (char: string, opts: HtmlEscapeOptions): string | null => {
+	const table = opts.entityForm === 'named' ? HTML_NAMED_ENTITIES : HTML_NUMERIC_ENTITIES;
+	const mapped = table[char];
+	if (mapped !== undefined) return mapped;
+	if (!opts.encodeNonAscii) return null;
+	const code = char.codePointAt(0);
+	if (code !== undefined && code > 0x7e) {
+		return opts.entityForm === 'named' ? `&#${code};` : `&#${code};`;
+	}
+	return null;
+};
+
+export const escapeHtmlSegments = (
+	raw: string,
+	opts: HtmlEscapeOptions
+): readonly EscapedSegment[] =>
+	Array.from(raw).map((char) => {
+		const escaped = escapeHtmlChar(char, opts);
+		return escaped === null ? { text: char, changed: false } : { text: escaped, changed: true };
+	});
+
+export const escapeHtml = (raw: string, opts: HtmlEscapeOptions): string =>
+	concatSegments(escapeHtmlSegments(raw, opts));
+
+// Common named HTML entities used for the bidirectional unescape pass.
+const HTML_NAMED_DECODE: Record<string, string> = {
+	amp: '&',
+	lt: '<',
+	gt: '>',
+	quot: '"',
+	apos: "'",
+	nbsp: ' ',
+	copy: '©',
+	reg: '®',
+	trade: '™',
+	hellip: '…',
+	mdash: '—',
+	ndash: '–',
+	lsquo: '‘',
+	rsquo: '’',
+	ldquo: '“',
+	rdquo: '”',
+	laquo: '«',
+	raquo: '»',
+	cent: '¢',
+	pound: '£',
+	yen: '¥',
+	euro: '€',
+	sect: '§',
+	para: '¶',
+	middot: '·',
+	deg: '°',
+	plusmn: '±',
+	times: '×',
+	divide: '÷',
+};
+
+const decodeHtmlEntity = (entity: string): string | null => {
+	// Numeric: &#NN; or &#xHH;
+	if (entity.startsWith('#')) {
+		const isHex = entity.startsWith('#x') || entity.startsWith('#X');
+		const digits = isHex ? entity.slice(2) : entity.slice(1);
+		const radix = isHex ? 16 : 10;
+		if (!new RegExp(isHex ? '^[0-9a-fA-F]+$' : '^[0-9]+$').test(digits)) return null;
+		const code = Number.parseInt(digits, radix);
+		if (!Number.isFinite(code) || code < 0 || code > 0x10ffff) return null;
+		try {
+			return String.fromCodePoint(code);
+		} catch {
+			return null;
+		}
+	}
+	const named = HTML_NAMED_DECODE[entity];
+	return named ?? null;
+};
+
+export const unescapeHtml = (esc: string, _opts: HtmlEscapeOptions): string =>
+	esc.replace(/&([#a-zA-Z0-9]+);/g, (match, body: string) => {
+		const decoded = decodeHtmlEntity(body);
+		return decoded ?? match;
+	});
+
+// ---------------------------------------------------------------------------
+// XML
+// ---------------------------------------------------------------------------
+
+const escapeXmlChar = (char: string, opts: XmlEscapeOptions): string | null => {
+	if (char === '&' && opts.amp) return '&amp;';
+	if (char === '<' && opts.lt) return '&lt;';
+	if (char === '>' && opts.gt) return '&gt;';
+	if (char === '"' && opts.quot) return '&quot;';
+	if (char === "'" && opts.apos) return '&apos;';
+	return null;
+};
+
+export const escapeXmlSegments = (raw: string, opts: XmlEscapeOptions): readonly EscapedSegment[] =>
+	Array.from(raw).map((char) => {
+		const escaped = escapeXmlChar(char, opts);
+		return escaped === null ? { text: char, changed: false } : { text: escaped, changed: true };
+	});
+
+export const escapeXml = (raw: string, opts: XmlEscapeOptions): string =>
+	concatSegments(escapeXmlSegments(raw, opts));
+
+const XML_NAMED_DECODE: Record<string, string> = {
+	amp: '&',
+	lt: '<',
+	gt: '>',
+	quot: '"',
+	apos: "'",
+};
+
+const decodeXmlEntity = (entity: string): string | null => {
+	if (entity.startsWith('#')) {
+		const isHex = entity.startsWith('#x') || entity.startsWith('#X');
+		const digits = isHex ? entity.slice(2) : entity.slice(1);
+		const radix = isHex ? 16 : 10;
+		if (!new RegExp(isHex ? '^[0-9a-fA-F]+$' : '^[0-9]+$').test(digits)) return null;
+		const code = Number.parseInt(digits, radix);
+		if (!Number.isFinite(code) || code < 0 || code > 0x10ffff) return null;
+		try {
+			return String.fromCodePoint(code);
+		} catch {
+			return null;
+		}
+	}
+	const named = XML_NAMED_DECODE[entity];
+	return named ?? null;
+};
+
+export const unescapeXml = (esc: string, _opts: XmlEscapeOptions): string =>
+	esc.replace(/&([#a-zA-Z0-9]+);/g, (match, body: string) => {
+		const decoded = decodeXmlEntity(body);
+		return decoded ?? match;
+	});
+
+// ---------------------------------------------------------------------------
+// CSV
+// ---------------------------------------------------------------------------
+
+const csvNeedsQuoting = (raw: string, separator: CsvSeparator): boolean =>
+	raw.includes('"') || raw.includes(separator) || raw.includes('\n') || raw.includes('\r');
+
+export const escapeCsvSegments = (
+	raw: string,
+	opts: CsvEscapeOptions
+): readonly EscapedSegment[] => {
+	const mustQuote = opts.quoteStyle === 'always' || csvNeedsQuoting(raw, opts.separator);
+	if (!mustQuote) {
+		return [{ text: raw, changed: false }];
+	}
+	const segments: EscapedSegment[] = [{ text: '"', changed: true }];
+	for (const char of Array.from(raw)) {
+		if (char === '"') {
+			segments.push({ text: '""', changed: true });
+		} else {
+			segments.push({ text: char, changed: false });
+		}
+	}
+	segments.push({ text: '"', changed: true });
+	return segments;
+};
+
+export const escapeCsv = (raw: string, opts: CsvEscapeOptions): string =>
+	concatSegments(escapeCsvSegments(raw, opts));
+
+export const unescapeCsv = (esc: string, _opts: CsvEscapeOptions): string => {
+	if (esc.length < 2 || !esc.startsWith('"') || !esc.endsWith('"')) return esc;
+	const inner = esc.slice(1, -1);
+	return inner.replace(/""/g, '"');
+};
+
+// ---------------------------------------------------------------------------
+// Shell
+// ---------------------------------------------------------------------------
+
+const escapeShellBash = (raw: string): readonly EscapedSegment[] => {
+	// Single-quote wrap; embedded single quotes become `'\''`.
+	if (raw.length === 0) {
+		return [{ text: "''", changed: true }];
+	}
+	const segments: EscapedSegment[] = [{ text: "'", changed: true }];
+	for (const char of Array.from(raw)) {
+		if (char === "'") {
+			segments.push({ text: "'\\''", changed: true });
+		} else {
+			segments.push({ text: char, changed: false });
+		}
+	}
+	segments.push({ text: "'", changed: true });
+	return segments;
+};
+
+const escapeShellPowershell = (raw: string): readonly EscapedSegment[] => {
+	// Single-quote wrap; embedded single quotes are doubled.
+	if (raw.length === 0) {
+		return [{ text: "''", changed: true }];
+	}
+	const segments: EscapedSegment[] = [{ text: "'", changed: true }];
+	for (const char of Array.from(raw)) {
+		if (char === "'") {
+			segments.push({ text: "''", changed: true });
+		} else {
+			segments.push({ text: char, changed: false });
+		}
+	}
+	segments.push({ text: "'", changed: true });
+	return segments;
+};
+
+const CMD_SPECIAL = new Set(['^', '&', '|', '<', '>', '(', ')', '%', '!', '"']);
+
+const escapeShellCmd = (raw: string): readonly EscapedSegment[] => {
+	// Wrap in double quotes; escape `"` and special chars with `^`.
+	if (raw.length === 0) {
+		return [{ text: '""', changed: true }];
+	}
+	const segments: EscapedSegment[] = [{ text: '"', changed: true }];
+	for (const char of Array.from(raw)) {
+		if (char === '"') {
+			segments.push({ text: '\\"', changed: true });
+			continue;
+		}
+		if (CMD_SPECIAL.has(char)) {
+			segments.push({ text: `^${char}`, changed: true });
+			continue;
+		}
+		segments.push({ text: char, changed: false });
+	}
+	segments.push({ text: '"', changed: true });
+	return segments;
+};
+
+export const escapeShellSegments = (
+	raw: string,
+	opts: ShellEscapeOptions
+): readonly EscapedSegment[] => {
+	switch (opts.dialect) {
+		case 'powershell':
+			return escapeShellPowershell(raw);
+		case 'cmd':
+			return escapeShellCmd(raw);
+		default:
+			return escapeShellBash(raw);
+	}
+};
+
+export const escapeShell = (raw: string, opts: ShellEscapeOptions): string =>
+	concatSegments(escapeShellSegments(raw, opts));
+
+const unescapeShellBash = (esc: string): string => {
+	if (esc.length < 2 || !esc.startsWith("'") || !esc.endsWith("'")) return esc;
+	// Reverse the `'\''` -> `'` sequence used by the bash escaper, then drop
+	// the outer quotes.
+	return esc.slice(1, -1).replace(/'\\''/g, "'");
+};
+
+const unescapeShellPowershell = (esc: string): string => {
+	if (esc.length < 2 || !esc.startsWith("'") || !esc.endsWith("'")) return esc;
+	return esc.slice(1, -1).replace(/''/g, "'");
+};
+
+const unescapeShellCmd = (esc: string): string => {
+	if (esc.length < 2 || !esc.startsWith('"') || !esc.endsWith('"')) return esc;
+	const inner = esc.slice(1, -1);
+	const chars = Array.from(inner);
+	const out: string[] = [];
+	let i = 0;
+	while (i < chars.length) {
+		const ch = chars[i];
+		if (ch === undefined) break;
+		const next = chars[i + 1];
+		if (ch === '\\' && next === '"') {
+			out.push('"');
+			i += 2;
+			continue;
+		}
+		if (ch === '^' && next !== undefined && CMD_SPECIAL.has(next)) {
+			out.push(next);
+			i += 2;
+			continue;
+		}
+		out.push(ch);
+		i += 1;
+	}
+	return out.join('');
+};
+
+export const unescapeShell = (esc: string, opts: ShellEscapeOptions): string => {
+	switch (opts.dialect) {
+		case 'powershell':
+			return unescapeShellPowershell(esc);
+		case 'cmd':
+			return unescapeShellCmd(esc);
+		default:
+			return unescapeShellBash(esc);
+	}
+};
+
+// ---------------------------------------------------------------------------
+// Dispatchers
+// ---------------------------------------------------------------------------
+
+export const escapeSegmentsByFlavor = (
+	flavor: EscapeFlavor,
+	raw: string,
+	opts: FlavorOptions
+): readonly EscapedSegment[] => {
+	switch (flavor) {
+		case 'json':
+			return escapeJsonSegments(raw, opts.json);
+		case 'javascript':
+			return escapeJsSegments(raw, opts.javascript);
+		case 'html':
+			return escapeHtmlSegments(raw, opts.html);
+		case 'xml':
+			return escapeXmlSegments(raw, opts.xml);
+		case 'csv':
+			return escapeCsvSegments(raw, opts.csv);
+		case 'shell':
+			return escapeShellSegments(raw, opts.shell);
+	}
+};
+
+export const escapeByFlavor = (flavor: EscapeFlavor, raw: string, opts: FlavorOptions): string =>
+	concatSegments(escapeSegmentsByFlavor(flavor, raw, opts));
+
+export const unescapeByFlavor = (
+	flavor: EscapeFlavor,
+	esc: string,
+	opts: FlavorOptions
+): string => {
+	switch (flavor) {
+		case 'json':
+			return unescapeJson(esc, opts.json);
+		case 'javascript':
+			return unescapeJs(esc, opts.javascript);
+		case 'html':
+			return unescapeHtml(esc, opts.html);
+		case 'xml':
+			return unescapeXml(esc, opts.xml);
+		case 'csv':
+			return unescapeCsv(esc, opts.csv);
+		case 'shell':
+			return unescapeShell(esc, opts.shell);
+	}
+};
+
+// ---------------------------------------------------------------------------
+// Samples
+// ---------------------------------------------------------------------------
+
+export interface FlavorSample {
+	readonly raw: string;
+	readonly escaped: string;
+}
+
+export const SAMPLES: Record<EscapeFlavor, FlavorSample> = {
+	json: {
+		raw: `Hello "world"
+New line	tab`,
+		escaped: '"Hello \\"world\\"\\nNew line\\ttab"',
+	},
+	javascript: {
+		raw: `She's "here"
+on a new line`,
+		escaped: "'She\\'s \"here\"\\non a new line'",
+	},
+	html: {
+		raw: '<a href="x">A & B</a>',
+		escaped: '&lt;a href=&quot;x&quot;&gt;A &amp; B&lt;/a&gt;',
+	},
+	xml: {
+		raw: `<x attr="v">A & B's</x>`,
+		escaped: '&lt;x attr=&quot;v&quot;&gt;A &amp; B&apos;s&lt;/x&gt;',
+	},
+	csv: {
+		raw: `hello,"world"
+row 2`,
+		escaped: `"hello,""world""
+row 2"`,
+	},
+	shell: {
+		raw: "echo 'hi $USER'",
+		escaped: "'echo '\\''hi $USER'\\'''",
+	},
+};
+
+export const FLAVOR_LABELS: Record<EscapeFlavor, string> = {
+	json: 'JSON string',
+	javascript: 'JavaScript string',
+	html: 'HTML entities',
+	xml: 'XML entities',
+	csv: 'CSV cell',
+	shell: 'Shell argument',
+};
+
+export const FLAVOR_DESCRIPTIONS: Record<EscapeFlavor, string> = {
+	json: 'Escape characters so the result is a valid JSON string literal — backslash, quote, control characters, and optionally non-ASCII.',
+	javascript:
+		'Escape characters so the result is a valid JavaScript string literal — backslash, the active quote character, and control characters.',
+	html: 'Convert HTML markup characters into named or numeric entities so they render as text instead of markup.',
+	xml: 'Convert XML markup characters into entity references. Each entity can be toggled individually.',
+	csv: 'Wrap fields containing separators, quotes, or newlines in double quotes; embedded quotes are doubled.',
+	shell: 'Quote and escape a shell argument so it survives parsing by the chosen shell dialect.',
+};

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -21,6 +21,7 @@ import {
 	FileText,
 	Fingerprint,
 	GitCompare,
+	Globe,
 	Hash,
 	House,
 	Key,
@@ -33,6 +34,7 @@ import {
 	Pencil,
 	Play,
 	QrCode,
+	Quote,
 	Radar,
 	Regex,
 	Search,
@@ -40,6 +42,7 @@ import {
 	Shield,
 	ShieldCheck,
 	Sparkles,
+	Table,
 	Terminal,
 } from 'lucide-react';
 
@@ -175,6 +178,23 @@ export const PAGES: readonly PageDefinition[] = [
 		description: 'Decode X.509 / PEM certificates with chain visualization and fingerprints',
 		color: 'text-teal-600',
 		category: 'encoders',
+	},
+	{
+		id: 'escape-tool',
+		title: 'Escape / Unescape',
+		url: '/escape-tool',
+		icon: Quote,
+		description: 'Multi-flavor escape and unescape for JSON / JS / HTML / XML / CSV / Shell',
+		color: 'text-rose-600',
+		category: 'encoders',
+		tabs: [
+			{ id: 'json', label: 'JSON', icon: Braces },
+			{ id: 'javascript', label: 'JS', icon: FileCode },
+			{ id: 'html', label: 'HTML', icon: Globe },
+			{ id: 'xml', label: 'XML', icon: FileCode },
+			{ id: 'csv', label: 'CSV', icon: Table },
+			{ id: 'shell', label: 'Shell', icon: Terminal },
+		],
 	},
 	{
 		id: 'uuid-generator',

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -30,6 +30,7 @@ import { Route as JwtDecoderRouteImport } from './routes/jwt-decoder';
 import { Route as JsonFormatterRouteImport } from './routes/json-formatter';
 import { Route as HashGeneratorRouteImport } from './routes/hash-generator';
 import { Route as GpgKeyGeneratorRouteImport } from './routes/gpg-key-generator';
+import { Route as EscapeToolRouteImport } from './routes/escape-tool';
 import { Route as DiffViewerRouteImport } from './routes/diff-viewer';
 import { Route as DateTimestampConverterRouteImport } from './routes/date-timestamp-converter';
 import { Route as CurlBuilderRouteImport } from './routes/curl-builder';
@@ -143,6 +144,11 @@ const GpgKeyGeneratorRoute = GpgKeyGeneratorRouteImport.update({
 	path: '/gpg-key-generator',
 	getParentRoute: () => rootRouteImport,
 } as any);
+const EscapeToolRoute = EscapeToolRouteImport.update({
+	id: '/escape-tool',
+	path: '/escape-tool',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const DiffViewerRoute = DiffViewerRouteImport.update({
 	id: '/diff-viewer',
 	path: '/diff-viewer',
@@ -187,6 +193,7 @@ export interface FileRoutesByFullPath {
 	'/curl-builder': typeof CurlBuilderRoute;
 	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
 	'/diff-viewer': typeof DiffViewerRoute;
+	'/escape-tool': typeof EscapeToolRoute;
 	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
 	'/hash-generator': typeof HashGeneratorRoute;
 	'/json-formatter': typeof JsonFormatterRoute;
@@ -217,6 +224,7 @@ export interface FileRoutesByTo {
 	'/curl-builder': typeof CurlBuilderRoute;
 	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
 	'/diff-viewer': typeof DiffViewerRoute;
+	'/escape-tool': typeof EscapeToolRoute;
 	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
 	'/hash-generator': typeof HashGeneratorRoute;
 	'/json-formatter': typeof JsonFormatterRoute;
@@ -248,6 +256,7 @@ export interface FileRoutesById {
 	'/curl-builder': typeof CurlBuilderRoute;
 	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
 	'/diff-viewer': typeof DiffViewerRoute;
+	'/escape-tool': typeof EscapeToolRoute;
 	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
 	'/hash-generator': typeof HashGeneratorRoute;
 	'/json-formatter': typeof JsonFormatterRoute;
@@ -280,6 +289,7 @@ export interface FileRouteTypes {
 		| '/curl-builder'
 		| '/date-timestamp-converter'
 		| '/diff-viewer'
+		| '/escape-tool'
 		| '/gpg-key-generator'
 		| '/hash-generator'
 		| '/json-formatter'
@@ -310,6 +320,7 @@ export interface FileRouteTypes {
 		| '/curl-builder'
 		| '/date-timestamp-converter'
 		| '/diff-viewer'
+		| '/escape-tool'
 		| '/gpg-key-generator'
 		| '/hash-generator'
 		| '/json-formatter'
@@ -340,6 +351,7 @@ export interface FileRouteTypes {
 		| '/curl-builder'
 		| '/date-timestamp-converter'
 		| '/diff-viewer'
+		| '/escape-tool'
 		| '/gpg-key-generator'
 		| '/hash-generator'
 		| '/json-formatter'
@@ -371,6 +383,7 @@ export interface RootRouteChildren {
 	CurlBuilderRoute: typeof CurlBuilderRoute;
 	DateTimestampConverterRoute: typeof DateTimestampConverterRoute;
 	DiffViewerRoute: typeof DiffViewerRoute;
+	EscapeToolRoute: typeof EscapeToolRoute;
 	GpgKeyGeneratorRoute: typeof GpgKeyGeneratorRoute;
 	HashGeneratorRoute: typeof HashGeneratorRoute;
 	JsonFormatterRoute: typeof JsonFormatterRoute;
@@ -543,6 +556,13 @@ declare module '@tanstack/react-router' {
 			preLoaderRoute: typeof GpgKeyGeneratorRouteImport;
 			parentRoute: typeof rootRouteImport;
 		};
+		'/escape-tool': {
+			id: '/escape-tool';
+			path: '/escape-tool';
+			fullPath: '/escape-tool';
+			preLoaderRoute: typeof EscapeToolRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
 		'/diff-viewer': {
 			id: '/diff-viewer';
 			path: '/diff-viewer';
@@ -603,6 +623,7 @@ const rootRouteChildren: RootRouteChildren = {
 	CurlBuilderRoute: CurlBuilderRoute,
 	DateTimestampConverterRoute: DateTimestampConverterRoute,
 	DiffViewerRoute: DiffViewerRoute,
+	EscapeToolRoute: EscapeToolRoute,
 	GpgKeyGeneratorRoute: GpgKeyGeneratorRoute,
 	HashGeneratorRoute: HashGeneratorRoute,
 	JsonFormatterRoute: JsonFormatterRoute,

--- a/src/routes/escape-tool.tsx
+++ b/src/routes/escape-tool.tsx
@@ -1,0 +1,520 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useEffect, useRef, useState } from 'react';
+import {
+	Braces,
+	ClipboardPaste,
+	Eraser,
+	FileCode,
+	FlaskConical,
+	Globe,
+	RotateCcw,
+	Table,
+	Terminal,
+} from 'lucide-react';
+
+import { CopyButton } from '@/lib/components/action';
+import {
+	FormCheckbox,
+	FormCheckboxGroup,
+	FormInfo,
+	FormMode,
+	FormSection,
+	FormSelect,
+} from '@/lib/components/form';
+import { ToolShell } from '@/lib/components/shell';
+import { StatItem } from '@/lib/components/status';
+import { Button } from '@/lib/components/ui/button';
+import { IconTooltip } from '@/lib/components/ui/icon-tooltip';
+import { Textarea } from '@/lib/components/ui/textarea';
+import { useDocumentTitle } from '@/lib/hooks';
+import { createToolOptionsStore, useActiveTab, useTabStore } from '@/lib/stores';
+import { cn } from '@/lib/utils';
+import { pasteFromClipboard } from '@/lib/utils/file-operations';
+import {
+	type CsvEscapeOptions,
+	type CsvSeparator,
+	DEFAULT_FLAVOR_OPTIONS,
+	type EscapeFlavor,
+	type EscapedSegment,
+	FLAVOR_DESCRIPTIONS,
+	type FlavorOptions,
+	type HtmlEscapeOptions,
+	type JsEscapeOptions,
+	SAMPLES,
+	type ShellDialect,
+	type XmlEscapeOptions,
+	escapeByFlavor,
+	escapeSegmentsByFlavor,
+	unescapeByFlavor,
+} from '@/lib/services/escape';
+
+type Side = 'raw' | 'escaped';
+
+const FLAVOR_TABS = [
+	{ id: 'json' as const, label: 'JSON', icon: Braces },
+	{ id: 'javascript' as const, label: 'JS', icon: FileCode },
+	{ id: 'html' as const, label: 'HTML', icon: Globe },
+	{ id: 'xml' as const, label: 'XML', icon: FileCode },
+	{ id: 'csv' as const, label: 'CSV', icon: Table },
+	{ id: 'shell' as const, label: 'Shell', icon: Terminal },
+] as const;
+
+const PERSIST_KEY = 'escape-tool';
+
+const EMPTY_BY_FLAVOR: Record<EscapeFlavor, string> = {
+	json: '',
+	javascript: '',
+	html: '',
+	xml: '',
+	csv: '',
+	shell: '',
+};
+
+interface PersistedOptions {
+	readonly activeFlavor: EscapeFlavor;
+	readonly options: FlavorOptions;
+}
+
+const PERSISTED_DEFAULTS: PersistedOptions = {
+	activeFlavor: 'json',
+	options: DEFAULT_FLAVOR_OPTIONS,
+};
+
+const useEscapeOptions = createToolOptionsStore<PersistedOptions>(
+	'escape-tool',
+	PERSISTED_DEFAULTS
+);
+
+const isEscapeFlavor = (value: string): value is EscapeFlavor =>
+	value === 'json' ||
+	value === 'javascript' ||
+	value === 'html' ||
+	value === 'xml' ||
+	value === 'csv' ||
+	value === 'shell';
+
+export const Route = createFileRoute('/escape-tool')({
+	component: EscapeToolPage,
+});
+
+function EscapeToolPage() {
+	const persistedTab = useActiveTab(PERSIST_KEY);
+	const setActive = useTabStore((s) => s.setActive);
+
+	const persisted = useEscapeOptions((s) => s.value);
+	const patchPersisted = useEscapeOptions((s) => s.patch);
+
+	const activeFlavor: EscapeFlavor = (() => {
+		if (persistedTab && isEscapeFlavor(persistedTab)) return persistedTab;
+		return persisted.activeFlavor;
+	})();
+
+	useDocumentTitle('Escape / Unescape');
+
+	const handleTabChange = (tab: string) => {
+		if (!isEscapeFlavor(tab)) return;
+		setActive(PERSIST_KEY, tab);
+		patchPersisted({ activeFlavor: tab });
+	};
+
+	const [rawByFlavor, setRawByFlavor] = useState<Record<EscapeFlavor, string>>({
+		...EMPTY_BY_FLAVOR,
+	});
+	const [escapedByFlavor, setEscapedByFlavor] = useState<Record<EscapeFlavor, string>>({
+		...EMPTY_BY_FLAVOR,
+	});
+
+	// `lastEditedSide` tracks which textarea the user typed into last so the
+	// reactive sync effect knows which direction to transform.
+	const lastEditedSideRef = useRef<Side>('raw');
+
+	const raw = rawByFlavor[activeFlavor];
+	const escaped = escapedByFlavor[activeFlavor];
+
+	// Sync: when the raw side or options change after a raw edit, recompute the
+	// escaped side. Symmetrically, after an escaped edit recompute the raw
+	// side. Driven by `[activeFlavor, persisted.options, raw, escaped]` so
+	// option toggles take effect immediately.
+	useEffect(() => {
+		if (lastEditedSideRef.current === 'raw') {
+			const nextEscaped = escapeByFlavor(activeFlavor, raw, persisted.options);
+			if (nextEscaped !== escaped) {
+				setEscapedByFlavor((prev) => ({ ...prev, [activeFlavor]: nextEscaped }));
+			}
+		} else {
+			const nextRaw = unescapeByFlavor(activeFlavor, escaped, persisted.options);
+			if (nextRaw !== raw) {
+				setRawByFlavor((prev) => ({ ...prev, [activeFlavor]: nextRaw }));
+			}
+		}
+	}, [activeFlavor, persisted.options, raw, escaped]);
+
+	const updateRaw = (value: string) => {
+		lastEditedSideRef.current = 'raw';
+		setRawByFlavor((prev) => ({ ...prev, [activeFlavor]: value }));
+	};
+
+	const updateEscaped = (value: string) => {
+		lastEditedSideRef.current = 'escaped';
+		setEscapedByFlavor((prev) => ({ ...prev, [activeFlavor]: value }));
+	};
+
+	const updateOptions = <K extends EscapeFlavor>(flavor: K, next: FlavorOptions[K]) => {
+		patchPersisted({
+			options: {
+				...persisted.options,
+				[flavor]: next,
+			},
+		});
+	};
+
+	const resetFlavorOptions = () => {
+		patchPersisted({
+			options: {
+				...persisted.options,
+				[activeFlavor]: DEFAULT_FLAVOR_OPTIONS[activeFlavor],
+			},
+		});
+	};
+
+	const handlePaste = async (side: Side) => {
+		const text = await pasteFromClipboard();
+		if (text === null) return;
+		if (side === 'raw') updateRaw(text);
+		else updateEscaped(text);
+	};
+
+	const handleClear = (side: Side) => {
+		if (side === 'raw') updateRaw('');
+		else updateEscaped('');
+	};
+
+	const handleSample = () => {
+		const sample = SAMPLES[activeFlavor];
+		lastEditedSideRef.current = 'raw';
+		setRawByFlavor((prev) => ({ ...prev, [activeFlavor]: sample.raw }));
+	};
+
+	const segments: readonly EscapedSegment[] =
+		raw.length === 0 ? [] : escapeSegmentsByFlavor(activeFlavor, raw, persisted.options);
+
+	const rawLength = raw.length;
+	const escapedLength = escaped.length;
+	const delta = escapedLength - rawLength;
+
+	const renderOptionsForFlavor = () => {
+		if (activeFlavor === 'json') {
+			const opts = persisted.options.json;
+			return (
+				<FormCheckboxGroup>
+					<FormCheckbox
+						label="Escape non-ASCII characters as \\uHHHH"
+						checked={opts.escapeUnicode}
+						onCheckedChange={(v) => updateOptions<'json'>('json', { ...opts, escapeUnicode: v })}
+						size="compact"
+					/>
+					<FormCheckbox
+						label="Preserve forward slash (/)"
+						checked={opts.preserveForwardSlash}
+						onCheckedChange={(v) =>
+							updateOptions<'json'>('json', { ...opts, preserveForwardSlash: v })
+						}
+						size="compact"
+					/>
+				</FormCheckboxGroup>
+			);
+		}
+		if (activeFlavor === 'javascript') {
+			const opts = persisted.options.javascript;
+			return (
+				<div className="space-y-3">
+					<FormMode<JsEscapeOptions['quoteStyle']>
+						label="Quote style"
+						value={opts.quoteStyle}
+						onValueChange={(v) =>
+							updateOptions<'javascript'>('javascript', { ...opts, quoteStyle: v })
+						}
+						options={[
+							{ value: 'single', label: "Single (')" },
+							{ value: 'double', label: 'Double (")' },
+						]}
+					/>
+					<FormCheckboxGroup>
+						<FormCheckbox
+							label="Escape non-ASCII characters"
+							checked={opts.escapeUnicode}
+							onCheckedChange={(v) =>
+								updateOptions<'javascript'>('javascript', { ...opts, escapeUnicode: v })
+							}
+							size="compact"
+						/>
+					</FormCheckboxGroup>
+				</div>
+			);
+		}
+		if (activeFlavor === 'html') {
+			const opts = persisted.options.html;
+			return (
+				<div className="space-y-3">
+					<FormMode<HtmlEscapeOptions['entityForm']>
+						label="Entity form"
+						value={opts.entityForm}
+						onValueChange={(v) => updateOptions<'html'>('html', { ...opts, entityForm: v })}
+						options={[
+							{ value: 'named', label: 'Named (&amp;)' },
+							{ value: 'numeric', label: 'Numeric (&#38;)' },
+						]}
+					/>
+					<FormCheckboxGroup>
+						<FormCheckbox
+							label="Encode non-ASCII characters"
+							checked={opts.encodeNonAscii}
+							onCheckedChange={(v) => updateOptions<'html'>('html', { ...opts, encodeNonAscii: v })}
+							size="compact"
+						/>
+					</FormCheckboxGroup>
+				</div>
+			);
+		}
+		if (activeFlavor === 'xml') {
+			const opts = persisted.options.xml;
+			const toggle = (key: keyof XmlEscapeOptions, v: boolean) =>
+				updateOptions<'xml'>('xml', { ...opts, [key]: v });
+			return (
+				<FormCheckboxGroup>
+					<FormCheckbox
+						label="& → &amp;"
+						checked={opts.amp}
+						onCheckedChange={(v) => toggle('amp', v)}
+						size="compact"
+					/>
+					<FormCheckbox
+						label="< → &lt;"
+						checked={opts.lt}
+						onCheckedChange={(v) => toggle('lt', v)}
+						size="compact"
+					/>
+					<FormCheckbox
+						label="> → &gt;"
+						checked={opts.gt}
+						onCheckedChange={(v) => toggle('gt', v)}
+						size="compact"
+					/>
+					<FormCheckbox
+						label={'" → &quot;'}
+						checked={opts.quot}
+						onCheckedChange={(v) => toggle('quot', v)}
+						size="compact"
+					/>
+					<FormCheckbox
+						label={"' → &apos;"}
+						checked={opts.apos}
+						onCheckedChange={(v) => toggle('apos', v)}
+						size="compact"
+					/>
+				</FormCheckboxGroup>
+			);
+		}
+		if (activeFlavor === 'csv') {
+			const opts = persisted.options.csv;
+			const isAllowedSeparator = (v: string): v is CsvSeparator =>
+				v === ',' || v === ';' || v === '\t';
+			return (
+				<div className="space-y-3">
+					<FormMode<CsvSeparator>
+						label="Separator"
+						value={opts.separator}
+						onValueChange={(v) => {
+							if (isAllowedSeparator(v)) {
+								updateOptions<'csv'>('csv', { ...opts, separator: v });
+							}
+						}}
+						options={[
+							{ value: ',', label: 'Comma' },
+							{ value: ';', label: 'Semicolon' },
+							{ value: '\t', label: 'Tab' },
+						]}
+					/>
+					<FormMode<CsvEscapeOptions['quoteStyle']>
+						label="Quote style"
+						value={opts.quoteStyle}
+						onValueChange={(v) => updateOptions<'csv'>('csv', { ...opts, quoteStyle: v })}
+						options={[
+							{
+								value: 'minimal',
+								label: 'Minimal',
+								description: 'Quote only when needed',
+							},
+							{
+								value: 'always',
+								label: 'Always',
+								description: 'Always wrap in quotes',
+							},
+						]}
+					/>
+				</div>
+			);
+		}
+		if (activeFlavor === 'shell') {
+			const opts = persisted.options.shell;
+			return (
+				<FormSelect
+					label="Dialect"
+					value={opts.dialect}
+					onValueChange={(v) =>
+						updateOptions<'shell'>('shell', { ...opts, dialect: v as ShellDialect })
+					}
+					options={[
+						{ value: 'bash', label: 'Bash / POSIX', description: 'Single-quote wrap' },
+						{ value: 'powershell', label: 'PowerShell', description: 'Single-quote wrap' },
+						{ value: 'cmd', label: 'Windows CMD', description: 'Double-quote + caret' },
+					]}
+					size="compact"
+				/>
+			);
+		}
+		return null;
+	};
+
+	const rail = (
+		<>
+			<FormSection title="Mode">
+				<FormInfo>
+					Both panes are editable. Typing in the raw side updates the escaped side; typing in the
+					escaped side updates the raw side via parsing.
+				</FormInfo>
+			</FormSection>
+
+			<FormSection title="Options">{renderOptionsForFlavor()}</FormSection>
+
+			<FormSection title="Actions">
+				<Button variant="outline" size="sm" className="w-full" onClick={resetFlavorOptions}>
+					<RotateCcw className="size-3.5" />
+					Reset {FLAVOR_TABS.find((t) => t.id === activeFlavor)?.label} options
+				</Button>
+			</FormSection>
+
+			<FormSection title="About">
+				<FormInfo>{FLAVOR_DESCRIPTIONS[activeFlavor]}</FormInfo>
+			</FormSection>
+		</>
+	);
+
+	const renderPaneHeader = (label: string, side: Side) => {
+		const value = side === 'raw' ? raw : escaped;
+		const onClear = () => handleClear(side);
+		const onPaste = (): void => {
+			handlePaste(side).catch(() => {
+				// `pasteFromClipboard` already surfaces clipboard failures via toast.
+			});
+		};
+		return (
+			<div className="flex items-center justify-between gap-2 border-b bg-surface-2 px-3 py-2">
+				<span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+					{label}
+				</span>
+				<div className="flex items-center gap-1">
+					<CopyButton text={value} toastLabel={label} variant="ghost" size="sm" showLabel={false} />
+					<IconTooltip label={`Paste into ${label.toLowerCase()}`}>
+						<Button variant="ghost" size="icon-sm" onClick={onPaste}>
+							<ClipboardPaste className="size-3.5" />
+							<span className="sr-only">Paste</span>
+						</Button>
+					</IconTooltip>
+					<IconTooltip label={`Clear ${label.toLowerCase()}`}>
+						<Button variant="ghost" size="icon-sm" onClick={onClear}>
+							<Eraser className="size-3.5" />
+							<span className="sr-only">Clear</span>
+						</Button>
+					</IconTooltip>
+					{side === 'raw' ? (
+						<IconTooltip label="Load sample">
+							<Button variant="ghost" size="icon-sm" onClick={handleSample}>
+								<FlaskConical className="size-3.5" />
+								<span className="sr-only">Sample</span>
+							</Button>
+						</IconTooltip>
+					) : null}
+				</div>
+			</div>
+		);
+	};
+
+	const renderHighlightOverlay = () => {
+		if (segments.length === 0) {
+			return (
+				<div className="pointer-events-none flex h-full items-center justify-center text-xs text-muted-foreground">
+					Enter raw input above to see the escaped output and highlighted changes.
+				</div>
+			);
+		}
+		// Carry a running offset into each segment so React keys reflect both
+		// position and content, avoiding the array-index anti-pattern.
+		let offset = 0;
+		const keyedSegments = segments.map((seg) => {
+			const key = `${offset}:${seg.text}`;
+			offset += seg.text.length;
+			return { key, seg };
+		});
+		return (
+			<pre className="m-0 h-full overflow-auto whitespace-pre-wrap break-words bg-muted/20 px-3 py-2 font-mono text-sm leading-relaxed">
+				{keyedSegments.map(({ key, seg }) => (
+					<span key={key} className={cn(seg.changed && 'rounded-sm bg-warning/20 text-foreground')}>
+						{seg.text}
+					</span>
+				))}
+			</pre>
+		);
+	};
+
+	const renderMain = () => (
+		<div className="flex h-full min-h-0 flex-col gap-3 p-3">
+			<div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border bg-card">
+				{renderPaneHeader('Raw', 'raw')}
+				<Textarea
+					value={raw}
+					onChange={(e) => updateRaw(e.currentTarget.value)}
+					placeholder="Type or paste the raw text to escape..."
+					spellCheck={false}
+					className="min-h-32 flex-1 resize-none rounded-none border-0 bg-transparent font-mono text-sm focus-visible:ring-0"
+				/>
+			</div>
+
+			<div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border bg-card">
+				{renderPaneHeader('Escaped', 'escaped')}
+				<div className="grid min-h-0 flex-1 grid-rows-2 divide-y">
+					<Textarea
+						value={escaped}
+						onChange={(e) => updateEscaped(e.currentTarget.value)}
+						placeholder="Escaped output appears here. Edit directly to unescape back to raw."
+						spellCheck={false}
+						className="min-h-32 h-full resize-none rounded-none border-0 bg-transparent font-mono text-sm focus-visible:ring-0"
+					/>
+					<div className="min-h-32 overflow-hidden">{renderHighlightOverlay()}</div>
+				</div>
+			</div>
+		</div>
+	);
+
+	return (
+		<ToolShell
+			layout="tabbed"
+			tabs={FLAVOR_TABS}
+			activeTab={activeFlavor}
+			onTabChange={handleTabChange}
+			rail={rail}
+			statusContent={
+				<>
+					<StatItem label="Raw" value={`${rawLength} chars`} />
+					<StatItem label="Escaped" value={`${escapedLength} chars`} />
+					<StatItem
+						label="Δ"
+						value={delta > 0 ? `+${delta}` : `${delta}`}
+						variant={delta > 0 ? 'warning' : 'default'}
+					/>
+				</>
+			}
+			renderTabContent={() => renderMain()}
+		/>
+	);
+}


### PR DESCRIPTION
## Summary

Add a multi-flavor Escape / Unescape tool under **Encoders** that consolidates JSON / JavaScript / HTML / XML / CSV / shell escaping into a single tabbed view with bidirectional reactivity and inline change highlighting. Closes #222.

## Features

- **Six flavors as tabs**: JSON string / JavaScript string / HTML entities / XML entities / CSV cell / Shell argument.
- **Bidirectional in one view**: top textarea is the "raw" side, bottom is the "escaped" side — both editable, both reactive (typing in one transforms the other).
- **Inline diff highlight** under the escaped side: each character that needed escaping is wrapped in a tinted span so the change is visible at a glance.
- **Per-flavor option panel** in the rail:
  - JSON: escape Unicode / preserve forward slash
  - JS: quote style (single / double) / escape Unicode
  - HTML: named vs numeric entities / encode non-ASCII
  - XML: per-entity toggle (`&amp;` `&lt;` `&gt;` `&quot;` `&apos;`)
  - CSV: separator (`,` / `;` / tab) / quote style (minimal vs always)
  - Shell: dialect (bash / powershell / cmd)
- **Per-side actions**: Copy / Paste / Clear / Sample (Sample on the raw side).
- **Persisted options** per route via `createToolOptionsStore('escape-tool', ...)`.

## Changes

### Added

- `src/routes/escape-tool.tsx` — page component built on `ToolShell` with `layout="tabbed"` and `renderTabContent`.
- `src/lib/services/escape.ts` — pure per-flavor escape / unescape functions, segment producers for inline highlighting, dispatcher helpers, and per-flavor samples.

### Changed

- `src/lib/services/pages.ts` — register the new page under `category: 'encoders'` with all six flavor tabs so they are searchable from the title-bar palette.
- `src/route-tree.gen.ts` — auto-regenerated by the TanStack Router Vite plugin to include the new route.

## Test plan

- [x] `bun run check` (TypeScript + validate-pages + audit-design) green
- [x] `bun run lint` no new errors
- [x] `bun run format` clean
- [ ] Manual: cycle each tab; verify sample loads and escape / unescape round-trips
- [ ] Manual: edit raw, verify escaped updates; edit escaped, verify raw updates
- [ ] Manual: toggle each flavor option, verify output changes accordingly
- [ ] Manual: paste into raw, verify highlights mark escaped chars

Closes #222
