### PR TITLE
fix(form,routes): remove duplicate page titles and stack long FormMode options

### DIFF
--- a/src/lib/components/form/form-mode.tsx
+++ b/src/lib/components/form/form-mode.tsx
@@ -63,10 +63,10 @@ export function FormMode<T extends string>({
 				aria-labelledby={label ? `${uid}-label` : undefined}
 				className={cn(
 					// Choice Card layout: each option is its own card with full
-					// rounding regardless of orientation. Drop the horizontal
-					// segmented-control language so vertical groups read as a
-					// list of independent radio cards rather than a connected
-					// segmented switch.
+					// rounding regardless of orientation. Horizontal grids work for
+					// short single-word labels (e.g. "On" / "Off"). For longer or
+					// mixed-length labels, pass `layout="stacked"` so the cards
+					// flow vertically and labels never need to wrap.
 					'gap-2',
 					layout === 'horizontal' ? `grid ${gridColsClass}` : 'flex flex-col'
 				)}
@@ -95,10 +95,10 @@ export function FormMode<T extends string>({
 							<div className="flex min-w-0 flex-1 flex-col gap-0.5">
 								<div className="flex items-center gap-1.5">
 									{Icon ? <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" /> : null}
-									<span className="leading-snug">{option.label}</span>
+									<span className="min-w-0 break-words leading-snug">{option.label}</span>
 								</div>
 								{showDescription ? (
-									<span className="text-2xs leading-snug font-normal text-muted-foreground">
+									<span className="text-2xs min-w-0 break-words leading-snug font-normal text-muted-foreground">
 										{option.description}
 									</span>
 								) : null}

--- a/src/routes/escape-tool.tsx
+++ b/src/routes/escape-tool.tsx
@@ -264,6 +264,7 @@ function EscapeToolPage() {
 							{ value: 'named', label: 'Named (&amp;)' },
 							{ value: 'numeric', label: 'Numeric (&#38;)' },
 						]}
+						layout="stacked"
 					/>
 					<FormCheckboxGroup>
 						<FormCheckbox
@@ -334,6 +335,7 @@ function EscapeToolPage() {
 							{ value: ';', label: 'Semicolon' },
 							{ value: '\t', label: 'Tab' },
 						]}
+						layout="stacked"
 					/>
 					<FormMode<CsvEscapeOptions['quoteStyle']>
 						label="Quote style"
@@ -351,6 +353,7 @@ function EscapeToolPage() {
 								description: 'Always wrap in quotes',
 							},
 						]}
+						layout="stacked"
 					/>
 				</div>
 			);

--- a/src/routes/list-comparer.tsx
+++ b/src/routes/list-comparer.tsx
@@ -351,17 +351,7 @@ function ListComparerPage() {
 	);
 
 	return (
-		<ToolShell
-			valid={validity}
-			rail={rail}
-			statusContent={statusContent}
-			toolbarLeading={
-				<div className="flex items-center gap-2 text-sm font-semibold">
-					<ListChecks className="h-4 w-4 text-cyan-600" />
-					<span>List Comparer</span>
-				</div>
-			}
-		>
+		<ToolShell valid={validity} rail={rail} statusContent={statusContent}>
 			<div className="flex h-full flex-col gap-3 overflow-hidden p-3">
 				<div className="grid h-1/3 min-h-44 shrink-0 gap-3 sm:grid-cols-2">
 					<ListInputCard

--- a/src/routes/semver-tools.tsx
+++ b/src/routes/semver-tools.tsx
@@ -6,7 +6,6 @@ import {
 	ArrowUp,
 	Check,
 	FlaskConical,
-	GitBranch,
 	GitCompare,
 	History,
 	ListChecks,
@@ -958,12 +957,6 @@ function SemverToolsPage() {
 			onTabChange={handleTabChange}
 			valid={currentValid}
 			rail={rail}
-			toolbarLeading={
-				<div className="flex items-center gap-2 text-sm text-muted-foreground">
-					<GitBranch className="h-4 w-4" />
-					<span>SemVer Tools</span>
-				</div>
-			}
 			statusContent={statusContent}
 			renderTabContent={(tab) => {
 				if (tab === 'parse') return renderParseTab();

--- a/src/routes/string-compressor.tsx
+++ b/src/routes/string-compressor.tsx
@@ -301,6 +301,7 @@ function StringCompressorPage() {
 						<FormMode<Direction>
 							value={direction}
 							onValueChange={handleDirectionChange}
+							layout="stacked"
 							options={[
 								{ value: 'compress', label: 'Compress', description: 'Text -> bytes' },
 								{ value: 'decompress', label: 'Decompress', description: 'Bytes -> text' },
@@ -312,6 +313,7 @@ function StringCompressorPage() {
 						<FormMode<CompressionAlgorithm>
 							value={algorithm}
 							onValueChange={handleAlgorithmChange}
+							layout="stacked"
 							options={[
 								{ value: 'gzip', label: 'GZIP', description: 'RFC 1952' },
 								{ value: 'brotli', label: 'Brotli', description: 'RFC 7932' },


### PR DESCRIPTION
## Summary

Two visual regressions reported during review:

1. **SemVer Tools** and **List Comparer** rendered their page title twice in the toolbar
2. **Escape / Unescape** (CSV tab) had Separator labels (`Comma` / `Semicolon` / `Tab`) overflowing or wrapping mid-word in the 3-column rail grid

## Fixes

### Duplicate page title

`ToolBar` already injects the page title via `getPageByUrl()`. SemVer Tools and List Comparer additionally passed `toolbarLeading={<… icon + label />}` containing the same title text. Removed the redundant `toolbarLeading` on both routes so the title renders exactly once.

### FormMode stacked layout for long labels

`FormMode` already supports `layout="stacked"` (vertical card list) for cases where horizontal grid cells are too narrow for the labels. Default stays `horizontal`. Switched the following call sites to `stacked` per visual inspection:

- `Escape / Unescape` — HTML Entity form, CSV Separator, CSV Quote style
- `String Compressor` — Direction, Algorithm (descriptions force narrow cells)

Reinforced the `FormMode` label `<span>` with `min-w-0 break-words` as a safety net for any single long-word label that exceeds its card width.

## Changes

### Modified
- `src/lib/components/form/form-mode.tsx` — `min-w-0 break-words` on label/description spans, refreshed inline doc
- `src/routes/list-comparer.tsx` — drop `toolbarLeading`
- `src/routes/semver-tools.tsx` — drop `toolbarLeading` + the now-unused `GitBranch` import
- `src/routes/escape-tool.tsx` — `layout="stacked"` on HTML Entity form / CSV Separator / CSV Quote style
- `src/routes/string-compressor.tsx` — `layout="stacked"` on Direction / Algorithm

## Test plan
- [x] `bun run check` (TS + validate-pages + audit-design) green
- [x] Manual: SemVer Tools toolbar shows the title once
- [x] Manual: List Comparer toolbar shows the title once
- [x] Manual: Escape / Unescape CSV tab Separator shows `Comma` / `Semicolon` / `Tab` each on its own row, no clipping
- [x] Manual: Escape / Unescape CSV Quote style shows `Minimal` (with description) / `Always` (with description) stacked
- [x] Manual: Escape / Unescape HTML Entity form labels (`Named (&amp;)` / `Numeric (&#38;)`) wrap cleanly
- [x] Manual: String Compressor Direction / Algorithm cards stack vertically with descriptions readable
