### PR TITLE
fix(x509,calendar): repair X.509 page boot and Calendar grid layout

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,6 +58,7 @@
         "react-day-picker": "^10.0.1",
         "react-dom": "^19",
         "react-resizable-panels": "^4.11.1",
+        "reflect-metadata": "^0.2.2",
         "regexp-tree": "^0.1.27",
         "shadcn": "^4.7.0",
         "sonner": "^2.0.7",
@@ -1645,6 +1646,8 @@
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
     "regexp-to-ast": ["regexp-to-ast@0.5.0", "", {}, "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="],
 

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
 		"react-day-picker": "^10.0.1",
 		"react-dom": "^19",
 		"react-resizable-panels": "^4.11.1",
+		"reflect-metadata": "^0.2.2",
 		"regexp-tree": "^0.1.27",
 		"shadcn": "^4.7.0",
 		"sonner": "^2.0.7",

--- a/src/lib/components/ui/calendar.tsx
+++ b/src/lib/components/ui/calendar.tsx
@@ -23,7 +23,7 @@ function Calendar({
 		<DayPicker
 			showOutsideDays={showOutsideDays}
 			className={cn(
-				'bg-background group/calendar p-3 [--cell-size:2rem] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent',
+				'bg-background group/calendar p-3 [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent',
 				String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
 				String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
 				className
@@ -43,20 +43,20 @@ function Calendar({
 				),
 				button_previous: cn(
 					buttonVariants({ variant: buttonVariant }),
-					'h-[--cell-size] w-[--cell-size] select-none p-0 aria-disabled:opacity-50',
+					'h-8 w-8 select-none p-0 aria-disabled:opacity-50',
 					defaultClassNames.button_previous
 				),
 				button_next: cn(
 					buttonVariants({ variant: buttonVariant }),
-					'h-[--cell-size] w-[--cell-size] select-none p-0 aria-disabled:opacity-50',
+					'h-8 w-8 select-none p-0 aria-disabled:opacity-50',
 					defaultClassNames.button_next
 				),
 				month_caption: cn(
-					'flex h-[--cell-size] w-full items-center justify-center px-[--cell-size]',
+					'flex h-8 w-full items-center justify-center px-8',
 					defaultClassNames.month_caption
 				),
 				dropdowns: cn(
-					'flex h-[--cell-size] w-full items-center justify-center gap-1.5 text-sm font-medium',
+					'flex h-8 w-full items-center justify-center gap-1.5 text-sm font-medium',
 					defaultClassNames.dropdowns
 				),
 				dropdown_root: cn(
@@ -71,20 +71,20 @@ function Calendar({
 						: '[&>svg]:text-muted-foreground flex h-8 items-center gap-1 rounded-md pl-2 pr-1 text-sm [&>svg]:size-3.5',
 					defaultClassNames.caption_label
 				),
-				month_grid: 'w-full border-collapse',
+				month_grid: 'w-full',
 				weekdays: cn('flex', defaultClassNames.weekdays),
 				weekday: cn(
-					'text-muted-foreground flex-1 select-none rounded-md text-[0.8rem] font-normal',
+					'text-muted-foreground flex h-8 w-8 shrink-0 select-none items-center justify-center rounded-md text-[0.8rem] font-normal',
 					defaultClassNames.weekday
 				),
-				week: cn('mt-2 flex w-full', defaultClassNames.week),
-				week_number_header: cn('w-[--cell-size] select-none', defaultClassNames.week_number_header),
+				week: cn('mt-2 flex', defaultClassNames.week),
+				week_number_header: cn('w-8 select-none', defaultClassNames.week_number_header),
 				week_number: cn(
 					'text-muted-foreground select-none text-[0.8rem]',
 					defaultClassNames.week_number
 				),
 				day: cn(
-					'group/day relative aspect-square h-full w-full select-none p-0 text-center [&:first-child[data-selected=true]_button]:rounded-l-md [&:last-child[data-selected=true]_button]:rounded-r-md',
+					'group/day relative aspect-square h-8 w-8 shrink-0 select-none p-0 text-center [&:first-child[data-selected=true]_button]:rounded-l-md [&:last-child[data-selected=true]_button]:rounded-r-md',
 					defaultClassNames.day
 				),
 				range_start: cn('bg-accent rounded-l-md', defaultClassNames.range_start),
@@ -118,15 +118,46 @@ function Calendar({
 					return <ChevronDownIcon className={cn('size-4', className)} {...props} />;
 				},
 				DayButton: CalendarDayButton,
-				WeekNumber: ({ children, ...props }) => {
-					return (
-						<td {...props}>
-							<div className="flex size-[--cell-size] items-center justify-center text-center">
-								{children}
-							</div>
-						</td>
-					);
-				},
+				// Override the default <table>/<tr>/<td> rendering with semantic
+				// <div>s so the Tailwind flex/grid utilities on `month_grid`,
+				// `weekdays`, `week`, and `day` actually take effect. `display: flex`
+				// on a <tr> is silently dropped by the browser, which collapsed every
+				// day cell into a single horizontal line.
+				MonthGrid: ({ className, children }) => (
+					<div role="grid" className={cn(className)}>
+						{children}
+					</div>
+				),
+				Weeks: ({ className, children }) => (
+					<div role="rowgroup" className={cn(className)}>
+						{children}
+					</div>
+				),
+				Week: ({ className, children }) => (
+					<div role="row" className={cn(className)}>
+						{children}
+					</div>
+				),
+				Weekdays: ({ className, children }) => (
+					<div role="row" className={cn(className)}>
+						{children}
+					</div>
+				),
+				Weekday: ({ className, children }) => (
+					<div role="columnheader" className={cn(className)}>
+						{children}
+					</div>
+				),
+				Day: ({ className, children }) => (
+					<div role="gridcell" className={cn(className)}>
+						{children}
+					</div>
+				),
+				WeekNumber: ({ children }) => (
+					<div role="rowheader">
+						<div className="flex size-8 items-center justify-center text-center">{children}</div>
+					</div>
+				),
 				...components,
 			}}
 			{...props}
@@ -163,7 +194,7 @@ function CalendarDayButton({
 			data-range-end={modifiers['range_end']}
 			data-range-middle={modifiers['range_middle']}
 			className={cn(
-				'data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 flex aspect-square h-auto w-full min-w-[--cell-size] flex-col gap-1 font-normal leading-none data-[range-end=true]:rounded-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] [&>span]:text-xs [&>span]:opacity-70',
+				'data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 flex aspect-square h-auto w-full min-w-8 flex-col gap-1 font-normal leading-none data-[range-end=true]:rounded-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] [&>span]:text-xs [&>span]:opacity-70',
 				defaultClassNames.day,
 				className
 			)}

--- a/src/lib/services/x509-samples.ts
+++ b/src/lib/services/x509-samples.ts
@@ -6,6 +6,10 @@
  * source tree (which would otherwise grow stale and bloat the bundle).
  */
 
+// Required polyfill for `tsyringe` (transitive dep of `@peculiar/x509`).
+// Side-effect import — must precede the package import below.
+import 'reflect-metadata';
+
 import {
 	BasicConstraintsExtension,
 	cryptoProvider,

--- a/src/lib/services/x509.ts
+++ b/src/lib/services/x509.ts
@@ -8,6 +8,11 @@
  * never performs network I/O.
  */
 
+// `@peculiar/x509` depends on `tsyringe`, which requires the `reflect-metadata`
+// polyfill to be loaded before any decorator metadata is read. Side-effect
+// import — must precede the package import below.
+import 'reflect-metadata';
+
 import {
 	AuthorityInfoAccessExtension,
 	AuthorityKeyIdentifierExtension,

--- a/src/routes/x509-decoder.tsx
+++ b/src/routes/x509-decoder.tsx
@@ -284,16 +284,19 @@ function X509DecoderPage() {
 								label="SHA-256"
 								checked={prefs.showSha256}
 								onCheckedChange={(c) => patch({ showSha256: c })}
+								size="compact"
 							/>
 							<FormCheckbox
 								label="SHA-1"
 								checked={prefs.showSha1}
 								onCheckedChange={(c) => patch({ showSha1: c })}
+								size="compact"
 							/>
 							<FormCheckbox
 								label="MD5"
 								checked={prefs.showMd5}
 								onCheckedChange={(c) => patch({ showMd5: c })}
+								size="compact"
 							/>
 						</FormCheckboxGroup>
 					</FormSection>


### PR DESCRIPTION
## Summary

Two regressions surfaced once recently-merged tools landed in `main`:

1. **X.509 Certificate Decoder** — the page failed to mount with `tsyringe requires a reflect polyfill`.
2. **Date / Timestamp Converter** — the embedded Calendar collapsed every day cell onto a single horizontal line.

A small inconsistency on the X.509 rail was also reported (Fingerprint checkboxes were larger than every other rail checkbox in the app). Bundled here because the touched surface overlaps.

## Root cause and fix

### 1. X.509 polyfill (`reflect-metadata`)

`@peculiar/x509` depends on `tsyringe`, whose dependency injection container reads decorator metadata at module load. Without the `reflect-metadata` polyfill on `Reflect`, every `@peculiar/x509` import throws on first use.

- Add `reflect-metadata@^0.2.2` to `dependencies`.
- Import it once as a side-effect at the top of `src/lib/services/x509.ts` and `src/lib/services/x509-samples.ts`.

### 2. Calendar grid layout

`react-day-picker` v10 still emits a `<table>` / `<tr>` / `<td>` DOM for the month grid by default. The shadcn Calendar registry layers Tailwind `flex` utilities on those nodes. Browsers silently drop `display: flex` on `<tr>` — the day cells collapsed.

- Replace the default `<table>` / `<tr>` / `<td>` chain with `<div>`s via `components` overrides (`MonthGrid`, `Weeks`, `Week`, `Weekdays`, `Weekday`, `Day`, `WeekNumber`). Each gets the matching ARIA role (`grid` / `rowgroup` / `row` / `columnheader` / `gridcell` / `rowheader`).
- Replace the broken Tailwind v4 arbitrary syntax `[--cell-size]` (which evaluates to invalid `width: --cell-size`) with concrete `h-8` / `w-8` utilities (2rem each).
- Add `shrink-0` so flex children honour their declared cell size instead of being squeezed by the `w-fit` root.

### 3. Compact checkboxes on the X.509 rail

The rail Fingerprint toggles used `<FormCheckbox>` at the default `size`, which is reserved for primary content; every other rail in the app uses `size="compact"`. Aligns the X.509 page with the rest.

## Changes

### Added

- `reflect-metadata` runtime dependency

### Modified

- `src/lib/services/x509.ts` — side-effect import of `reflect-metadata`
- `src/lib/services/x509-samples.ts` — same
- `src/lib/components/ui/calendar.tsx` — div-based component overrides, concrete cell sizes, `shrink-0`
- `src/routes/x509-decoder.tsx` — `size="compact"` on the three Fingerprint checkboxes

## Test plan

- [x] `bun run check` (TS + validate-pages + audit-design) green
- [x] `bun run lint` clean
- [x] `bun run format` clean
- [x] Manual: navigate to `/x509-decoder`, click "Generate sample cert" — Subject / Issuer / Public Key / SAN / Fingerprints / Extensions all render
- [x] Manual: navigate to `/date-timestamp-converter` — Calendar shows a 6-row × 7-column grid with 32×32px cells, the active day highlighted
- [x] Manual: confirm X.509 rail Fingerprint checkboxes match the other rails visually
