### PR TITLE
feat(ip-converter): add IPv4 / IPv6 Address Converter tool

### DIFF
--- a/src/lib/services/ip-convert.ts
+++ b/src/lib/services/ip-convert.ts
@@ -1,0 +1,392 @@
+/**
+ * Pure helpers for the IPv4 / IPv6 Address Converter route.
+ *
+ * Handles every well-known cross-family encoding:
+ *   - IPv4-mapped IPv6 (`::ffff:a.b.c.d`)
+ *   - IPv4-compatible IPv6 (`::a.b.c.d`, deprecated by RFC 4291)
+ *   - 6to4 prefix (`2002::/16`, RFC 3056)
+ *   - Teredo (`2001::/32`, RFC 4380)
+ *   - ISATAP (`::5efe:a.b.c.d` in the low 64 bits, RFC 5214)
+ *
+ * Reuses the canonical parse / format helpers from `./cidr` so this module
+ * does not re-implement RFC 5952 compression.
+ */
+
+import { formatIp, type IpFamily, parseIp as parseIpCidr } from './cidr';
+
+export type { IpFamily };
+
+const ZERO = 0n;
+const ONE = 1n;
+const U32_MASK = (ONE << 32n) - ONE;
+const U16_MASK = 0xffffn;
+const U128_MASK = (ONE << 128n) - ONE;
+
+/* -------------------------------------------------------------------------- */
+/* Parsing                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export interface ParsedAddress {
+	readonly family: IpFamily;
+	readonly value: bigint;
+}
+
+export type ParseError = { readonly ok: false; readonly error: string };
+export type ParseResult = { readonly ok: true; readonly parsed: ParsedAddress } | ParseError;
+
+export const parseIp = (text: string): ParseResult => {
+	const trimmed = text.trim();
+	if (trimmed.length === 0) {
+		return { ok: false, error: 'Enter an IPv4 or IPv6 address.' };
+	}
+	if (trimmed.includes('/')) {
+		return {
+			ok: false,
+			error: 'Plain address only — remove the CIDR prefix (use the CIDR Calculator for prefixes).',
+		};
+	}
+	const ip = parseIpCidr(trimmed);
+	if (ip === null) {
+		return {
+			ok: false,
+			error: `Invalid IP address: "${trimmed}". Expected dotted-quad IPv4 or colon-separated IPv6.`,
+		};
+	}
+	return { ok: true, parsed: { family: ip.family, value: ip.value } };
+};
+
+/* -------------------------------------------------------------------------- */
+/* IPv6 notation normalizer                                                   */
+/* -------------------------------------------------------------------------- */
+
+export interface NormalizedIpv6 {
+	readonly compressed: string;
+	readonly expanded: string;
+	readonly mixed: string;
+}
+
+const formatIpv6Expanded = (value: bigint): string => {
+	const masked = value & U128_MASK;
+	const groups: string[] = [];
+	for (let i = 7; i >= 0; i -= 1) {
+		const shift = BigInt(i) * 16n;
+		const group = Number((masked >> shift) & U16_MASK);
+		groups.push(group.toString(16).padStart(4, '0'));
+	}
+	return groups.join(':');
+};
+
+const formatIpv6Mixed = (value: bigint): string => {
+	const masked = value & U128_MASK;
+	// Use mixed form only when the address looks like it embeds an IPv4 tail:
+	// the top 96 bits match either ::ffff:0:0/96 (mapped) or all zeros
+	// (compatible / unspecified). For everything else, fall back to the canonical
+	// compressed form so we never emit ambiguous mixed-notation hextets.
+	const top96 = masked >> 32n;
+	const v4Tail = masked & U32_MASK;
+	const ipv4Text = formatIp(v4Tail, 'ipv4');
+	if (top96 === 0xffffn) {
+		return `::ffff:${ipv4Text}`;
+	}
+	if (top96 === ZERO && v4Tail !== ZERO) {
+		return `::${ipv4Text}`;
+	}
+	return formatIp(value, 'ipv6');
+};
+
+export const normalizeIpv6 = (value: bigint): NormalizedIpv6 => ({
+	compressed: formatIp(value, 'ipv6'),
+	expanded: formatIpv6Expanded(value),
+	mixed: formatIpv6Mixed(value),
+});
+
+/* -------------------------------------------------------------------------- */
+/* Embedding detector                                                         */
+/* -------------------------------------------------------------------------- */
+
+export type EmbeddingKind =
+	| 'ipv4-mapped'
+	| 'ipv4-compatible'
+	| '6to4'
+	| 'teredo'
+	| 'isatap'
+	| 'none';
+
+export interface TeredoFlags {
+	readonly cone: boolean;
+	readonly reserved: number;
+	readonly individual: boolean;
+}
+
+export interface EmbeddingInfo {
+	readonly kind: EmbeddingKind;
+	readonly description: string;
+	readonly embeddedIpv4?: string;
+	readonly teredoServer?: string;
+	readonly teredoMappedAddress?: string;
+	readonly teredoMappedPort?: number;
+	readonly teredoFlags?: TeredoFlags;
+}
+
+const slice = (value: bigint, hiBit: number, width: number): bigint => {
+	// Extract `width` bits starting at the most significant bit `hiBit` from a
+	// 128-bit value where bit 0 is the most significant bit.
+	const lsbIndex = 128 - hiBit - width;
+	const mask = (ONE << BigInt(width)) - ONE;
+	return (value >> BigInt(lsbIndex)) & mask;
+};
+
+const detectIsatap = (value: bigint): EmbeddingInfo | null => {
+	// ISATAP places `5efe` at hextet 5 (bits 80-95) within the EUI-64 host
+	// portion, with hextet 4 (bits 64-79) being either 0000 (private) or 0200
+	// (global, after the universal/local bit flip on 0000).
+	const hextet4 = Number(slice(value, 64, 16));
+	const hextet5 = Number(slice(value, 80, 16));
+	if (hextet5 !== 0x5efe) return null;
+	if (hextet4 !== 0x0000 && hextet4 !== 0x0200) return null;
+	const v4 = slice(value, 96, 32);
+	return {
+		kind: 'isatap',
+		description: 'ISATAP interface identifier (RFC 5214): low 32 bits encode an IPv4 address.',
+		embeddedIpv4: formatIp(v4, 'ipv4'),
+	};
+};
+
+export const detectEmbedding = (value: bigint): EmbeddingInfo => {
+	const masked = value & U128_MASK;
+	const top80 = masked >> 48n;
+	const wordAt80 = Number(slice(masked, 80, 16));
+	const top96 = masked >> 32n;
+	const v4Tail = masked & U32_MASK;
+
+	if (top80 === ZERO && wordAt80 === 0xffff) {
+		return {
+			kind: 'ipv4-mapped',
+			description: 'IPv4-mapped IPv6 (::ffff:0:0/96, RFC 4291): low 32 bits hold an IPv4 address.',
+			embeddedIpv4: formatIp(v4Tail, 'ipv4'),
+		};
+	}
+
+	if (top96 === ZERO && v4Tail !== ZERO && v4Tail !== ONE) {
+		return {
+			kind: 'ipv4-compatible',
+			description:
+				'IPv4-compatible IPv6 (::/96, deprecated by RFC 4291): low 32 bits encode an IPv4 address.',
+			embeddedIpv4: formatIp(v4Tail, 'ipv4'),
+		};
+	}
+
+	const top16 = Number(slice(masked, 0, 16));
+	if (top16 === 0x2002) {
+		const v4 = slice(masked, 16, 32);
+		return {
+			kind: '6to4',
+			description:
+				'6to4 tunneling (2002::/16, RFC 3056): bits 16-47 hold the gateway IPv4 address.',
+			embeddedIpv4: formatIp(v4, 'ipv4'),
+		};
+	}
+
+	const top32 = masked >> 96n;
+	if (top32 === 0x20010000n) {
+		const serverRaw = slice(masked, 32, 32);
+		const flagsRaw = Number(slice(masked, 64, 16));
+		const portRaw = Number(slice(masked, 80, 16));
+		const clientRaw = slice(masked, 96, 32);
+		// Per RFC 4380, the mapped port and client IPv4 are XOR-obfuscated with
+		// all-ones to keep them out of NAT rewrite paths.
+		const port = portRaw ^ 0xffff;
+		const client = clientRaw ^ U32_MASK;
+		const cone = (flagsRaw & 0x8000) !== 0;
+		const individual = (flagsRaw & 0x0100) === 0;
+		const reserved = flagsRaw & 0x7eff;
+		return {
+			kind: 'teredo',
+			description:
+				'Teredo tunneling (2001::/32, RFC 4380): decomposed into server, flags, mapped port, and mapped client.',
+			teredoServer: formatIp(serverRaw, 'ipv4'),
+			teredoMappedAddress: formatIp(client, 'ipv4'),
+			teredoMappedPort: port,
+			teredoFlags: { cone, reserved, individual },
+		};
+	}
+
+	const isatap = detectIsatap(masked);
+	if (isatap !== null) return isatap;
+
+	return {
+		kind: 'none',
+		description: 'No known IPv4 embedding detected; this is a plain IPv6 address.',
+	};
+};
+
+/* -------------------------------------------------------------------------- */
+/* IPv4 -> derived representations                                            */
+/* -------------------------------------------------------------------------- */
+
+export interface ConvertedFromIpv4 {
+	readonly ipv4: string;
+	readonly mapped: string;
+	readonly compatible: string;
+	readonly sixToFour: string;
+	readonly sixToFourFull: string;
+	readonly decimalInteger: bigint;
+	readonly hexInteger: string;
+	readonly binary: string;
+}
+
+const formatBinaryV4 = (value: bigint): string => {
+	const bits = (value & U32_MASK).toString(2).padStart(32, '0');
+	return [bits.slice(0, 8), bits.slice(8, 16), bits.slice(16, 24), bits.slice(24, 32)].join('.');
+};
+
+export const convertFromIpv4 = (value: bigint): ConvertedFromIpv4 => {
+	const masked = value & U32_MASK;
+	const ipv4 = formatIp(masked, 'ipv4');
+	// Build the 6to4 prefix by placing the 32-bit IPv4 at hextets 1-2 of a
+	// 2002::/16 base, then re-format through the canonical IPv6 formatter so
+	// we always emit RFC 5952 compression.
+	const sixToFourBase = (0x2002n << 112n) | (masked << 80n);
+	const sixToFourPrefix = formatIp(sixToFourBase & U128_MASK, 'ipv6');
+	const sixToFourHost = formatIp((sixToFourBase | ONE) & U128_MASK, 'ipv6');
+	return {
+		ipv4,
+		mapped: `::ffff:${ipv4}`,
+		compatible: `::${ipv4}`,
+		sixToFour: `${sixToFourPrefix}/48`,
+		sixToFourFull: `${sixToFourHost}/64`,
+		decimalInteger: masked,
+		hexInteger: `0x${masked.toString(16).padStart(8, '0').toUpperCase()}`,
+		binary: formatBinaryV4(masked),
+	};
+};
+
+/* -------------------------------------------------------------------------- */
+/* IPv6 -> derived representations                                            */
+/* -------------------------------------------------------------------------- */
+
+export interface ConvertedFromIpv6 {
+	readonly ipv6: NormalizedIpv6;
+	readonly embedding: EmbeddingInfo;
+	readonly decimalInteger: bigint;
+	readonly hexInteger: string;
+}
+
+export const convertFromIpv6 = (value: bigint): ConvertedFromIpv6 => {
+	const masked = value & U128_MASK;
+	return {
+		ipv6: normalizeIpv6(masked),
+		embedding: detectEmbedding(masked),
+		decimalInteger: masked,
+		hexInteger: `0x${masked.toString(16).padStart(32, '0').toUpperCase()}`,
+	};
+};
+
+/* -------------------------------------------------------------------------- */
+/* Bit visualization                                                          */
+/* -------------------------------------------------------------------------- */
+
+export interface BitCell {
+	readonly value: 0 | 1;
+	readonly field?: string;
+	readonly fieldColor?: string;
+}
+
+// Field color tokens — each maps to a semantic palette in app.css. Bound here
+// so callers can render a legend that stays in sync with the bitmap.
+export const BIT_FIELD_COLORS = {
+	prefix: 'bg-info/60',
+	server: 'bg-warning/60',
+	flags: 'bg-muted-foreground/50',
+	port: 'bg-success/60',
+	client: 'bg-primary/60',
+	ipv4: 'bg-primary/60',
+	host: 'bg-muted-foreground/30',
+	zero: 'bg-muted-foreground/20',
+} as const;
+
+type FieldKey = keyof typeof BIT_FIELD_COLORS;
+
+interface FieldSpan {
+	readonly start: number;
+	readonly width: number;
+	readonly field: FieldKey;
+	readonly label: string;
+}
+
+const fieldSpansFor = (family: IpFamily, embedding: EmbeddingInfo | undefined): FieldSpan[] => {
+	if (family === 'ipv4') {
+		return [{ start: 0, width: 32, field: 'ipv4', label: 'IPv4 address' }];
+	}
+	if (!embedding || embedding.kind === 'none') {
+		return [{ start: 0, width: 128, field: 'host', label: 'IPv6 address' }];
+	}
+	if (embedding.kind === 'ipv4-mapped') {
+		return [
+			{ start: 0, width: 80, field: 'zero', label: 'Zeros (80 bits)' },
+			{ start: 80, width: 16, field: 'prefix', label: 'IPv4-mapped marker (0xffff)' },
+			{ start: 96, width: 32, field: 'ipv4', label: 'Embedded IPv4' },
+		];
+	}
+	if (embedding.kind === 'ipv4-compatible') {
+		return [
+			{ start: 0, width: 96, field: 'zero', label: 'Zeros (96 bits)' },
+			{ start: 96, width: 32, field: 'ipv4', label: 'Embedded IPv4 (deprecated)' },
+		];
+	}
+	if (embedding.kind === '6to4') {
+		return [
+			{ start: 0, width: 16, field: 'prefix', label: '6to4 prefix (0x2002)' },
+			{ start: 16, width: 32, field: 'ipv4', label: 'Gateway IPv4' },
+			{ start: 48, width: 16, field: 'flags', label: 'Subnet ID' },
+			{ start: 64, width: 64, field: 'host', label: 'Interface identifier' },
+		];
+	}
+	if (embedding.kind === 'teredo') {
+		return [
+			{ start: 0, width: 32, field: 'prefix', label: 'Teredo prefix (2001::/32)' },
+			{ start: 32, width: 32, field: 'server', label: 'Server IPv4' },
+			{ start: 64, width: 16, field: 'flags', label: 'Flags' },
+			{ start: 80, width: 16, field: 'port', label: 'Obfuscated mapped port' },
+			{ start: 96, width: 32, field: 'client', label: 'Obfuscated mapped client IPv4' },
+		];
+	}
+	// isatap
+	return [
+		{ start: 0, width: 64, field: 'host', label: 'IPv6 routing prefix + subnet' },
+		{ start: 64, width: 16, field: 'flags', label: 'Universal/local + group bits' },
+		{ start: 80, width: 16, field: 'prefix', label: 'ISATAP marker (0x5efe)' },
+		{ start: 96, width: 32, field: 'ipv4', label: 'Embedded IPv4' },
+	];
+};
+
+export const bitsFor = (
+	value: bigint,
+	family: IpFamily,
+	embedding?: EmbeddingInfo
+): readonly BitCell[] => {
+	const width = family === 'ipv4' ? 32 : 128;
+	const masked = family === 'ipv4' ? value & U32_MASK : value & U128_MASK;
+	const spans = fieldSpansFor(family, embedding);
+	return Array.from({ length: width }, (_, idx) => {
+		const span = spans.find((s) => idx >= s.start && idx < s.start + s.width);
+		const shift = BigInt(width - 1 - idx);
+		const bit = Number((masked >> shift) & ONE) as 0 | 1;
+		const key = (span?.field ?? 'host') as FieldKey;
+		return {
+			value: bit,
+			field: span?.label,
+			fieldColor: BIT_FIELD_COLORS[key],
+		};
+	});
+};
+
+/* -------------------------------------------------------------------------- */
+/* Samples                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export const SAMPLE_V4 = '192.0.2.1';
+export const SAMPLE_V6 = '2001:db8::1';
+export const SAMPLE_MAPPED = '::ffff:192.0.2.1';
+export const SAMPLE_6TO4 = '2002:c000:0201::1';
+export const SAMPLE_TEREDO = '2001:0:4136:e378:8000:63bf:3fff:fdd2';

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -427,6 +427,16 @@ export const PAGES: readonly PageDefinition[] = [
 		category: 'network',
 	},
 	{
+		id: 'ip-converter',
+		title: 'IP Address Converter',
+		url: '/ip-converter',
+		icon: Globe,
+		description:
+			'Convert between IPv4 and IPv6 with IPv4-mapped / 6to4 / Teredo embeddings and notation normalizer',
+		color: 'text-sky-600',
+		category: 'network',
+	},
+	{
 		id: 'network-interfaces',
 		title: 'Network Interfaces',
 		url: '/network-interfaces',

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -8,770 +8,791 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as YamlFormatterRouteImport } from './routes/yaml-formatter'
-import { Route as XmlFormatterRouteImport } from './routes/xml-formatter'
-import { Route as X509DecoderRouteImport } from './routes/x509-decoder'
-import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator'
-import { Route as UrlEncoderRouteImport } from './routes/url-encoder'
-import { Route as StringCompressorRouteImport } from './routes/string-compressor'
-import { Route as StringCaseConverterRouteImport } from './routes/string-case-converter'
-import { Route as SshKeyGeneratorRouteImport } from './routes/ssh-key-generator'
-import { Route as SqlFormatterRouteImport } from './routes/sql-formatter'
-import { Route as SettingsRouteImport } from './routes/settings'
-import { Route as SemverToolsRouteImport } from './routes/semver-tools'
-import { Route as RsaToolsRouteImport } from './routes/rsa-tools'
-import { Route as RegexTesterRouteImport } from './routes/regex-tester'
-import { Route as QrCodeGeneratorRouteImport } from './routes/qr-code-generator'
-import { Route as PasswordGeneratorRouteImport } from './routes/password-generator'
-import { Route as NumberBaseConverterRouteImport } from './routes/number-base-converter'
-import { Route as NetworkScannerRouteImport } from './routes/network-scanner'
-import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces'
-import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor'
-import { Route as LoremIpsumRouteImport } from './routes/lorem-ipsum'
-import { Route as ListComparerRouteImport } from './routes/list-comparer'
-import { Route as JwtDecoderRouteImport } from './routes/jwt-decoder'
-import { Route as JsonFormatterRouteImport } from './routes/json-formatter'
-import { Route as ImageConverterRouteImport } from './routes/image-converter'
-import { Route as HashGeneratorRouteImport } from './routes/hash-generator'
-import { Route as GpgKeyGeneratorRouteImport } from './routes/gpg-key-generator'
-import { Route as EscapeToolRouteImport } from './routes/escape-tool'
-import { Route as DiffViewerRouteImport } from './routes/diff-viewer'
-import { Route as DateTimestampConverterRouteImport } from './routes/date-timestamp-converter'
-import { Route as CurlBuilderRouteImport } from './routes/curl-builder'
-import { Route as CronExpressionBuilderRouteImport } from './routes/cron-expression-builder'
-import { Route as CidrCalculatorRouteImport } from './routes/cidr-calculator'
-import { Route as BcryptGeneratorRouteImport } from './routes/bcrypt-generator'
-import { Route as Base64EncoderRouteImport } from './routes/base64-encoder'
-import { Route as IndexRouteImport } from './routes/index'
+import { Route as rootRouteImport } from './routes/__root';
+import { Route as YamlFormatterRouteImport } from './routes/yaml-formatter';
+import { Route as XmlFormatterRouteImport } from './routes/xml-formatter';
+import { Route as X509DecoderRouteImport } from './routes/x509-decoder';
+import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator';
+import { Route as UrlEncoderRouteImport } from './routes/url-encoder';
+import { Route as StringCompressorRouteImport } from './routes/string-compressor';
+import { Route as StringCaseConverterRouteImport } from './routes/string-case-converter';
+import { Route as SshKeyGeneratorRouteImport } from './routes/ssh-key-generator';
+import { Route as SqlFormatterRouteImport } from './routes/sql-formatter';
+import { Route as SettingsRouteImport } from './routes/settings';
+import { Route as SemverToolsRouteImport } from './routes/semver-tools';
+import { Route as RsaToolsRouteImport } from './routes/rsa-tools';
+import { Route as RegexTesterRouteImport } from './routes/regex-tester';
+import { Route as QrCodeGeneratorRouteImport } from './routes/qr-code-generator';
+import { Route as PasswordGeneratorRouteImport } from './routes/password-generator';
+import { Route as NumberBaseConverterRouteImport } from './routes/number-base-converter';
+import { Route as NetworkScannerRouteImport } from './routes/network-scanner';
+import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces';
+import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor';
+import { Route as LoremIpsumRouteImport } from './routes/lorem-ipsum';
+import { Route as ListComparerRouteImport } from './routes/list-comparer';
+import { Route as JwtDecoderRouteImport } from './routes/jwt-decoder';
+import { Route as JsonFormatterRouteImport } from './routes/json-formatter';
+import { Route as IpConverterRouteImport } from './routes/ip-converter';
+import { Route as ImageConverterRouteImport } from './routes/image-converter';
+import { Route as HashGeneratorRouteImport } from './routes/hash-generator';
+import { Route as GpgKeyGeneratorRouteImport } from './routes/gpg-key-generator';
+import { Route as EscapeToolRouteImport } from './routes/escape-tool';
+import { Route as DiffViewerRouteImport } from './routes/diff-viewer';
+import { Route as DateTimestampConverterRouteImport } from './routes/date-timestamp-converter';
+import { Route as CurlBuilderRouteImport } from './routes/curl-builder';
+import { Route as CronExpressionBuilderRouteImport } from './routes/cron-expression-builder';
+import { Route as CidrCalculatorRouteImport } from './routes/cidr-calculator';
+import { Route as BcryptGeneratorRouteImport } from './routes/bcrypt-generator';
+import { Route as Base64EncoderRouteImport } from './routes/base64-encoder';
+import { Route as IndexRouteImport } from './routes/index';
 
 const YamlFormatterRoute = YamlFormatterRouteImport.update({
-  id: '/yaml-formatter',
-  path: '/yaml-formatter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/yaml-formatter',
+	path: '/yaml-formatter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const XmlFormatterRoute = XmlFormatterRouteImport.update({
-  id: '/xml-formatter',
-  path: '/xml-formatter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/xml-formatter',
+	path: '/xml-formatter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const X509DecoderRoute = X509DecoderRouteImport.update({
-  id: '/x509-decoder',
-  path: '/x509-decoder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/x509-decoder',
+	path: '/x509-decoder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const UuidGeneratorRoute = UuidGeneratorRouteImport.update({
-  id: '/uuid-generator',
-  path: '/uuid-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/uuid-generator',
+	path: '/uuid-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const UrlEncoderRoute = UrlEncoderRouteImport.update({
-  id: '/url-encoder',
-  path: '/url-encoder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/url-encoder',
+	path: '/url-encoder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const StringCompressorRoute = StringCompressorRouteImport.update({
-  id: '/string-compressor',
-  path: '/string-compressor',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/string-compressor',
+	path: '/string-compressor',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const StringCaseConverterRoute = StringCaseConverterRouteImport.update({
-  id: '/string-case-converter',
-  path: '/string-case-converter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/string-case-converter',
+	path: '/string-case-converter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const SshKeyGeneratorRoute = SshKeyGeneratorRouteImport.update({
-  id: '/ssh-key-generator',
-  path: '/ssh-key-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/ssh-key-generator',
+	path: '/ssh-key-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const SqlFormatterRoute = SqlFormatterRouteImport.update({
-  id: '/sql-formatter',
-  path: '/sql-formatter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/sql-formatter',
+	path: '/sql-formatter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const SettingsRoute = SettingsRouteImport.update({
-  id: '/settings',
-  path: '/settings',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/settings',
+	path: '/settings',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const SemverToolsRoute = SemverToolsRouteImport.update({
-  id: '/semver-tools',
-  path: '/semver-tools',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/semver-tools',
+	path: '/semver-tools',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const RsaToolsRoute = RsaToolsRouteImport.update({
-  id: '/rsa-tools',
-  path: '/rsa-tools',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/rsa-tools',
+	path: '/rsa-tools',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const RegexTesterRoute = RegexTesterRouteImport.update({
-  id: '/regex-tester',
-  path: '/regex-tester',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/regex-tester',
+	path: '/regex-tester',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const QrCodeGeneratorRoute = QrCodeGeneratorRouteImport.update({
-  id: '/qr-code-generator',
-  path: '/qr-code-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/qr-code-generator',
+	path: '/qr-code-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const PasswordGeneratorRoute = PasswordGeneratorRouteImport.update({
-  id: '/password-generator',
-  path: '/password-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/password-generator',
+	path: '/password-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const NumberBaseConverterRoute = NumberBaseConverterRouteImport.update({
-  id: '/number-base-converter',
-  path: '/number-base-converter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/number-base-converter',
+	path: '/number-base-converter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const NetworkScannerRoute = NetworkScannerRouteImport.update({
-  id: '/network-scanner',
-  path: '/network-scanner',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/network-scanner',
+	path: '/network-scanner',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const NetworkInterfacesRoute = NetworkInterfacesRouteImport.update({
-  id: '/network-interfaces',
-  path: '/network-interfaces',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/network-interfaces',
+	path: '/network-interfaces',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const MarkdownEditorRoute = MarkdownEditorRouteImport.update({
-  id: '/markdown-editor',
-  path: '/markdown-editor',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/markdown-editor',
+	path: '/markdown-editor',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const LoremIpsumRoute = LoremIpsumRouteImport.update({
-  id: '/lorem-ipsum',
-  path: '/lorem-ipsum',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/lorem-ipsum',
+	path: '/lorem-ipsum',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const ListComparerRoute = ListComparerRouteImport.update({
-  id: '/list-comparer',
-  path: '/list-comparer',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/list-comparer',
+	path: '/list-comparer',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const JwtDecoderRoute = JwtDecoderRouteImport.update({
-  id: '/jwt-decoder',
-  path: '/jwt-decoder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/jwt-decoder',
+	path: '/jwt-decoder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const JsonFormatterRoute = JsonFormatterRouteImport.update({
-  id: '/json-formatter',
-  path: '/json-formatter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/json-formatter',
+	path: '/json-formatter',
+	getParentRoute: () => rootRouteImport,
+} as any);
+const IpConverterRoute = IpConverterRouteImport.update({
+	id: '/ip-converter',
+	path: '/ip-converter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const ImageConverterRoute = ImageConverterRouteImport.update({
-  id: '/image-converter',
-  path: '/image-converter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/image-converter',
+	path: '/image-converter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const HashGeneratorRoute = HashGeneratorRouteImport.update({
-  id: '/hash-generator',
-  path: '/hash-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/hash-generator',
+	path: '/hash-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const GpgKeyGeneratorRoute = GpgKeyGeneratorRouteImport.update({
-  id: '/gpg-key-generator',
-  path: '/gpg-key-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/gpg-key-generator',
+	path: '/gpg-key-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const EscapeToolRoute = EscapeToolRouteImport.update({
-  id: '/escape-tool',
-  path: '/escape-tool',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/escape-tool',
+	path: '/escape-tool',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const DiffViewerRoute = DiffViewerRouteImport.update({
-  id: '/diff-viewer',
-  path: '/diff-viewer',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/diff-viewer',
+	path: '/diff-viewer',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const DateTimestampConverterRoute = DateTimestampConverterRouteImport.update({
-  id: '/date-timestamp-converter',
-  path: '/date-timestamp-converter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/date-timestamp-converter',
+	path: '/date-timestamp-converter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const CurlBuilderRoute = CurlBuilderRouteImport.update({
-  id: '/curl-builder',
-  path: '/curl-builder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/curl-builder',
+	path: '/curl-builder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const CronExpressionBuilderRoute = CronExpressionBuilderRouteImport.update({
-  id: '/cron-expression-builder',
-  path: '/cron-expression-builder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/cron-expression-builder',
+	path: '/cron-expression-builder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const CidrCalculatorRoute = CidrCalculatorRouteImport.update({
-  id: '/cidr-calculator',
-  path: '/cidr-calculator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/cidr-calculator',
+	path: '/cidr-calculator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const BcryptGeneratorRoute = BcryptGeneratorRouteImport.update({
-  id: '/bcrypt-generator',
-  path: '/bcrypt-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/bcrypt-generator',
+	path: '/bcrypt-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const Base64EncoderRoute = Base64EncoderRouteImport.update({
-  id: '/base64-encoder',
-  path: '/base64-encoder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/base64-encoder',
+	path: '/base64-encoder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/',
+	path: '/',
+	getParentRoute: () => rootRouteImport,
+} as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/base64-encoder': typeof Base64EncoderRoute
-  '/bcrypt-generator': typeof BcryptGeneratorRoute
-  '/cidr-calculator': typeof CidrCalculatorRoute
-  '/cron-expression-builder': typeof CronExpressionBuilderRoute
-  '/curl-builder': typeof CurlBuilderRoute
-  '/date-timestamp-converter': typeof DateTimestampConverterRoute
-  '/diff-viewer': typeof DiffViewerRoute
-  '/escape-tool': typeof EscapeToolRoute
-  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
-  '/hash-generator': typeof HashGeneratorRoute
-  '/image-converter': typeof ImageConverterRoute
-  '/json-formatter': typeof JsonFormatterRoute
-  '/jwt-decoder': typeof JwtDecoderRoute
-  '/list-comparer': typeof ListComparerRoute
-  '/lorem-ipsum': typeof LoremIpsumRoute
-  '/markdown-editor': typeof MarkdownEditorRoute
-  '/network-interfaces': typeof NetworkInterfacesRoute
-  '/network-scanner': typeof NetworkScannerRoute
-  '/number-base-converter': typeof NumberBaseConverterRoute
-  '/password-generator': typeof PasswordGeneratorRoute
-  '/qr-code-generator': typeof QrCodeGeneratorRoute
-  '/regex-tester': typeof RegexTesterRoute
-  '/rsa-tools': typeof RsaToolsRoute
-  '/semver-tools': typeof SemverToolsRoute
-  '/settings': typeof SettingsRoute
-  '/sql-formatter': typeof SqlFormatterRoute
-  '/ssh-key-generator': typeof SshKeyGeneratorRoute
-  '/string-case-converter': typeof StringCaseConverterRoute
-  '/string-compressor': typeof StringCompressorRoute
-  '/url-encoder': typeof UrlEncoderRoute
-  '/uuid-generator': typeof UuidGeneratorRoute
-  '/x509-decoder': typeof X509DecoderRoute
-  '/xml-formatter': typeof XmlFormatterRoute
-  '/yaml-formatter': typeof YamlFormatterRoute
+	'/': typeof IndexRoute;
+	'/base64-encoder': typeof Base64EncoderRoute;
+	'/bcrypt-generator': typeof BcryptGeneratorRoute;
+	'/cidr-calculator': typeof CidrCalculatorRoute;
+	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
+	'/curl-builder': typeof CurlBuilderRoute;
+	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
+	'/diff-viewer': typeof DiffViewerRoute;
+	'/escape-tool': typeof EscapeToolRoute;
+	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
+	'/hash-generator': typeof HashGeneratorRoute;
+	'/image-converter': typeof ImageConverterRoute;
+	'/ip-converter': typeof IpConverterRoute;
+	'/json-formatter': typeof JsonFormatterRoute;
+	'/jwt-decoder': typeof JwtDecoderRoute;
+	'/list-comparer': typeof ListComparerRoute;
+	'/lorem-ipsum': typeof LoremIpsumRoute;
+	'/markdown-editor': typeof MarkdownEditorRoute;
+	'/network-interfaces': typeof NetworkInterfacesRoute;
+	'/network-scanner': typeof NetworkScannerRoute;
+	'/number-base-converter': typeof NumberBaseConverterRoute;
+	'/password-generator': typeof PasswordGeneratorRoute;
+	'/qr-code-generator': typeof QrCodeGeneratorRoute;
+	'/regex-tester': typeof RegexTesterRoute;
+	'/rsa-tools': typeof RsaToolsRoute;
+	'/semver-tools': typeof SemverToolsRoute;
+	'/settings': typeof SettingsRoute;
+	'/sql-formatter': typeof SqlFormatterRoute;
+	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
+	'/string-case-converter': typeof StringCaseConverterRoute;
+	'/string-compressor': typeof StringCompressorRoute;
+	'/url-encoder': typeof UrlEncoderRoute;
+	'/uuid-generator': typeof UuidGeneratorRoute;
+	'/x509-decoder': typeof X509DecoderRoute;
+	'/xml-formatter': typeof XmlFormatterRoute;
+	'/yaml-formatter': typeof YamlFormatterRoute;
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/base64-encoder': typeof Base64EncoderRoute
-  '/bcrypt-generator': typeof BcryptGeneratorRoute
-  '/cidr-calculator': typeof CidrCalculatorRoute
-  '/cron-expression-builder': typeof CronExpressionBuilderRoute
-  '/curl-builder': typeof CurlBuilderRoute
-  '/date-timestamp-converter': typeof DateTimestampConverterRoute
-  '/diff-viewer': typeof DiffViewerRoute
-  '/escape-tool': typeof EscapeToolRoute
-  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
-  '/hash-generator': typeof HashGeneratorRoute
-  '/image-converter': typeof ImageConverterRoute
-  '/json-formatter': typeof JsonFormatterRoute
-  '/jwt-decoder': typeof JwtDecoderRoute
-  '/list-comparer': typeof ListComparerRoute
-  '/lorem-ipsum': typeof LoremIpsumRoute
-  '/markdown-editor': typeof MarkdownEditorRoute
-  '/network-interfaces': typeof NetworkInterfacesRoute
-  '/network-scanner': typeof NetworkScannerRoute
-  '/number-base-converter': typeof NumberBaseConverterRoute
-  '/password-generator': typeof PasswordGeneratorRoute
-  '/qr-code-generator': typeof QrCodeGeneratorRoute
-  '/regex-tester': typeof RegexTesterRoute
-  '/rsa-tools': typeof RsaToolsRoute
-  '/semver-tools': typeof SemverToolsRoute
-  '/settings': typeof SettingsRoute
-  '/sql-formatter': typeof SqlFormatterRoute
-  '/ssh-key-generator': typeof SshKeyGeneratorRoute
-  '/string-case-converter': typeof StringCaseConverterRoute
-  '/string-compressor': typeof StringCompressorRoute
-  '/url-encoder': typeof UrlEncoderRoute
-  '/uuid-generator': typeof UuidGeneratorRoute
-  '/x509-decoder': typeof X509DecoderRoute
-  '/xml-formatter': typeof XmlFormatterRoute
-  '/yaml-formatter': typeof YamlFormatterRoute
+	'/': typeof IndexRoute;
+	'/base64-encoder': typeof Base64EncoderRoute;
+	'/bcrypt-generator': typeof BcryptGeneratorRoute;
+	'/cidr-calculator': typeof CidrCalculatorRoute;
+	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
+	'/curl-builder': typeof CurlBuilderRoute;
+	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
+	'/diff-viewer': typeof DiffViewerRoute;
+	'/escape-tool': typeof EscapeToolRoute;
+	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
+	'/hash-generator': typeof HashGeneratorRoute;
+	'/image-converter': typeof ImageConverterRoute;
+	'/ip-converter': typeof IpConverterRoute;
+	'/json-formatter': typeof JsonFormatterRoute;
+	'/jwt-decoder': typeof JwtDecoderRoute;
+	'/list-comparer': typeof ListComparerRoute;
+	'/lorem-ipsum': typeof LoremIpsumRoute;
+	'/markdown-editor': typeof MarkdownEditorRoute;
+	'/network-interfaces': typeof NetworkInterfacesRoute;
+	'/network-scanner': typeof NetworkScannerRoute;
+	'/number-base-converter': typeof NumberBaseConverterRoute;
+	'/password-generator': typeof PasswordGeneratorRoute;
+	'/qr-code-generator': typeof QrCodeGeneratorRoute;
+	'/regex-tester': typeof RegexTesterRoute;
+	'/rsa-tools': typeof RsaToolsRoute;
+	'/semver-tools': typeof SemverToolsRoute;
+	'/settings': typeof SettingsRoute;
+	'/sql-formatter': typeof SqlFormatterRoute;
+	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
+	'/string-case-converter': typeof StringCaseConverterRoute;
+	'/string-compressor': typeof StringCompressorRoute;
+	'/url-encoder': typeof UrlEncoderRoute;
+	'/uuid-generator': typeof UuidGeneratorRoute;
+	'/x509-decoder': typeof X509DecoderRoute;
+	'/xml-formatter': typeof XmlFormatterRoute;
+	'/yaml-formatter': typeof YamlFormatterRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/base64-encoder': typeof Base64EncoderRoute
-  '/bcrypt-generator': typeof BcryptGeneratorRoute
-  '/cidr-calculator': typeof CidrCalculatorRoute
-  '/cron-expression-builder': typeof CronExpressionBuilderRoute
-  '/curl-builder': typeof CurlBuilderRoute
-  '/date-timestamp-converter': typeof DateTimestampConverterRoute
-  '/diff-viewer': typeof DiffViewerRoute
-  '/escape-tool': typeof EscapeToolRoute
-  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
-  '/hash-generator': typeof HashGeneratorRoute
-  '/image-converter': typeof ImageConverterRoute
-  '/json-formatter': typeof JsonFormatterRoute
-  '/jwt-decoder': typeof JwtDecoderRoute
-  '/list-comparer': typeof ListComparerRoute
-  '/lorem-ipsum': typeof LoremIpsumRoute
-  '/markdown-editor': typeof MarkdownEditorRoute
-  '/network-interfaces': typeof NetworkInterfacesRoute
-  '/network-scanner': typeof NetworkScannerRoute
-  '/number-base-converter': typeof NumberBaseConverterRoute
-  '/password-generator': typeof PasswordGeneratorRoute
-  '/qr-code-generator': typeof QrCodeGeneratorRoute
-  '/regex-tester': typeof RegexTesterRoute
-  '/rsa-tools': typeof RsaToolsRoute
-  '/semver-tools': typeof SemverToolsRoute
-  '/settings': typeof SettingsRoute
-  '/sql-formatter': typeof SqlFormatterRoute
-  '/ssh-key-generator': typeof SshKeyGeneratorRoute
-  '/string-case-converter': typeof StringCaseConverterRoute
-  '/string-compressor': typeof StringCompressorRoute
-  '/url-encoder': typeof UrlEncoderRoute
-  '/uuid-generator': typeof UuidGeneratorRoute
-  '/x509-decoder': typeof X509DecoderRoute
-  '/xml-formatter': typeof XmlFormatterRoute
-  '/yaml-formatter': typeof YamlFormatterRoute
+	__root__: typeof rootRouteImport;
+	'/': typeof IndexRoute;
+	'/base64-encoder': typeof Base64EncoderRoute;
+	'/bcrypt-generator': typeof BcryptGeneratorRoute;
+	'/cidr-calculator': typeof CidrCalculatorRoute;
+	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
+	'/curl-builder': typeof CurlBuilderRoute;
+	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
+	'/diff-viewer': typeof DiffViewerRoute;
+	'/escape-tool': typeof EscapeToolRoute;
+	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
+	'/hash-generator': typeof HashGeneratorRoute;
+	'/image-converter': typeof ImageConverterRoute;
+	'/ip-converter': typeof IpConverterRoute;
+	'/json-formatter': typeof JsonFormatterRoute;
+	'/jwt-decoder': typeof JwtDecoderRoute;
+	'/list-comparer': typeof ListComparerRoute;
+	'/lorem-ipsum': typeof LoremIpsumRoute;
+	'/markdown-editor': typeof MarkdownEditorRoute;
+	'/network-interfaces': typeof NetworkInterfacesRoute;
+	'/network-scanner': typeof NetworkScannerRoute;
+	'/number-base-converter': typeof NumberBaseConverterRoute;
+	'/password-generator': typeof PasswordGeneratorRoute;
+	'/qr-code-generator': typeof QrCodeGeneratorRoute;
+	'/regex-tester': typeof RegexTesterRoute;
+	'/rsa-tools': typeof RsaToolsRoute;
+	'/semver-tools': typeof SemverToolsRoute;
+	'/settings': typeof SettingsRoute;
+	'/sql-formatter': typeof SqlFormatterRoute;
+	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
+	'/string-case-converter': typeof StringCaseConverterRoute;
+	'/string-compressor': typeof StringCompressorRoute;
+	'/url-encoder': typeof UrlEncoderRoute;
+	'/uuid-generator': typeof UuidGeneratorRoute;
+	'/x509-decoder': typeof X509DecoderRoute;
+	'/xml-formatter': typeof XmlFormatterRoute;
+	'/yaml-formatter': typeof YamlFormatterRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths:
-    | '/'
-    | '/base64-encoder'
-    | '/bcrypt-generator'
-    | '/cidr-calculator'
-    | '/cron-expression-builder'
-    | '/curl-builder'
-    | '/date-timestamp-converter'
-    | '/diff-viewer'
-    | '/escape-tool'
-    | '/gpg-key-generator'
-    | '/hash-generator'
-    | '/image-converter'
-    | '/json-formatter'
-    | '/jwt-decoder'
-    | '/list-comparer'
-    | '/lorem-ipsum'
-    | '/markdown-editor'
-    | '/network-interfaces'
-    | '/network-scanner'
-    | '/number-base-converter'
-    | '/password-generator'
-    | '/qr-code-generator'
-    | '/regex-tester'
-    | '/rsa-tools'
-    | '/semver-tools'
-    | '/settings'
-    | '/sql-formatter'
-    | '/ssh-key-generator'
-    | '/string-case-converter'
-    | '/string-compressor'
-    | '/url-encoder'
-    | '/uuid-generator'
-    | '/x509-decoder'
-    | '/xml-formatter'
-    | '/yaml-formatter'
-  fileRoutesByTo: FileRoutesByTo
-  to:
-    | '/'
-    | '/base64-encoder'
-    | '/bcrypt-generator'
-    | '/cidr-calculator'
-    | '/cron-expression-builder'
-    | '/curl-builder'
-    | '/date-timestamp-converter'
-    | '/diff-viewer'
-    | '/escape-tool'
-    | '/gpg-key-generator'
-    | '/hash-generator'
-    | '/image-converter'
-    | '/json-formatter'
-    | '/jwt-decoder'
-    | '/list-comparer'
-    | '/lorem-ipsum'
-    | '/markdown-editor'
-    | '/network-interfaces'
-    | '/network-scanner'
-    | '/number-base-converter'
-    | '/password-generator'
-    | '/qr-code-generator'
-    | '/regex-tester'
-    | '/rsa-tools'
-    | '/semver-tools'
-    | '/settings'
-    | '/sql-formatter'
-    | '/ssh-key-generator'
-    | '/string-case-converter'
-    | '/string-compressor'
-    | '/url-encoder'
-    | '/uuid-generator'
-    | '/x509-decoder'
-    | '/xml-formatter'
-    | '/yaml-formatter'
-  id:
-    | '__root__'
-    | '/'
-    | '/base64-encoder'
-    | '/bcrypt-generator'
-    | '/cidr-calculator'
-    | '/cron-expression-builder'
-    | '/curl-builder'
-    | '/date-timestamp-converter'
-    | '/diff-viewer'
-    | '/escape-tool'
-    | '/gpg-key-generator'
-    | '/hash-generator'
-    | '/image-converter'
-    | '/json-formatter'
-    | '/jwt-decoder'
-    | '/list-comparer'
-    | '/lorem-ipsum'
-    | '/markdown-editor'
-    | '/network-interfaces'
-    | '/network-scanner'
-    | '/number-base-converter'
-    | '/password-generator'
-    | '/qr-code-generator'
-    | '/regex-tester'
-    | '/rsa-tools'
-    | '/semver-tools'
-    | '/settings'
-    | '/sql-formatter'
-    | '/ssh-key-generator'
-    | '/string-case-converter'
-    | '/string-compressor'
-    | '/url-encoder'
-    | '/uuid-generator'
-    | '/x509-decoder'
-    | '/xml-formatter'
-    | '/yaml-formatter'
-  fileRoutesById: FileRoutesById
+	fileRoutesByFullPath: FileRoutesByFullPath;
+	fullPaths:
+		| '/'
+		| '/base64-encoder'
+		| '/bcrypt-generator'
+		| '/cidr-calculator'
+		| '/cron-expression-builder'
+		| '/curl-builder'
+		| '/date-timestamp-converter'
+		| '/diff-viewer'
+		| '/escape-tool'
+		| '/gpg-key-generator'
+		| '/hash-generator'
+		| '/image-converter'
+		| '/ip-converter'
+		| '/json-formatter'
+		| '/jwt-decoder'
+		| '/list-comparer'
+		| '/lorem-ipsum'
+		| '/markdown-editor'
+		| '/network-interfaces'
+		| '/network-scanner'
+		| '/number-base-converter'
+		| '/password-generator'
+		| '/qr-code-generator'
+		| '/regex-tester'
+		| '/rsa-tools'
+		| '/semver-tools'
+		| '/settings'
+		| '/sql-formatter'
+		| '/ssh-key-generator'
+		| '/string-case-converter'
+		| '/string-compressor'
+		| '/url-encoder'
+		| '/uuid-generator'
+		| '/x509-decoder'
+		| '/xml-formatter'
+		| '/yaml-formatter';
+	fileRoutesByTo: FileRoutesByTo;
+	to:
+		| '/'
+		| '/base64-encoder'
+		| '/bcrypt-generator'
+		| '/cidr-calculator'
+		| '/cron-expression-builder'
+		| '/curl-builder'
+		| '/date-timestamp-converter'
+		| '/diff-viewer'
+		| '/escape-tool'
+		| '/gpg-key-generator'
+		| '/hash-generator'
+		| '/image-converter'
+		| '/ip-converter'
+		| '/json-formatter'
+		| '/jwt-decoder'
+		| '/list-comparer'
+		| '/lorem-ipsum'
+		| '/markdown-editor'
+		| '/network-interfaces'
+		| '/network-scanner'
+		| '/number-base-converter'
+		| '/password-generator'
+		| '/qr-code-generator'
+		| '/regex-tester'
+		| '/rsa-tools'
+		| '/semver-tools'
+		| '/settings'
+		| '/sql-formatter'
+		| '/ssh-key-generator'
+		| '/string-case-converter'
+		| '/string-compressor'
+		| '/url-encoder'
+		| '/uuid-generator'
+		| '/x509-decoder'
+		| '/xml-formatter'
+		| '/yaml-formatter';
+	id:
+		| '__root__'
+		| '/'
+		| '/base64-encoder'
+		| '/bcrypt-generator'
+		| '/cidr-calculator'
+		| '/cron-expression-builder'
+		| '/curl-builder'
+		| '/date-timestamp-converter'
+		| '/diff-viewer'
+		| '/escape-tool'
+		| '/gpg-key-generator'
+		| '/hash-generator'
+		| '/image-converter'
+		| '/ip-converter'
+		| '/json-formatter'
+		| '/jwt-decoder'
+		| '/list-comparer'
+		| '/lorem-ipsum'
+		| '/markdown-editor'
+		| '/network-interfaces'
+		| '/network-scanner'
+		| '/number-base-converter'
+		| '/password-generator'
+		| '/qr-code-generator'
+		| '/regex-tester'
+		| '/rsa-tools'
+		| '/semver-tools'
+		| '/settings'
+		| '/sql-formatter'
+		| '/ssh-key-generator'
+		| '/string-case-converter'
+		| '/string-compressor'
+		| '/url-encoder'
+		| '/uuid-generator'
+		| '/x509-decoder'
+		| '/xml-formatter'
+		| '/yaml-formatter';
+	fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  Base64EncoderRoute: typeof Base64EncoderRoute
-  BcryptGeneratorRoute: typeof BcryptGeneratorRoute
-  CidrCalculatorRoute: typeof CidrCalculatorRoute
-  CronExpressionBuilderRoute: typeof CronExpressionBuilderRoute
-  CurlBuilderRoute: typeof CurlBuilderRoute
-  DateTimestampConverterRoute: typeof DateTimestampConverterRoute
-  DiffViewerRoute: typeof DiffViewerRoute
-  EscapeToolRoute: typeof EscapeToolRoute
-  GpgKeyGeneratorRoute: typeof GpgKeyGeneratorRoute
-  HashGeneratorRoute: typeof HashGeneratorRoute
-  ImageConverterRoute: typeof ImageConverterRoute
-  JsonFormatterRoute: typeof JsonFormatterRoute
-  JwtDecoderRoute: typeof JwtDecoderRoute
-  ListComparerRoute: typeof ListComparerRoute
-  LoremIpsumRoute: typeof LoremIpsumRoute
-  MarkdownEditorRoute: typeof MarkdownEditorRoute
-  NetworkInterfacesRoute: typeof NetworkInterfacesRoute
-  NetworkScannerRoute: typeof NetworkScannerRoute
-  NumberBaseConverterRoute: typeof NumberBaseConverterRoute
-  PasswordGeneratorRoute: typeof PasswordGeneratorRoute
-  QrCodeGeneratorRoute: typeof QrCodeGeneratorRoute
-  RegexTesterRoute: typeof RegexTesterRoute
-  RsaToolsRoute: typeof RsaToolsRoute
-  SemverToolsRoute: typeof SemverToolsRoute
-  SettingsRoute: typeof SettingsRoute
-  SqlFormatterRoute: typeof SqlFormatterRoute
-  SshKeyGeneratorRoute: typeof SshKeyGeneratorRoute
-  StringCaseConverterRoute: typeof StringCaseConverterRoute
-  StringCompressorRoute: typeof StringCompressorRoute
-  UrlEncoderRoute: typeof UrlEncoderRoute
-  UuidGeneratorRoute: typeof UuidGeneratorRoute
-  X509DecoderRoute: typeof X509DecoderRoute
-  XmlFormatterRoute: typeof XmlFormatterRoute
-  YamlFormatterRoute: typeof YamlFormatterRoute
+	IndexRoute: typeof IndexRoute;
+	Base64EncoderRoute: typeof Base64EncoderRoute;
+	BcryptGeneratorRoute: typeof BcryptGeneratorRoute;
+	CidrCalculatorRoute: typeof CidrCalculatorRoute;
+	CronExpressionBuilderRoute: typeof CronExpressionBuilderRoute;
+	CurlBuilderRoute: typeof CurlBuilderRoute;
+	DateTimestampConverterRoute: typeof DateTimestampConverterRoute;
+	DiffViewerRoute: typeof DiffViewerRoute;
+	EscapeToolRoute: typeof EscapeToolRoute;
+	GpgKeyGeneratorRoute: typeof GpgKeyGeneratorRoute;
+	HashGeneratorRoute: typeof HashGeneratorRoute;
+	ImageConverterRoute: typeof ImageConverterRoute;
+	IpConverterRoute: typeof IpConverterRoute;
+	JsonFormatterRoute: typeof JsonFormatterRoute;
+	JwtDecoderRoute: typeof JwtDecoderRoute;
+	ListComparerRoute: typeof ListComparerRoute;
+	LoremIpsumRoute: typeof LoremIpsumRoute;
+	MarkdownEditorRoute: typeof MarkdownEditorRoute;
+	NetworkInterfacesRoute: typeof NetworkInterfacesRoute;
+	NetworkScannerRoute: typeof NetworkScannerRoute;
+	NumberBaseConverterRoute: typeof NumberBaseConverterRoute;
+	PasswordGeneratorRoute: typeof PasswordGeneratorRoute;
+	QrCodeGeneratorRoute: typeof QrCodeGeneratorRoute;
+	RegexTesterRoute: typeof RegexTesterRoute;
+	RsaToolsRoute: typeof RsaToolsRoute;
+	SemverToolsRoute: typeof SemverToolsRoute;
+	SettingsRoute: typeof SettingsRoute;
+	SqlFormatterRoute: typeof SqlFormatterRoute;
+	SshKeyGeneratorRoute: typeof SshKeyGeneratorRoute;
+	StringCaseConverterRoute: typeof StringCaseConverterRoute;
+	StringCompressorRoute: typeof StringCompressorRoute;
+	UrlEncoderRoute: typeof UrlEncoderRoute;
+	UuidGeneratorRoute: typeof UuidGeneratorRoute;
+	X509DecoderRoute: typeof X509DecoderRoute;
+	XmlFormatterRoute: typeof XmlFormatterRoute;
+	YamlFormatterRoute: typeof YamlFormatterRoute;
 }
 
 declare module '@tanstack/react-router' {
-  interface FileRoutesByPath {
-    '/yaml-formatter': {
-      id: '/yaml-formatter'
-      path: '/yaml-formatter'
-      fullPath: '/yaml-formatter'
-      preLoaderRoute: typeof YamlFormatterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/xml-formatter': {
-      id: '/xml-formatter'
-      path: '/xml-formatter'
-      fullPath: '/xml-formatter'
-      preLoaderRoute: typeof XmlFormatterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/x509-decoder': {
-      id: '/x509-decoder'
-      path: '/x509-decoder'
-      fullPath: '/x509-decoder'
-      preLoaderRoute: typeof X509DecoderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/uuid-generator': {
-      id: '/uuid-generator'
-      path: '/uuid-generator'
-      fullPath: '/uuid-generator'
-      preLoaderRoute: typeof UuidGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/url-encoder': {
-      id: '/url-encoder'
-      path: '/url-encoder'
-      fullPath: '/url-encoder'
-      preLoaderRoute: typeof UrlEncoderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/string-compressor': {
-      id: '/string-compressor'
-      path: '/string-compressor'
-      fullPath: '/string-compressor'
-      preLoaderRoute: typeof StringCompressorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/string-case-converter': {
-      id: '/string-case-converter'
-      path: '/string-case-converter'
-      fullPath: '/string-case-converter'
-      preLoaderRoute: typeof StringCaseConverterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/ssh-key-generator': {
-      id: '/ssh-key-generator'
-      path: '/ssh-key-generator'
-      fullPath: '/ssh-key-generator'
-      preLoaderRoute: typeof SshKeyGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/sql-formatter': {
-      id: '/sql-formatter'
-      path: '/sql-formatter'
-      fullPath: '/sql-formatter'
-      preLoaderRoute: typeof SqlFormatterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/settings': {
-      id: '/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof SettingsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/semver-tools': {
-      id: '/semver-tools'
-      path: '/semver-tools'
-      fullPath: '/semver-tools'
-      preLoaderRoute: typeof SemverToolsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/rsa-tools': {
-      id: '/rsa-tools'
-      path: '/rsa-tools'
-      fullPath: '/rsa-tools'
-      preLoaderRoute: typeof RsaToolsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/regex-tester': {
-      id: '/regex-tester'
-      path: '/regex-tester'
-      fullPath: '/regex-tester'
-      preLoaderRoute: typeof RegexTesterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/qr-code-generator': {
-      id: '/qr-code-generator'
-      path: '/qr-code-generator'
-      fullPath: '/qr-code-generator'
-      preLoaderRoute: typeof QrCodeGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/password-generator': {
-      id: '/password-generator'
-      path: '/password-generator'
-      fullPath: '/password-generator'
-      preLoaderRoute: typeof PasswordGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/number-base-converter': {
-      id: '/number-base-converter'
-      path: '/number-base-converter'
-      fullPath: '/number-base-converter'
-      preLoaderRoute: typeof NumberBaseConverterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/network-scanner': {
-      id: '/network-scanner'
-      path: '/network-scanner'
-      fullPath: '/network-scanner'
-      preLoaderRoute: typeof NetworkScannerRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/network-interfaces': {
-      id: '/network-interfaces'
-      path: '/network-interfaces'
-      fullPath: '/network-interfaces'
-      preLoaderRoute: typeof NetworkInterfacesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/markdown-editor': {
-      id: '/markdown-editor'
-      path: '/markdown-editor'
-      fullPath: '/markdown-editor'
-      preLoaderRoute: typeof MarkdownEditorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/lorem-ipsum': {
-      id: '/lorem-ipsum'
-      path: '/lorem-ipsum'
-      fullPath: '/lorem-ipsum'
-      preLoaderRoute: typeof LoremIpsumRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/list-comparer': {
-      id: '/list-comparer'
-      path: '/list-comparer'
-      fullPath: '/list-comparer'
-      preLoaderRoute: typeof ListComparerRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/jwt-decoder': {
-      id: '/jwt-decoder'
-      path: '/jwt-decoder'
-      fullPath: '/jwt-decoder'
-      preLoaderRoute: typeof JwtDecoderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/json-formatter': {
-      id: '/json-formatter'
-      path: '/json-formatter'
-      fullPath: '/json-formatter'
-      preLoaderRoute: typeof JsonFormatterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/image-converter': {
-      id: '/image-converter'
-      path: '/image-converter'
-      fullPath: '/image-converter'
-      preLoaderRoute: typeof ImageConverterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/hash-generator': {
-      id: '/hash-generator'
-      path: '/hash-generator'
-      fullPath: '/hash-generator'
-      preLoaderRoute: typeof HashGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/gpg-key-generator': {
-      id: '/gpg-key-generator'
-      path: '/gpg-key-generator'
-      fullPath: '/gpg-key-generator'
-      preLoaderRoute: typeof GpgKeyGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/escape-tool': {
-      id: '/escape-tool'
-      path: '/escape-tool'
-      fullPath: '/escape-tool'
-      preLoaderRoute: typeof EscapeToolRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/diff-viewer': {
-      id: '/diff-viewer'
-      path: '/diff-viewer'
-      fullPath: '/diff-viewer'
-      preLoaderRoute: typeof DiffViewerRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/date-timestamp-converter': {
-      id: '/date-timestamp-converter'
-      path: '/date-timestamp-converter'
-      fullPath: '/date-timestamp-converter'
-      preLoaderRoute: typeof DateTimestampConverterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/curl-builder': {
-      id: '/curl-builder'
-      path: '/curl-builder'
-      fullPath: '/curl-builder'
-      preLoaderRoute: typeof CurlBuilderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/cron-expression-builder': {
-      id: '/cron-expression-builder'
-      path: '/cron-expression-builder'
-      fullPath: '/cron-expression-builder'
-      preLoaderRoute: typeof CronExpressionBuilderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/cidr-calculator': {
-      id: '/cidr-calculator'
-      path: '/cidr-calculator'
-      fullPath: '/cidr-calculator'
-      preLoaderRoute: typeof CidrCalculatorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/bcrypt-generator': {
-      id: '/bcrypt-generator'
-      path: '/bcrypt-generator'
-      fullPath: '/bcrypt-generator'
-      preLoaderRoute: typeof BcryptGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/base64-encoder': {
-      id: '/base64-encoder'
-      path: '/base64-encoder'
-      fullPath: '/base64-encoder'
-      preLoaderRoute: typeof Base64EncoderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-  }
+	interface FileRoutesByPath {
+		'/yaml-formatter': {
+			id: '/yaml-formatter';
+			path: '/yaml-formatter';
+			fullPath: '/yaml-formatter';
+			preLoaderRoute: typeof YamlFormatterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/xml-formatter': {
+			id: '/xml-formatter';
+			path: '/xml-formatter';
+			fullPath: '/xml-formatter';
+			preLoaderRoute: typeof XmlFormatterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/x509-decoder': {
+			id: '/x509-decoder';
+			path: '/x509-decoder';
+			fullPath: '/x509-decoder';
+			preLoaderRoute: typeof X509DecoderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/uuid-generator': {
+			id: '/uuid-generator';
+			path: '/uuid-generator';
+			fullPath: '/uuid-generator';
+			preLoaderRoute: typeof UuidGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/url-encoder': {
+			id: '/url-encoder';
+			path: '/url-encoder';
+			fullPath: '/url-encoder';
+			preLoaderRoute: typeof UrlEncoderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/string-compressor': {
+			id: '/string-compressor';
+			path: '/string-compressor';
+			fullPath: '/string-compressor';
+			preLoaderRoute: typeof StringCompressorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/string-case-converter': {
+			id: '/string-case-converter';
+			path: '/string-case-converter';
+			fullPath: '/string-case-converter';
+			preLoaderRoute: typeof StringCaseConverterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/ssh-key-generator': {
+			id: '/ssh-key-generator';
+			path: '/ssh-key-generator';
+			fullPath: '/ssh-key-generator';
+			preLoaderRoute: typeof SshKeyGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/sql-formatter': {
+			id: '/sql-formatter';
+			path: '/sql-formatter';
+			fullPath: '/sql-formatter';
+			preLoaderRoute: typeof SqlFormatterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/settings': {
+			id: '/settings';
+			path: '/settings';
+			fullPath: '/settings';
+			preLoaderRoute: typeof SettingsRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/semver-tools': {
+			id: '/semver-tools';
+			path: '/semver-tools';
+			fullPath: '/semver-tools';
+			preLoaderRoute: typeof SemverToolsRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/rsa-tools': {
+			id: '/rsa-tools';
+			path: '/rsa-tools';
+			fullPath: '/rsa-tools';
+			preLoaderRoute: typeof RsaToolsRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/regex-tester': {
+			id: '/regex-tester';
+			path: '/regex-tester';
+			fullPath: '/regex-tester';
+			preLoaderRoute: typeof RegexTesterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/qr-code-generator': {
+			id: '/qr-code-generator';
+			path: '/qr-code-generator';
+			fullPath: '/qr-code-generator';
+			preLoaderRoute: typeof QrCodeGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/password-generator': {
+			id: '/password-generator';
+			path: '/password-generator';
+			fullPath: '/password-generator';
+			preLoaderRoute: typeof PasswordGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/number-base-converter': {
+			id: '/number-base-converter';
+			path: '/number-base-converter';
+			fullPath: '/number-base-converter';
+			preLoaderRoute: typeof NumberBaseConverterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/network-scanner': {
+			id: '/network-scanner';
+			path: '/network-scanner';
+			fullPath: '/network-scanner';
+			preLoaderRoute: typeof NetworkScannerRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/network-interfaces': {
+			id: '/network-interfaces';
+			path: '/network-interfaces';
+			fullPath: '/network-interfaces';
+			preLoaderRoute: typeof NetworkInterfacesRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/markdown-editor': {
+			id: '/markdown-editor';
+			path: '/markdown-editor';
+			fullPath: '/markdown-editor';
+			preLoaderRoute: typeof MarkdownEditorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/lorem-ipsum': {
+			id: '/lorem-ipsum';
+			path: '/lorem-ipsum';
+			fullPath: '/lorem-ipsum';
+			preLoaderRoute: typeof LoremIpsumRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/list-comparer': {
+			id: '/list-comparer';
+			path: '/list-comparer';
+			fullPath: '/list-comparer';
+			preLoaderRoute: typeof ListComparerRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/jwt-decoder': {
+			id: '/jwt-decoder';
+			path: '/jwt-decoder';
+			fullPath: '/jwt-decoder';
+			preLoaderRoute: typeof JwtDecoderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/json-formatter': {
+			id: '/json-formatter';
+			path: '/json-formatter';
+			fullPath: '/json-formatter';
+			preLoaderRoute: typeof JsonFormatterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/ip-converter': {
+			id: '/ip-converter';
+			path: '/ip-converter';
+			fullPath: '/ip-converter';
+			preLoaderRoute: typeof IpConverterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/image-converter': {
+			id: '/image-converter';
+			path: '/image-converter';
+			fullPath: '/image-converter';
+			preLoaderRoute: typeof ImageConverterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/hash-generator': {
+			id: '/hash-generator';
+			path: '/hash-generator';
+			fullPath: '/hash-generator';
+			preLoaderRoute: typeof HashGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/gpg-key-generator': {
+			id: '/gpg-key-generator';
+			path: '/gpg-key-generator';
+			fullPath: '/gpg-key-generator';
+			preLoaderRoute: typeof GpgKeyGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/escape-tool': {
+			id: '/escape-tool';
+			path: '/escape-tool';
+			fullPath: '/escape-tool';
+			preLoaderRoute: typeof EscapeToolRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/diff-viewer': {
+			id: '/diff-viewer';
+			path: '/diff-viewer';
+			fullPath: '/diff-viewer';
+			preLoaderRoute: typeof DiffViewerRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/date-timestamp-converter': {
+			id: '/date-timestamp-converter';
+			path: '/date-timestamp-converter';
+			fullPath: '/date-timestamp-converter';
+			preLoaderRoute: typeof DateTimestampConverterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/curl-builder': {
+			id: '/curl-builder';
+			path: '/curl-builder';
+			fullPath: '/curl-builder';
+			preLoaderRoute: typeof CurlBuilderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/cron-expression-builder': {
+			id: '/cron-expression-builder';
+			path: '/cron-expression-builder';
+			fullPath: '/cron-expression-builder';
+			preLoaderRoute: typeof CronExpressionBuilderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/cidr-calculator': {
+			id: '/cidr-calculator';
+			path: '/cidr-calculator';
+			fullPath: '/cidr-calculator';
+			preLoaderRoute: typeof CidrCalculatorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/bcrypt-generator': {
+			id: '/bcrypt-generator';
+			path: '/bcrypt-generator';
+			fullPath: '/bcrypt-generator';
+			preLoaderRoute: typeof BcryptGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/base64-encoder': {
+			id: '/base64-encoder';
+			path: '/base64-encoder';
+			fullPath: '/base64-encoder';
+			preLoaderRoute: typeof Base64EncoderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/': {
+			id: '/';
+			path: '/';
+			fullPath: '/';
+			preLoaderRoute: typeof IndexRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+	}
 }
 
 const rootRouteChildren: RootRouteChildren = {
-  IndexRoute: IndexRoute,
-  Base64EncoderRoute: Base64EncoderRoute,
-  BcryptGeneratorRoute: BcryptGeneratorRoute,
-  CidrCalculatorRoute: CidrCalculatorRoute,
-  CronExpressionBuilderRoute: CronExpressionBuilderRoute,
-  CurlBuilderRoute: CurlBuilderRoute,
-  DateTimestampConverterRoute: DateTimestampConverterRoute,
-  DiffViewerRoute: DiffViewerRoute,
-  EscapeToolRoute: EscapeToolRoute,
-  GpgKeyGeneratorRoute: GpgKeyGeneratorRoute,
-  HashGeneratorRoute: HashGeneratorRoute,
-  ImageConverterRoute: ImageConverterRoute,
-  JsonFormatterRoute: JsonFormatterRoute,
-  JwtDecoderRoute: JwtDecoderRoute,
-  ListComparerRoute: ListComparerRoute,
-  LoremIpsumRoute: LoremIpsumRoute,
-  MarkdownEditorRoute: MarkdownEditorRoute,
-  NetworkInterfacesRoute: NetworkInterfacesRoute,
-  NetworkScannerRoute: NetworkScannerRoute,
-  NumberBaseConverterRoute: NumberBaseConverterRoute,
-  PasswordGeneratorRoute: PasswordGeneratorRoute,
-  QrCodeGeneratorRoute: QrCodeGeneratorRoute,
-  RegexTesterRoute: RegexTesterRoute,
-  RsaToolsRoute: RsaToolsRoute,
-  SemverToolsRoute: SemverToolsRoute,
-  SettingsRoute: SettingsRoute,
-  SqlFormatterRoute: SqlFormatterRoute,
-  SshKeyGeneratorRoute: SshKeyGeneratorRoute,
-  StringCaseConverterRoute: StringCaseConverterRoute,
-  StringCompressorRoute: StringCompressorRoute,
-  UrlEncoderRoute: UrlEncoderRoute,
-  UuidGeneratorRoute: UuidGeneratorRoute,
-  X509DecoderRoute: X509DecoderRoute,
-  XmlFormatterRoute: XmlFormatterRoute,
-  YamlFormatterRoute: YamlFormatterRoute,
-}
+	IndexRoute: IndexRoute,
+	Base64EncoderRoute: Base64EncoderRoute,
+	BcryptGeneratorRoute: BcryptGeneratorRoute,
+	CidrCalculatorRoute: CidrCalculatorRoute,
+	CronExpressionBuilderRoute: CronExpressionBuilderRoute,
+	CurlBuilderRoute: CurlBuilderRoute,
+	DateTimestampConverterRoute: DateTimestampConverterRoute,
+	DiffViewerRoute: DiffViewerRoute,
+	EscapeToolRoute: EscapeToolRoute,
+	GpgKeyGeneratorRoute: GpgKeyGeneratorRoute,
+	HashGeneratorRoute: HashGeneratorRoute,
+	ImageConverterRoute: ImageConverterRoute,
+	IpConverterRoute: IpConverterRoute,
+	JsonFormatterRoute: JsonFormatterRoute,
+	JwtDecoderRoute: JwtDecoderRoute,
+	ListComparerRoute: ListComparerRoute,
+	LoremIpsumRoute: LoremIpsumRoute,
+	MarkdownEditorRoute: MarkdownEditorRoute,
+	NetworkInterfacesRoute: NetworkInterfacesRoute,
+	NetworkScannerRoute: NetworkScannerRoute,
+	NumberBaseConverterRoute: NumberBaseConverterRoute,
+	PasswordGeneratorRoute: PasswordGeneratorRoute,
+	QrCodeGeneratorRoute: QrCodeGeneratorRoute,
+	RegexTesterRoute: RegexTesterRoute,
+	RsaToolsRoute: RsaToolsRoute,
+	SemverToolsRoute: SemverToolsRoute,
+	SettingsRoute: SettingsRoute,
+	SqlFormatterRoute: SqlFormatterRoute,
+	SshKeyGeneratorRoute: SshKeyGeneratorRoute,
+	StringCaseConverterRoute: StringCaseConverterRoute,
+	StringCompressorRoute: StringCompressorRoute,
+	UrlEncoderRoute: UrlEncoderRoute,
+	UuidGeneratorRoute: UuidGeneratorRoute,
+	X509DecoderRoute: X509DecoderRoute,
+	XmlFormatterRoute: XmlFormatterRoute,
+	YamlFormatterRoute: YamlFormatterRoute,
+};
 export const routeTree = rootRouteImport
-  ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+	._addFileChildren(rootRouteChildren)
+	._addFileTypes<FileRouteTypes>();

--- a/src/routes/ip-converter.tsx
+++ b/src/routes/ip-converter.tsx
@@ -1,0 +1,628 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { Globe } from 'lucide-react';
+import { type CSSProperties, type ReactNode, useMemo, useState } from 'react';
+
+import { ActionButton, CopyButton } from '@/lib/components/action';
+import { FormCheckbox, FormError, FormInfo, FormInput, FormSection } from '@/lib/components/form';
+import { ToolShell } from '@/lib/components/shell';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { ToneBadge } from '@/lib/components/ui/tone-badge';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/lib/components/ui/tooltip';
+import { useDocumentTitle } from '@/lib/hooks';
+import {
+	BIT_FIELD_COLORS,
+	bitsFor,
+	type ConvertedFromIpv4,
+	type ConvertedFromIpv6,
+	convertFromIpv4,
+	convertFromIpv6,
+	type EmbeddingInfo,
+	type EmbeddingKind,
+	type IpFamily,
+	type ParsedAddress,
+	parseIp,
+	SAMPLE_6TO4,
+	SAMPLE_MAPPED,
+	SAMPLE_TEREDO,
+	SAMPLE_V4,
+	SAMPLE_V6,
+} from '@/lib/services/ip-convert';
+import { createToolOptionsStore } from '@/lib/stores';
+import { cn } from '@/lib/utils';
+
+interface IpConverterOptions {
+	readonly showBitmap: boolean;
+	readonly favorMixedForMapped: boolean;
+}
+
+const DEFAULTS: IpConverterOptions = {
+	showBitmap: true,
+	favorMixedForMapped: true,
+};
+
+const useIpConverterOptions = createToolOptionsStore<IpConverterOptions>('ip-converter', DEFAULTS);
+
+const EMBEDDING_TONE: Record<EmbeddingKind, 'success' | 'warning' | 'info' | 'destructive'> = {
+	'ipv4-mapped': 'info',
+	'ipv4-compatible': 'warning',
+	'6to4': 'info',
+	teredo: 'info',
+	isatap: 'info',
+	none: 'success',
+};
+
+const EMBEDDING_LABEL: Record<EmbeddingKind, string> = {
+	'ipv4-mapped': 'IPv4-mapped',
+	'ipv4-compatible': 'IPv4-compatible',
+	'6to4': '6to4',
+	teredo: 'Teredo',
+	isatap: 'ISATAP',
+	none: 'Plain IPv6',
+};
+
+export const Route = createFileRoute('/ip-converter')({
+	component: IpConverterPage,
+});
+
+function IpConverterPage() {
+	useDocumentTitle('IP Address Converter');
+
+	const { value: options, patch } = useIpConverterOptions();
+	const { showBitmap, favorMixedForMapped } = options;
+
+	const [input, setInput] = useState<string>(SAMPLE_V4);
+	const [showRail, setShowRail] = useState(true);
+
+	const result = useMemo(() => parseIp(input), [input]);
+	const fromIpv4 = useMemo(
+		() =>
+			result.ok && result.parsed.family === 'ipv4' ? convertFromIpv4(result.parsed.value) : null,
+		[result]
+	);
+	const fromIpv6 = useMemo(
+		() =>
+			result.ok && result.parsed.family === 'ipv6' ? convertFromIpv6(result.parsed.value) : null,
+		[result]
+	);
+
+	const trimmed = input.trim();
+	const validity: boolean | null = trimmed.length === 0 ? null : result.ok;
+	const embedding: EmbeddingInfo | null = fromIpv6?.embedding ?? null;
+	const family: IpFamily | null = result.ok ? result.parsed.family : null;
+
+	return (
+		<ToolShell
+			valid={validity}
+			error={!result.ok && trimmed.length > 0 ? result.error : undefined}
+			showRail={showRail}
+			onShowRailChange={setShowRail}
+			statusContent={
+				<IpConverterStatus family={family} embedding={embedding} parsedOk={result.ok} />
+			}
+			rail={
+				<IpConverterRail
+					showBitmap={showBitmap}
+					favorMixedForMapped={favorMixedForMapped}
+					onLoadSample={setInput}
+					onClear={() => setInput('')}
+					onPatch={patch}
+				/>
+			}
+		>
+			<IpConverterMain
+				input={input}
+				trimmed={trimmed}
+				parsed={result.ok ? result.parsed : null}
+				error={!result.ok && trimmed.length > 0 ? result.error : null}
+				embedding={embedding}
+				fromIpv4={fromIpv4}
+				fromIpv6={fromIpv6}
+				favorMixedForMapped={favorMixedForMapped}
+				showBitmap={showBitmap}
+				onInputChange={setInput}
+			/>
+		</ToolShell>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface IpConverterStatusProps {
+	readonly family: IpFamily | null;
+	readonly embedding: EmbeddingInfo | null;
+	readonly parsedOk: boolean;
+}
+
+function IpConverterStatus({ family, embedding, parsedOk }: IpConverterStatusProps) {
+	if (!parsedOk || family === null) return null;
+	return (
+		<>
+			<StatItem label="Family" value={family === 'ipv4' ? 'IPv4' : 'IPv6'} />
+			{embedding ? <StatItem label="Embedding" value={EMBEDDING_LABEL[embedding.kind]} /> : null}
+			<StatItem label="Integer bytes" value={family === 'ipv4' ? 4 : 16} />
+		</>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface IpConverterRailProps {
+	readonly showBitmap: boolean;
+	readonly favorMixedForMapped: boolean;
+	readonly onLoadSample: (value: string) => void;
+	readonly onClear: () => void;
+	readonly onPatch: (delta: Partial<IpConverterOptions>) => void;
+}
+
+function IpConverterRail({
+	showBitmap,
+	favorMixedForMapped,
+	onLoadSample,
+	onClear,
+	onPatch,
+}: IpConverterRailProps) {
+	return (
+		<>
+			<FormSection title="Input">
+				<FormInfo>
+					Paste any IPv4 (e.g. <code className="font-mono">192.0.2.1</code>) or IPv6 (e.g.{' '}
+					<code className="font-mono">2001:db8::1</code>). The family is auto-detected.
+				</FormInfo>
+				<div className="grid grid-cols-2 gap-1">
+					<Button variant="outline" size="sm" onClick={() => onLoadSample(SAMPLE_V4)}>
+						Load sample IPv4
+					</Button>
+					<Button variant="outline" size="sm" onClick={() => onLoadSample(SAMPLE_V6)}>
+						Load sample IPv6
+					</Button>
+					<Button variant="outline" size="sm" onClick={() => onLoadSample(SAMPLE_MAPPED)}>
+						Load IPv4-mapped sample
+					</Button>
+					<Button variant="outline" size="sm" onClick={() => onLoadSample(SAMPLE_6TO4)}>
+						Load 6to4 sample
+					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						className="col-span-2"
+						onClick={() => onLoadSample(SAMPLE_TEREDO)}
+					>
+						Load Teredo sample
+					</Button>
+				</div>
+				<ActionButton label="Clear" variant="outline" onClick={onClear} />
+			</FormSection>
+
+			<FormSection title="Visualization">
+				<FormCheckbox
+					label="Show bit visualization"
+					checked={showBitmap}
+					onCheckedChange={(checked) => onPatch({ showBitmap: checked })}
+				/>
+			</FormSection>
+
+			<FormSection title="Display">
+				<FormCheckbox
+					label="Use mixed form for IPv4-mapped (::ffff:a.b.c.d)"
+					checked={favorMixedForMapped}
+					onCheckedChange={(checked) => onPatch({ favorMixedForMapped: checked })}
+				/>
+			</FormSection>
+
+			<FormSection title="About">
+				<FormInfo>
+					<ul className="list-inside list-disc space-y-0.5">
+						<li>All conversions happen in-browser; no network calls.</li>
+						<li>IPv6 compressed form follows RFC 5952.</li>
+						<li>Embeddings: IPv4-mapped (RFC 4291), 6to4 (RFC 3056), Teredo (RFC 4380).</li>
+						<li>Math runs on bigint; no precision loss for u128.</li>
+					</ul>
+				</FormInfo>
+			</FormSection>
+		</>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface IpConverterMainProps {
+	readonly input: string;
+	readonly trimmed: string;
+	readonly parsed: ParsedAddress | null;
+	readonly error: string | null;
+	readonly embedding: EmbeddingInfo | null;
+	readonly fromIpv4: ConvertedFromIpv4 | null;
+	readonly fromIpv6: ConvertedFromIpv6 | null;
+	readonly favorMixedForMapped: boolean;
+	readonly showBitmap: boolean;
+	readonly onInputChange: (value: string) => void;
+}
+
+function IpConverterMain({
+	input,
+	trimmed,
+	parsed,
+	error,
+	embedding,
+	fromIpv4,
+	fromIpv6,
+	favorMixedForMapped,
+	showBitmap,
+	onInputChange,
+}: IpConverterMainProps) {
+	const isEmpty = trimmed.length === 0 || parsed === null;
+	return (
+		<div className="flex h-full flex-col overflow-auto p-3">
+			<div className="space-y-3">
+				<InputCard
+					input={input}
+					onInputChange={onInputChange}
+					parsed={parsed}
+					error={error}
+					embedding={embedding}
+				/>
+				{isEmpty ? (
+					<EmptyCard />
+				) : fromIpv4 ? (
+					<FromIpv4Section converted={fromIpv4} favorMixedForMapped={favorMixedForMapped} />
+				) : fromIpv6 ? (
+					<FromIpv6Section converted={fromIpv6} />
+				) : null}
+				{showBitmap && parsed ? (
+					<BitGridCard parsed={parsed} embedding={embedding ?? undefined} />
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+function EmptyCard() {
+	return (
+		<Card density="compact">
+			<CardContent>
+				<EmbeddedEmptyState
+					icon={Globe}
+					title="Enter an IP address"
+					description="Type an IPv4 or IPv6 address to see the cross-family encodings, notation normalization, embedding detection, and bit-level breakdown."
+				/>
+			</CardContent>
+		</Card>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface InputCardProps {
+	readonly input: string;
+	readonly onInputChange: (value: string) => void;
+	readonly parsed: ParsedAddress | null;
+	readonly error: string | null;
+	readonly embedding: EmbeddingInfo | null;
+}
+
+function InputCard({ input, onInputChange, parsed, error, embedding }: InputCardProps) {
+	return (
+		<Card density="compact">
+			<CardHeader className="pb-2">
+				<CardTitle>Address</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<FormInput
+					label="IPv4 or IPv6 address"
+					value={input}
+					onValueChange={onInputChange}
+					placeholder="e.g. 192.0.2.1, 2001:db8::1, or ::ffff:192.0.2.1"
+					size="default"
+				/>
+				{error ? <FormError message={error} className="mt-2" /> : null}
+				{parsed ? (
+					<div className="mt-3 flex flex-wrap gap-1.5">
+						<ToneBadge tone={parsed.family === 'ipv4' ? 'info' : 'success'}>
+							{parsed.family === 'ipv4' ? 'IPv4' : 'IPv6'}
+						</ToneBadge>
+						{embedding && embedding.kind !== 'none' ? (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<span>
+										<ToneBadge tone={EMBEDDING_TONE[embedding.kind]}>
+											{EMBEDDING_LABEL[embedding.kind]}
+										</ToneBadge>
+									</span>
+								</TooltipTrigger>
+								<TooltipContent>{embedding.description}</TooltipContent>
+							</Tooltip>
+						) : null}
+					</div>
+				) : null}
+			</CardContent>
+		</Card>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface FromIpv4SectionProps {
+	readonly converted: ConvertedFromIpv4;
+	readonly favorMixedForMapped: boolean;
+}
+
+interface DetailItem {
+	readonly key: string;
+	readonly label: string;
+	readonly value: string;
+	readonly hint?: string;
+}
+
+function FromIpv4Section({ converted, favorMixedForMapped }: FromIpv4SectionProps) {
+	// When the user opts out of mixed (dotted-quad) form, render the IPv4-mapped
+	// address using pure hextets so the entire IPv6 surface stays in colon-hex.
+	const mappedDisplay = useMemo(() => {
+		if (favorMixedForMapped) return converted.mapped;
+		const v = converted.decimalInteger;
+		const hi = (v >> 16n) & 0xffffn;
+		const lo = v & 0xffffn;
+		return `::ffff:${hi.toString(16)}:${lo.toString(16)}`;
+	}, [favorMixedForMapped, converted.mapped, converted.decimalInteger]);
+
+	const items: readonly DetailItem[] = [
+		{ key: 'decimal', label: 'Decimal integer (u32)', value: converted.decimalInteger.toString() },
+		{ key: 'hex', label: 'Hex', value: converted.hexInteger },
+		{ key: 'binary', label: 'Binary', value: converted.binary },
+		{
+			key: 'mapped',
+			label: 'IPv4-mapped (::ffff:…)',
+			value: mappedDisplay,
+			hint: 'Used by dual-stack sockets (RFC 4291).',
+		},
+		{
+			key: 'compatible',
+			label: 'IPv4-compatible (::…)',
+			value: converted.compatible,
+			hint: 'Deprecated by RFC 4291; shown for completeness.',
+		},
+		{
+			key: 'sixToFour',
+			label: '6to4 prefix (2002:…::/48)',
+			value: converted.sixToFour,
+			hint: 'Each IPv4 maps to its own /48 site prefix (RFC 3056).',
+		},
+		{
+			key: 'sixToFourHost',
+			label: '6to4 host (typical /64)',
+			value: converted.sixToFourFull,
+		},
+	];
+
+	return <DetailsGrid items={items} />;
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface FromIpv6SectionProps {
+	readonly converted: ConvertedFromIpv6;
+}
+
+function FromIpv6Section({ converted }: FromIpv6SectionProps) {
+	const items: readonly DetailItem[] = [
+		{ key: 'compressed', label: 'Compressed (RFC 5952)', value: converted.ipv6.compressed },
+		{ key: 'expanded', label: 'Expanded (full 8 groups)', value: converted.ipv6.expanded },
+		{ key: 'mixed', label: 'Mixed (dotted-quad tail)', value: converted.ipv6.mixed },
+		{ key: 'decimal', label: 'Decimal integer (u128)', value: converted.decimalInteger.toString() },
+		{ key: 'hex', label: 'Hex', value: converted.hexInteger },
+	];
+
+	return (
+		<>
+			<DetailsGrid items={items} />
+			<EmbeddingCard embedding={converted.embedding} />
+		</>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface DetailsGridProps {
+	readonly items: readonly DetailItem[];
+}
+
+function DetailsGrid({ items }: DetailsGridProps) {
+	return (
+		<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+			{items.map((item) => (
+				<Card key={item.key} density="compact">
+					<CardHeader className="flex flex-row items-center justify-between gap-2 pb-2">
+						<CardTitle className="truncate text-xs uppercase tracking-wide text-muted-foreground">
+							{item.label}
+						</CardTitle>
+						<CopyButton
+							text={item.value}
+							toastLabel={item.label}
+							size="sm"
+							variant="ghost"
+							showLabel={false}
+						/>
+					</CardHeader>
+					<CardContent>
+						<div className="font-mono text-sm break-all tabular-nums">{item.value}</div>
+						{item.hint ? (
+							<p className="mt-1.5 text-2xs text-muted-foreground">{item.hint}</p>
+						) : null}
+					</CardContent>
+				</Card>
+			))}
+		</div>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface EmbeddingCardProps {
+	readonly embedding: EmbeddingInfo;
+}
+
+function EmbeddingCard({ embedding }: EmbeddingCardProps) {
+	return (
+		<Card density="compact">
+			<CardHeader className="pb-2">
+				<div className="flex items-center justify-between gap-2">
+					<CardTitle className="flex items-center gap-2">
+						Embedding
+						<ToneBadge tone={EMBEDDING_TONE[embedding.kind]}>
+							{EMBEDDING_LABEL[embedding.kind]}
+						</ToneBadge>
+					</CardTitle>
+				</div>
+			</CardHeader>
+			<CardContent className="space-y-2">
+				<p className="text-xs text-muted-foreground">{embedding.description}</p>
+				{embedding.embeddedIpv4 ? (
+					<EmbeddingRow label="Embedded IPv4" value={embedding.embeddedIpv4} />
+				) : null}
+				{embedding.teredoServer ? (
+					<EmbeddingRow label="Teredo server" value={embedding.teredoServer} />
+				) : null}
+				{embedding.teredoMappedAddress ? (
+					<EmbeddingRow label="Mapped client" value={embedding.teredoMappedAddress} />
+				) : null}
+				{embedding.teredoMappedPort !== undefined ? (
+					<EmbeddingRow label="Mapped port" value={String(embedding.teredoMappedPort)} copyable />
+				) : null}
+				{embedding.teredoFlags ? (
+					<EmbeddingRow
+						label="Flags"
+						value={`cone=${embedding.teredoFlags.cone ? 'yes' : 'no'} · individual=${embedding.teredoFlags.individual ? 'yes' : 'no'} · reserved=0x${embedding.teredoFlags.reserved.toString(16).padStart(4, '0')}`}
+						copyable={false}
+					/>
+				) : null}
+			</CardContent>
+		</Card>
+	);
+}
+
+interface EmbeddingRowProps {
+	readonly label: string;
+	readonly value: string;
+	readonly copyable?: boolean;
+}
+
+function EmbeddingRow({ label, value, copyable = true }: EmbeddingRowProps) {
+	return (
+		<div className="flex items-center justify-between gap-2 rounded-md border bg-muted/30 px-2.5 py-1.5">
+			<div className="min-w-0">
+				<div className="text-2xs uppercase tracking-wide text-muted-foreground">{label}</div>
+				<div className="font-mono text-sm break-all tabular-nums">{value}</div>
+			</div>
+			{copyable ? (
+				<CopyButton text={value} toastLabel={label} size="sm" variant="ghost" showLabel={false} />
+			) : null}
+		</div>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface BitGridCardProps {
+	readonly parsed: ParsedAddress;
+	readonly embedding?: EmbeddingInfo;
+}
+
+function BitGridCard({ parsed, embedding }: BitGridCardProps) {
+	const bits = useMemo(
+		() => bitsFor(parsed.value, parsed.family, embedding),
+		[parsed.value, parsed.family, embedding]
+	);
+	const groupSize = parsed.family === 'ipv4' ? 8 : 16;
+	const totalBits = parsed.family === 'ipv4' ? 32 : 128;
+	const groupCount = totalBits / groupSize;
+	const groupLabel = parsed.family === 'ipv4' ? 'octet' : 'hextet';
+
+	const legend: readonly ReactNode[] = useMemo(() => {
+		const seen = new Set<string>();
+		return bits.flatMap((cell) => {
+			if (!cell.field || seen.has(cell.field)) return [];
+			seen.add(cell.field);
+			return [
+				<span key={cell.field} className="inline-flex items-center gap-1">
+					<span className={cn('inline-block size-2.5 rounded-sm', cell.fieldColor)} />
+					{cell.field}
+				</span>,
+			];
+		});
+	}, [bits]);
+
+	return (
+		<Card density="compact">
+			<CardHeader className="pb-2">
+				<div className="flex items-center justify-between gap-2">
+					<CardTitle>Bit Layout</CardTitle>
+					<div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-2xs text-muted-foreground">
+						{legend}
+					</div>
+				</div>
+			</CardHeader>
+			<CardContent>
+				<div className="overflow-x-auto">
+					<div
+						className="grid gap-y-1"
+						style={
+							{
+								gridTemplateColumns: `repeat(${totalBits}, minmax(0.5rem, 1fr))`,
+							} as CSSProperties
+						}
+					>
+						{bits.map((cell, idx) => {
+							const isGroupStart = idx % groupSize === 0 && idx > 0;
+							const bitKey = `${parsed.family}-bit-${idx}`;
+							return (
+								<Tooltip key={bitKey}>
+									<TooltipTrigger asChild>
+										<span
+											className={cn(
+												'flex h-5 items-center justify-center rounded-sm border font-mono text-2xs leading-none transition-colors',
+												cell.value === 1
+													? cn(
+															cell.fieldColor ?? BIT_FIELD_COLORS.host,
+															'border-transparent text-foreground'
+														)
+													: 'border-border bg-muted text-muted-foreground/60',
+												isGroupStart && 'ml-1'
+											)}
+										>
+											{cell.value}
+										</span>
+									</TooltipTrigger>
+									<TooltipContent>
+										<span className="font-mono text-2xs">
+											bit {idx + 1} of {totalBits}
+											{cell.field ? ` · ${cell.field}` : ''}
+										</span>
+									</TooltipContent>
+								</Tooltip>
+							);
+						})}
+					</div>
+					<div
+						className="mt-1 grid gap-y-1"
+						style={
+							{ gridTemplateColumns: `repeat(${groupCount}, minmax(0, 1fr))` } as CSSProperties
+						}
+					>
+						{Array.from({ length: groupCount }, (_, i) => {
+							const labelKey = `${parsed.family}-${groupLabel}-${i}`;
+							return (
+								<span
+									key={labelKey}
+									className="text-center font-mono text-2xs text-muted-foreground"
+								>
+									{groupLabel} {i + 1}
+								</span>
+							);
+						})}
+					</div>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}


### PR DESCRIPTION
## Summary
Add an IPv4 / IPv6 Address Converter under **Network** that handles every well-known cross-family encoding (IPv4-mapped, IPv4-compatible, 6to4, Teredo) plus IPv6 notation normalization. Closes #229.

## Features
- **Auto-detect** IPv4 vs IPv6 input
- **From IPv4**: IPv4-mapped (`::ffff:…`), IPv4-compatible (`::…`), 6to4 prefix + host, decimal u32, hex, binary with octet boundaries
- **From IPv6 — notation normalizer**: compressed (RFC 5952), fully-expanded, mixed (dotted-quad tail)
- **Embedding detector**: ipv4-mapped / ipv4-compatible / 6to4 / Teredo / isatap / none
- **Teredo decomposition**: server, mapped client, mapped port, flags
- **Bit visualization** with per-field coloring + tooltips
- **Pure bigint** math, no external deps

## Changes
### Added
- `src/routes/ip-converter.tsx`
- `src/lib/services/ip-convert.ts`
- Page registration entry in `src/lib/services/pages.ts`

## Test plan
- [x] `bun run check` green
- [x] `bun run lint` no new errors
- [x] `bun run format` clean
- [ ] Manual: `192.0.2.1` — IPv4-mapped `::ffff:192.0.2.1`, 6to4 `2002:c000:0201::/48`
- [ ] Manual: `::ffff:192.0.2.1` — embedding kind "ipv4-mapped", extracts `192.0.2.1`
- [ ] Manual: `2002:c000:0201::1` — embedding kind "6to4", extracts `192.0.2.1`
- [ ] Manual: Teredo sample — decomposes server / mapped / port / flags

Closes #229
