### PR TITLE
fix(ci): drop Node.js 20-only awalsh128/cache-apt-pkgs-action

### DIFF
--- a/.github/actions/setup-tauri-deps/action.yml
+++ b/.github/actions/setup-tauri-deps/action.yml
@@ -1,11 +1,22 @@
 name: Setup Tauri Dependencies
 description: Install system dependencies required for Tauri on Ubuntu
 
+# Inlined `apt-get install` instead of awalsh128/cache-apt-pkgs-action so this
+# composite step keeps running on Node.js 24. As of mid-2026, that action's
+# v1.x line still pulls actions/cache/restore@v4 internally, which GitHub
+# Actions deprecated on 2026-06-02. The four Tauri packages install in roughly
+# 10-20 seconds, so the foregone apt-cache restore is acceptable. Switch back
+# to a cached install once awalsh128/cache-apt-pkgs-action#198 (or a v2 release)
+# lands and uses actions/cache@v5.
 runs:
   using: composite
   steps:
     - name: Install system dependencies
-      uses: awalsh128/cache-apt-pkgs-action@v1
-      with:
-        packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
-        version: 1.0
+      shell: bash
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y --no-install-recommends \
+          libwebkit2gtk-4.1-dev \
+          libappindicator3-dev \
+          librsvg2-dev \
+          patchelf


### PR DESCRIPTION
## Summary

`Test Backend` was emitting a Node.js 20 deprecation warning on every CI run:

```
Node.js 20 actions are deprecated. The following actions are running on
Node.js 20 and may not work as expected: actions/cache/restore@v4.
```

The warning traces back to `awalsh128/cache-apt-pkgs-action@v1` (used inside `.github/actions/setup-tauri-deps`), which internally pins `actions/cache/restore@v4` and `actions/cache/save@v4`. Upstream PR [#198](https://github.com/awalsh128/cache-apt-pkgs-action/pull/198) migrates it to `actions/cache@v5` (Node 24) but is not merged yet, and no Node 24-compatible release is available.

## Fix

Inline `apt-get install` directly in the composite action. The four Tauri Linux packages (`libwebkit2gtk-4.1-dev`, `libappindicator3-dev`, `librsvg2-dev`, `patchelf`) install in roughly 10–20 seconds — the foregone apt-cache restore is acceptable until upstream ships a Node 24 release.

A comment in the action file documents the rationale so the cached variant can be reinstated once the upstream PR lands.

## Changes
### Modified
- `.github/actions/setup-tauri-deps/action.yml` — replace `awalsh128/cache-apt-pkgs-action@v1` with inline `sudo apt-get install`

## Test plan
- [ ] Verify `Test Backend` no longer emits the Node 20 deprecation warning
- [ ] Verify Tauri Rust build still succeeds (libwebkit2gtk + the other three packages install correctly)
