### PR TITLE
feat(string-compressor): add GZIP / Brotli String Compressor tool

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "@xml-tools/parser": "^1.0.11",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
+        "brotli-wasm": "^3.0.1",
         "class-variance-authority": "^0.7.1",
         "cmdk": "^1.1.1",
         "cron-parser": "^5.5.0",
@@ -914,6 +915,8 @@
     "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "brotli-wasm": ["brotli-wasm@3.0.1", "", {}, "sha512-U3K72/JAi3jITpdhZBqzSUq+DUY697tLxOuFXB+FpAE/Ug+5C3VZrv4uA674EUZHxNAuQ9wETXNqQkxZD6oL4A=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
 		"@xml-tools/parser": "^1.0.11",
 		"ajv": "^8.20.0",
 		"ajv-formats": "^3.0.1",
+		"brotli-wasm": "^3.0.1",
 		"class-variance-authority": "^0.7.1",
 		"cmdk": "^1.1.1",
 		"cron-parser": "^5.5.0",

--- a/src/lib/services/compression.ts
+++ b/src/lib/services/compression.ts
@@ -1,0 +1,324 @@
+/**
+ * Text compression service backed by `CompressionStream` (gzip) and
+ * `brotli-wasm` (brotli). All operations are async because the platform
+ * compression API and the wasm module are both asynchronous.
+ *
+ * Note: `CompressionStream` does not expose a compression-level knob; gzip is
+ * always emitted at the platform-default level. The level slider is therefore
+ * only consulted for brotli, where it maps to the brotli quality parameter.
+ */
+import brotliPromise from 'brotli-wasm';
+
+/** Compression algorithm identifier. */
+export type CompressionAlgorithm = 'gzip' | 'brotli';
+
+/** Algorithm choice on decompress; `auto` sniffs gzip magic bytes. */
+export type DecompressAlgorithm = CompressionAlgorithm | 'auto';
+
+/** Output representation for compressed bytes. */
+export type OutputFormat = 'base64' | 'hex' | 'data-uri';
+
+/** Options for compressing raw text. */
+export interface CompressOptions {
+	readonly algorithm: CompressionAlgorithm;
+	/** 1-9 for gzip (informational, see module note); 0-11 for brotli. */
+	readonly level: number;
+}
+
+/** Successful compression result. */
+export interface CompressResult {
+	readonly ok: true;
+	readonly inputBytes: number;
+	readonly outputBytes: number;
+	/** outputBytes / inputBytes — clamped to a finite number when input is empty. */
+	readonly ratio: number;
+	readonly bytesSaved: number;
+	readonly bytes: Uint8Array;
+}
+
+/** Successful decompression result. */
+export interface DecompressResult {
+	readonly ok: true;
+	readonly text: string;
+	readonly algorithm: CompressionAlgorithm;
+	readonly inputBytes: number;
+	readonly outputBytes: number;
+}
+
+/** Failure case shared by compress / decompress. */
+export interface CompressionError {
+	readonly ok: false;
+	readonly error: string;
+}
+
+/** GZIP RFC 1952 magic bytes (`\x1F\x8B`). */
+const GZIP_MAGIC_0 = 0x1f;
+const GZIP_MAGIC_1 = 0x8b;
+
+/** Default level per algorithm. */
+export const DEFAULT_LEVEL: Readonly<Record<CompressionAlgorithm, number>> = {
+	gzip: 6,
+	brotli: 6,
+};
+
+/** Inclusive level range per algorithm. */
+export const LEVEL_RANGE: Readonly<
+	Record<CompressionAlgorithm, { readonly min: number; readonly max: number }>
+> = {
+	gzip: { min: 1, max: 9 },
+	brotli: { min: 0, max: 11 },
+};
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder('utf-8', { fatal: false });
+
+const errorMessage = (e: unknown, fallback: string): string => {
+	if (e instanceof Error) return e.message;
+	if (typeof e === 'string') return e;
+	return fallback;
+};
+
+/** Pipe bytes through a Web Streams transformer and collect the result. */
+const runStream = async (
+	input: Uint8Array,
+	transformer: GenericTransformStream
+): Promise<Uint8Array> => {
+	// `Blob` accepts `Uint8Array` at runtime but DOM lib's `BlobPart` only
+	// allows the narrower `Uint8Array<ArrayBuffer>` variant. Reinterpret as
+	// `ArrayBuffer` so the broader `Uint8Array<ArrayBufferLike>` upcasts.
+	const part = new Uint8Array(input.buffer as ArrayBuffer, input.byteOffset, input.byteLength);
+	const inputStream = new Blob([part]).stream();
+	const responseStream = inputStream.pipeThrough(transformer);
+	const buffer = await new Response(responseStream).arrayBuffer();
+	return new Uint8Array(buffer);
+};
+
+const compressGzip = (bytes: Uint8Array): Promise<Uint8Array> =>
+	runStream(bytes, new CompressionStream('gzip'));
+
+const decompressGzip = (bytes: Uint8Array): Promise<Uint8Array> =>
+	runStream(bytes, new DecompressionStream('gzip'));
+
+const getBrotli = async () => brotliPromise;
+
+const compressBrotli = async (bytes: Uint8Array, quality: number): Promise<Uint8Array> => {
+	const brotli = await getBrotli();
+	return brotli.compress(bytes, { quality });
+};
+
+const decompressBrotli = async (bytes: Uint8Array): Promise<Uint8Array> => {
+	const brotli = await getBrotli();
+	return brotli.decompress(bytes);
+};
+
+/** Compress UTF-8-encoded text under the requested algorithm and level. */
+export const compressText = async (
+	text: string,
+	opts: CompressOptions
+): Promise<CompressResult | CompressionError> => {
+	if (text.length === 0) return { ok: false, error: 'Input is empty' };
+
+	try {
+		const inputBytes = textEncoder.encode(text);
+		const compressed =
+			opts.algorithm === 'gzip'
+				? await compressGzip(inputBytes)
+				: await compressBrotli(inputBytes, clampLevel(opts.level, 'brotli'));
+
+		const inputLen = inputBytes.byteLength;
+		const outputLen = compressed.byteLength;
+
+		return {
+			ok: true,
+			inputBytes: inputLen,
+			outputBytes: outputLen,
+			ratio: inputLen === 0 ? 0 : outputLen / inputLen,
+			bytesSaved: inputLen - outputLen,
+			bytes: compressed,
+		};
+	} catch (e) {
+		return { ok: false, error: errorMessage(e, 'Compression failed') };
+	}
+};
+
+/** Sniff the algorithm from a byte prefix. */
+const sniffAlgorithm = (bytes: Uint8Array): CompressionAlgorithm => {
+	if (bytes.byteLength >= 2 && bytes[0] === GZIP_MAGIC_0 && bytes[1] === GZIP_MAGIC_1) {
+		return 'gzip';
+	}
+	// Brotli has no fixed magic prefix — fall through to it on negative gzip
+	// match. If the bytes are neither gzip nor valid brotli the wasm call will
+	// surface a parse error.
+	return 'brotli';
+};
+
+/** Decompress raw bytes; `auto` sniffs gzip magic and falls back to brotli. */
+export const decompressBytes = async (
+	bytes: Uint8Array,
+	algorithm: DecompressAlgorithm
+): Promise<DecompressResult | CompressionError> => {
+	if (bytes.byteLength === 0) return { ok: false, error: 'Input is empty' };
+
+	const resolved: CompressionAlgorithm = algorithm === 'auto' ? sniffAlgorithm(bytes) : algorithm;
+
+	try {
+		const out = resolved === 'gzip' ? await decompressGzip(bytes) : await decompressBrotli(bytes);
+		const text = textDecoder.decode(out);
+		return {
+			ok: true,
+			text,
+			algorithm: resolved,
+			inputBytes: bytes.byteLength,
+			outputBytes: out.byteLength,
+		};
+	} catch (e) {
+		return { ok: false, error: errorMessage(e, 'Decompression failed') };
+	}
+};
+
+/** Clamp a level into the algorithm's supported range. */
+export const clampLevel = (level: number, algorithm: CompressionAlgorithm): number => {
+	const { min, max } = LEVEL_RANGE[algorithm];
+	if (Number.isNaN(level)) return DEFAULT_LEVEL[algorithm];
+	return Math.min(max, Math.max(min, Math.round(level)));
+};
+
+/** Encode bytes as standard base64 (with `=` padding). */
+export const bytesToBase64 = (bytes: Uint8Array): string => {
+	// Avoid String.fromCharCode.apply on large arrays — chunk to stay under
+	// the call-stack limit on Safari/WKWebView.
+	const CHUNK = 0x8000;
+	const parts: string[] = [];
+	for (let i = 0; i < bytes.byteLength; i += CHUNK) {
+		const slice = bytes.subarray(i, Math.min(i + CHUNK, bytes.byteLength));
+		parts.push(String.fromCharCode(...slice));
+	}
+	return btoa(parts.join(''));
+};
+
+/** Decode a standard or URL-safe base64 string to bytes. */
+export const base64ToBytes = (b64: string): Uint8Array => {
+	const trimmed = b64.trim();
+	if (trimmed.length === 0) return new Uint8Array(0);
+
+	// Accept URL-safe alphabet and tolerate missing padding.
+	const normalized = trimmed.replace(/-/g, '+').replace(/_/g, '/').replace(/\s+/g, '');
+	const padLength = (4 - (normalized.length % 4)) % 4;
+	const padded = normalized + '='.repeat(padLength);
+
+	const binary = atob(padded);
+	const out = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i += 1) {
+		out[i] = binary.charCodeAt(i);
+	}
+	return out;
+};
+
+/** Render bytes as a hex string with optional grouping and case. */
+export const bytesToHex = (
+	bytes: Uint8Array,
+	opts?: { readonly upper?: boolean; readonly group?: number; readonly separator?: string }
+): string => {
+	const upper = opts?.upper ?? true;
+	const group = opts?.group ?? 0;
+	const separator = opts?.separator ?? ':';
+
+	const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'));
+	const cased = upper ? hex.map((h) => h.toUpperCase()) : hex;
+
+	if (group <= 0) return cased.join('');
+
+	const groups: string[] = [];
+	for (let i = 0; i < cased.length; i += group) {
+		groups.push(cased.slice(i, i + group).join(''));
+	}
+	return groups.join(separator);
+};
+
+/** Parse a hex string back into bytes; tolerates whitespace and `:` / `-` separators. */
+export const hexToBytes = (hex: string): Uint8Array => {
+	const stripped = hex.replace(/[\s:_-]/g, '');
+	if (stripped.length === 0) return new Uint8Array(0);
+	if (stripped.length % 2 !== 0) {
+		throw new Error('Hex string has an odd character count');
+	}
+	if (!/^[0-9a-fA-F]+$/.test(stripped)) {
+		throw new Error('Hex string contains non-hex characters');
+	}
+	const out = new Uint8Array(stripped.length / 2);
+	for (let i = 0; i < stripped.length; i += 2) {
+		out[i / 2] = Number.parseInt(stripped.slice(i, i + 2), 16);
+	}
+	return out;
+};
+
+/** Render bytes as a `data:` URI with the supplied MIME type. */
+export const bytesToDataUri = (bytes: Uint8Array, mime?: string): string =>
+	`data:${mime ?? 'application/octet-stream'};base64,${bytesToBase64(bytes)}`;
+
+/** Parse a `data:` URI; returns raw bytes when the payload is base64. */
+export const dataUriToBytes = (uri: string): Uint8Array => {
+	const trimmed = uri.trim();
+	if (!trimmed.toLowerCase().startsWith('data:')) {
+		throw new Error('Not a data: URI');
+	}
+	const commaIndex = trimmed.indexOf(',');
+	if (commaIndex === -1) throw new Error('Malformed data: URI (missing comma)');
+	const header = trimmed.slice(5, commaIndex);
+	const body = trimmed.slice(commaIndex + 1);
+	if (header.includes(';base64')) return base64ToBytes(body);
+	// URL-encoded payload: re-use the decoded text path.
+	return textEncoder.encode(decodeURIComponent(body));
+};
+
+const CURL_DATA_FLAGS: readonly string[] = [
+	'--data-raw',
+	'--data-binary',
+	'--data-urlencode',
+	'--data',
+	'-d',
+];
+
+const escapeRegex = (flag: string): string => flag.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+
+const unescapeShellEscapes = (value: string): string => value.replace(/\\(['"`$\\])/g, '$1');
+
+const matchCurlFlag = (input: string, flag: string): string | null => {
+	// Match either `<flag><space><value>` or `<flag>=<value>`. Value may be
+	// wrapped in single or double quotes, optionally prefixed with `$` (as
+	// emitted by browser "copy as curl" exports that use ANSI-C quoting).
+	const sep = '(?:\\s+|=)';
+	const quoted = '(?:\'((?:\\\\.|[^\'\\\\])*)\'|"((?:\\\\.|[^"\\\\])*)")';
+	const bare = '(\\S+)';
+	const pattern = new RegExp(`(?:^|\\s)\\$?${escapeRegex(flag)}${sep}(?:${quoted}|${bare})`, 's');
+	const match = input.match(pattern);
+	if (!match) return null;
+	const raw = match[1] ?? match[2] ?? match[3] ?? null;
+	if (raw === null) return null;
+	return unescapeShellEscapes(raw);
+};
+
+/** Best-effort extractor for a `--data-raw` / `-d` / `--data` payload in a curl command. */
+export const extractCurlDataRaw = (curl: string): string | null => {
+	const trimmed = curl.trim();
+	if (trimmed.length === 0) return null;
+	return CURL_DATA_FLAGS.reduce<string | null>(
+		(acc, flag) => acc ?? matchCurlFlag(trimmed, flag),
+		null
+	);
+};
+
+/** Multi-line sample input that compresses well and demonstrates the ratio bar. */
+export const SAMPLE_TEXT = `Compression algorithms exploit redundancy in data: repeating words, common
+phrases, and predictable byte patterns. The Lempel-Ziv family (used by gzip)
+substitutes repeated sequences with back-references; Brotli adds a static
+dictionary of common web tokens and a smarter context-mixing model, often
+producing 15-25% smaller payloads on natural language at the cost of higher CPU.
+
+The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the
+lazy dog. The quick brown fox jumps over the lazy dog. The quick brown fox jumps
+over the lazy dog. The quick brown fox jumps over the lazy dog.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.`;

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -3,6 +3,7 @@
  * Update this file when adding new pages or tabs.
  */
 import {
+	ArchiveRestore,
 	ArrowRightLeft,
 	BadgeCheck,
 	Binary,
@@ -195,6 +196,16 @@ export const PAGES: readonly PageDefinition[] = [
 			{ id: 'csv', label: 'CSV', icon: Table },
 			{ id: 'shell', label: 'Shell', icon: Terminal },
 		],
+	},
+	{
+		id: 'string-compressor',
+		title: 'String Compressor',
+		url: '/string-compressor',
+		icon: ArchiveRestore,
+		description:
+			'Compress and decompress text with GZIP and Brotli, with live compression-ratio visualization',
+		color: 'text-emerald-600',
+		category: 'encoders',
 	},
 	{
 		id: 'uuid-generator',

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -14,6 +14,7 @@ import { Route as XmlFormatterRouteImport } from './routes/xml-formatter';
 import { Route as X509DecoderRouteImport } from './routes/x509-decoder';
 import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator';
 import { Route as UrlEncoderRouteImport } from './routes/url-encoder';
+import { Route as StringCompressorRouteImport } from './routes/string-compressor';
 import { Route as StringCaseConverterRouteImport } from './routes/string-case-converter';
 import { Route as SshKeyGeneratorRouteImport } from './routes/ssh-key-generator';
 import { Route as SqlFormatterRouteImport } from './routes/sql-formatter';
@@ -62,6 +63,11 @@ const UuidGeneratorRoute = UuidGeneratorRouteImport.update({
 const UrlEncoderRoute = UrlEncoderRouteImport.update({
 	id: '/url-encoder',
 	path: '/url-encoder',
+	getParentRoute: () => rootRouteImport,
+} as any);
+const StringCompressorRoute = StringCompressorRouteImport.update({
+	id: '/string-compressor',
+	path: '/string-compressor',
 	getParentRoute: () => rootRouteImport,
 } as any);
 const StringCaseConverterRoute = StringCaseConverterRouteImport.update({
@@ -210,6 +216,7 @@ export interface FileRoutesByFullPath {
 	'/sql-formatter': typeof SqlFormatterRoute;
 	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
 	'/string-case-converter': typeof StringCaseConverterRoute;
+	'/string-compressor': typeof StringCompressorRoute;
 	'/url-encoder': typeof UrlEncoderRoute;
 	'/uuid-generator': typeof UuidGeneratorRoute;
 	'/x509-decoder': typeof X509DecoderRoute;
@@ -241,6 +248,7 @@ export interface FileRoutesByTo {
 	'/sql-formatter': typeof SqlFormatterRoute;
 	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
 	'/string-case-converter': typeof StringCaseConverterRoute;
+	'/string-compressor': typeof StringCompressorRoute;
 	'/url-encoder': typeof UrlEncoderRoute;
 	'/uuid-generator': typeof UuidGeneratorRoute;
 	'/x509-decoder': typeof X509DecoderRoute;
@@ -273,6 +281,7 @@ export interface FileRoutesById {
 	'/sql-formatter': typeof SqlFormatterRoute;
 	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
 	'/string-case-converter': typeof StringCaseConverterRoute;
+	'/string-compressor': typeof StringCompressorRoute;
 	'/url-encoder': typeof UrlEncoderRoute;
 	'/uuid-generator': typeof UuidGeneratorRoute;
 	'/x509-decoder': typeof X509DecoderRoute;
@@ -306,6 +315,7 @@ export interface FileRouteTypes {
 		| '/sql-formatter'
 		| '/ssh-key-generator'
 		| '/string-case-converter'
+		| '/string-compressor'
 		| '/url-encoder'
 		| '/uuid-generator'
 		| '/x509-decoder'
@@ -337,6 +347,7 @@ export interface FileRouteTypes {
 		| '/sql-formatter'
 		| '/ssh-key-generator'
 		| '/string-case-converter'
+		| '/string-compressor'
 		| '/url-encoder'
 		| '/uuid-generator'
 		| '/x509-decoder'
@@ -368,6 +379,7 @@ export interface FileRouteTypes {
 		| '/sql-formatter'
 		| '/ssh-key-generator'
 		| '/string-case-converter'
+		| '/string-compressor'
 		| '/url-encoder'
 		| '/uuid-generator'
 		| '/x509-decoder'
@@ -400,6 +412,7 @@ export interface RootRouteChildren {
 	SqlFormatterRoute: typeof SqlFormatterRoute;
 	SshKeyGeneratorRoute: typeof SshKeyGeneratorRoute;
 	StringCaseConverterRoute: typeof StringCaseConverterRoute;
+	StringCompressorRoute: typeof StringCompressorRoute;
 	UrlEncoderRoute: typeof UrlEncoderRoute;
 	UuidGeneratorRoute: typeof UuidGeneratorRoute;
 	X509DecoderRoute: typeof X509DecoderRoute;
@@ -442,6 +455,13 @@ declare module '@tanstack/react-router' {
 			path: '/url-encoder';
 			fullPath: '/url-encoder';
 			preLoaderRoute: typeof UrlEncoderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/string-compressor': {
+			id: '/string-compressor';
+			path: '/string-compressor';
+			fullPath: '/string-compressor';
+			preLoaderRoute: typeof StringCompressorRouteImport;
 			parentRoute: typeof rootRouteImport;
 		};
 		'/string-case-converter': {
@@ -640,6 +660,7 @@ const rootRouteChildren: RootRouteChildren = {
 	SqlFormatterRoute: SqlFormatterRoute,
 	SshKeyGeneratorRoute: SshKeyGeneratorRoute,
 	StringCaseConverterRoute: StringCaseConverterRoute,
+	StringCompressorRoute: StringCompressorRoute,
 	UrlEncoderRoute: UrlEncoderRoute,
 	UuidGeneratorRoute: UuidGeneratorRoute,
 	X509DecoderRoute: X509DecoderRoute,

--- a/src/routes/string-compressor.tsx
+++ b/src/routes/string-compressor.tsx
@@ -1,0 +1,582 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+import { FileText, Terminal } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { CopyButton } from '@/lib/components/action';
+import {
+	FormCheckbox,
+	FormError,
+	FormInfo,
+	FormMode,
+	FormSection,
+	FormSelect,
+	FormSlider,
+	FormTextarea,
+} from '@/lib/components/form';
+import { ToolShell } from '@/lib/components/shell';
+import { StatItem } from '@/lib/components/status';
+import { Badge } from '@/lib/components/ui/badge';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { Textarea } from '@/lib/components/ui/textarea';
+import { useDocumentTitle } from '@/lib/hooks';
+import {
+	type CompressionAlgorithm,
+	type CompressResult,
+	DEFAULT_LEVEL,
+	LEVEL_RANGE,
+	type OutputFormat,
+	SAMPLE_TEXT,
+	base64ToBytes,
+	bytesToBase64,
+	bytesToDataUri,
+	bytesToHex,
+	clampLevel,
+	compressText,
+	dataUriToBytes,
+	decompressBytes,
+	extractCurlDataRaw,
+	hexToBytes,
+} from '@/lib/services/compression';
+import { createToolOptionsStore } from '@/lib/stores';
+import { cn, formatBytes } from '@/lib/utils';
+
+type Direction = 'compress' | 'decompress';
+
+interface StringCompressorOptions {
+	readonly algorithm: CompressionAlgorithm;
+	readonly level: number;
+	readonly outputFormat: OutputFormat;
+	readonly autoDetect: boolean;
+}
+
+const DEFAULTS: StringCompressorOptions = {
+	algorithm: 'gzip',
+	level: DEFAULT_LEVEL.gzip,
+	outputFormat: 'base64',
+	autoDetect: true,
+};
+
+const useStringCompressorOptions = createToolOptionsStore<StringCompressorOptions>(
+	'string-compressor',
+	DEFAULTS
+);
+
+const HEX_GROUP_SIZE = 1;
+const HEX_SEPARATOR = ':';
+const DEBOUNCE_MS = 200;
+
+const isOutputFormat = (v: string): v is OutputFormat =>
+	v === 'base64' || v === 'hex' || v === 'data-uri';
+
+const decodeInputForDecompress = (input: string): Uint8Array => {
+	const trimmed = input.trim();
+	if (trimmed.length === 0) return new Uint8Array(0);
+	if (trimmed.toLowerCase().startsWith('data:')) return dataUriToBytes(trimmed);
+
+	// Heuristic: if the payload contains only hex chars plus common separators,
+	// treat it as hex; otherwise interpret as base64 (standard or URL-safe).
+	const isHexLike =
+		/^[0-9a-fA-F\s:_-]+$/.test(trimmed) && trimmed.replace(/[\s:_-]/g, '').length % 2 === 0;
+	if (isHexLike && /[a-fA-F0-9]{2,}/.test(trimmed)) {
+		try {
+			return hexToBytes(trimmed);
+		} catch {
+			return base64ToBytes(trimmed);
+		}
+	}
+	return base64ToBytes(trimmed);
+};
+
+const formatCompressedBytes = (bytes: Uint8Array, format: OutputFormat): string => {
+	if (format === 'hex')
+		return bytesToHex(bytes, { upper: true, group: HEX_GROUP_SIZE, separator: HEX_SEPARATOR });
+	if (format === 'data-uri') return bytesToDataUri(bytes, 'application/octet-stream');
+	return bytesToBase64(bytes);
+};
+
+interface DerivedState {
+	readonly output: string;
+	readonly error: string | null;
+	readonly result: CompressResult | null;
+	readonly detectedAlgorithm: CompressionAlgorithm | null;
+}
+
+const EMPTY_DERIVED: DerivedState = {
+	output: '',
+	error: null,
+	result: null,
+	detectedAlgorithm: null,
+};
+
+const errorState = (message: string): DerivedState => ({
+	output: '',
+	error: message,
+	result: null,
+	detectedAlgorithm: null,
+});
+
+const runCompress = async (
+	text: string,
+	algorithm: CompressionAlgorithm,
+	level: number,
+	outputFormat: OutputFormat
+): Promise<DerivedState> => {
+	const result = await compressText(text, { algorithm, level });
+	if (!result.ok) return errorState(result.error);
+	return {
+		output: formatCompressedBytes(result.bytes, outputFormat),
+		error: null,
+		result,
+		detectedAlgorithm: null,
+	};
+};
+
+const runDecompress = async (
+	text: string,
+	algorithm: CompressionAlgorithm,
+	autoDetect: boolean
+): Promise<DerivedState> => {
+	let bytes: Uint8Array;
+	try {
+		bytes = decodeInputForDecompress(text);
+	} catch (e) {
+		return errorState(e instanceof Error ? e.message : 'Failed to decode input');
+	}
+	if (bytes.byteLength === 0) {
+		return errorState('Could not decode input as base64 / hex / data URI');
+	}
+	const result = await decompressBytes(bytes, autoDetect ? 'auto' : algorithm);
+	if (!result.ok) return errorState(result.error);
+	return {
+		output: result.text,
+		error: null,
+		detectedAlgorithm: result.algorithm,
+		result: {
+			ok: true,
+			inputBytes: result.outputBytes,
+			outputBytes: result.inputBytes,
+			ratio: result.outputBytes === 0 ? 0 : result.inputBytes / result.outputBytes,
+			bytesSaved: result.outputBytes - result.inputBytes,
+			bytes,
+		},
+	};
+};
+
+export const Route = createFileRoute('/string-compressor')({
+	component: StringCompressorPage,
+});
+
+function StringCompressorPage() {
+	useDocumentTitle('String Compressor');
+
+	const { value: options, patch } = useStringCompressorOptions();
+	const { algorithm, level, outputFormat, autoDetect } = options;
+
+	const [direction, setDirection] = useState<Direction>('compress');
+	const [inputText, setInputText] = useState('');
+	const [curlInput, setCurlInput] = useState('');
+	const [showCurlPanel, setShowCurlPanel] = useState(false);
+	const [outputText, setOutputText] = useState('');
+	const [error, setError] = useState<string | null>(null);
+	const [lastResult, setLastResult] = useState<CompressResult | null>(null);
+	const [detectedAlgorithm, setDetectedAlgorithm] = useState<CompressionAlgorithm | null>(null);
+	const [busy, setBusy] = useState(false);
+	const [showRail, setShowRail] = useState(true);
+
+	const handleAlgorithmChange = (next: CompressionAlgorithm) => {
+		// Re-clamp level into the new algorithm's range so the slider stays valid.
+		patch({ algorithm: next, level: clampLevel(level, next) });
+	};
+
+	const handleDirectionChange = (next: Direction) => {
+		setDirection(next);
+		setOutputText('');
+		setError(null);
+		setLastResult(null);
+		setDetectedAlgorithm(null);
+	};
+
+	const handleLoadSample = () => {
+		setDirection('compress');
+		setInputText(SAMPLE_TEXT);
+	};
+
+	const handleApplyCurl = () => {
+		const extracted = extractCurlDataRaw(curlInput);
+		if (extracted === null) {
+			toast.error('No --data-raw payload found in the curl command');
+			return;
+		}
+		setDirection('compress');
+		setInputText(extracted);
+		setShowCurlPanel(false);
+		setCurlInput('');
+		toast.success(`Extracted ${extracted.length} characters from curl`);
+	};
+
+	const handleClearInput = () => {
+		setInputText('');
+		setOutputText('');
+		setError(null);
+		setLastResult(null);
+		setDetectedAlgorithm(null);
+	};
+
+	useEffect(() => {
+		const trimmed = inputText.trim();
+		const apply = (state: DerivedState) => {
+			setOutputText(state.output);
+			setError(state.error);
+			setLastResult(state.result);
+			setDetectedAlgorithm(state.detectedAlgorithm);
+			setBusy(false);
+		};
+
+		if (trimmed.length === 0) {
+			apply(EMPTY_DERIVED);
+			return;
+		}
+
+		let cancelled = false;
+		setBusy(true);
+
+		const timer = window.setTimeout(async () => {
+			const next =
+				direction === 'compress'
+					? await runCompress(inputText, algorithm, level, outputFormat)
+					: await runDecompress(inputText, algorithm, autoDetect);
+			if (cancelled) return;
+			apply(next);
+		}, DEBOUNCE_MS);
+
+		return () => {
+			cancelled = true;
+			window.clearTimeout(timer);
+		};
+	}, [inputText, direction, algorithm, level, outputFormat, autoDetect]);
+
+	const valid: boolean | null = inputText.trim().length === 0 ? null : error === null;
+
+	const { min: levelMin, max: levelMax } = LEVEL_RANGE[algorithm];
+
+	const inputBytes = lastResult?.inputBytes ?? 0;
+	const outputBytesValue = lastResult?.outputBytes ?? 0;
+	const ratioPercent =
+		lastResult && lastResult.inputBytes > 0
+			? (lastResult.outputBytes / lastResult.inputBytes) * 100
+			: 0;
+	const savings = lastResult ? lastResult.inputBytes - lastResult.outputBytes : 0;
+	const savingsPercent =
+		lastResult && lastResult.inputBytes > 0 ? (savings / lastResult.inputBytes) * 100 : 0;
+	// Fill width is clamped to 100% so an expansion (ratio > 1, e.g. gzipping
+	// a 4-byte input) does not break the bar layout.
+	const fillPercent = Math.min(100, Math.max(0, ratioPercent));
+	const fillSavings = savings >= 0;
+
+	return (
+		<ToolShell
+			valid={valid}
+			error={error ?? undefined}
+			showRail={showRail}
+			onShowRailChange={setShowRail}
+			statusContent={
+				lastResult ? (
+					<>
+						<StatItem label="Algorithm" value={detectedAlgorithm ?? algorithm} />
+						<StatItem label="Input" value={formatBytes(inputBytes)} />
+						<StatItem label="Output" value={formatBytes(outputBytesValue)} />
+						<StatItem
+							label="Ratio"
+							value={`${ratioPercent.toFixed(1)}%`}
+							variant={ratioPercent <= 100 ? 'success' : 'warning'}
+						/>
+					</>
+				) : null
+			}
+			rail={
+				<>
+					<FormSection title="Direction">
+						<FormMode<Direction>
+							value={direction}
+							onValueChange={handleDirectionChange}
+							options={[
+								{ value: 'compress', label: 'Compress', description: 'Text -> bytes' },
+								{ value: 'decompress', label: 'Decompress', description: 'Bytes -> text' },
+							]}
+						/>
+					</FormSection>
+
+					<FormSection title="Algorithm">
+						<FormMode<CompressionAlgorithm>
+							value={algorithm}
+							onValueChange={handleAlgorithmChange}
+							options={[
+								{ value: 'gzip', label: 'GZIP', description: 'RFC 1952' },
+								{ value: 'brotli', label: 'Brotli', description: 'RFC 7932' },
+							]}
+						/>
+						{direction === 'decompress' ? (
+							<div className="pt-2">
+								<FormCheckbox
+									label="Auto-detect from magic bytes"
+									checked={autoDetect}
+									onCheckedChange={(v) => patch({ autoDetect: v })}
+									size="compact"
+								/>
+							</div>
+						) : null}
+					</FormSection>
+
+					<FormSection title="Level">
+						<FormSlider
+							label={algorithm === 'brotli' ? 'Brotli quality' : 'GZIP level'}
+							value={level}
+							onValueChange={(v) => patch({ level: clampLevel(v, algorithm) })}
+							min={levelMin}
+							max={levelMax}
+							step={1}
+							size="compact"
+							hint={
+								algorithm === 'gzip'
+									? 'CompressionStream uses the platform default; level is informational.'
+									: 'Higher values produce smaller output at the cost of CPU.'
+							}
+						/>
+					</FormSection>
+
+					{direction === 'compress' ? (
+						<FormSection title="Output Format">
+							<FormSelect
+								label="Format"
+								value={outputFormat}
+								onValueChange={(v) => {
+									if (isOutputFormat(v)) patch({ outputFormat: v });
+								}}
+								options={[
+									{ value: 'base64', label: 'Base64', description: 'RFC 4648 standard' },
+									{ value: 'hex', label: 'Hex', description: 'Colon-grouped pairs (FF:E0:...)' },
+									{
+										value: 'data-uri',
+										label: 'Data URI',
+										description: 'data:application/octet-stream;base64,...',
+									},
+								]}
+								size="compact"
+							/>
+						</FormSection>
+					) : null}
+
+					<FormSection title="Helpers">
+						<div className="flex flex-col gap-2">
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								className="justify-start"
+								onClick={handleLoadSample}
+							>
+								<FileText className="h-3.5 w-3.5" />
+								Load sample text
+							</Button>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								className="justify-start"
+								onClick={() => setShowCurlPanel((s) => !s)}
+								aria-expanded={showCurlPanel}
+							>
+								<Terminal className="h-3.5 w-3.5" />
+								{showCurlPanel ? 'Hide curl panel' : 'Paste from curl'}
+							</Button>
+						</div>
+						{showCurlPanel ? (
+							<div className="space-y-2 pt-2">
+								<FormTextarea
+									label="curl command"
+									placeholder={'curl \'https://example.com\' --data-raw \'{"hello":"world"}\''}
+									value={curlInput}
+									onValueChange={setCurlInput}
+									rows={4}
+									size="compact"
+								/>
+								<div className="flex gap-2">
+									<Button
+										type="button"
+										size="sm"
+										onClick={handleApplyCurl}
+										disabled={!curlInput.trim()}
+									>
+										Extract data
+									</Button>
+									<Button
+										type="button"
+										variant="ghost"
+										size="sm"
+										onClick={() => {
+											setCurlInput('');
+											setShowCurlPanel(false);
+										}}
+									>
+										Cancel
+									</Button>
+								</div>
+							</div>
+						) : null}
+					</FormSection>
+
+					<FormSection title="About" open={false}>
+						<FormInfo title="How compression is performed">
+							<p>
+								GZIP runs through the browser <code>CompressionStream</code> API, which does not
+								expose a compression-level parameter. Brotli uses a WebAssembly module with a
+								configurable quality from 0 (fastest) to 11 (smallest).
+							</p>
+							<p className="mt-1.5">
+								Text is encoded as UTF-8 before compression. On decompress, auto-detect uses the
+								gzip magic bytes (<code>1F 8B</code>); inputs that do not match are routed to
+								brotli.
+							</p>
+						</FormInfo>
+					</FormSection>
+				</>
+			}
+		>
+			<div className="flex h-full min-h-0 flex-1 flex-col gap-3 overflow-auto p-3">
+				<Card density="compact">
+					<CardHeader className="flex flex-row items-center justify-between space-y-0">
+						<div className="flex flex-col gap-0.5">
+							<CardTitle className="text-sm font-medium">Input</CardTitle>
+							<span className="text-xs text-muted-foreground">
+								{direction === 'compress'
+									? 'Plain text to compress (UTF-8).'
+									: `Compressed payload encoded as base64 / hex / data: URI.`}
+							</span>
+						</div>
+						<div className="flex items-center gap-1">
+							<Badge variant="outline" className="font-mono">
+								{inputText.length} chars
+							</Badge>
+							<Button
+								type="button"
+								variant="ghost"
+								size="sm"
+								onClick={handleClearInput}
+								disabled={!inputText}
+							>
+								Clear
+							</Button>
+						</div>
+					</CardHeader>
+					<CardContent>
+						<Textarea
+							placeholder={
+								direction === 'compress'
+									? 'Paste text here...'
+									: 'Paste base64-encoded compressed payload here...'
+							}
+							value={inputText}
+							onChange={(e) => setInputText(e.target.value)}
+							rows={8}
+							className="resize-none font-mono text-xs"
+							aria-label="Input"
+						/>
+					</CardContent>
+				</Card>
+
+				<Card density="compact" className="border-l-2 border-l-info/40">
+					<CardContent>
+						<div className="flex flex-wrap items-center justify-between gap-2 text-xs">
+							<div className="flex items-center gap-3">
+								<span className="text-muted-foreground">
+									Input:{' '}
+									<strong className="font-semibold text-foreground tabular-nums">
+										{formatBytes(inputBytes)}
+									</strong>
+								</span>
+								<span className="text-muted-foreground">
+									Output:{' '}
+									<strong className="font-semibold text-foreground tabular-nums">
+										{formatBytes(outputBytesValue)}
+									</strong>
+								</span>
+							</div>
+							<div className="flex items-center gap-2">
+								<Badge
+									variant="outline"
+									className={cn(
+										'font-mono tabular-nums',
+										fillSavings
+											? 'border-success/40 bg-success/10 text-success'
+											: 'border-warning/40 bg-warning/10 text-warning'
+									)}
+								>
+									{fillSavings ? '−' : '+'}
+									{formatBytes(Math.abs(savings))} ({fillSavings ? '−' : '+'}
+									{Math.abs(savingsPercent).toFixed(1)}%)
+								</Badge>
+								<Badge variant="outline" className="font-mono tabular-nums">
+									Ratio {ratioPercent.toFixed(1)}%
+								</Badge>
+							</div>
+						</div>
+						<div
+							className="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted/70"
+							role="progressbar"
+							aria-label="Compression ratio"
+							aria-valuemin={0}
+							aria-valuemax={100}
+							aria-valuenow={Math.round(fillPercent)}
+						>
+							<div
+								className={cn('h-full transition-all', fillSavings ? 'bg-success' : 'bg-warning')}
+								style={{ width: `${fillPercent}%` }}
+							/>
+						</div>
+					</CardContent>
+				</Card>
+
+				<Card density="compact">
+					<CardHeader className="flex flex-row items-center justify-between space-y-0">
+						<div className="flex flex-col gap-0.5">
+							<CardTitle className="text-sm font-medium">Output</CardTitle>
+							<span className="text-xs text-muted-foreground">
+								{direction === 'compress'
+									? `Compressed bytes as ${outputFormat === 'data-uri' ? 'data: URI' : outputFormat}.`
+									: 'Decompressed text (UTF-8).'}
+								{detectedAlgorithm && direction === 'decompress' ? (
+									<span className="ml-2 text-info">Detected: {detectedAlgorithm}</span>
+								) : null}
+							</span>
+						</div>
+						<div className="flex items-center gap-1">
+							{busy ? (
+								<Badge variant="outline" className="font-mono text-muted-foreground">
+									Working...
+								</Badge>
+							) : null}
+							<CopyButton text={outputText} toastLabel="Output" disabled={!outputText} />
+						</div>
+					</CardHeader>
+					<CardContent>
+						<Textarea
+							placeholder={
+								direction === 'compress'
+									? 'Compressed output will appear here...'
+									: 'Decompressed text will appear here...'
+							}
+							value={outputText}
+							readOnly
+							rows={8}
+							className="resize-none font-mono text-xs"
+							aria-label="Output"
+						/>
+						<FormError message={error} className="pt-2" />
+					</CardContent>
+				</Card>
+			</div>
+		</ToolShell>
+	);
+}


### PR DESCRIPTION
## Summary
Add a String Compressor under **Encoders** that GZIP- or Brotli-compresses arbitrary text and visualises the ratio inline. Closes #223.

## Features
- **Two algorithms**: GZIP (via platform `CompressionStream`) and Brotli (via `brotli-wasm`)
- **Bidirectional**: compress text → base64 / hex / data-URI; decompress base64 / hex back to text
- **Compression level slider**: Brotli quality 0–11 (GZIP is locked to the platform default — `CompressionStream` does not expose a level knob)
- **Auto-detect** on decompress: gzip magic bytes (`1F 8B`) route through gzip, otherwise brotli
- **Compression-ratio bar** with bytes-saved badge
- **"Paste from curl"** helper extracts `--data-raw` from a copied curl command and feeds it into the compressor
- **Output format**: base64 / colon-grouped hex / `data:` URI

## Changes
### Added
- `src/routes/string-compressor.tsx`
- `src/lib/services/compression.ts`
- Page registration in `src/lib/services/pages.ts`

### Dependencies
- `brotli-wasm` (Brotli compress / decompress; `CompressionStream` covers gzip without a dep)

## Test plan
- [x] `bun run check` (TS + validate-pages + audit-design) green
- [x] `bun run lint` no new errors
- [x] `bun run format` clean
- [ ] Manual: load sample, toggle GZIP / Brotli, observe ratio change
- [ ] Manual: switch to decompress, paste base64 output, verify round-trip
- [ ] Manual: auto-detect on a gzip-magic stream vs Brotli stream
- [ ] Manual: drag Brotli slider 0..11 and watch ratio update
- [ ] Manual: "Paste from curl" with `curl ... --data-raw 'hello world' ...` → body extracted

Closes #223
