### PR TITLE
feat(image-converter): add Image Converter / Compressor tool

### DIFF
--- a/src/lib/services/image-convert.ts
+++ b/src/lib/services/image-convert.ts
@@ -1,0 +1,225 @@
+/**
+ * In-browser image conversion service.
+ *
+ * Converts a source image (as a `Blob`/`File`) to one or more target
+ * formats via Canvas. All processing is done in the user's browser; no
+ * uploads are performed.
+ *
+ * AVIF encoding is currently not implemented and `convertImage` throws
+ * when called with `format: 'avif'`. AVIF support requires WASM (e.g.
+ * `@jsquash/avif`) and is intentionally deferred to a follow-up PR to
+ * keep the bundle small.
+ */
+
+export type ImageFormat = 'png' | 'jpeg' | 'webp' | 'avif';
+export type RotationDeg = 0 | 90 | 180 | 270;
+
+export interface FlipOptions {
+	readonly h: boolean;
+	readonly v: boolean;
+}
+
+export interface ConvertOptions {
+	readonly format: ImageFormat;
+	readonly quality: number; // 1-100, ignored for png
+	readonly width: number;
+	readonly height: number;
+	readonly rotation: RotationDeg;
+	readonly flip: FlipOptions;
+	readonly backgroundFill: string; // hex, used when format is jpeg (no alpha)
+}
+
+export interface SourceImage {
+	readonly blob: Blob;
+	readonly bitmap: ImageBitmap;
+	readonly mime: string;
+	readonly width: number;
+	readonly height: number;
+	readonly bytes: number;
+	readonly filename: string;
+}
+
+export interface ConvertedImage {
+	readonly format: ImageFormat;
+	readonly blob: Blob;
+	readonly url: string; // ObjectURL — caller revokes when no longer needed
+	readonly bytes: number;
+	readonly width: number;
+	readonly height: number;
+}
+
+export const FORMAT_MIME: Readonly<Record<ImageFormat, string>> = {
+	png: 'image/png',
+	jpeg: 'image/jpeg',
+	webp: 'image/webp',
+	avif: 'image/avif',
+};
+
+export const FORMAT_LABEL: Readonly<Record<ImageFormat, string>> = {
+	png: 'PNG',
+	jpeg: 'JPEG',
+	webp: 'WebP',
+	avif: 'AVIF',
+};
+
+export const FORMAT_SUPPORTS_QUALITY: Readonly<Record<ImageFormat, boolean>> = {
+	png: false,
+	jpeg: true,
+	webp: true,
+	avif: true,
+};
+
+export const FORMAT_HAS_ALPHA: Readonly<Record<ImageFormat, boolean>> = {
+	png: true,
+	jpeg: false,
+	webp: true,
+	avif: true,
+};
+
+export const FORMAT_EXTENSION: Readonly<Record<ImageFormat, string>> = {
+	png: 'png',
+	jpeg: 'jpg',
+	webp: 'webp',
+	avif: 'avif',
+};
+
+export const RESIZE_PRESETS = [256, 512, 1024, 2048] as const;
+
+export const ALL_FORMATS: readonly ImageFormat[] = ['png', 'jpeg', 'webp', 'avif'];
+
+/** Decode a file into an in-memory bitmap with original metadata. */
+export const loadSource = async (file: File): Promise<SourceImage> => {
+	const bitmap = await createImageBitmap(file);
+	return {
+		blob: file,
+		bitmap,
+		mime: file.type || 'image/*',
+		width: bitmap.width,
+		height: bitmap.height,
+		bytes: file.size,
+		filename: file.name || 'image',
+	};
+};
+
+/** Render the source bitmap onto an offscreen canvas applying transforms,
+ * then encode it as the requested format. AVIF is not supported yet. */
+export const convertImage = async (
+	source: SourceImage,
+	opts: ConvertOptions
+): Promise<ConvertedImage> => {
+	if (opts.format === 'avif') {
+		// TODO: integrate @jsquash/avif WASM encoder in a follow-up PR.
+		throw new Error('AVIF encoding is not implemented in this build');
+	}
+
+	const swapAxes = opts.rotation === 90 || opts.rotation === 270;
+	const outW = Math.max(1, Math.round(swapAxes ? opts.height : opts.width));
+	const outH = Math.max(1, Math.round(swapAxes ? opts.width : opts.height));
+
+	const canvas = new OffscreenCanvas(outW, outH);
+	const ctx = canvas.getContext('2d');
+	if (!ctx) throw new Error('Canvas 2D context unavailable');
+
+	// Fill background for formats without an alpha channel so transparent
+	// pixels become the chosen color instead of black.
+	if (!FORMAT_HAS_ALPHA[opts.format]) {
+		ctx.fillStyle = opts.backgroundFill;
+		ctx.fillRect(0, 0, outW, outH);
+	}
+
+	ctx.save();
+	ctx.translate(outW / 2, outH / 2);
+	ctx.rotate((opts.rotation * Math.PI) / 180);
+	ctx.scale(opts.flip.h ? -1 : 1, opts.flip.v ? -1 : 1);
+	ctx.drawImage(source.bitmap, -opts.width / 2, -opts.height / 2, opts.width, opts.height);
+	ctx.restore();
+
+	const blob = await canvas.convertToBlob({
+		type: FORMAT_MIME[opts.format],
+		quality: Math.max(0, Math.min(1, opts.quality / 100)),
+	});
+	const url = URL.createObjectURL(blob);
+	return { format: opts.format, blob, url, bytes: blob.size, width: outW, height: outH };
+};
+
+export interface MultiConvertResult {
+	readonly format: ImageFormat;
+	readonly ok: true;
+	readonly converted: ConvertedImage;
+}
+
+export interface MultiConvertError {
+	readonly format: ImageFormat;
+	readonly ok: false;
+	readonly error: string;
+}
+
+export type MultiConvertOutcome = MultiConvertResult | MultiConvertError;
+
+/** Convert one source image to multiple target formats in parallel. */
+export const convertMany = (
+	source: SourceImage,
+	formats: readonly ImageFormat[],
+	optsFor: (format: ImageFormat) => ConvertOptions
+): Promise<readonly MultiConvertOutcome[]> =>
+	Promise.all(
+		formats.map(async (f): Promise<MultiConvertOutcome> => {
+			try {
+				const converted = await convertImage(source, optsFor(f));
+				return { format: f, ok: true, converted };
+			} catch (e) {
+				return {
+					format: f,
+					ok: false,
+					error: e instanceof Error ? e.message : String(e),
+				};
+			}
+		})
+	);
+
+/** Build a deterministic demo image at runtime so the route does not
+ * need to ship a hard-coded blob. Renders a gradient with a label. */
+export const generateDemoImage = async (): Promise<File> => {
+	const c = new OffscreenCanvas(512, 384);
+	const g = c.getContext('2d');
+	if (!g) throw new Error('Canvas 2D context unavailable');
+	const gradient = g.createLinearGradient(0, 0, 512, 384);
+	gradient.addColorStop(0, '#3b82f6');
+	gradient.addColorStop(0.5, '#a855f7');
+	gradient.addColorStop(1, '#ec4899');
+	g.fillStyle = gradient;
+	g.fillRect(0, 0, 512, 384);
+	g.fillStyle = 'rgba(255,255,255,0.9)';
+	g.font = 'bold 48px sans-serif';
+	g.textAlign = 'center';
+	g.textBaseline = 'middle';
+	g.fillText('Kogu Sample', 256, 192);
+	const blob = await c.convertToBlob({ type: 'image/png' });
+	return new File([blob], 'sample.png', { type: 'image/png' });
+};
+
+/** Trigger the browser download for a blob with the given filename. */
+export const triggerDownload = (blob: Blob, filename: string): void => {
+	const url = URL.createObjectURL(blob);
+	const a = document.createElement('a');
+	a.href = url;
+	a.download = filename;
+	document.body.appendChild(a);
+	a.click();
+	document.body.removeChild(a);
+	setTimeout(() => URL.revokeObjectURL(url), 1000);
+};
+
+/** Format a byte count as a short human-readable string. */
+export const humanBytes = (n: number): string => {
+	if (n < 1024) return `${n} B`;
+	if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+	return `${(n / (1024 * 1024)).toFixed(2)} MB`;
+};
+
+/** Build a target filename from the source filename and target format. */
+export const buildOutputFilename = (sourceFilename: string, format: ImageFormat): string => {
+	const dot = sourceFilename.lastIndexOf('.');
+	const base = dot > 0 ? sourceFilename.slice(0, dot) : sourceFilename;
+	return `${base || 'image'}.${FORMAT_EXTENSION[format]}`;
+};

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -8,6 +8,7 @@ import {
 	BadgeCheck,
 	Binary,
 	Braces,
+	Aperture,
 	Calculator,
 	CalendarClock,
 	CaseSensitive,
@@ -300,6 +301,15 @@ export const PAGES: readonly PageDefinition[] = [
 		description:
 			'Convert between binary, octal, decimal, and hex with bitwise operations and IEEE 754 view',
 		color: 'text-orange-600',
+		category: 'generators',
+	},
+	{
+		id: 'image-converter',
+		title: 'Image Converter',
+		url: '/image-converter',
+		icon: Aperture,
+		description: 'Convert and compress images (PNG / JPEG / WebP) with resize and rotation',
+		color: 'text-pink-600',
 		category: 'generators',
 	},
 	{

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -8,665 +8,686 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root';
-import { Route as YamlFormatterRouteImport } from './routes/yaml-formatter';
-import { Route as XmlFormatterRouteImport } from './routes/xml-formatter';
-import { Route as X509DecoderRouteImport } from './routes/x509-decoder';
-import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator';
-import { Route as UrlEncoderRouteImport } from './routes/url-encoder';
-import { Route as StringCompressorRouteImport } from './routes/string-compressor';
-import { Route as StringCaseConverterRouteImport } from './routes/string-case-converter';
-import { Route as SshKeyGeneratorRouteImport } from './routes/ssh-key-generator';
-import { Route as SqlFormatterRouteImport } from './routes/sql-formatter';
-import { Route as SettingsRouteImport } from './routes/settings';
-import { Route as RegexTesterRouteImport } from './routes/regex-tester';
-import { Route as QrCodeGeneratorRouteImport } from './routes/qr-code-generator';
-import { Route as PasswordGeneratorRouteImport } from './routes/password-generator';
-import { Route as NumberBaseConverterRouteImport } from './routes/number-base-converter';
-import { Route as NetworkScannerRouteImport } from './routes/network-scanner';
-import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces';
-import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor';
-import { Route as ListComparerRouteImport } from './routes/list-comparer';
-import { Route as JwtDecoderRouteImport } from './routes/jwt-decoder';
-import { Route as JsonFormatterRouteImport } from './routes/json-formatter';
-import { Route as HashGeneratorRouteImport } from './routes/hash-generator';
-import { Route as GpgKeyGeneratorRouteImport } from './routes/gpg-key-generator';
-import { Route as EscapeToolRouteImport } from './routes/escape-tool';
-import { Route as DiffViewerRouteImport } from './routes/diff-viewer';
-import { Route as DateTimestampConverterRouteImport } from './routes/date-timestamp-converter';
-import { Route as CurlBuilderRouteImport } from './routes/curl-builder';
-import { Route as CronExpressionBuilderRouteImport } from './routes/cron-expression-builder';
-import { Route as BcryptGeneratorRouteImport } from './routes/bcrypt-generator';
-import { Route as Base64EncoderRouteImport } from './routes/base64-encoder';
-import { Route as IndexRouteImport } from './routes/index';
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as YamlFormatterRouteImport } from './routes/yaml-formatter'
+import { Route as XmlFormatterRouteImport } from './routes/xml-formatter'
+import { Route as X509DecoderRouteImport } from './routes/x509-decoder'
+import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator'
+import { Route as UrlEncoderRouteImport } from './routes/url-encoder'
+import { Route as StringCompressorRouteImport } from './routes/string-compressor'
+import { Route as StringCaseConverterRouteImport } from './routes/string-case-converter'
+import { Route as SshKeyGeneratorRouteImport } from './routes/ssh-key-generator'
+import { Route as SqlFormatterRouteImport } from './routes/sql-formatter'
+import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as RegexTesterRouteImport } from './routes/regex-tester'
+import { Route as QrCodeGeneratorRouteImport } from './routes/qr-code-generator'
+import { Route as PasswordGeneratorRouteImport } from './routes/password-generator'
+import { Route as NumberBaseConverterRouteImport } from './routes/number-base-converter'
+import { Route as NetworkScannerRouteImport } from './routes/network-scanner'
+import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces'
+import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor'
+import { Route as ListComparerRouteImport } from './routes/list-comparer'
+import { Route as JwtDecoderRouteImport } from './routes/jwt-decoder'
+import { Route as JsonFormatterRouteImport } from './routes/json-formatter'
+import { Route as ImageConverterRouteImport } from './routes/image-converter'
+import { Route as HashGeneratorRouteImport } from './routes/hash-generator'
+import { Route as GpgKeyGeneratorRouteImport } from './routes/gpg-key-generator'
+import { Route as EscapeToolRouteImport } from './routes/escape-tool'
+import { Route as DiffViewerRouteImport } from './routes/diff-viewer'
+import { Route as DateTimestampConverterRouteImport } from './routes/date-timestamp-converter'
+import { Route as CurlBuilderRouteImport } from './routes/curl-builder'
+import { Route as CronExpressionBuilderRouteImport } from './routes/cron-expression-builder'
+import { Route as BcryptGeneratorRouteImport } from './routes/bcrypt-generator'
+import { Route as Base64EncoderRouteImport } from './routes/base64-encoder'
+import { Route as IndexRouteImport } from './routes/index'
 
 const YamlFormatterRoute = YamlFormatterRouteImport.update({
-	id: '/yaml-formatter',
-	path: '/yaml-formatter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/yaml-formatter',
+  path: '/yaml-formatter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const XmlFormatterRoute = XmlFormatterRouteImport.update({
-	id: '/xml-formatter',
-	path: '/xml-formatter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/xml-formatter',
+  path: '/xml-formatter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const X509DecoderRoute = X509DecoderRouteImport.update({
-	id: '/x509-decoder',
-	path: '/x509-decoder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/x509-decoder',
+  path: '/x509-decoder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const UuidGeneratorRoute = UuidGeneratorRouteImport.update({
-	id: '/uuid-generator',
-	path: '/uuid-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/uuid-generator',
+  path: '/uuid-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const UrlEncoderRoute = UrlEncoderRouteImport.update({
-	id: '/url-encoder',
-	path: '/url-encoder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/url-encoder',
+  path: '/url-encoder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const StringCompressorRoute = StringCompressorRouteImport.update({
-	id: '/string-compressor',
-	path: '/string-compressor',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/string-compressor',
+  path: '/string-compressor',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const StringCaseConverterRoute = StringCaseConverterRouteImport.update({
-	id: '/string-case-converter',
-	path: '/string-case-converter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/string-case-converter',
+  path: '/string-case-converter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SshKeyGeneratorRoute = SshKeyGeneratorRouteImport.update({
-	id: '/ssh-key-generator',
-	path: '/ssh-key-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/ssh-key-generator',
+  path: '/ssh-key-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SqlFormatterRoute = SqlFormatterRouteImport.update({
-	id: '/sql-formatter',
-	path: '/sql-formatter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/sql-formatter',
+  path: '/sql-formatter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SettingsRoute = SettingsRouteImport.update({
-	id: '/settings',
-	path: '/settings',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const RegexTesterRoute = RegexTesterRouteImport.update({
-	id: '/regex-tester',
-	path: '/regex-tester',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/regex-tester',
+  path: '/regex-tester',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const QrCodeGeneratorRoute = QrCodeGeneratorRouteImport.update({
-	id: '/qr-code-generator',
-	path: '/qr-code-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/qr-code-generator',
+  path: '/qr-code-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const PasswordGeneratorRoute = PasswordGeneratorRouteImport.update({
-	id: '/password-generator',
-	path: '/password-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/password-generator',
+  path: '/password-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const NumberBaseConverterRoute = NumberBaseConverterRouteImport.update({
-	id: '/number-base-converter',
-	path: '/number-base-converter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/number-base-converter',
+  path: '/number-base-converter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const NetworkScannerRoute = NetworkScannerRouteImport.update({
-	id: '/network-scanner',
-	path: '/network-scanner',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/network-scanner',
+  path: '/network-scanner',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const NetworkInterfacesRoute = NetworkInterfacesRouteImport.update({
-	id: '/network-interfaces',
-	path: '/network-interfaces',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/network-interfaces',
+  path: '/network-interfaces',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MarkdownEditorRoute = MarkdownEditorRouteImport.update({
-	id: '/markdown-editor',
-	path: '/markdown-editor',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/markdown-editor',
+  path: '/markdown-editor',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ListComparerRoute = ListComparerRouteImport.update({
-	id: '/list-comparer',
-	path: '/list-comparer',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/list-comparer',
+  path: '/list-comparer',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const JwtDecoderRoute = JwtDecoderRouteImport.update({
-	id: '/jwt-decoder',
-	path: '/jwt-decoder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/jwt-decoder',
+  path: '/jwt-decoder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const JsonFormatterRoute = JsonFormatterRouteImport.update({
-	id: '/json-formatter',
-	path: '/json-formatter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/json-formatter',
+  path: '/json-formatter',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ImageConverterRoute = ImageConverterRouteImport.update({
+  id: '/image-converter',
+  path: '/image-converter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const HashGeneratorRoute = HashGeneratorRouteImport.update({
-	id: '/hash-generator',
-	path: '/hash-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/hash-generator',
+  path: '/hash-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const GpgKeyGeneratorRoute = GpgKeyGeneratorRouteImport.update({
-	id: '/gpg-key-generator',
-	path: '/gpg-key-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/gpg-key-generator',
+  path: '/gpg-key-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const EscapeToolRoute = EscapeToolRouteImport.update({
-	id: '/escape-tool',
-	path: '/escape-tool',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/escape-tool',
+  path: '/escape-tool',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DiffViewerRoute = DiffViewerRouteImport.update({
-	id: '/diff-viewer',
-	path: '/diff-viewer',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/diff-viewer',
+  path: '/diff-viewer',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DateTimestampConverterRoute = DateTimestampConverterRouteImport.update({
-	id: '/date-timestamp-converter',
-	path: '/date-timestamp-converter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/date-timestamp-converter',
+  path: '/date-timestamp-converter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CurlBuilderRoute = CurlBuilderRouteImport.update({
-	id: '/curl-builder',
-	path: '/curl-builder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/curl-builder',
+  path: '/curl-builder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CronExpressionBuilderRoute = CronExpressionBuilderRouteImport.update({
-	id: '/cron-expression-builder',
-	path: '/cron-expression-builder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/cron-expression-builder',
+  path: '/cron-expression-builder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const BcryptGeneratorRoute = BcryptGeneratorRouteImport.update({
-	id: '/bcrypt-generator',
-	path: '/bcrypt-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/bcrypt-generator',
+  path: '/bcrypt-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const Base64EncoderRoute = Base64EncoderRouteImport.update({
-	id: '/base64-encoder',
-	path: '/base64-encoder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/base64-encoder',
+  path: '/base64-encoder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
-	id: '/',
-	path: '/',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
-	'/': typeof IndexRoute;
-	'/base64-encoder': typeof Base64EncoderRoute;
-	'/bcrypt-generator': typeof BcryptGeneratorRoute;
-	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
-	'/curl-builder': typeof CurlBuilderRoute;
-	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
-	'/diff-viewer': typeof DiffViewerRoute;
-	'/escape-tool': typeof EscapeToolRoute;
-	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
-	'/hash-generator': typeof HashGeneratorRoute;
-	'/json-formatter': typeof JsonFormatterRoute;
-	'/jwt-decoder': typeof JwtDecoderRoute;
-	'/list-comparer': typeof ListComparerRoute;
-	'/markdown-editor': typeof MarkdownEditorRoute;
-	'/network-interfaces': typeof NetworkInterfacesRoute;
-	'/network-scanner': typeof NetworkScannerRoute;
-	'/number-base-converter': typeof NumberBaseConverterRoute;
-	'/password-generator': typeof PasswordGeneratorRoute;
-	'/qr-code-generator': typeof QrCodeGeneratorRoute;
-	'/regex-tester': typeof RegexTesterRoute;
-	'/settings': typeof SettingsRoute;
-	'/sql-formatter': typeof SqlFormatterRoute;
-	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
-	'/string-case-converter': typeof StringCaseConverterRoute;
-	'/string-compressor': typeof StringCompressorRoute;
-	'/url-encoder': typeof UrlEncoderRoute;
-	'/uuid-generator': typeof UuidGeneratorRoute;
-	'/x509-decoder': typeof X509DecoderRoute;
-	'/xml-formatter': typeof XmlFormatterRoute;
-	'/yaml-formatter': typeof YamlFormatterRoute;
+  '/': typeof IndexRoute
+  '/base64-encoder': typeof Base64EncoderRoute
+  '/bcrypt-generator': typeof BcryptGeneratorRoute
+  '/cron-expression-builder': typeof CronExpressionBuilderRoute
+  '/curl-builder': typeof CurlBuilderRoute
+  '/date-timestamp-converter': typeof DateTimestampConverterRoute
+  '/diff-viewer': typeof DiffViewerRoute
+  '/escape-tool': typeof EscapeToolRoute
+  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
+  '/hash-generator': typeof HashGeneratorRoute
+  '/image-converter': typeof ImageConverterRoute
+  '/json-formatter': typeof JsonFormatterRoute
+  '/jwt-decoder': typeof JwtDecoderRoute
+  '/list-comparer': typeof ListComparerRoute
+  '/markdown-editor': typeof MarkdownEditorRoute
+  '/network-interfaces': typeof NetworkInterfacesRoute
+  '/network-scanner': typeof NetworkScannerRoute
+  '/number-base-converter': typeof NumberBaseConverterRoute
+  '/password-generator': typeof PasswordGeneratorRoute
+  '/qr-code-generator': typeof QrCodeGeneratorRoute
+  '/regex-tester': typeof RegexTesterRoute
+  '/settings': typeof SettingsRoute
+  '/sql-formatter': typeof SqlFormatterRoute
+  '/ssh-key-generator': typeof SshKeyGeneratorRoute
+  '/string-case-converter': typeof StringCaseConverterRoute
+  '/string-compressor': typeof StringCompressorRoute
+  '/url-encoder': typeof UrlEncoderRoute
+  '/uuid-generator': typeof UuidGeneratorRoute
+  '/x509-decoder': typeof X509DecoderRoute
+  '/xml-formatter': typeof XmlFormatterRoute
+  '/yaml-formatter': typeof YamlFormatterRoute
 }
 export interface FileRoutesByTo {
-	'/': typeof IndexRoute;
-	'/base64-encoder': typeof Base64EncoderRoute;
-	'/bcrypt-generator': typeof BcryptGeneratorRoute;
-	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
-	'/curl-builder': typeof CurlBuilderRoute;
-	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
-	'/diff-viewer': typeof DiffViewerRoute;
-	'/escape-tool': typeof EscapeToolRoute;
-	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
-	'/hash-generator': typeof HashGeneratorRoute;
-	'/json-formatter': typeof JsonFormatterRoute;
-	'/jwt-decoder': typeof JwtDecoderRoute;
-	'/list-comparer': typeof ListComparerRoute;
-	'/markdown-editor': typeof MarkdownEditorRoute;
-	'/network-interfaces': typeof NetworkInterfacesRoute;
-	'/network-scanner': typeof NetworkScannerRoute;
-	'/number-base-converter': typeof NumberBaseConverterRoute;
-	'/password-generator': typeof PasswordGeneratorRoute;
-	'/qr-code-generator': typeof QrCodeGeneratorRoute;
-	'/regex-tester': typeof RegexTesterRoute;
-	'/settings': typeof SettingsRoute;
-	'/sql-formatter': typeof SqlFormatterRoute;
-	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
-	'/string-case-converter': typeof StringCaseConverterRoute;
-	'/string-compressor': typeof StringCompressorRoute;
-	'/url-encoder': typeof UrlEncoderRoute;
-	'/uuid-generator': typeof UuidGeneratorRoute;
-	'/x509-decoder': typeof X509DecoderRoute;
-	'/xml-formatter': typeof XmlFormatterRoute;
-	'/yaml-formatter': typeof YamlFormatterRoute;
+  '/': typeof IndexRoute
+  '/base64-encoder': typeof Base64EncoderRoute
+  '/bcrypt-generator': typeof BcryptGeneratorRoute
+  '/cron-expression-builder': typeof CronExpressionBuilderRoute
+  '/curl-builder': typeof CurlBuilderRoute
+  '/date-timestamp-converter': typeof DateTimestampConverterRoute
+  '/diff-viewer': typeof DiffViewerRoute
+  '/escape-tool': typeof EscapeToolRoute
+  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
+  '/hash-generator': typeof HashGeneratorRoute
+  '/image-converter': typeof ImageConverterRoute
+  '/json-formatter': typeof JsonFormatterRoute
+  '/jwt-decoder': typeof JwtDecoderRoute
+  '/list-comparer': typeof ListComparerRoute
+  '/markdown-editor': typeof MarkdownEditorRoute
+  '/network-interfaces': typeof NetworkInterfacesRoute
+  '/network-scanner': typeof NetworkScannerRoute
+  '/number-base-converter': typeof NumberBaseConverterRoute
+  '/password-generator': typeof PasswordGeneratorRoute
+  '/qr-code-generator': typeof QrCodeGeneratorRoute
+  '/regex-tester': typeof RegexTesterRoute
+  '/settings': typeof SettingsRoute
+  '/sql-formatter': typeof SqlFormatterRoute
+  '/ssh-key-generator': typeof SshKeyGeneratorRoute
+  '/string-case-converter': typeof StringCaseConverterRoute
+  '/string-compressor': typeof StringCompressorRoute
+  '/url-encoder': typeof UrlEncoderRoute
+  '/uuid-generator': typeof UuidGeneratorRoute
+  '/x509-decoder': typeof X509DecoderRoute
+  '/xml-formatter': typeof XmlFormatterRoute
+  '/yaml-formatter': typeof YamlFormatterRoute
 }
 export interface FileRoutesById {
-	__root__: typeof rootRouteImport;
-	'/': typeof IndexRoute;
-	'/base64-encoder': typeof Base64EncoderRoute;
-	'/bcrypt-generator': typeof BcryptGeneratorRoute;
-	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
-	'/curl-builder': typeof CurlBuilderRoute;
-	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
-	'/diff-viewer': typeof DiffViewerRoute;
-	'/escape-tool': typeof EscapeToolRoute;
-	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
-	'/hash-generator': typeof HashGeneratorRoute;
-	'/json-formatter': typeof JsonFormatterRoute;
-	'/jwt-decoder': typeof JwtDecoderRoute;
-	'/list-comparer': typeof ListComparerRoute;
-	'/markdown-editor': typeof MarkdownEditorRoute;
-	'/network-interfaces': typeof NetworkInterfacesRoute;
-	'/network-scanner': typeof NetworkScannerRoute;
-	'/number-base-converter': typeof NumberBaseConverterRoute;
-	'/password-generator': typeof PasswordGeneratorRoute;
-	'/qr-code-generator': typeof QrCodeGeneratorRoute;
-	'/regex-tester': typeof RegexTesterRoute;
-	'/settings': typeof SettingsRoute;
-	'/sql-formatter': typeof SqlFormatterRoute;
-	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
-	'/string-case-converter': typeof StringCaseConverterRoute;
-	'/string-compressor': typeof StringCompressorRoute;
-	'/url-encoder': typeof UrlEncoderRoute;
-	'/uuid-generator': typeof UuidGeneratorRoute;
-	'/x509-decoder': typeof X509DecoderRoute;
-	'/xml-formatter': typeof XmlFormatterRoute;
-	'/yaml-formatter': typeof YamlFormatterRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/base64-encoder': typeof Base64EncoderRoute
+  '/bcrypt-generator': typeof BcryptGeneratorRoute
+  '/cron-expression-builder': typeof CronExpressionBuilderRoute
+  '/curl-builder': typeof CurlBuilderRoute
+  '/date-timestamp-converter': typeof DateTimestampConverterRoute
+  '/diff-viewer': typeof DiffViewerRoute
+  '/escape-tool': typeof EscapeToolRoute
+  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
+  '/hash-generator': typeof HashGeneratorRoute
+  '/image-converter': typeof ImageConverterRoute
+  '/json-formatter': typeof JsonFormatterRoute
+  '/jwt-decoder': typeof JwtDecoderRoute
+  '/list-comparer': typeof ListComparerRoute
+  '/markdown-editor': typeof MarkdownEditorRoute
+  '/network-interfaces': typeof NetworkInterfacesRoute
+  '/network-scanner': typeof NetworkScannerRoute
+  '/number-base-converter': typeof NumberBaseConverterRoute
+  '/password-generator': typeof PasswordGeneratorRoute
+  '/qr-code-generator': typeof QrCodeGeneratorRoute
+  '/regex-tester': typeof RegexTesterRoute
+  '/settings': typeof SettingsRoute
+  '/sql-formatter': typeof SqlFormatterRoute
+  '/ssh-key-generator': typeof SshKeyGeneratorRoute
+  '/string-case-converter': typeof StringCaseConverterRoute
+  '/string-compressor': typeof StringCompressorRoute
+  '/url-encoder': typeof UrlEncoderRoute
+  '/uuid-generator': typeof UuidGeneratorRoute
+  '/x509-decoder': typeof X509DecoderRoute
+  '/xml-formatter': typeof XmlFormatterRoute
+  '/yaml-formatter': typeof YamlFormatterRoute
 }
 export interface FileRouteTypes {
-	fileRoutesByFullPath: FileRoutesByFullPath;
-	fullPaths:
-		| '/'
-		| '/base64-encoder'
-		| '/bcrypt-generator'
-		| '/cron-expression-builder'
-		| '/curl-builder'
-		| '/date-timestamp-converter'
-		| '/diff-viewer'
-		| '/escape-tool'
-		| '/gpg-key-generator'
-		| '/hash-generator'
-		| '/json-formatter'
-		| '/jwt-decoder'
-		| '/list-comparer'
-		| '/markdown-editor'
-		| '/network-interfaces'
-		| '/network-scanner'
-		| '/number-base-converter'
-		| '/password-generator'
-		| '/qr-code-generator'
-		| '/regex-tester'
-		| '/settings'
-		| '/sql-formatter'
-		| '/ssh-key-generator'
-		| '/string-case-converter'
-		| '/string-compressor'
-		| '/url-encoder'
-		| '/uuid-generator'
-		| '/x509-decoder'
-		| '/xml-formatter'
-		| '/yaml-formatter';
-	fileRoutesByTo: FileRoutesByTo;
-	to:
-		| '/'
-		| '/base64-encoder'
-		| '/bcrypt-generator'
-		| '/cron-expression-builder'
-		| '/curl-builder'
-		| '/date-timestamp-converter'
-		| '/diff-viewer'
-		| '/escape-tool'
-		| '/gpg-key-generator'
-		| '/hash-generator'
-		| '/json-formatter'
-		| '/jwt-decoder'
-		| '/list-comparer'
-		| '/markdown-editor'
-		| '/network-interfaces'
-		| '/network-scanner'
-		| '/number-base-converter'
-		| '/password-generator'
-		| '/qr-code-generator'
-		| '/regex-tester'
-		| '/settings'
-		| '/sql-formatter'
-		| '/ssh-key-generator'
-		| '/string-case-converter'
-		| '/string-compressor'
-		| '/url-encoder'
-		| '/uuid-generator'
-		| '/x509-decoder'
-		| '/xml-formatter'
-		| '/yaml-formatter';
-	id:
-		| '__root__'
-		| '/'
-		| '/base64-encoder'
-		| '/bcrypt-generator'
-		| '/cron-expression-builder'
-		| '/curl-builder'
-		| '/date-timestamp-converter'
-		| '/diff-viewer'
-		| '/escape-tool'
-		| '/gpg-key-generator'
-		| '/hash-generator'
-		| '/json-formatter'
-		| '/jwt-decoder'
-		| '/list-comparer'
-		| '/markdown-editor'
-		| '/network-interfaces'
-		| '/network-scanner'
-		| '/number-base-converter'
-		| '/password-generator'
-		| '/qr-code-generator'
-		| '/regex-tester'
-		| '/settings'
-		| '/sql-formatter'
-		| '/ssh-key-generator'
-		| '/string-case-converter'
-		| '/string-compressor'
-		| '/url-encoder'
-		| '/uuid-generator'
-		| '/x509-decoder'
-		| '/xml-formatter'
-		| '/yaml-formatter';
-	fileRoutesById: FileRoutesById;
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/base64-encoder'
+    | '/bcrypt-generator'
+    | '/cron-expression-builder'
+    | '/curl-builder'
+    | '/date-timestamp-converter'
+    | '/diff-viewer'
+    | '/escape-tool'
+    | '/gpg-key-generator'
+    | '/hash-generator'
+    | '/image-converter'
+    | '/json-formatter'
+    | '/jwt-decoder'
+    | '/list-comparer'
+    | '/markdown-editor'
+    | '/network-interfaces'
+    | '/network-scanner'
+    | '/number-base-converter'
+    | '/password-generator'
+    | '/qr-code-generator'
+    | '/regex-tester'
+    | '/settings'
+    | '/sql-formatter'
+    | '/ssh-key-generator'
+    | '/string-case-converter'
+    | '/string-compressor'
+    | '/url-encoder'
+    | '/uuid-generator'
+    | '/x509-decoder'
+    | '/xml-formatter'
+    | '/yaml-formatter'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/base64-encoder'
+    | '/bcrypt-generator'
+    | '/cron-expression-builder'
+    | '/curl-builder'
+    | '/date-timestamp-converter'
+    | '/diff-viewer'
+    | '/escape-tool'
+    | '/gpg-key-generator'
+    | '/hash-generator'
+    | '/image-converter'
+    | '/json-formatter'
+    | '/jwt-decoder'
+    | '/list-comparer'
+    | '/markdown-editor'
+    | '/network-interfaces'
+    | '/network-scanner'
+    | '/number-base-converter'
+    | '/password-generator'
+    | '/qr-code-generator'
+    | '/regex-tester'
+    | '/settings'
+    | '/sql-formatter'
+    | '/ssh-key-generator'
+    | '/string-case-converter'
+    | '/string-compressor'
+    | '/url-encoder'
+    | '/uuid-generator'
+    | '/x509-decoder'
+    | '/xml-formatter'
+    | '/yaml-formatter'
+  id:
+    | '__root__'
+    | '/'
+    | '/base64-encoder'
+    | '/bcrypt-generator'
+    | '/cron-expression-builder'
+    | '/curl-builder'
+    | '/date-timestamp-converter'
+    | '/diff-viewer'
+    | '/escape-tool'
+    | '/gpg-key-generator'
+    | '/hash-generator'
+    | '/image-converter'
+    | '/json-formatter'
+    | '/jwt-decoder'
+    | '/list-comparer'
+    | '/markdown-editor'
+    | '/network-interfaces'
+    | '/network-scanner'
+    | '/number-base-converter'
+    | '/password-generator'
+    | '/qr-code-generator'
+    | '/regex-tester'
+    | '/settings'
+    | '/sql-formatter'
+    | '/ssh-key-generator'
+    | '/string-case-converter'
+    | '/string-compressor'
+    | '/url-encoder'
+    | '/uuid-generator'
+    | '/x509-decoder'
+    | '/xml-formatter'
+    | '/yaml-formatter'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-	IndexRoute: typeof IndexRoute;
-	Base64EncoderRoute: typeof Base64EncoderRoute;
-	BcryptGeneratorRoute: typeof BcryptGeneratorRoute;
-	CronExpressionBuilderRoute: typeof CronExpressionBuilderRoute;
-	CurlBuilderRoute: typeof CurlBuilderRoute;
-	DateTimestampConverterRoute: typeof DateTimestampConverterRoute;
-	DiffViewerRoute: typeof DiffViewerRoute;
-	EscapeToolRoute: typeof EscapeToolRoute;
-	GpgKeyGeneratorRoute: typeof GpgKeyGeneratorRoute;
-	HashGeneratorRoute: typeof HashGeneratorRoute;
-	JsonFormatterRoute: typeof JsonFormatterRoute;
-	JwtDecoderRoute: typeof JwtDecoderRoute;
-	ListComparerRoute: typeof ListComparerRoute;
-	MarkdownEditorRoute: typeof MarkdownEditorRoute;
-	NetworkInterfacesRoute: typeof NetworkInterfacesRoute;
-	NetworkScannerRoute: typeof NetworkScannerRoute;
-	NumberBaseConverterRoute: typeof NumberBaseConverterRoute;
-	PasswordGeneratorRoute: typeof PasswordGeneratorRoute;
-	QrCodeGeneratorRoute: typeof QrCodeGeneratorRoute;
-	RegexTesterRoute: typeof RegexTesterRoute;
-	SettingsRoute: typeof SettingsRoute;
-	SqlFormatterRoute: typeof SqlFormatterRoute;
-	SshKeyGeneratorRoute: typeof SshKeyGeneratorRoute;
-	StringCaseConverterRoute: typeof StringCaseConverterRoute;
-	StringCompressorRoute: typeof StringCompressorRoute;
-	UrlEncoderRoute: typeof UrlEncoderRoute;
-	UuidGeneratorRoute: typeof UuidGeneratorRoute;
-	X509DecoderRoute: typeof X509DecoderRoute;
-	XmlFormatterRoute: typeof XmlFormatterRoute;
-	YamlFormatterRoute: typeof YamlFormatterRoute;
+  IndexRoute: typeof IndexRoute
+  Base64EncoderRoute: typeof Base64EncoderRoute
+  BcryptGeneratorRoute: typeof BcryptGeneratorRoute
+  CronExpressionBuilderRoute: typeof CronExpressionBuilderRoute
+  CurlBuilderRoute: typeof CurlBuilderRoute
+  DateTimestampConverterRoute: typeof DateTimestampConverterRoute
+  DiffViewerRoute: typeof DiffViewerRoute
+  EscapeToolRoute: typeof EscapeToolRoute
+  GpgKeyGeneratorRoute: typeof GpgKeyGeneratorRoute
+  HashGeneratorRoute: typeof HashGeneratorRoute
+  ImageConverterRoute: typeof ImageConverterRoute
+  JsonFormatterRoute: typeof JsonFormatterRoute
+  JwtDecoderRoute: typeof JwtDecoderRoute
+  ListComparerRoute: typeof ListComparerRoute
+  MarkdownEditorRoute: typeof MarkdownEditorRoute
+  NetworkInterfacesRoute: typeof NetworkInterfacesRoute
+  NetworkScannerRoute: typeof NetworkScannerRoute
+  NumberBaseConverterRoute: typeof NumberBaseConverterRoute
+  PasswordGeneratorRoute: typeof PasswordGeneratorRoute
+  QrCodeGeneratorRoute: typeof QrCodeGeneratorRoute
+  RegexTesterRoute: typeof RegexTesterRoute
+  SettingsRoute: typeof SettingsRoute
+  SqlFormatterRoute: typeof SqlFormatterRoute
+  SshKeyGeneratorRoute: typeof SshKeyGeneratorRoute
+  StringCaseConverterRoute: typeof StringCaseConverterRoute
+  StringCompressorRoute: typeof StringCompressorRoute
+  UrlEncoderRoute: typeof UrlEncoderRoute
+  UuidGeneratorRoute: typeof UuidGeneratorRoute
+  X509DecoderRoute: typeof X509DecoderRoute
+  XmlFormatterRoute: typeof XmlFormatterRoute
+  YamlFormatterRoute: typeof YamlFormatterRoute
 }
 
 declare module '@tanstack/react-router' {
-	interface FileRoutesByPath {
-		'/yaml-formatter': {
-			id: '/yaml-formatter';
-			path: '/yaml-formatter';
-			fullPath: '/yaml-formatter';
-			preLoaderRoute: typeof YamlFormatterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/xml-formatter': {
-			id: '/xml-formatter';
-			path: '/xml-formatter';
-			fullPath: '/xml-formatter';
-			preLoaderRoute: typeof XmlFormatterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/x509-decoder': {
-			id: '/x509-decoder';
-			path: '/x509-decoder';
-			fullPath: '/x509-decoder';
-			preLoaderRoute: typeof X509DecoderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/uuid-generator': {
-			id: '/uuid-generator';
-			path: '/uuid-generator';
-			fullPath: '/uuid-generator';
-			preLoaderRoute: typeof UuidGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/url-encoder': {
-			id: '/url-encoder';
-			path: '/url-encoder';
-			fullPath: '/url-encoder';
-			preLoaderRoute: typeof UrlEncoderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/string-compressor': {
-			id: '/string-compressor';
-			path: '/string-compressor';
-			fullPath: '/string-compressor';
-			preLoaderRoute: typeof StringCompressorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/string-case-converter': {
-			id: '/string-case-converter';
-			path: '/string-case-converter';
-			fullPath: '/string-case-converter';
-			preLoaderRoute: typeof StringCaseConverterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/ssh-key-generator': {
-			id: '/ssh-key-generator';
-			path: '/ssh-key-generator';
-			fullPath: '/ssh-key-generator';
-			preLoaderRoute: typeof SshKeyGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/sql-formatter': {
-			id: '/sql-formatter';
-			path: '/sql-formatter';
-			fullPath: '/sql-formatter';
-			preLoaderRoute: typeof SqlFormatterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/settings': {
-			id: '/settings';
-			path: '/settings';
-			fullPath: '/settings';
-			preLoaderRoute: typeof SettingsRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/regex-tester': {
-			id: '/regex-tester';
-			path: '/regex-tester';
-			fullPath: '/regex-tester';
-			preLoaderRoute: typeof RegexTesterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/qr-code-generator': {
-			id: '/qr-code-generator';
-			path: '/qr-code-generator';
-			fullPath: '/qr-code-generator';
-			preLoaderRoute: typeof QrCodeGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/password-generator': {
-			id: '/password-generator';
-			path: '/password-generator';
-			fullPath: '/password-generator';
-			preLoaderRoute: typeof PasswordGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/number-base-converter': {
-			id: '/number-base-converter';
-			path: '/number-base-converter';
-			fullPath: '/number-base-converter';
-			preLoaderRoute: typeof NumberBaseConverterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/network-scanner': {
-			id: '/network-scanner';
-			path: '/network-scanner';
-			fullPath: '/network-scanner';
-			preLoaderRoute: typeof NetworkScannerRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/network-interfaces': {
-			id: '/network-interfaces';
-			path: '/network-interfaces';
-			fullPath: '/network-interfaces';
-			preLoaderRoute: typeof NetworkInterfacesRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/markdown-editor': {
-			id: '/markdown-editor';
-			path: '/markdown-editor';
-			fullPath: '/markdown-editor';
-			preLoaderRoute: typeof MarkdownEditorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/list-comparer': {
-			id: '/list-comparer';
-			path: '/list-comparer';
-			fullPath: '/list-comparer';
-			preLoaderRoute: typeof ListComparerRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/jwt-decoder': {
-			id: '/jwt-decoder';
-			path: '/jwt-decoder';
-			fullPath: '/jwt-decoder';
-			preLoaderRoute: typeof JwtDecoderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/json-formatter': {
-			id: '/json-formatter';
-			path: '/json-formatter';
-			fullPath: '/json-formatter';
-			preLoaderRoute: typeof JsonFormatterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/hash-generator': {
-			id: '/hash-generator';
-			path: '/hash-generator';
-			fullPath: '/hash-generator';
-			preLoaderRoute: typeof HashGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/gpg-key-generator': {
-			id: '/gpg-key-generator';
-			path: '/gpg-key-generator';
-			fullPath: '/gpg-key-generator';
-			preLoaderRoute: typeof GpgKeyGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/escape-tool': {
-			id: '/escape-tool';
-			path: '/escape-tool';
-			fullPath: '/escape-tool';
-			preLoaderRoute: typeof EscapeToolRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/diff-viewer': {
-			id: '/diff-viewer';
-			path: '/diff-viewer';
-			fullPath: '/diff-viewer';
-			preLoaderRoute: typeof DiffViewerRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/date-timestamp-converter': {
-			id: '/date-timestamp-converter';
-			path: '/date-timestamp-converter';
-			fullPath: '/date-timestamp-converter';
-			preLoaderRoute: typeof DateTimestampConverterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/curl-builder': {
-			id: '/curl-builder';
-			path: '/curl-builder';
-			fullPath: '/curl-builder';
-			preLoaderRoute: typeof CurlBuilderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/cron-expression-builder': {
-			id: '/cron-expression-builder';
-			path: '/cron-expression-builder';
-			fullPath: '/cron-expression-builder';
-			preLoaderRoute: typeof CronExpressionBuilderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/bcrypt-generator': {
-			id: '/bcrypt-generator';
-			path: '/bcrypt-generator';
-			fullPath: '/bcrypt-generator';
-			preLoaderRoute: typeof BcryptGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/base64-encoder': {
-			id: '/base64-encoder';
-			path: '/base64-encoder';
-			fullPath: '/base64-encoder';
-			preLoaderRoute: typeof Base64EncoderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/': {
-			id: '/';
-			path: '/';
-			fullPath: '/';
-			preLoaderRoute: typeof IndexRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-	}
+  interface FileRoutesByPath {
+    '/yaml-formatter': {
+      id: '/yaml-formatter'
+      path: '/yaml-formatter'
+      fullPath: '/yaml-formatter'
+      preLoaderRoute: typeof YamlFormatterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/xml-formatter': {
+      id: '/xml-formatter'
+      path: '/xml-formatter'
+      fullPath: '/xml-formatter'
+      preLoaderRoute: typeof XmlFormatterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/x509-decoder': {
+      id: '/x509-decoder'
+      path: '/x509-decoder'
+      fullPath: '/x509-decoder'
+      preLoaderRoute: typeof X509DecoderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/uuid-generator': {
+      id: '/uuid-generator'
+      path: '/uuid-generator'
+      fullPath: '/uuid-generator'
+      preLoaderRoute: typeof UuidGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/url-encoder': {
+      id: '/url-encoder'
+      path: '/url-encoder'
+      fullPath: '/url-encoder'
+      preLoaderRoute: typeof UrlEncoderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/string-compressor': {
+      id: '/string-compressor'
+      path: '/string-compressor'
+      fullPath: '/string-compressor'
+      preLoaderRoute: typeof StringCompressorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/string-case-converter': {
+      id: '/string-case-converter'
+      path: '/string-case-converter'
+      fullPath: '/string-case-converter'
+      preLoaderRoute: typeof StringCaseConverterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/ssh-key-generator': {
+      id: '/ssh-key-generator'
+      path: '/ssh-key-generator'
+      fullPath: '/ssh-key-generator'
+      preLoaderRoute: typeof SshKeyGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sql-formatter': {
+      id: '/sql-formatter'
+      path: '/sql-formatter'
+      fullPath: '/sql-formatter'
+      preLoaderRoute: typeof SqlFormatterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/regex-tester': {
+      id: '/regex-tester'
+      path: '/regex-tester'
+      fullPath: '/regex-tester'
+      preLoaderRoute: typeof RegexTesterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/qr-code-generator': {
+      id: '/qr-code-generator'
+      path: '/qr-code-generator'
+      fullPath: '/qr-code-generator'
+      preLoaderRoute: typeof QrCodeGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/password-generator': {
+      id: '/password-generator'
+      path: '/password-generator'
+      fullPath: '/password-generator'
+      preLoaderRoute: typeof PasswordGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/number-base-converter': {
+      id: '/number-base-converter'
+      path: '/number-base-converter'
+      fullPath: '/number-base-converter'
+      preLoaderRoute: typeof NumberBaseConverterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/network-scanner': {
+      id: '/network-scanner'
+      path: '/network-scanner'
+      fullPath: '/network-scanner'
+      preLoaderRoute: typeof NetworkScannerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/network-interfaces': {
+      id: '/network-interfaces'
+      path: '/network-interfaces'
+      fullPath: '/network-interfaces'
+      preLoaderRoute: typeof NetworkInterfacesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/markdown-editor': {
+      id: '/markdown-editor'
+      path: '/markdown-editor'
+      fullPath: '/markdown-editor'
+      preLoaderRoute: typeof MarkdownEditorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/list-comparer': {
+      id: '/list-comparer'
+      path: '/list-comparer'
+      fullPath: '/list-comparer'
+      preLoaderRoute: typeof ListComparerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/jwt-decoder': {
+      id: '/jwt-decoder'
+      path: '/jwt-decoder'
+      fullPath: '/jwt-decoder'
+      preLoaderRoute: typeof JwtDecoderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/json-formatter': {
+      id: '/json-formatter'
+      path: '/json-formatter'
+      fullPath: '/json-formatter'
+      preLoaderRoute: typeof JsonFormatterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/image-converter': {
+      id: '/image-converter'
+      path: '/image-converter'
+      fullPath: '/image-converter'
+      preLoaderRoute: typeof ImageConverterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/hash-generator': {
+      id: '/hash-generator'
+      path: '/hash-generator'
+      fullPath: '/hash-generator'
+      preLoaderRoute: typeof HashGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/gpg-key-generator': {
+      id: '/gpg-key-generator'
+      path: '/gpg-key-generator'
+      fullPath: '/gpg-key-generator'
+      preLoaderRoute: typeof GpgKeyGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/escape-tool': {
+      id: '/escape-tool'
+      path: '/escape-tool'
+      fullPath: '/escape-tool'
+      preLoaderRoute: typeof EscapeToolRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/diff-viewer': {
+      id: '/diff-viewer'
+      path: '/diff-viewer'
+      fullPath: '/diff-viewer'
+      preLoaderRoute: typeof DiffViewerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/date-timestamp-converter': {
+      id: '/date-timestamp-converter'
+      path: '/date-timestamp-converter'
+      fullPath: '/date-timestamp-converter'
+      preLoaderRoute: typeof DateTimestampConverterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/curl-builder': {
+      id: '/curl-builder'
+      path: '/curl-builder'
+      fullPath: '/curl-builder'
+      preLoaderRoute: typeof CurlBuilderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/cron-expression-builder': {
+      id: '/cron-expression-builder'
+      path: '/cron-expression-builder'
+      fullPath: '/cron-expression-builder'
+      preLoaderRoute: typeof CronExpressionBuilderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/bcrypt-generator': {
+      id: '/bcrypt-generator'
+      path: '/bcrypt-generator'
+      fullPath: '/bcrypt-generator'
+      preLoaderRoute: typeof BcryptGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/base64-encoder': {
+      id: '/base64-encoder'
+      path: '/base64-encoder'
+      fullPath: '/base64-encoder'
+      preLoaderRoute: typeof Base64EncoderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+  }
 }
 
 const rootRouteChildren: RootRouteChildren = {
-	IndexRoute: IndexRoute,
-	Base64EncoderRoute: Base64EncoderRoute,
-	BcryptGeneratorRoute: BcryptGeneratorRoute,
-	CronExpressionBuilderRoute: CronExpressionBuilderRoute,
-	CurlBuilderRoute: CurlBuilderRoute,
-	DateTimestampConverterRoute: DateTimestampConverterRoute,
-	DiffViewerRoute: DiffViewerRoute,
-	EscapeToolRoute: EscapeToolRoute,
-	GpgKeyGeneratorRoute: GpgKeyGeneratorRoute,
-	HashGeneratorRoute: HashGeneratorRoute,
-	JsonFormatterRoute: JsonFormatterRoute,
-	JwtDecoderRoute: JwtDecoderRoute,
-	ListComparerRoute: ListComparerRoute,
-	MarkdownEditorRoute: MarkdownEditorRoute,
-	NetworkInterfacesRoute: NetworkInterfacesRoute,
-	NetworkScannerRoute: NetworkScannerRoute,
-	NumberBaseConverterRoute: NumberBaseConverterRoute,
-	PasswordGeneratorRoute: PasswordGeneratorRoute,
-	QrCodeGeneratorRoute: QrCodeGeneratorRoute,
-	RegexTesterRoute: RegexTesterRoute,
-	SettingsRoute: SettingsRoute,
-	SqlFormatterRoute: SqlFormatterRoute,
-	SshKeyGeneratorRoute: SshKeyGeneratorRoute,
-	StringCaseConverterRoute: StringCaseConverterRoute,
-	StringCompressorRoute: StringCompressorRoute,
-	UrlEncoderRoute: UrlEncoderRoute,
-	UuidGeneratorRoute: UuidGeneratorRoute,
-	X509DecoderRoute: X509DecoderRoute,
-	XmlFormatterRoute: XmlFormatterRoute,
-	YamlFormatterRoute: YamlFormatterRoute,
-};
+  IndexRoute: IndexRoute,
+  Base64EncoderRoute: Base64EncoderRoute,
+  BcryptGeneratorRoute: BcryptGeneratorRoute,
+  CronExpressionBuilderRoute: CronExpressionBuilderRoute,
+  CurlBuilderRoute: CurlBuilderRoute,
+  DateTimestampConverterRoute: DateTimestampConverterRoute,
+  DiffViewerRoute: DiffViewerRoute,
+  EscapeToolRoute: EscapeToolRoute,
+  GpgKeyGeneratorRoute: GpgKeyGeneratorRoute,
+  HashGeneratorRoute: HashGeneratorRoute,
+  ImageConverterRoute: ImageConverterRoute,
+  JsonFormatterRoute: JsonFormatterRoute,
+  JwtDecoderRoute: JwtDecoderRoute,
+  ListComparerRoute: ListComparerRoute,
+  MarkdownEditorRoute: MarkdownEditorRoute,
+  NetworkInterfacesRoute: NetworkInterfacesRoute,
+  NetworkScannerRoute: NetworkScannerRoute,
+  NumberBaseConverterRoute: NumberBaseConverterRoute,
+  PasswordGeneratorRoute: PasswordGeneratorRoute,
+  QrCodeGeneratorRoute: QrCodeGeneratorRoute,
+  RegexTesterRoute: RegexTesterRoute,
+  SettingsRoute: SettingsRoute,
+  SqlFormatterRoute: SqlFormatterRoute,
+  SshKeyGeneratorRoute: SshKeyGeneratorRoute,
+  StringCaseConverterRoute: StringCaseConverterRoute,
+  StringCompressorRoute: StringCompressorRoute,
+  UrlEncoderRoute: UrlEncoderRoute,
+  UuidGeneratorRoute: UuidGeneratorRoute,
+  X509DecoderRoute: X509DecoderRoute,
+  XmlFormatterRoute: XmlFormatterRoute,
+  YamlFormatterRoute: YamlFormatterRoute,
+}
 export const routeTree = rootRouteImport
-	._addFileChildren(rootRouteChildren)
-	._addFileTypes<FileRouteTypes>();
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()

--- a/src/routes/image-converter.tsx
+++ b/src/routes/image-converter.tsx
@@ -1,0 +1,629 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { Download, RotateCw, Sparkles, Trash2, Upload } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState, type ChangeEvent, type DragEvent } from 'react';
+import { toast } from 'sonner';
+
+import { ActionButton } from '@/lib/components/action';
+import {
+	FormCheckbox,
+	FormCheckboxGroup,
+	FormInfo,
+	FormInput,
+	FormSection,
+	FormSlider,
+} from '@/lib/components/form';
+import { ToolShell } from '@/lib/components/shell';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { Badge } from '@/lib/components/ui/badge';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/lib/components/ui/tabs';
+import { useDocumentTitle } from '@/lib/hooks';
+import { createToolOptionsStore } from '@/lib/stores';
+import {
+	ALL_FORMATS,
+	buildOutputFilename,
+	convertMany,
+	FORMAT_LABEL,
+	FORMAT_SUPPORTS_QUALITY,
+	generateDemoImage,
+	humanBytes,
+	type ImageFormat,
+	loadSource,
+	type MultiConvertOutcome,
+	RESIZE_PRESETS,
+	type RotationDeg,
+	type SourceImage,
+	triggerDownload,
+} from '@/lib/services/image-convert';
+import { cn } from '@/lib/utils';
+
+interface ImageConverterPrefs {
+	readonly targets: readonly ImageFormat[];
+	readonly quality: number;
+	readonly backgroundFill: string;
+	readonly stripExif: boolean;
+	readonly lockAspect: boolean;
+}
+
+const DEFAULT_PREFS: ImageConverterPrefs = {
+	targets: ['png', 'jpeg', 'webp'],
+	quality: 80,
+	backgroundFill: '#ffffff',
+	stripExif: true,
+	lockAspect: true,
+};
+
+const useImageConverterPrefs = createToolOptionsStore<ImageConverterPrefs>(
+	'image-converter',
+	DEFAULT_PREFS
+);
+
+const ROTATIONS: readonly RotationDeg[] = [0, 90, 180, 270];
+
+const nextRotation = (current: RotationDeg, delta: 90 | 180 | 270): RotationDeg => {
+	const idx = ROTATIONS.indexOf(current);
+	const stepIdx = ROTATIONS.indexOf(delta as RotationDeg);
+	return ROTATIONS[(idx + stepIdx) % 4] ?? 0;
+};
+
+export const Route = createFileRoute('/image-converter')({
+	component: ImageConverterPage,
+});
+
+function ImageConverterPage() {
+	useDocumentTitle('Image Converter');
+
+	const { value: prefs, patch } = useImageConverterPrefs();
+
+	const [source, setSource] = useState<SourceImage | null>(null);
+	const [sourceUrl, setSourceUrl] = useState<string | null>(null);
+	const [dragOver, setDragOver] = useState(false);
+	const [width, setWidth] = useState(0);
+	const [height, setHeight] = useState(0);
+	const [rotation, setRotation] = useState<RotationDeg>(0);
+	const [flipH, setFlipH] = useState(false);
+	const [flipV, setFlipV] = useState(false);
+	const [results, setResults] = useState<readonly MultiConvertOutcome[]>([]);
+	const [activeFormat, setActiveFormat] = useState<ImageFormat | null>(null);
+	const [converting, setConverting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [showRail, setShowRail] = useState(true);
+
+	const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+	useEffect(() => {
+		if (!source) return;
+		setWidth(source.width);
+		setHeight(source.height);
+		setRotation(0);
+		setFlipH(false);
+		setFlipV(false);
+	}, [source]);
+
+	useEffect(() => {
+		return () => {
+			results.forEach((r) => {
+				if (r.ok) URL.revokeObjectURL(r.converted.url);
+			});
+		};
+	}, [results]);
+
+	useEffect(() => {
+		if (!source) {
+			setSourceUrl(null);
+			return;
+		}
+		const url = URL.createObjectURL(source.blob);
+		setSourceUrl(url);
+		return () => URL.revokeObjectURL(url);
+	}, [source]);
+
+	const aspect = source ? source.width / source.height : 1;
+
+	const updateWidth = (next: number) => {
+		const clamped = Math.max(1, Math.min(10000, Math.round(next)));
+		setWidth(clamped);
+		if (prefs.lockAspect && aspect > 0) setHeight(Math.max(1, Math.round(clamped / aspect)));
+	};
+
+	const updateHeight = (next: number) => {
+		const clamped = Math.max(1, Math.min(10000, Math.round(next)));
+		setHeight(clamped);
+		if (prefs.lockAspect && aspect > 0) setWidth(Math.max(1, Math.round(clamped * aspect)));
+	};
+
+	const acceptFile = async (file: File) => {
+		setError(null);
+		try {
+			const next = await loadSource(file);
+			setSource(next);
+			setResults([]);
+			setActiveFormat(null);
+		} catch (e) {
+			setError(e instanceof Error ? e.message : 'Failed to load image');
+			toast.error('Failed to load image');
+		}
+	};
+
+	const handleFileInput = (e: ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		if (file) void acceptFile(file);
+		e.target.value = '';
+	};
+
+	const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		setDragOver(false);
+		const file = e.dataTransfer.files?.[0];
+		if (file && file.type.startsWith('image/')) void acceptFile(file);
+		else if (file) toast.error('Only image files are supported');
+	};
+
+	const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		setDragOver(true);
+	};
+
+	const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		setDragOver(false);
+	};
+
+	const handleLoadDemo = async () => {
+		const demo = await generateDemoImage();
+		void acceptFile(demo);
+	};
+
+	const handleConvert = async () => {
+		if (!source || prefs.targets.length === 0) return;
+		setConverting(true);
+		setError(null);
+		results.forEach((r) => {
+			if (r.ok) URL.revokeObjectURL(r.converted.url);
+		});
+		try {
+			const outcomes = await convertMany(source, prefs.targets, (format) => ({
+				format,
+				quality: prefs.quality,
+				width,
+				height,
+				rotation,
+				flip: { h: flipH, v: flipV },
+				backgroundFill: prefs.backgroundFill,
+			}));
+			setResults(outcomes);
+			const firstOk = outcomes.find((o): o is Extract<MultiConvertOutcome, { ok: true }> => o.ok);
+			setActiveFormat(firstOk?.format ?? null);
+			const failures = outcomes.filter((o) => !o.ok);
+			if (failures.length > 0) {
+				toast.warning(`Converted ${outcomes.length - failures.length}/${outcomes.length} formats`, {
+					description: failures.map((f) => `${FORMAT_LABEL[f.format]}: ${f.ok ? '' : f.error}`).join(', '),
+				});
+			} else {
+				toast.success(`Converted ${outcomes.length} format${outcomes.length === 1 ? '' : 's'}`);
+			}
+		} catch (e) {
+			setError(e instanceof Error ? e.message : 'Conversion failed');
+			toast.error('Conversion failed');
+		} finally {
+			setConverting(false);
+		}
+	};
+
+	const handleDownload = (outcome: MultiConvertOutcome) => {
+		if (!outcome.ok || !source) return;
+		triggerDownload(outcome.converted.blob, buildOutputFilename(source.filename, outcome.format));
+	};
+
+	const handleClearSource = () => {
+		setSource(null);
+		setResults([]);
+		setActiveFormat(null);
+		setError(null);
+	};
+
+	const toggleTarget = (format: ImageFormat, checked: boolean) => {
+		const next = checked
+			? [...new Set([...prefs.targets, format])]
+			: prefs.targets.filter((f) => f !== format);
+		patch({ targets: next as readonly ImageFormat[] });
+	};
+
+	const someTargetLossy = prefs.targets.some((f) => FORMAT_SUPPORTS_QUALITY[f]);
+	const scalePercent = source && source.width > 0 ? Math.round((width / source.width) * 100) : 100;
+
+	const bestRatio = useMemo(() => {
+		if (!source || results.length === 0) return null;
+		const okResults = results.filter((r): r is Extract<MultiConvertOutcome, { ok: true }> => r.ok);
+		if (okResults.length === 0) return null;
+		const smallest = okResults.reduce((acc, r) =>
+			r.converted.bytes < acc.converted.bytes ? r : acc
+		);
+		return Math.round((smallest.converted.bytes / source.bytes) * 100);
+	}, [results, source]);
+
+	const okResults = useMemo(
+		() => results.filter((r): r is Extract<MultiConvertOutcome, { ok: true }> => r.ok),
+		[results]
+	);
+
+	return (
+		<ToolShell
+			showRail={showRail}
+			onShowRailChange={setShowRail}
+			statusContent={
+				<>
+					<StatItem label="Source" value={source ? `${source.width}×${source.height}` : '—'} />
+					<StatItem label="Targets" value={prefs.targets.length} />
+					<StatItem label="Best ratio" value={bestRatio !== null ? `${bestRatio}%` : '—'} />
+				</>
+			}
+			rail={
+				<>
+					<FormSection title="Target Formats">
+						<FormCheckboxGroup>
+							{ALL_FORMATS.map((format) => {
+								const isAvif = format === 'avif';
+								return (
+									<FormCheckbox
+										key={format}
+										label={FORMAT_LABEL[format] + (isAvif ? ' (coming soon)' : '')}
+										checked={prefs.targets.includes(format)}
+										onCheckedChange={(c) => toggleTarget(format, c)}
+										disabled={isAvif}
+										size="compact"
+									/>
+								);
+							})}
+						</FormCheckboxGroup>
+					</FormSection>
+
+					{someTargetLossy ? (
+						<FormSection title="Quality">
+							<FormSlider
+								label="Lossy quality"
+								value={prefs.quality}
+								onValueChange={(v) => patch({ quality: v })}
+								min={1}
+								max={100}
+								step={1}
+								valueLabel={`${prefs.quality}%`}
+								size="compact"
+							/>
+						</FormSection>
+					) : null}
+
+					<FormSection title="Resize">
+						<FormCheckbox
+							label="Lock aspect ratio"
+							checked={prefs.lockAspect}
+							onCheckedChange={(c) => patch({ lockAspect: c })}
+							size="compact"
+						/>
+						{source ? (
+							<>
+								<div className="grid grid-cols-2 gap-2">
+									<FormInput
+										label="Width"
+										value={String(width)}
+										onValueChange={(v) => {
+											const n = Number(v);
+											if (!Number.isNaN(n)) updateWidth(n);
+										}}
+										size="compact"
+									/>
+									<FormInput
+										label="Height"
+										value={String(height)}
+										onValueChange={(v) => {
+											const n = Number(v);
+											if (!Number.isNaN(n)) updateHeight(n);
+										}}
+										size="compact"
+									/>
+								</div>
+								<FormSlider
+									label="Scale"
+									value={scalePercent}
+									onValueChange={(v) => updateWidth(Math.round((source.width * v) / 100))}
+									min={10}
+									max={200}
+									step={1}
+									valueLabel={`${scalePercent}%`}
+									size="compact"
+								/>
+							</>
+						) : (
+							<p className="text-xs text-muted-foreground">Drop an image to enable resize controls.</p>
+						)}
+						<div className="flex flex-wrap gap-1.5">
+							{RESIZE_PRESETS.map((p) => (
+								<Button
+									key={p}
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={() => updateWidth(p)}
+									disabled={!source}
+								>
+									{p}px
+								</Button>
+							))}
+						</div>
+					</FormSection>
+
+					<FormSection title="Transform">
+						<div className="flex flex-wrap gap-1.5">
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => setRotation(nextRotation(rotation, 90))}
+								disabled={!source}
+							>
+								<RotateCw className="size-3.5" /> 90°
+							</Button>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => setRotation(nextRotation(rotation, 180))}
+								disabled={!source}
+							>
+								180°
+							</Button>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => setRotation(nextRotation(rotation, 270))}
+								disabled={!source}
+							>
+								270°
+							</Button>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => setRotation(0)}
+								disabled={!source}
+							>
+								Reset
+							</Button>
+						</div>
+						<FormCheckbox
+							label="Flip horizontal"
+							checked={flipH}
+							onCheckedChange={setFlipH}
+							size="compact"
+						/>
+						<FormCheckbox
+							label="Flip vertical"
+							checked={flipV}
+							onCheckedChange={setFlipV}
+							size="compact"
+						/>
+					</FormSection>
+
+					<FormSection title="JPEG Background">
+						<label className="flex items-center gap-2 text-xs text-muted-foreground">
+							<input
+								type="color"
+								value={prefs.backgroundFill}
+								onChange={(e) => patch({ backgroundFill: e.target.value })}
+								className="h-7 w-10 cursor-pointer rounded border border-border bg-background"
+							/>
+							<span className="font-mono">{prefs.backgroundFill}</span>
+						</label>
+						<FormInfo>
+							Fills transparent pixels when the source has an alpha channel and the target is JPEG.
+						</FormInfo>
+					</FormSection>
+
+					<FormSection title="Privacy">
+						<FormCheckbox
+							label="Strip EXIF metadata"
+							checked={prefs.stripExif}
+							onCheckedChange={(c) => patch({ stripExif: c })}
+							hint="Canvas re-render already removes it"
+							size="compact"
+						/>
+					</FormSection>
+
+					<FormSection title="Actions">
+						<div className="flex flex-col gap-2">
+							<ActionButton
+								label={converting ? 'Converting…' : 'Convert'}
+								icon={Sparkles}
+								disabled={!source || prefs.targets.length === 0 || converting}
+								onClick={() => void handleConvert()}
+							/>
+							<Button
+								type="button"
+								variant="outline"
+								onClick={() => void handleLoadDemo()}
+								size="sm"
+							>
+								<Upload className="size-3.5" /> Load demo image
+							</Button>
+							{source ? (
+								<Button type="button" variant="outline" onClick={handleClearSource} size="sm">
+									<Trash2 className="size-3.5" /> Clear source
+								</Button>
+							) : null}
+						</div>
+					</FormSection>
+
+					<FormSection title="About">
+						<FormInfo>
+							All processing happens in your browser. Nothing is uploaded. Canvas re-render
+							strips EXIF metadata inherently.
+						</FormInfo>
+					</FormSection>
+				</>
+			}
+		>
+			<div className="flex h-full flex-col overflow-hidden p-4">
+				<input
+					ref={fileInputRef}
+					type="file"
+					accept="image/*"
+					onChange={handleFileInput}
+					className="hidden"
+				/>
+				{!source ? (
+					<div
+						className={cn(
+							'flex h-full flex-1 items-center justify-center rounded-xl border-2 border-dashed transition-colors',
+							dragOver
+								? 'border-primary bg-primary/5'
+								: 'border-border bg-surface-1'
+						)}
+						onDrop={handleDrop}
+						onDragOver={handleDragOver}
+						onDragLeave={handleDragLeave}
+					>
+						<div className="flex flex-col items-center gap-3 p-8">
+							<EmbeddedEmptyState
+								icon={Upload}
+								title="Drop an image here"
+								description="PNG, JPEG, WebP, or GIF (first frame). You can also use the file picker."
+							/>
+							<div className="flex gap-2">
+								<Button type="button" onClick={() => fileInputRef.current?.click()} size="sm">
+									Choose file
+								</Button>
+								<Button type="button" variant="outline" onClick={() => void handleLoadDemo()} size="sm">
+									Load demo image
+								</Button>
+							</div>
+						</div>
+					</div>
+				) : (
+					<div className="flex flex-col gap-4 overflow-auto">
+						{error ? (
+							<Card density="compact">
+								<CardContent>
+									<p className="text-sm text-destructive">{error}</p>
+								</CardContent>
+							</Card>
+						) : null}
+						<div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+							<Card density="compact">
+								<CardHeader>
+									<CardTitle className="text-sm">Source</CardTitle>
+								</CardHeader>
+								<CardContent>
+									<div className="flex flex-col gap-2">
+										{sourceUrl ? (
+											<img
+												src={sourceUrl}
+												alt="Source"
+												className="max-h-72 w-full rounded border border-border bg-surface-2 object-contain"
+											/>
+										) : null}
+										<div className="flex flex-wrap gap-1.5">
+											<Badge variant="outline">{source.mime.replace('image/', '').toUpperCase()}</Badge>
+											<Badge variant="outline">
+												{source.width}×{source.height}
+											</Badge>
+											<Badge variant="outline">{humanBytes(source.bytes)}</Badge>
+										</div>
+									</div>
+								</CardContent>
+							</Card>
+							<Card density="compact">
+								<CardHeader>
+									<CardTitle className="text-sm">Converted</CardTitle>
+								</CardHeader>
+								<CardContent>
+									{okResults.length === 0 ? (
+										<p className="text-sm text-muted-foreground">
+											Configure targets and click <span className="font-medium">Convert</span>{' '}
+											to generate previews.
+										</p>
+									) : (
+										<Tabs
+											value={activeFormat ?? okResults[0]?.format ?? 'png'}
+											onValueChange={(v) => setActiveFormat(v as ImageFormat)}
+										>
+											<TabsList>
+												{okResults.map((r) => (
+													<TabsTrigger key={r.format} value={r.format}>
+														{FORMAT_LABEL[r.format]}
+													</TabsTrigger>
+												))}
+											</TabsList>
+											{okResults.map((r) => {
+												const deltaPct = Math.round((r.converted.bytes / source.bytes) * 100);
+												return (
+													<TabsContent key={r.format} value={r.format}>
+														<div className="flex flex-col gap-2 pt-2">
+															<img
+																src={r.converted.url}
+																alt={FORMAT_LABEL[r.format]}
+																className="max-h-72 w-full rounded border border-border bg-surface-2 object-contain"
+															/>
+															<div className="flex flex-wrap items-center gap-2">
+																<Badge variant="outline">
+																	{r.converted.width}×{r.converted.height}
+																</Badge>
+																<Badge variant="outline">{humanBytes(r.converted.bytes)}</Badge>
+																<Badge
+																	variant="outline"
+																	className={cn(
+																		deltaPct < 100
+																			? 'border-success/30 bg-success/10 text-success'
+																			: 'border-warning/30 bg-warning/10 text-warning'
+																	)}
+																>
+																	{deltaPct < 100 ? '−' : '+'}
+																	{Math.abs(100 - deltaPct)}% vs source
+																</Badge>
+																<Button
+																	type="button"
+																	size="sm"
+																	variant="outline"
+																	onClick={() => handleDownload(r)}
+																>
+																	<Download className="size-3.5" /> Download
+																</Button>
+															</div>
+														</div>
+													</TabsContent>
+												);
+											})}
+										</Tabs>
+									)}
+								</CardContent>
+							</Card>
+						</div>
+						{results.some((r) => !r.ok) ? (
+							<Card density="compact">
+								<CardHeader>
+									<CardTitle className="text-sm">Conversion errors</CardTitle>
+								</CardHeader>
+								<CardContent>
+									<ul className="space-y-1 text-sm text-destructive">
+										{results
+											.filter((r) => !r.ok)
+											.map((r) =>
+												r.ok ? null : (
+													<li key={r.format}>
+														<span className="font-medium">{FORMAT_LABEL[r.format]}:</span>{' '}
+														{r.error}
+													</li>
+												)
+											)}
+									</ul>
+								</CardContent>
+							</Card>
+						) : null}
+					</div>
+				)}
+			</div>
+		</ToolShell>
+	);
+}
+


### PR DESCRIPTION
## Summary
Add an Image Converter / Compressor under **Generators** that swaps formats (PNG / JPEG / WebP) and exports multiple targets in a single pass with size + delta badges. All processing is in-browser via the Canvas API. Closes #224.

## Features
- **Drag-drop or file-picker** input
- **Multi-format export** in one click: PNG / JPEG / WebP via the platform Canvas API
  - AVIF is intentionally stubbed (disabled checkbox with "coming soon"); follow-up PR will integrate a WASM AVIF encoder
- **Source vs converted preview** side-by-side with tabs to flip between target formats
- **Per-target badges**: file size + delta percent vs source (green if smaller, warning if larger)
- **Resize**: width / height with aspect-ratio lock; presets 256 / 512 / 1024 / 2048; scale slider 10–200%
- **Transform**: rotate 90° / 180° / 270°, flip horizontal / vertical
- **Quality slider** for lossy targets
- **JPEG background-fill** color picker for transparent sources
- **Privacy**: 100% browser-side processing; nothing leaves the device
- **Runtime-generated demo image** (gradient + label drawn onto an OffscreenCanvas) — no sample blob shipped in source

## Deferred (follow-up PR)
- AVIF encoding (needs WASM encoder integration)
- Crop UI (needs canvas drag-handles + per-edge manipulation)
- Clipboard paste — drag-drop + file picker cover the common path

## Changes
### Added
- `src/routes/image-converter.tsx` — page component (drag-drop zone + preview tabs + download buttons)
- `src/lib/services/image-convert.ts` — pure pipeline: `loadSource`, `convertImage`, `convertMany`, `generateDemoImage`, `triggerDownload`, `humanBytes`, `buildOutputFilename`
- Page registration entry in `src/lib/services/pages.ts` (Aperture icon, `text-pink-600`)

## Test plan
- [x] `bun run check` (TS + validate-pages + audit-design) green
- [x] `bun run lint` no new errors
- [x] `bun run format` clean
- [ ] Manual: drop a PNG, select PNG + JPEG + WebP, click Convert — verify three Download buttons with size badges
- [ ] Manual: drop a transparent PNG, target JPEG with colored background — verify the fill renders
- [ ] Manual: drag scale slider 50% → 200% — width / height update live
- [ ] Manual: rotate 90° / 180° / 270° — preview rotates; 90/270 swap dimensions
- [ ] Manual: flip horizontal + vertical — preview mirrors

Closes #224
