### PR TITLE
feat(http-status-codes): add HTTP Status Code Reference tool

### DIFF
--- a/src/lib/services/http-status.ts
+++ b/src/lib/services/http-status.ts
@@ -1,0 +1,976 @@
+/**
+ * HTTP Status Code reference data and filter logic.
+ *
+ * Catalog includes all IANA-registered codes (100-599) defined primarily in
+ * RFC 9110 (Semantics, June 2022), plus widely-used non-standard codes
+ * (Cloudflare 520-527, nginx 444/494/499, etc.). Each entry carries a
+ * one-sentence summary, an RFC reference where applicable, optional
+ * "when to use" guidance, optional misuse warnings on commonly-confused
+ * codes, and a list of semantically-adjacent codes.
+ *
+ * All data and filters are framework-agnostic and pure.
+ */
+
+export type StatusCategory = '1xx' | '2xx' | '3xx' | '4xx' | '5xx';
+
+export type StatusKind = 'informational' | 'success' | 'redirection' | 'client-error' | 'server-error';
+
+export interface StatusCode {
+	readonly code: number;
+	readonly phrase: string;
+	readonly category: StatusCategory;
+	readonly kind: StatusKind;
+	readonly summary: string;
+	readonly rfc?: string;
+	readonly rfcUrl?: string;
+	readonly whenToUse?: string;
+	readonly misuse?: string;
+	readonly related?: readonly number[];
+	readonly standard: boolean;
+}
+
+/** Canonical IANA registry URL. */
+const IANA_URL = 'https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml';
+
+/** RFC 9110 (HTTP Semantics) anchor for a section number, e.g. "15.5.5". */
+const rfc9110 = (section: string): string =>
+	`https://www.rfc-editor.org/rfc/rfc9110#section-${section}`;
+
+const rfcUrl = (rfc: string, section: string): string =>
+	`https://www.rfc-editor.org/rfc/${rfc.toLowerCase()}#section-${section}`;
+
+export const STATUS_CODES: readonly StatusCode[] = [
+	// ---------------------------------------------------------------- 1xx ----
+	{
+		code: 100,
+		phrase: 'Continue',
+		category: '1xx',
+		kind: 'informational',
+		summary:
+			'Initial part of the request received and the client should continue sending the request body.',
+		rfc: 'RFC 9110 §15.2.1',
+		rfcUrl: rfc9110('15.2.1'),
+		whenToUse: 'Respond when the client sent "Expect: 100-continue" and the request looks acceptable.',
+		standard: true,
+	},
+	{
+		code: 101,
+		phrase: 'Switching Protocols',
+		category: '1xx',
+		kind: 'informational',
+		summary: 'Server is switching protocols as requested by the client in the Upgrade header.',
+		rfc: 'RFC 9110 §15.2.2',
+		rfcUrl: rfc9110('15.2.2'),
+		whenToUse: 'Use when upgrading from HTTP/1.1 to WebSocket or HTTP/2 over the same TCP connection.',
+		standard: true,
+	},
+	{
+		code: 102,
+		phrase: 'Processing',
+		category: '1xx',
+		kind: 'informational',
+		summary:
+			'WebDAV interim response indicating the server has accepted the complete request but is still processing it.',
+		rfc: 'RFC 2518 §10.1',
+		rfcUrl: rfcUrl('rfc2518', '10.1'),
+		whenToUse: 'Send periodically during a long WebDAV operation to keep the client from timing out.',
+		standard: true,
+	},
+	{
+		code: 103,
+		phrase: 'Early Hints',
+		category: '1xx',
+		kind: 'informational',
+		summary:
+			'Allows the user agent to start preloading resources while the server prepares the final response.',
+		rfc: 'RFC 8297',
+		rfcUrl: 'https://www.rfc-editor.org/rfc/rfc8297',
+		whenToUse: 'Send Link headers early so the browser can begin fetching critical CSS / JS in parallel.',
+		standard: true,
+	},
+
+	// ---------------------------------------------------------------- 2xx ----
+	{
+		code: 200,
+		phrase: 'OK',
+		category: '2xx',
+		kind: 'success',
+		summary: 'Request succeeded; the meaning of the success depends on the HTTP method.',
+		rfc: 'RFC 9110 §15.3.1',
+		rfcUrl: rfc9110('15.3.1'),
+		whenToUse: 'Default success response for GET, HEAD, PUT, POST, DELETE when no more specific code applies.',
+		misuse: 'Do not return 200 with an error body — pick the right 4xx/5xx code instead.',
+		related: [201, 202, 204],
+		standard: true,
+	},
+	{
+		code: 201,
+		phrase: 'Created',
+		category: '2xx',
+		kind: 'success',
+		summary: 'Request succeeded and a new resource has been created as a result.',
+		rfc: 'RFC 9110 §15.3.2',
+		rfcUrl: rfc9110('15.3.2'),
+		whenToUse: 'Respond to POST / PUT that creates a resource; include a Location header pointing to it.',
+		related: [200, 202, 204],
+		standard: true,
+	},
+	{
+		code: 202,
+		phrase: 'Accepted',
+		category: '2xx',
+		kind: 'success',
+		summary: 'Request accepted for processing but processing has not been completed.',
+		rfc: 'RFC 9110 §15.3.3',
+		rfcUrl: rfc9110('15.3.3'),
+		whenToUse: 'Acknowledge work that is dispatched asynchronously; return a status URL clients can poll.',
+		related: [200, 201, 204],
+		standard: true,
+	},
+	{
+		code: 203,
+		phrase: 'Non-Authoritative Information',
+		category: '2xx',
+		kind: 'success',
+		summary:
+			'Returned metadata is not exactly the same as available from the origin but is from a local or third-party copy.',
+		rfc: 'RFC 9110 §15.3.4',
+		rfcUrl: rfc9110('15.3.4'),
+		whenToUse: 'Use on a proxy that transformed the upstream response.',
+		standard: true,
+	},
+	{
+		code: 204,
+		phrase: 'No Content',
+		category: '2xx',
+		kind: 'success',
+		summary: 'Request succeeded and there is no additional content to send in the response body.',
+		rfc: 'RFC 9110 §15.3.5',
+		rfcUrl: rfc9110('15.3.5'),
+		whenToUse: 'Respond to DELETE or to a PUT/PATCH that does not return the resource representation.',
+		related: [200, 205, 304],
+		standard: true,
+	},
+	{
+		code: 205,
+		phrase: 'Reset Content',
+		category: '2xx',
+		kind: 'success',
+		summary:
+			'Instructs the user agent to reset the document that sent the request (e.g. clear the submitted form).',
+		rfc: 'RFC 9110 §15.3.6',
+		rfcUrl: rfc9110('15.3.6'),
+		whenToUse: 'After a data-entry submission, when you want the client to clear and reset the form.',
+		related: [204],
+		standard: true,
+	},
+	{
+		code: 206,
+		phrase: 'Partial Content',
+		category: '2xx',
+		kind: 'success',
+		summary: 'Server is delivering only part of the resource due to a Range header in the request.',
+		rfc: 'RFC 9110 §15.3.7',
+		rfcUrl: rfc9110('15.3.7'),
+		whenToUse: 'Reply to range requests for downloads, video streaming, or resumable uploads.',
+		related: [200, 416],
+		standard: true,
+	},
+	{
+		code: 207,
+		phrase: 'Multi-Status',
+		category: '2xx',
+		kind: 'success',
+		summary: 'WebDAV: response body conveys the status of multiple independent operations.',
+		rfc: 'RFC 4918 §11.1',
+		rfcUrl: rfcUrl('rfc4918', '11.1'),
+		whenToUse: 'Reply to a WebDAV PROPFIND / batch operation where individual items may differ in status.',
+		standard: true,
+	},
+	{
+		code: 208,
+		phrase: 'Already Reported',
+		category: '2xx',
+		kind: 'success',
+		summary:
+			'WebDAV: members of a DAV binding have already been enumerated in a previous part of the multistatus.',
+		rfc: 'RFC 5842 §7.1',
+		rfcUrl: rfcUrl('rfc5842', '7.1'),
+		whenToUse: 'Avoid repeating internal members in WebDAV PROPFIND responses with bindings.',
+		standard: true,
+	},
+	{
+		code: 226,
+		phrase: 'IM Used',
+		category: '2xx',
+		kind: 'success',
+		summary:
+			'Server fulfilled a GET request and the response is a representation of the result of one or more instance manipulations.',
+		rfc: 'RFC 3229 §10.4.1',
+		rfcUrl: rfcUrl('rfc3229', '10.4.1'),
+		whenToUse: 'Use with delta encoding when responding to clients that advertise A-IM support.',
+		standard: true,
+	},
+
+	// ---------------------------------------------------------------- 3xx ----
+	{
+		code: 300,
+		phrase: 'Multiple Choices',
+		category: '3xx',
+		kind: 'redirection',
+		summary: 'Request has more than one possible response; the user agent or user should choose one of them.',
+		rfc: 'RFC 9110 §15.4.1',
+		rfcUrl: rfc9110('15.4.1'),
+		whenToUse: 'Offer alternative representations (e.g. language variants) and let the client pick.',
+		standard: true,
+	},
+	{
+		code: 301,
+		phrase: 'Moved Permanently',
+		category: '3xx',
+		kind: 'redirection',
+		summary: 'Resource has been permanently moved to the URL in the Location header.',
+		rfc: 'RFC 9110 §15.4.2',
+		rfcUrl: rfc9110('15.4.2'),
+		whenToUse: 'Use for permanent URL changes that should be cached and update bookmarks.',
+		misuse: '301 is aggressively cached. Prefer 302 for temporary moves; once cached, 301 is hard to undo.',
+		related: [302, 303, 307, 308],
+		standard: true,
+	},
+	{
+		code: 302,
+		phrase: 'Found',
+		category: '3xx',
+		kind: 'redirection',
+		summary: 'Resource resides temporarily under a different URL; future requests should still use the original URL.',
+		rfc: 'RFC 9110 §15.4.3',
+		rfcUrl: rfc9110('15.4.3'),
+		whenToUse: 'Default temporary redirect when method-preservation does not matter (browsers often rewrite to GET).',
+		misuse: 'Many clients rewrite the method to GET; if you need the original method preserved, use 307 instead.',
+		related: [301, 303, 307, 308],
+		standard: true,
+	},
+	{
+		code: 303,
+		phrase: 'See Other',
+		category: '3xx',
+		kind: 'redirection',
+		summary:
+			'Response can be found at another URL using a GET method; commonly used after POST to redirect to a result page.',
+		rfc: 'RFC 9110 §15.4.4',
+		rfcUrl: rfc9110('15.4.4'),
+		whenToUse: 'Implement the Post/Redirect/Get pattern after form submission to avoid duplicate POSTs on refresh.',
+		related: [301, 302, 307],
+		standard: true,
+	},
+	{
+		code: 304,
+		phrase: 'Not Modified',
+		category: '3xx',
+		kind: 'redirection',
+		summary: 'Cached copy is still fresh; client should use its stored representation.',
+		rfc: 'RFC 9110 §15.4.5',
+		rfcUrl: rfc9110('15.4.5'),
+		whenToUse: 'Respond to conditional GET (If-None-Match / If-Modified-Since) when the resource is unchanged.',
+		related: [200, 412],
+		standard: true,
+	},
+	{
+		code: 305,
+		phrase: 'Use Proxy',
+		category: '3xx',
+		kind: 'redirection',
+		summary: 'Deprecated: requested resource must be accessed through the proxy given in the Location field.',
+		rfc: 'RFC 9110 §15.4.6',
+		rfcUrl: rfc9110('15.4.6'),
+		whenToUse: 'Do not use — deprecated due to security concerns.',
+		standard: true,
+	},
+	{
+		code: 307,
+		phrase: 'Temporary Redirect',
+		category: '3xx',
+		kind: 'redirection',
+		summary:
+			'Resource resides temporarily under a different URL; the request method and body must not change when redirecting.',
+		rfc: 'RFC 9110 §15.4.8',
+		rfcUrl: rfc9110('15.4.8'),
+		whenToUse: 'Temporary redirect that preserves the HTTP method (POST stays POST).',
+		misuse: '307/308 preserve the request method. Use 307 (not 302) when redirecting a POST and you want it re-POSTed.',
+		related: [302, 308],
+		standard: true,
+	},
+	{
+		code: 308,
+		phrase: 'Permanent Redirect',
+		category: '3xx',
+		kind: 'redirection',
+		summary:
+			'Resource has been permanently moved; the request method and body must not change when following the redirect.',
+		rfc: 'RFC 9110 §15.4.9',
+		rfcUrl: rfc9110('15.4.9'),
+		whenToUse: 'Permanent redirect for APIs where the original method (POST / PUT) must be preserved.',
+		misuse: '307/308 preserve the request method. Use 308 (not 301) for permanent API URL changes that must keep POST.',
+		related: [301, 307],
+		standard: true,
+	},
+
+	// ---------------------------------------------------------------- 4xx ----
+	{
+		code: 400,
+		phrase: 'Bad Request',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Server cannot or will not process the request due to a client error (malformed syntax, invalid framing, etc.).',
+		rfc: 'RFC 9110 §15.5.1',
+		rfcUrl: rfc9110('15.5.1'),
+		whenToUse: 'Reject malformed JSON, invalid headers, or otherwise unparseable input at the protocol layer.',
+		misuse: 'Reserve 400 for malformed input. Use 422 when the body is well-formed but semantically invalid.',
+		related: [422],
+		standard: true,
+	},
+	{
+		code: 401,
+		phrase: 'Unauthorized',
+		category: '4xx',
+		kind: 'client-error',
+		summary:
+			'Request lacks valid authentication credentials for the target resource; "Unauthenticated" would be more accurate.',
+		rfc: 'RFC 9110 §15.5.2',
+		rfcUrl: rfc9110('15.5.2'),
+		whenToUse: 'Use when no credentials were sent or the credentials are invalid; include a WWW-Authenticate header.',
+		misuse: '401 = not authenticated (missing/invalid credentials). 403 = authenticated but not authorized for this resource.',
+		related: [403, 407],
+		standard: true,
+	},
+	{
+		code: 402,
+		phrase: 'Payment Required',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Reserved for future use; sometimes returned by APIs to indicate a billing issue or quota exhaustion.',
+		rfc: 'RFC 9110 §15.5.3',
+		rfcUrl: rfc9110('15.5.3'),
+		whenToUse: 'Optionally used by paid APIs to flag subscription/billing failures; behavior is non-standard.',
+		standard: true,
+	},
+	{
+		code: 403,
+		phrase: 'Forbidden',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Server understood the request but refuses to authorize it; re-authenticating will not help.',
+		rfc: 'RFC 9110 §15.5.4',
+		rfcUrl: rfc9110('15.5.4'),
+		whenToUse: 'Use when the authenticated principal lacks permission for the action regardless of credentials.',
+		misuse: '403 means "not allowed even with valid credentials". Use 401 when credentials are missing or invalid.',
+		related: [401, 404, 405],
+		standard: true,
+	},
+	{
+		code: 404,
+		phrase: 'Not Found',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Server cannot find the requested resource; the URL may be wrong or the resource may not exist.',
+		rfc: 'RFC 9110 §15.5.5',
+		rfcUrl: rfc9110('15.5.5'),
+		whenToUse: 'Use when the resource identified by the URL does not exist (or to hide its existence from unauthorized callers).',
+		misuse: '404 for a missing item is correct; 404 for an existing collection endpoint with zero results is wrong — return 200 with [].',
+		related: [403, 410],
+		standard: true,
+	},
+	{
+		code: 405,
+		phrase: 'Method Not Allowed',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Request method is known by the server but not supported by the target resource.',
+		rfc: 'RFC 9110 §15.5.6',
+		rfcUrl: rfc9110('15.5.6'),
+		whenToUse: 'Reject methods the endpoint does not support; include an Allow header listing valid methods.',
+		related: [403, 501],
+		standard: true,
+	},
+	{
+		code: 406,
+		phrase: 'Not Acceptable',
+		category: '4xx',
+		kind: 'client-error',
+		summary:
+			'Server cannot produce a response matching the list of acceptable values defined in the request Accept headers.',
+		rfc: 'RFC 9110 §15.5.7',
+		rfcUrl: rfc9110('15.5.7'),
+		whenToUse: 'Use when content negotiation fails for Accept / Accept-Language / Accept-Encoding.',
+		standard: true,
+	},
+	{
+		code: 407,
+		phrase: 'Proxy Authentication Required',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Similar to 401, but authentication must be done by a proxy.',
+		rfc: 'RFC 9110 §15.5.8',
+		rfcUrl: rfc9110('15.5.8'),
+		whenToUse: 'Returned by a proxy that requires authentication before forwarding the request.',
+		related: [401],
+		standard: true,
+	},
+	{
+		code: 408,
+		phrase: 'Request Timeout',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Server timed out waiting for the request; the client may repeat the request without modifications.',
+		rfc: 'RFC 9110 §15.5.9',
+		rfcUrl: rfc9110('15.5.9'),
+		whenToUse: 'Close idle connections that did not finish sending the request within the server timeout.',
+		standard: true,
+	},
+	{
+		code: 409,
+		phrase: 'Conflict',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Request conflicts with the current state of the target resource (e.g. concurrent edit).',
+		rfc: 'RFC 9110 §15.5.10',
+		rfcUrl: rfc9110('15.5.10'),
+		whenToUse: 'Reject optimistic-concurrency conflicts, duplicate-key inserts, or competing edits.',
+		standard: true,
+	},
+	{
+		code: 410,
+		phrase: 'Gone',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Resource is no longer available and will not be available again; the condition is expected to be permanent.',
+		rfc: 'RFC 9110 §15.5.11',
+		rfcUrl: rfc9110('15.5.11'),
+		whenToUse: 'Signal that a resource has been intentionally retired so search engines and caches can purge it.',
+		related: [404],
+		standard: true,
+	},
+	{
+		code: 411,
+		phrase: 'Length Required',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Server refuses to accept the request without a defined Content-Length header.',
+		rfc: 'RFC 9110 §15.5.12',
+		rfcUrl: rfc9110('15.5.12'),
+		whenToUse: 'Demand Content-Length for endpoints that cannot stream the request body.',
+		standard: true,
+	},
+	{
+		code: 412,
+		phrase: 'Precondition Failed',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'One or more conditions given in the request header fields evaluated to false.',
+		rfc: 'RFC 9110 §15.5.13',
+		rfcUrl: rfc9110('15.5.13'),
+		whenToUse: 'Reject conditional PUT / PATCH when If-Match / If-Unmodified-Since does not hold (optimistic concurrency).',
+		related: [304, 428],
+		standard: true,
+	},
+	{
+		code: 413,
+		phrase: 'Content Too Large',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Request body is larger than the server is willing or able to process. Previously "Payload Too Large".',
+		rfc: 'RFC 9110 §15.5.14',
+		rfcUrl: rfc9110('15.5.14'),
+		whenToUse: 'Reject uploads beyond the configured maximum size.',
+		standard: true,
+	},
+	{
+		code: 414,
+		phrase: 'URI Too Long',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Request-target is longer than the server is willing to interpret.',
+		rfc: 'RFC 9110 §15.5.15',
+		rfcUrl: rfc9110('15.5.15'),
+		whenToUse: 'Reject pathologically long URLs (often a sign of misuse or attack).',
+		standard: true,
+	},
+	{
+		code: 415,
+		phrase: 'Unsupported Media Type',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Server refuses to accept the request because the payload format is in an unsupported media type.',
+		rfc: 'RFC 9110 §15.5.16',
+		rfcUrl: rfc9110('15.5.16'),
+		whenToUse: 'Reject Content-Type values that the endpoint does not support.',
+		standard: true,
+	},
+	{
+		code: 416,
+		phrase: 'Range Not Satisfiable',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'None of the ranges in the request Range header overlap the current extent of the selected resource.',
+		rfc: 'RFC 9110 §15.5.17',
+		rfcUrl: rfc9110('15.5.17'),
+		whenToUse: 'Respond when a Range request asks for bytes beyond the size of the resource.',
+		related: [206],
+		standard: true,
+	},
+	{
+		code: 417,
+		phrase: 'Expectation Failed',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Expectation given in the request Expect header could not be met by the server.',
+		rfc: 'RFC 9110 §15.5.18',
+		rfcUrl: rfc9110('15.5.18'),
+		whenToUse: 'Reject "Expect: 100-continue" when the request would not be acceptable.',
+		standard: true,
+	},
+	{
+		code: 418,
+		phrase: "I'm a teapot",
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Joke status from RFC 2324 (Hyper Text Coffee Pot Control Protocol); occasionally used as a sentinel value.',
+		rfc: 'RFC 2324 §2.3.2',
+		rfcUrl: rfcUrl('rfc2324', '2.3.2'),
+		whenToUse: 'Avoid in production APIs; some services return it to flag bot / abuse traffic.',
+		standard: false,
+	},
+	{
+		code: 421,
+		phrase: 'Misdirected Request',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Request was directed at a server that is not able to produce a response (e.g. wrong SNI / authority).',
+		rfc: 'RFC 9110 §15.5.20',
+		rfcUrl: rfc9110('15.5.20'),
+		whenToUse: 'Reject HTTP/2 connection coalescing when the authority does not match the certificate.',
+		standard: true,
+	},
+	{
+		code: 422,
+		phrase: 'Unprocessable Content',
+		category: '4xx',
+		kind: 'client-error',
+		summary:
+			'Server understands the content type and syntax of the request but was unable to process the contained instructions.',
+		rfc: 'RFC 9110 §15.5.21',
+		rfcUrl: rfc9110('15.5.21'),
+		whenToUse: 'Reject well-formed input that fails business / semantic validation (e.g. invalid email, value out of range).',
+		misuse: '422 = well-formed body with semantic errors. 400 = malformed body (bad JSON, missing required header).',
+		related: [400],
+		standard: true,
+	},
+	{
+		code: 423,
+		phrase: 'Locked',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'WebDAV: source or destination resource of a method is locked.',
+		rfc: 'RFC 4918 §11.3',
+		rfcUrl: rfcUrl('rfc4918', '11.3'),
+		whenToUse: 'Reject WebDAV operations that conflict with an active lock.',
+		standard: true,
+	},
+	{
+		code: 424,
+		phrase: 'Failed Dependency',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'WebDAV: method could not be performed because the requested action depended on another action that failed.',
+		rfc: 'RFC 4918 §11.4',
+		rfcUrl: rfcUrl('rfc4918', '11.4'),
+		whenToUse: 'Use within a WebDAV multistatus when one operation cascades a failure.',
+		standard: true,
+	},
+	{
+		code: 425,
+		phrase: 'Too Early',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Server is unwilling to risk processing a request that might be replayed (TLS 1.3 0-RTT).',
+		rfc: 'RFC 8470',
+		rfcUrl: 'https://www.rfc-editor.org/rfc/rfc8470',
+		whenToUse: 'Reject early-data requests for endpoints whose effects are not safe to replay.',
+		standard: true,
+	},
+	{
+		code: 426,
+		phrase: 'Upgrade Required',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Server refuses to perform the request using the current protocol but might after the client upgrades.',
+		rfc: 'RFC 9110 §15.5.22',
+		rfcUrl: rfc9110('15.5.22'),
+		whenToUse: 'Demand TLS / HTTP/2 by including an Upgrade header in the response.',
+		standard: true,
+	},
+	{
+		code: 428,
+		phrase: 'Precondition Required',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Origin server requires the request to be conditional (prevents lost-update / "lost edit" problems).',
+		rfc: 'RFC 6585 §3',
+		rfcUrl: rfcUrl('rfc6585', '3'),
+		whenToUse: 'Require If-Match on PUT / PATCH so concurrent edits cannot silently overwrite each other.',
+		related: [412],
+		standard: true,
+	},
+	{
+		code: 429,
+		phrase: 'Too Many Requests',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'User has sent too many requests in a given amount of time ("rate limiting").',
+		rfc: 'RFC 6585 §4',
+		rfcUrl: rfcUrl('rfc6585', '4'),
+		whenToUse: 'Throttle abusive clients; include a Retry-After header indicating when to retry.',
+		related: [503],
+		standard: true,
+	},
+	{
+		code: 431,
+		phrase: 'Request Header Fields Too Large',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Server is unwilling to process the request because its header fields are too large.',
+		rfc: 'RFC 6585 §5',
+		rfcUrl: rfcUrl('rfc6585', '5'),
+		whenToUse: 'Reject requests with oversized cookies or header blocks.',
+		standard: true,
+	},
+	{
+		code: 451,
+		phrase: 'Unavailable For Legal Reasons',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Resource is unavailable due to legal demands (e.g. court order, government censorship).',
+		rfc: 'RFC 7725',
+		rfcUrl: 'https://www.rfc-editor.org/rfc/rfc7725',
+		whenToUse: 'Indicate that content was removed for legal reasons rather than because it does not exist.',
+		standard: true,
+	},
+	{
+		code: 499,
+		phrase: 'Client Closed Request',
+		category: '4xx',
+		kind: 'client-error',
+		summary: 'Non-standard nginx code logged when the client closed the connection before the server could respond.',
+		whenToUse: 'Recognise in nginx access logs as a client-side abort; not a code you should emit yourself.',
+		standard: false,
+	},
+
+	// ---------------------------------------------------------------- 5xx ----
+	{
+		code: 500,
+		phrase: 'Internal Server Error',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Server encountered an unexpected condition that prevented it from fulfilling the request.',
+		rfc: 'RFC 9110 §15.6.1',
+		rfcUrl: rfc9110('15.6.1'),
+		whenToUse: 'Generic catch-all when no more specific 5xx applies; log details server-side but do not leak them.',
+		standard: true,
+	},
+	{
+		code: 501,
+		phrase: 'Not Implemented',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Server does not support the functionality required to fulfill the request.',
+		rfc: 'RFC 9110 §15.6.2',
+		rfcUrl: rfc9110('15.6.2'),
+		whenToUse: 'Respond when the method is unknown (e.g. unknown verb) or feature is not built.',
+		related: [405],
+		standard: true,
+	},
+	{
+		code: 502,
+		phrase: 'Bad Gateway',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Server, while acting as a gateway or proxy, received an invalid response from the upstream server.',
+		rfc: 'RFC 9110 §15.6.3',
+		rfcUrl: rfc9110('15.6.3'),
+		whenToUse: 'Returned by load balancers / reverse proxies when upstream returns garbage or closes prematurely.',
+		standard: true,
+	},
+	{
+		code: 503,
+		phrase: 'Service Unavailable',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Server is currently unable to handle the request due to temporary overload or scheduled maintenance.',
+		rfc: 'RFC 9110 §15.6.4',
+		rfcUrl: rfc9110('15.6.4'),
+		whenToUse: 'Reject during maintenance windows or when capacity is exhausted; include Retry-After.',
+		related: [429, 504],
+		standard: true,
+	},
+	{
+		code: 504,
+		phrase: 'Gateway Timeout',
+		category: '5xx',
+		kind: 'server-error',
+		summary:
+			'Server, while acting as a gateway or proxy, did not receive a timely response from an upstream server it needed to access.',
+		rfc: 'RFC 9110 §15.6.5',
+		rfcUrl: rfc9110('15.6.5'),
+		whenToUse: 'Returned by load balancers when the upstream is slow / unresponsive beyond the configured timeout.',
+		related: [502, 503],
+		standard: true,
+	},
+	{
+		code: 505,
+		phrase: 'HTTP Version Not Supported',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Server does not support the major HTTP version used in the request.',
+		rfc: 'RFC 9110 §15.6.6',
+		rfcUrl: rfc9110('15.6.6'),
+		whenToUse: 'Reject HTTP/0.9 or otherwise unsupported protocol versions.',
+		standard: true,
+	},
+	{
+		code: 506,
+		phrase: 'Variant Also Negotiates',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Transparent content negotiation for the request results in a circular reference.',
+		rfc: 'RFC 2295 §8.1',
+		rfcUrl: rfcUrl('rfc2295', '8.1'),
+		whenToUse: 'Signal a configuration error in transparent content negotiation.',
+		standard: true,
+	},
+	{
+		code: 507,
+		phrase: 'Insufficient Storage',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'WebDAV: server is unable to store the representation needed to complete the request.',
+		rfc: 'RFC 4918 §11.5',
+		rfcUrl: rfcUrl('rfc4918', '11.5'),
+		whenToUse: 'Reject WebDAV writes when the backing store has no room.',
+		standard: true,
+	},
+	{
+		code: 508,
+		phrase: 'Loop Detected',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'WebDAV: server detected an infinite loop while processing the request.',
+		rfc: 'RFC 5842 §7.2',
+		rfcUrl: rfcUrl('rfc5842', '7.2'),
+		whenToUse: 'Terminate WebDAV recursion that would otherwise never converge.',
+		standard: true,
+	},
+	{
+		code: 510,
+		phrase: 'Not Extended',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Further extensions to the request are required for the server to fulfill it.',
+		rfc: 'RFC 2774 §7',
+		rfcUrl: rfcUrl('rfc2774', '7'),
+		whenToUse: 'Rarely used; signals that the request must include additional HTTP extension framing.',
+		standard: true,
+	},
+	{
+		code: 511,
+		phrase: 'Network Authentication Required',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Client needs to authenticate to gain network access (captive portal).',
+		rfc: 'RFC 6585 §6',
+		rfcUrl: rfcUrl('rfc6585', '6'),
+		whenToUse: 'Returned by captive portals to interrupt traffic until the user signs in.',
+		standard: true,
+	},
+	{
+		code: 520,
+		phrase: 'Web Server Returned an Unknown Error',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Non-standard CDN code: origin returned an empty, unknown, or otherwise unexpected response.',
+		whenToUse: 'CDN diagnostic only; investigate the origin server response if you encounter this.',
+		standard: false,
+	},
+	{
+		code: 521,
+		phrase: 'Web Server Is Down',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Non-standard CDN code: origin server refused the connection from the CDN.',
+		whenToUse: 'CDN diagnostic only; verify the origin is up and the CDN is allowlisted.',
+		standard: false,
+	},
+	{
+		code: 522,
+		phrase: 'Connection Timed Out',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Non-standard CDN code: CDN could not negotiate a TCP handshake with the origin.',
+		whenToUse: 'CDN diagnostic only; check network ACLs and origin health.',
+		standard: false,
+	},
+	{
+		code: 523,
+		phrase: 'Origin Is Unreachable',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Non-standard CDN code: CDN cannot reach the origin (DNS / routing failure).',
+		whenToUse: 'CDN diagnostic only; check DNS, BGP routing, and origin reachability.',
+		standard: false,
+	},
+	{
+		code: 524,
+		phrase: 'A Timeout Occurred',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Non-standard CDN code: TCP connection to the origin established, but no HTTP response within the timeout.',
+		whenToUse: 'CDN diagnostic only; tune origin response times or extend CDN timeout.',
+		standard: false,
+	},
+	{
+		code: 525,
+		phrase: 'SSL Handshake Failed',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Non-standard CDN code: TLS handshake with the origin failed.',
+		whenToUse: 'CDN diagnostic only; verify origin certificate, cipher suite, and SNI.',
+		standard: false,
+	},
+	{
+		code: 526,
+		phrase: 'Invalid SSL Certificate',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Non-standard CDN code: origin presented an invalid TLS certificate.',
+		whenToUse: 'CDN diagnostic only; renew or reconfigure the origin certificate chain.',
+		standard: false,
+	},
+	{
+		code: 527,
+		phrase: 'Railgun Error',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Non-standard CDN code: error in the tunneled connection between CDN edge and origin.',
+		whenToUse: 'CDN diagnostic only; involves the CDN-specific origin tunnel.',
+		standard: false,
+	},
+	{
+		code: 530,
+		phrase: 'Site Frozen / Origin Error',
+		category: '5xx',
+		kind: 'server-error',
+		summary:
+			'Non-standard CDN code: site is suspended or origin returned an error that triggered a CDN 1xxx error page.',
+		whenToUse: 'CDN diagnostic only; consult the CDN-specific error-code page for the underlying cause.',
+		standard: false,
+	},
+	{
+		code: 598,
+		phrase: 'Network Read Timeout Error',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Non-standard proxy code: used by some HTTP proxies when a read on the upstream connection times out.',
+		whenToUse: 'Proxy diagnostic only; not part of any RFC.',
+		standard: false,
+	},
+	{
+		code: 599,
+		phrase: 'Network Connect Timeout Error',
+		category: '5xx',
+		kind: 'server-error',
+		summary: 'Non-standard proxy code: used by some HTTP proxies when establishing the upstream connection times out.',
+		whenToUse: 'Proxy diagnostic only; not part of any RFC.',
+		standard: false,
+	},
+] as const;
+
+export const CATEGORY_LABELS: Readonly<Record<StatusCategory, string>> = {
+	'1xx': '1xx Informational',
+	'2xx': '2xx Success',
+	'3xx': '3xx Redirection',
+	'4xx': '4xx Client Error',
+	'5xx': '5xx Server Error',
+};
+
+/**
+ * Tailwind class fragment for the category's accent. Maps to the project's
+ * tone tokens (`success` / `info` / `warning` / `destructive`) used by
+ * `ToneBadge`.
+ */
+export const CATEGORY_TONES: Readonly<Record<StatusCategory, 'info' | 'success' | 'warning' | 'destructive'>> = {
+	'1xx': 'info',
+	'2xx': 'success',
+	'3xx': 'info',
+	'4xx': 'warning',
+	'5xx': 'destructive',
+};
+
+export const ALL_CATEGORIES: readonly StatusCategory[] = ['1xx', '2xx', '3xx', '4xx', '5xx'];
+
+/** Resolve a numeric code to its category, or `null` when outside 100-599. */
+export const categoryOf = (code: number): StatusCategory | null => {
+	if (code < 100 || code > 599) return null;
+	const bucket = Math.floor(code / 100);
+	if (bucket === 1) return '1xx';
+	if (bucket === 2) return '2xx';
+	if (bucket === 3) return '3xx';
+	if (bucket === 4) return '4xx';
+	if (bucket === 5) return '5xx';
+	return null;
+};
+
+/** Look up a status code by its numeric value. */
+export const getStatusCode = (code: number): StatusCode | undefined =>
+	STATUS_CODES.find((entry) => entry.code === code);
+
+export interface FilterOptions {
+	readonly query: string;
+	readonly categories: ReadonlySet<StatusCategory>;
+	readonly includeNonStandard: boolean;
+	readonly misuseOnly?: boolean;
+}
+
+/**
+ * Match a code against the search query. A numeric query (e.g. "4", "40",
+ * "404") matches by prefix of the code; an alphabetic query matches the
+ * phrase, summary, or "when to use" text as a substring.
+ */
+const matchesQuery = (entry: StatusCode, query: string): boolean => {
+	const trimmed = query.trim();
+	if (trimmed.length === 0) return true;
+
+	if (/^\d+$/.test(trimmed)) {
+		return entry.code.toString().startsWith(trimmed);
+	}
+
+	const needle = trimmed.toLowerCase();
+	const haystack = [entry.phrase, entry.summary, entry.whenToUse ?? '', entry.misuse ?? '']
+		.join(' ')
+		.toLowerCase();
+	return haystack.includes(needle);
+};
+
+export const filterStatusCodes = (
+	all: readonly StatusCode[],
+	opts: FilterOptions
+): readonly StatusCode[] =>
+	all
+		.filter((entry) => opts.includeNonStandard || entry.standard)
+		.filter((entry) => opts.categories.has(entry.category))
+		.filter((entry) => (opts.misuseOnly ? Boolean(entry.misuse) : true))
+		.filter((entry) => matchesQuery(entry, opts.query));
+
+/** Total catalog size — exported for status-bar display. */
+export const TOTAL_CODES = STATUS_CODES.length;
+
+/** IANA registry homepage. */
+export const IANA_REGISTRY_URL = IANA_URL;

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -8,6 +8,7 @@ import {
 	ArrowRightLeft,
 	BadgeCheck,
 	Binary,
+	BookOpen,
 	Braces,
 	Calculator,
 	CalendarClock,
@@ -462,6 +463,16 @@ export const PAGES: readonly PageDefinition[] = [
 		icon: FileType,
 		description: 'Bidirectional MIME type / extension lookup with magic bytes and charset info',
 		color: 'text-emerald-700',
+		category: 'network',
+	},
+	{
+		id: 'http-status-codes',
+		title: 'HTTP Status Codes',
+		url: '/http-status-codes',
+		icon: BookOpen,
+		description:
+			'Searchable HTTP status code reference with RFC citations and misuse warnings',
+		color: 'text-violet-600',
 		category: 'network',
 	},
 	{

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -8,812 +8,833 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root';
-import { Route as YamlFormatterRouteImport } from './routes/yaml-formatter';
-import { Route as XmlFormatterRouteImport } from './routes/xml-formatter';
-import { Route as X509DecoderRouteImport } from './routes/x509-decoder';
-import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator';
-import { Route as UrlEncoderRouteImport } from './routes/url-encoder';
-import { Route as StringCompressorRouteImport } from './routes/string-compressor';
-import { Route as StringCaseConverterRouteImport } from './routes/string-case-converter';
-import { Route as SshKeyGeneratorRouteImport } from './routes/ssh-key-generator';
-import { Route as SqlFormatterRouteImport } from './routes/sql-formatter';
-import { Route as SettingsRouteImport } from './routes/settings';
-import { Route as SemverToolsRouteImport } from './routes/semver-tools';
-import { Route as RsaToolsRouteImport } from './routes/rsa-tools';
-import { Route as RegexTesterRouteImport } from './routes/regex-tester';
-import { Route as QrCodeGeneratorRouteImport } from './routes/qr-code-generator';
-import { Route as PasswordGeneratorRouteImport } from './routes/password-generator';
-import { Route as NumberBaseConverterRouteImport } from './routes/number-base-converter';
-import { Route as NetworkScannerRouteImport } from './routes/network-scanner';
-import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces';
-import { Route as MimeTypesRouteImport } from './routes/mime-types';
-import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor';
-import { Route as LoremIpsumRouteImport } from './routes/lorem-ipsum';
-import { Route as ListComparerRouteImport } from './routes/list-comparer';
-import { Route as JwtDecoderRouteImport } from './routes/jwt-decoder';
-import { Route as JsonFormatterRouteImport } from './routes/json-formatter';
-import { Route as IpConverterRouteImport } from './routes/ip-converter';
-import { Route as ImageConverterRouteImport } from './routes/image-converter';
-import { Route as HashGeneratorRouteImport } from './routes/hash-generator';
-import { Route as GpgKeyGeneratorRouteImport } from './routes/gpg-key-generator';
-import { Route as EscapeToolRouteImport } from './routes/escape-tool';
-import { Route as DiffViewerRouteImport } from './routes/diff-viewer';
-import { Route as DateTimestampConverterRouteImport } from './routes/date-timestamp-converter';
-import { Route as CurlBuilderRouteImport } from './routes/curl-builder';
-import { Route as CronExpressionBuilderRouteImport } from './routes/cron-expression-builder';
-import { Route as CidrCalculatorRouteImport } from './routes/cidr-calculator';
-import { Route as BcryptGeneratorRouteImport } from './routes/bcrypt-generator';
-import { Route as Base64EncoderRouteImport } from './routes/base64-encoder';
-import { Route as IndexRouteImport } from './routes/index';
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as YamlFormatterRouteImport } from './routes/yaml-formatter'
+import { Route as XmlFormatterRouteImport } from './routes/xml-formatter'
+import { Route as X509DecoderRouteImport } from './routes/x509-decoder'
+import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator'
+import { Route as UrlEncoderRouteImport } from './routes/url-encoder'
+import { Route as StringCompressorRouteImport } from './routes/string-compressor'
+import { Route as StringCaseConverterRouteImport } from './routes/string-case-converter'
+import { Route as SshKeyGeneratorRouteImport } from './routes/ssh-key-generator'
+import { Route as SqlFormatterRouteImport } from './routes/sql-formatter'
+import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as SemverToolsRouteImport } from './routes/semver-tools'
+import { Route as RsaToolsRouteImport } from './routes/rsa-tools'
+import { Route as RegexTesterRouteImport } from './routes/regex-tester'
+import { Route as QrCodeGeneratorRouteImport } from './routes/qr-code-generator'
+import { Route as PasswordGeneratorRouteImport } from './routes/password-generator'
+import { Route as NumberBaseConverterRouteImport } from './routes/number-base-converter'
+import { Route as NetworkScannerRouteImport } from './routes/network-scanner'
+import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces'
+import { Route as MimeTypesRouteImport } from './routes/mime-types'
+import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor'
+import { Route as LoremIpsumRouteImport } from './routes/lorem-ipsum'
+import { Route as ListComparerRouteImport } from './routes/list-comparer'
+import { Route as JwtDecoderRouteImport } from './routes/jwt-decoder'
+import { Route as JsonFormatterRouteImport } from './routes/json-formatter'
+import { Route as IpConverterRouteImport } from './routes/ip-converter'
+import { Route as ImageConverterRouteImport } from './routes/image-converter'
+import { Route as HttpStatusCodesRouteImport } from './routes/http-status-codes'
+import { Route as HashGeneratorRouteImport } from './routes/hash-generator'
+import { Route as GpgKeyGeneratorRouteImport } from './routes/gpg-key-generator'
+import { Route as EscapeToolRouteImport } from './routes/escape-tool'
+import { Route as DiffViewerRouteImport } from './routes/diff-viewer'
+import { Route as DateTimestampConverterRouteImport } from './routes/date-timestamp-converter'
+import { Route as CurlBuilderRouteImport } from './routes/curl-builder'
+import { Route as CronExpressionBuilderRouteImport } from './routes/cron-expression-builder'
+import { Route as CidrCalculatorRouteImport } from './routes/cidr-calculator'
+import { Route as BcryptGeneratorRouteImport } from './routes/bcrypt-generator'
+import { Route as Base64EncoderRouteImport } from './routes/base64-encoder'
+import { Route as IndexRouteImport } from './routes/index'
 
 const YamlFormatterRoute = YamlFormatterRouteImport.update({
-	id: '/yaml-formatter',
-	path: '/yaml-formatter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/yaml-formatter',
+  path: '/yaml-formatter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const XmlFormatterRoute = XmlFormatterRouteImport.update({
-	id: '/xml-formatter',
-	path: '/xml-formatter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/xml-formatter',
+  path: '/xml-formatter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const X509DecoderRoute = X509DecoderRouteImport.update({
-	id: '/x509-decoder',
-	path: '/x509-decoder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/x509-decoder',
+  path: '/x509-decoder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const UuidGeneratorRoute = UuidGeneratorRouteImport.update({
-	id: '/uuid-generator',
-	path: '/uuid-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/uuid-generator',
+  path: '/uuid-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const UrlEncoderRoute = UrlEncoderRouteImport.update({
-	id: '/url-encoder',
-	path: '/url-encoder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/url-encoder',
+  path: '/url-encoder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const StringCompressorRoute = StringCompressorRouteImport.update({
-	id: '/string-compressor',
-	path: '/string-compressor',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/string-compressor',
+  path: '/string-compressor',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const StringCaseConverterRoute = StringCaseConverterRouteImport.update({
-	id: '/string-case-converter',
-	path: '/string-case-converter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/string-case-converter',
+  path: '/string-case-converter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SshKeyGeneratorRoute = SshKeyGeneratorRouteImport.update({
-	id: '/ssh-key-generator',
-	path: '/ssh-key-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/ssh-key-generator',
+  path: '/ssh-key-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SqlFormatterRoute = SqlFormatterRouteImport.update({
-	id: '/sql-formatter',
-	path: '/sql-formatter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/sql-formatter',
+  path: '/sql-formatter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SettingsRoute = SettingsRouteImport.update({
-	id: '/settings',
-	path: '/settings',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SemverToolsRoute = SemverToolsRouteImport.update({
-	id: '/semver-tools',
-	path: '/semver-tools',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/semver-tools',
+  path: '/semver-tools',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const RsaToolsRoute = RsaToolsRouteImport.update({
-	id: '/rsa-tools',
-	path: '/rsa-tools',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/rsa-tools',
+  path: '/rsa-tools',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const RegexTesterRoute = RegexTesterRouteImport.update({
-	id: '/regex-tester',
-	path: '/regex-tester',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/regex-tester',
+  path: '/regex-tester',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const QrCodeGeneratorRoute = QrCodeGeneratorRouteImport.update({
-	id: '/qr-code-generator',
-	path: '/qr-code-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/qr-code-generator',
+  path: '/qr-code-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const PasswordGeneratorRoute = PasswordGeneratorRouteImport.update({
-	id: '/password-generator',
-	path: '/password-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/password-generator',
+  path: '/password-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const NumberBaseConverterRoute = NumberBaseConverterRouteImport.update({
-	id: '/number-base-converter',
-	path: '/number-base-converter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/number-base-converter',
+  path: '/number-base-converter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const NetworkScannerRoute = NetworkScannerRouteImport.update({
-	id: '/network-scanner',
-	path: '/network-scanner',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/network-scanner',
+  path: '/network-scanner',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const NetworkInterfacesRoute = NetworkInterfacesRouteImport.update({
-	id: '/network-interfaces',
-	path: '/network-interfaces',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/network-interfaces',
+  path: '/network-interfaces',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MimeTypesRoute = MimeTypesRouteImport.update({
-	id: '/mime-types',
-	path: '/mime-types',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/mime-types',
+  path: '/mime-types',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MarkdownEditorRoute = MarkdownEditorRouteImport.update({
-	id: '/markdown-editor',
-	path: '/markdown-editor',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/markdown-editor',
+  path: '/markdown-editor',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LoremIpsumRoute = LoremIpsumRouteImport.update({
-	id: '/lorem-ipsum',
-	path: '/lorem-ipsum',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/lorem-ipsum',
+  path: '/lorem-ipsum',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ListComparerRoute = ListComparerRouteImport.update({
-	id: '/list-comparer',
-	path: '/list-comparer',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/list-comparer',
+  path: '/list-comparer',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const JwtDecoderRoute = JwtDecoderRouteImport.update({
-	id: '/jwt-decoder',
-	path: '/jwt-decoder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/jwt-decoder',
+  path: '/jwt-decoder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const JsonFormatterRoute = JsonFormatterRouteImport.update({
-	id: '/json-formatter',
-	path: '/json-formatter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/json-formatter',
+  path: '/json-formatter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IpConverterRoute = IpConverterRouteImport.update({
-	id: '/ip-converter',
-	path: '/ip-converter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/ip-converter',
+  path: '/ip-converter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ImageConverterRoute = ImageConverterRouteImport.update({
-	id: '/image-converter',
-	path: '/image-converter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/image-converter',
+  path: '/image-converter',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const HttpStatusCodesRoute = HttpStatusCodesRouteImport.update({
+  id: '/http-status-codes',
+  path: '/http-status-codes',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const HashGeneratorRoute = HashGeneratorRouteImport.update({
-	id: '/hash-generator',
-	path: '/hash-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/hash-generator',
+  path: '/hash-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const GpgKeyGeneratorRoute = GpgKeyGeneratorRouteImport.update({
-	id: '/gpg-key-generator',
-	path: '/gpg-key-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/gpg-key-generator',
+  path: '/gpg-key-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const EscapeToolRoute = EscapeToolRouteImport.update({
-	id: '/escape-tool',
-	path: '/escape-tool',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/escape-tool',
+  path: '/escape-tool',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DiffViewerRoute = DiffViewerRouteImport.update({
-	id: '/diff-viewer',
-	path: '/diff-viewer',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/diff-viewer',
+  path: '/diff-viewer',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DateTimestampConverterRoute = DateTimestampConverterRouteImport.update({
-	id: '/date-timestamp-converter',
-	path: '/date-timestamp-converter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/date-timestamp-converter',
+  path: '/date-timestamp-converter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CurlBuilderRoute = CurlBuilderRouteImport.update({
-	id: '/curl-builder',
-	path: '/curl-builder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/curl-builder',
+  path: '/curl-builder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CronExpressionBuilderRoute = CronExpressionBuilderRouteImport.update({
-	id: '/cron-expression-builder',
-	path: '/cron-expression-builder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/cron-expression-builder',
+  path: '/cron-expression-builder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CidrCalculatorRoute = CidrCalculatorRouteImport.update({
-	id: '/cidr-calculator',
-	path: '/cidr-calculator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/cidr-calculator',
+  path: '/cidr-calculator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const BcryptGeneratorRoute = BcryptGeneratorRouteImport.update({
-	id: '/bcrypt-generator',
-	path: '/bcrypt-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/bcrypt-generator',
+  path: '/bcrypt-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const Base64EncoderRoute = Base64EncoderRouteImport.update({
-	id: '/base64-encoder',
-	path: '/base64-encoder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/base64-encoder',
+  path: '/base64-encoder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
-	id: '/',
-	path: '/',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
-	'/': typeof IndexRoute;
-	'/base64-encoder': typeof Base64EncoderRoute;
-	'/bcrypt-generator': typeof BcryptGeneratorRoute;
-	'/cidr-calculator': typeof CidrCalculatorRoute;
-	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
-	'/curl-builder': typeof CurlBuilderRoute;
-	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
-	'/diff-viewer': typeof DiffViewerRoute;
-	'/escape-tool': typeof EscapeToolRoute;
-	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
-	'/hash-generator': typeof HashGeneratorRoute;
-	'/image-converter': typeof ImageConverterRoute;
-	'/ip-converter': typeof IpConverterRoute;
-	'/json-formatter': typeof JsonFormatterRoute;
-	'/jwt-decoder': typeof JwtDecoderRoute;
-	'/list-comparer': typeof ListComparerRoute;
-	'/lorem-ipsum': typeof LoremIpsumRoute;
-	'/markdown-editor': typeof MarkdownEditorRoute;
-	'/mime-types': typeof MimeTypesRoute;
-	'/network-interfaces': typeof NetworkInterfacesRoute;
-	'/network-scanner': typeof NetworkScannerRoute;
-	'/number-base-converter': typeof NumberBaseConverterRoute;
-	'/password-generator': typeof PasswordGeneratorRoute;
-	'/qr-code-generator': typeof QrCodeGeneratorRoute;
-	'/regex-tester': typeof RegexTesterRoute;
-	'/rsa-tools': typeof RsaToolsRoute;
-	'/semver-tools': typeof SemverToolsRoute;
-	'/settings': typeof SettingsRoute;
-	'/sql-formatter': typeof SqlFormatterRoute;
-	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
-	'/string-case-converter': typeof StringCaseConverterRoute;
-	'/string-compressor': typeof StringCompressorRoute;
-	'/url-encoder': typeof UrlEncoderRoute;
-	'/uuid-generator': typeof UuidGeneratorRoute;
-	'/x509-decoder': typeof X509DecoderRoute;
-	'/xml-formatter': typeof XmlFormatterRoute;
-	'/yaml-formatter': typeof YamlFormatterRoute;
+  '/': typeof IndexRoute
+  '/base64-encoder': typeof Base64EncoderRoute
+  '/bcrypt-generator': typeof BcryptGeneratorRoute
+  '/cidr-calculator': typeof CidrCalculatorRoute
+  '/cron-expression-builder': typeof CronExpressionBuilderRoute
+  '/curl-builder': typeof CurlBuilderRoute
+  '/date-timestamp-converter': typeof DateTimestampConverterRoute
+  '/diff-viewer': typeof DiffViewerRoute
+  '/escape-tool': typeof EscapeToolRoute
+  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
+  '/hash-generator': typeof HashGeneratorRoute
+  '/http-status-codes': typeof HttpStatusCodesRoute
+  '/image-converter': typeof ImageConverterRoute
+  '/ip-converter': typeof IpConverterRoute
+  '/json-formatter': typeof JsonFormatterRoute
+  '/jwt-decoder': typeof JwtDecoderRoute
+  '/list-comparer': typeof ListComparerRoute
+  '/lorem-ipsum': typeof LoremIpsumRoute
+  '/markdown-editor': typeof MarkdownEditorRoute
+  '/mime-types': typeof MimeTypesRoute
+  '/network-interfaces': typeof NetworkInterfacesRoute
+  '/network-scanner': typeof NetworkScannerRoute
+  '/number-base-converter': typeof NumberBaseConverterRoute
+  '/password-generator': typeof PasswordGeneratorRoute
+  '/qr-code-generator': typeof QrCodeGeneratorRoute
+  '/regex-tester': typeof RegexTesterRoute
+  '/rsa-tools': typeof RsaToolsRoute
+  '/semver-tools': typeof SemverToolsRoute
+  '/settings': typeof SettingsRoute
+  '/sql-formatter': typeof SqlFormatterRoute
+  '/ssh-key-generator': typeof SshKeyGeneratorRoute
+  '/string-case-converter': typeof StringCaseConverterRoute
+  '/string-compressor': typeof StringCompressorRoute
+  '/url-encoder': typeof UrlEncoderRoute
+  '/uuid-generator': typeof UuidGeneratorRoute
+  '/x509-decoder': typeof X509DecoderRoute
+  '/xml-formatter': typeof XmlFormatterRoute
+  '/yaml-formatter': typeof YamlFormatterRoute
 }
 export interface FileRoutesByTo {
-	'/': typeof IndexRoute;
-	'/base64-encoder': typeof Base64EncoderRoute;
-	'/bcrypt-generator': typeof BcryptGeneratorRoute;
-	'/cidr-calculator': typeof CidrCalculatorRoute;
-	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
-	'/curl-builder': typeof CurlBuilderRoute;
-	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
-	'/diff-viewer': typeof DiffViewerRoute;
-	'/escape-tool': typeof EscapeToolRoute;
-	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
-	'/hash-generator': typeof HashGeneratorRoute;
-	'/image-converter': typeof ImageConverterRoute;
-	'/ip-converter': typeof IpConverterRoute;
-	'/json-formatter': typeof JsonFormatterRoute;
-	'/jwt-decoder': typeof JwtDecoderRoute;
-	'/list-comparer': typeof ListComparerRoute;
-	'/lorem-ipsum': typeof LoremIpsumRoute;
-	'/markdown-editor': typeof MarkdownEditorRoute;
-	'/mime-types': typeof MimeTypesRoute;
-	'/network-interfaces': typeof NetworkInterfacesRoute;
-	'/network-scanner': typeof NetworkScannerRoute;
-	'/number-base-converter': typeof NumberBaseConverterRoute;
-	'/password-generator': typeof PasswordGeneratorRoute;
-	'/qr-code-generator': typeof QrCodeGeneratorRoute;
-	'/regex-tester': typeof RegexTesterRoute;
-	'/rsa-tools': typeof RsaToolsRoute;
-	'/semver-tools': typeof SemverToolsRoute;
-	'/settings': typeof SettingsRoute;
-	'/sql-formatter': typeof SqlFormatterRoute;
-	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
-	'/string-case-converter': typeof StringCaseConverterRoute;
-	'/string-compressor': typeof StringCompressorRoute;
-	'/url-encoder': typeof UrlEncoderRoute;
-	'/uuid-generator': typeof UuidGeneratorRoute;
-	'/x509-decoder': typeof X509DecoderRoute;
-	'/xml-formatter': typeof XmlFormatterRoute;
-	'/yaml-formatter': typeof YamlFormatterRoute;
+  '/': typeof IndexRoute
+  '/base64-encoder': typeof Base64EncoderRoute
+  '/bcrypt-generator': typeof BcryptGeneratorRoute
+  '/cidr-calculator': typeof CidrCalculatorRoute
+  '/cron-expression-builder': typeof CronExpressionBuilderRoute
+  '/curl-builder': typeof CurlBuilderRoute
+  '/date-timestamp-converter': typeof DateTimestampConverterRoute
+  '/diff-viewer': typeof DiffViewerRoute
+  '/escape-tool': typeof EscapeToolRoute
+  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
+  '/hash-generator': typeof HashGeneratorRoute
+  '/http-status-codes': typeof HttpStatusCodesRoute
+  '/image-converter': typeof ImageConverterRoute
+  '/ip-converter': typeof IpConverterRoute
+  '/json-formatter': typeof JsonFormatterRoute
+  '/jwt-decoder': typeof JwtDecoderRoute
+  '/list-comparer': typeof ListComparerRoute
+  '/lorem-ipsum': typeof LoremIpsumRoute
+  '/markdown-editor': typeof MarkdownEditorRoute
+  '/mime-types': typeof MimeTypesRoute
+  '/network-interfaces': typeof NetworkInterfacesRoute
+  '/network-scanner': typeof NetworkScannerRoute
+  '/number-base-converter': typeof NumberBaseConverterRoute
+  '/password-generator': typeof PasswordGeneratorRoute
+  '/qr-code-generator': typeof QrCodeGeneratorRoute
+  '/regex-tester': typeof RegexTesterRoute
+  '/rsa-tools': typeof RsaToolsRoute
+  '/semver-tools': typeof SemverToolsRoute
+  '/settings': typeof SettingsRoute
+  '/sql-formatter': typeof SqlFormatterRoute
+  '/ssh-key-generator': typeof SshKeyGeneratorRoute
+  '/string-case-converter': typeof StringCaseConverterRoute
+  '/string-compressor': typeof StringCompressorRoute
+  '/url-encoder': typeof UrlEncoderRoute
+  '/uuid-generator': typeof UuidGeneratorRoute
+  '/x509-decoder': typeof X509DecoderRoute
+  '/xml-formatter': typeof XmlFormatterRoute
+  '/yaml-formatter': typeof YamlFormatterRoute
 }
 export interface FileRoutesById {
-	__root__: typeof rootRouteImport;
-	'/': typeof IndexRoute;
-	'/base64-encoder': typeof Base64EncoderRoute;
-	'/bcrypt-generator': typeof BcryptGeneratorRoute;
-	'/cidr-calculator': typeof CidrCalculatorRoute;
-	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
-	'/curl-builder': typeof CurlBuilderRoute;
-	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
-	'/diff-viewer': typeof DiffViewerRoute;
-	'/escape-tool': typeof EscapeToolRoute;
-	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
-	'/hash-generator': typeof HashGeneratorRoute;
-	'/image-converter': typeof ImageConverterRoute;
-	'/ip-converter': typeof IpConverterRoute;
-	'/json-formatter': typeof JsonFormatterRoute;
-	'/jwt-decoder': typeof JwtDecoderRoute;
-	'/list-comparer': typeof ListComparerRoute;
-	'/lorem-ipsum': typeof LoremIpsumRoute;
-	'/markdown-editor': typeof MarkdownEditorRoute;
-	'/mime-types': typeof MimeTypesRoute;
-	'/network-interfaces': typeof NetworkInterfacesRoute;
-	'/network-scanner': typeof NetworkScannerRoute;
-	'/number-base-converter': typeof NumberBaseConverterRoute;
-	'/password-generator': typeof PasswordGeneratorRoute;
-	'/qr-code-generator': typeof QrCodeGeneratorRoute;
-	'/regex-tester': typeof RegexTesterRoute;
-	'/rsa-tools': typeof RsaToolsRoute;
-	'/semver-tools': typeof SemverToolsRoute;
-	'/settings': typeof SettingsRoute;
-	'/sql-formatter': typeof SqlFormatterRoute;
-	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
-	'/string-case-converter': typeof StringCaseConverterRoute;
-	'/string-compressor': typeof StringCompressorRoute;
-	'/url-encoder': typeof UrlEncoderRoute;
-	'/uuid-generator': typeof UuidGeneratorRoute;
-	'/x509-decoder': typeof X509DecoderRoute;
-	'/xml-formatter': typeof XmlFormatterRoute;
-	'/yaml-formatter': typeof YamlFormatterRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/base64-encoder': typeof Base64EncoderRoute
+  '/bcrypt-generator': typeof BcryptGeneratorRoute
+  '/cidr-calculator': typeof CidrCalculatorRoute
+  '/cron-expression-builder': typeof CronExpressionBuilderRoute
+  '/curl-builder': typeof CurlBuilderRoute
+  '/date-timestamp-converter': typeof DateTimestampConverterRoute
+  '/diff-viewer': typeof DiffViewerRoute
+  '/escape-tool': typeof EscapeToolRoute
+  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
+  '/hash-generator': typeof HashGeneratorRoute
+  '/http-status-codes': typeof HttpStatusCodesRoute
+  '/image-converter': typeof ImageConverterRoute
+  '/ip-converter': typeof IpConverterRoute
+  '/json-formatter': typeof JsonFormatterRoute
+  '/jwt-decoder': typeof JwtDecoderRoute
+  '/list-comparer': typeof ListComparerRoute
+  '/lorem-ipsum': typeof LoremIpsumRoute
+  '/markdown-editor': typeof MarkdownEditorRoute
+  '/mime-types': typeof MimeTypesRoute
+  '/network-interfaces': typeof NetworkInterfacesRoute
+  '/network-scanner': typeof NetworkScannerRoute
+  '/number-base-converter': typeof NumberBaseConverterRoute
+  '/password-generator': typeof PasswordGeneratorRoute
+  '/qr-code-generator': typeof QrCodeGeneratorRoute
+  '/regex-tester': typeof RegexTesterRoute
+  '/rsa-tools': typeof RsaToolsRoute
+  '/semver-tools': typeof SemverToolsRoute
+  '/settings': typeof SettingsRoute
+  '/sql-formatter': typeof SqlFormatterRoute
+  '/ssh-key-generator': typeof SshKeyGeneratorRoute
+  '/string-case-converter': typeof StringCaseConverterRoute
+  '/string-compressor': typeof StringCompressorRoute
+  '/url-encoder': typeof UrlEncoderRoute
+  '/uuid-generator': typeof UuidGeneratorRoute
+  '/x509-decoder': typeof X509DecoderRoute
+  '/xml-formatter': typeof XmlFormatterRoute
+  '/yaml-formatter': typeof YamlFormatterRoute
 }
 export interface FileRouteTypes {
-	fileRoutesByFullPath: FileRoutesByFullPath;
-	fullPaths:
-		| '/'
-		| '/base64-encoder'
-		| '/bcrypt-generator'
-		| '/cidr-calculator'
-		| '/cron-expression-builder'
-		| '/curl-builder'
-		| '/date-timestamp-converter'
-		| '/diff-viewer'
-		| '/escape-tool'
-		| '/gpg-key-generator'
-		| '/hash-generator'
-		| '/image-converter'
-		| '/ip-converter'
-		| '/json-formatter'
-		| '/jwt-decoder'
-		| '/list-comparer'
-		| '/lorem-ipsum'
-		| '/markdown-editor'
-		| '/mime-types'
-		| '/network-interfaces'
-		| '/network-scanner'
-		| '/number-base-converter'
-		| '/password-generator'
-		| '/qr-code-generator'
-		| '/regex-tester'
-		| '/rsa-tools'
-		| '/semver-tools'
-		| '/settings'
-		| '/sql-formatter'
-		| '/ssh-key-generator'
-		| '/string-case-converter'
-		| '/string-compressor'
-		| '/url-encoder'
-		| '/uuid-generator'
-		| '/x509-decoder'
-		| '/xml-formatter'
-		| '/yaml-formatter';
-	fileRoutesByTo: FileRoutesByTo;
-	to:
-		| '/'
-		| '/base64-encoder'
-		| '/bcrypt-generator'
-		| '/cidr-calculator'
-		| '/cron-expression-builder'
-		| '/curl-builder'
-		| '/date-timestamp-converter'
-		| '/diff-viewer'
-		| '/escape-tool'
-		| '/gpg-key-generator'
-		| '/hash-generator'
-		| '/image-converter'
-		| '/ip-converter'
-		| '/json-formatter'
-		| '/jwt-decoder'
-		| '/list-comparer'
-		| '/lorem-ipsum'
-		| '/markdown-editor'
-		| '/mime-types'
-		| '/network-interfaces'
-		| '/network-scanner'
-		| '/number-base-converter'
-		| '/password-generator'
-		| '/qr-code-generator'
-		| '/regex-tester'
-		| '/rsa-tools'
-		| '/semver-tools'
-		| '/settings'
-		| '/sql-formatter'
-		| '/ssh-key-generator'
-		| '/string-case-converter'
-		| '/string-compressor'
-		| '/url-encoder'
-		| '/uuid-generator'
-		| '/x509-decoder'
-		| '/xml-formatter'
-		| '/yaml-formatter';
-	id:
-		| '__root__'
-		| '/'
-		| '/base64-encoder'
-		| '/bcrypt-generator'
-		| '/cidr-calculator'
-		| '/cron-expression-builder'
-		| '/curl-builder'
-		| '/date-timestamp-converter'
-		| '/diff-viewer'
-		| '/escape-tool'
-		| '/gpg-key-generator'
-		| '/hash-generator'
-		| '/image-converter'
-		| '/ip-converter'
-		| '/json-formatter'
-		| '/jwt-decoder'
-		| '/list-comparer'
-		| '/lorem-ipsum'
-		| '/markdown-editor'
-		| '/mime-types'
-		| '/network-interfaces'
-		| '/network-scanner'
-		| '/number-base-converter'
-		| '/password-generator'
-		| '/qr-code-generator'
-		| '/regex-tester'
-		| '/rsa-tools'
-		| '/semver-tools'
-		| '/settings'
-		| '/sql-formatter'
-		| '/ssh-key-generator'
-		| '/string-case-converter'
-		| '/string-compressor'
-		| '/url-encoder'
-		| '/uuid-generator'
-		| '/x509-decoder'
-		| '/xml-formatter'
-		| '/yaml-formatter';
-	fileRoutesById: FileRoutesById;
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/base64-encoder'
+    | '/bcrypt-generator'
+    | '/cidr-calculator'
+    | '/cron-expression-builder'
+    | '/curl-builder'
+    | '/date-timestamp-converter'
+    | '/diff-viewer'
+    | '/escape-tool'
+    | '/gpg-key-generator'
+    | '/hash-generator'
+    | '/http-status-codes'
+    | '/image-converter'
+    | '/ip-converter'
+    | '/json-formatter'
+    | '/jwt-decoder'
+    | '/list-comparer'
+    | '/lorem-ipsum'
+    | '/markdown-editor'
+    | '/mime-types'
+    | '/network-interfaces'
+    | '/network-scanner'
+    | '/number-base-converter'
+    | '/password-generator'
+    | '/qr-code-generator'
+    | '/regex-tester'
+    | '/rsa-tools'
+    | '/semver-tools'
+    | '/settings'
+    | '/sql-formatter'
+    | '/ssh-key-generator'
+    | '/string-case-converter'
+    | '/string-compressor'
+    | '/url-encoder'
+    | '/uuid-generator'
+    | '/x509-decoder'
+    | '/xml-formatter'
+    | '/yaml-formatter'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/base64-encoder'
+    | '/bcrypt-generator'
+    | '/cidr-calculator'
+    | '/cron-expression-builder'
+    | '/curl-builder'
+    | '/date-timestamp-converter'
+    | '/diff-viewer'
+    | '/escape-tool'
+    | '/gpg-key-generator'
+    | '/hash-generator'
+    | '/http-status-codes'
+    | '/image-converter'
+    | '/ip-converter'
+    | '/json-formatter'
+    | '/jwt-decoder'
+    | '/list-comparer'
+    | '/lorem-ipsum'
+    | '/markdown-editor'
+    | '/mime-types'
+    | '/network-interfaces'
+    | '/network-scanner'
+    | '/number-base-converter'
+    | '/password-generator'
+    | '/qr-code-generator'
+    | '/regex-tester'
+    | '/rsa-tools'
+    | '/semver-tools'
+    | '/settings'
+    | '/sql-formatter'
+    | '/ssh-key-generator'
+    | '/string-case-converter'
+    | '/string-compressor'
+    | '/url-encoder'
+    | '/uuid-generator'
+    | '/x509-decoder'
+    | '/xml-formatter'
+    | '/yaml-formatter'
+  id:
+    | '__root__'
+    | '/'
+    | '/base64-encoder'
+    | '/bcrypt-generator'
+    | '/cidr-calculator'
+    | '/cron-expression-builder'
+    | '/curl-builder'
+    | '/date-timestamp-converter'
+    | '/diff-viewer'
+    | '/escape-tool'
+    | '/gpg-key-generator'
+    | '/hash-generator'
+    | '/http-status-codes'
+    | '/image-converter'
+    | '/ip-converter'
+    | '/json-formatter'
+    | '/jwt-decoder'
+    | '/list-comparer'
+    | '/lorem-ipsum'
+    | '/markdown-editor'
+    | '/mime-types'
+    | '/network-interfaces'
+    | '/network-scanner'
+    | '/number-base-converter'
+    | '/password-generator'
+    | '/qr-code-generator'
+    | '/regex-tester'
+    | '/rsa-tools'
+    | '/semver-tools'
+    | '/settings'
+    | '/sql-formatter'
+    | '/ssh-key-generator'
+    | '/string-case-converter'
+    | '/string-compressor'
+    | '/url-encoder'
+    | '/uuid-generator'
+    | '/x509-decoder'
+    | '/xml-formatter'
+    | '/yaml-formatter'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-	IndexRoute: typeof IndexRoute;
-	Base64EncoderRoute: typeof Base64EncoderRoute;
-	BcryptGeneratorRoute: typeof BcryptGeneratorRoute;
-	CidrCalculatorRoute: typeof CidrCalculatorRoute;
-	CronExpressionBuilderRoute: typeof CronExpressionBuilderRoute;
-	CurlBuilderRoute: typeof CurlBuilderRoute;
-	DateTimestampConverterRoute: typeof DateTimestampConverterRoute;
-	DiffViewerRoute: typeof DiffViewerRoute;
-	EscapeToolRoute: typeof EscapeToolRoute;
-	GpgKeyGeneratorRoute: typeof GpgKeyGeneratorRoute;
-	HashGeneratorRoute: typeof HashGeneratorRoute;
-	ImageConverterRoute: typeof ImageConverterRoute;
-	IpConverterRoute: typeof IpConverterRoute;
-	JsonFormatterRoute: typeof JsonFormatterRoute;
-	JwtDecoderRoute: typeof JwtDecoderRoute;
-	ListComparerRoute: typeof ListComparerRoute;
-	LoremIpsumRoute: typeof LoremIpsumRoute;
-	MarkdownEditorRoute: typeof MarkdownEditorRoute;
-	MimeTypesRoute: typeof MimeTypesRoute;
-	NetworkInterfacesRoute: typeof NetworkInterfacesRoute;
-	NetworkScannerRoute: typeof NetworkScannerRoute;
-	NumberBaseConverterRoute: typeof NumberBaseConverterRoute;
-	PasswordGeneratorRoute: typeof PasswordGeneratorRoute;
-	QrCodeGeneratorRoute: typeof QrCodeGeneratorRoute;
-	RegexTesterRoute: typeof RegexTesterRoute;
-	RsaToolsRoute: typeof RsaToolsRoute;
-	SemverToolsRoute: typeof SemverToolsRoute;
-	SettingsRoute: typeof SettingsRoute;
-	SqlFormatterRoute: typeof SqlFormatterRoute;
-	SshKeyGeneratorRoute: typeof SshKeyGeneratorRoute;
-	StringCaseConverterRoute: typeof StringCaseConverterRoute;
-	StringCompressorRoute: typeof StringCompressorRoute;
-	UrlEncoderRoute: typeof UrlEncoderRoute;
-	UuidGeneratorRoute: typeof UuidGeneratorRoute;
-	X509DecoderRoute: typeof X509DecoderRoute;
-	XmlFormatterRoute: typeof XmlFormatterRoute;
-	YamlFormatterRoute: typeof YamlFormatterRoute;
+  IndexRoute: typeof IndexRoute
+  Base64EncoderRoute: typeof Base64EncoderRoute
+  BcryptGeneratorRoute: typeof BcryptGeneratorRoute
+  CidrCalculatorRoute: typeof CidrCalculatorRoute
+  CronExpressionBuilderRoute: typeof CronExpressionBuilderRoute
+  CurlBuilderRoute: typeof CurlBuilderRoute
+  DateTimestampConverterRoute: typeof DateTimestampConverterRoute
+  DiffViewerRoute: typeof DiffViewerRoute
+  EscapeToolRoute: typeof EscapeToolRoute
+  GpgKeyGeneratorRoute: typeof GpgKeyGeneratorRoute
+  HashGeneratorRoute: typeof HashGeneratorRoute
+  HttpStatusCodesRoute: typeof HttpStatusCodesRoute
+  ImageConverterRoute: typeof ImageConverterRoute
+  IpConverterRoute: typeof IpConverterRoute
+  JsonFormatterRoute: typeof JsonFormatterRoute
+  JwtDecoderRoute: typeof JwtDecoderRoute
+  ListComparerRoute: typeof ListComparerRoute
+  LoremIpsumRoute: typeof LoremIpsumRoute
+  MarkdownEditorRoute: typeof MarkdownEditorRoute
+  MimeTypesRoute: typeof MimeTypesRoute
+  NetworkInterfacesRoute: typeof NetworkInterfacesRoute
+  NetworkScannerRoute: typeof NetworkScannerRoute
+  NumberBaseConverterRoute: typeof NumberBaseConverterRoute
+  PasswordGeneratorRoute: typeof PasswordGeneratorRoute
+  QrCodeGeneratorRoute: typeof QrCodeGeneratorRoute
+  RegexTesterRoute: typeof RegexTesterRoute
+  RsaToolsRoute: typeof RsaToolsRoute
+  SemverToolsRoute: typeof SemverToolsRoute
+  SettingsRoute: typeof SettingsRoute
+  SqlFormatterRoute: typeof SqlFormatterRoute
+  SshKeyGeneratorRoute: typeof SshKeyGeneratorRoute
+  StringCaseConverterRoute: typeof StringCaseConverterRoute
+  StringCompressorRoute: typeof StringCompressorRoute
+  UrlEncoderRoute: typeof UrlEncoderRoute
+  UuidGeneratorRoute: typeof UuidGeneratorRoute
+  X509DecoderRoute: typeof X509DecoderRoute
+  XmlFormatterRoute: typeof XmlFormatterRoute
+  YamlFormatterRoute: typeof YamlFormatterRoute
 }
 
 declare module '@tanstack/react-router' {
-	interface FileRoutesByPath {
-		'/yaml-formatter': {
-			id: '/yaml-formatter';
-			path: '/yaml-formatter';
-			fullPath: '/yaml-formatter';
-			preLoaderRoute: typeof YamlFormatterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/xml-formatter': {
-			id: '/xml-formatter';
-			path: '/xml-formatter';
-			fullPath: '/xml-formatter';
-			preLoaderRoute: typeof XmlFormatterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/x509-decoder': {
-			id: '/x509-decoder';
-			path: '/x509-decoder';
-			fullPath: '/x509-decoder';
-			preLoaderRoute: typeof X509DecoderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/uuid-generator': {
-			id: '/uuid-generator';
-			path: '/uuid-generator';
-			fullPath: '/uuid-generator';
-			preLoaderRoute: typeof UuidGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/url-encoder': {
-			id: '/url-encoder';
-			path: '/url-encoder';
-			fullPath: '/url-encoder';
-			preLoaderRoute: typeof UrlEncoderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/string-compressor': {
-			id: '/string-compressor';
-			path: '/string-compressor';
-			fullPath: '/string-compressor';
-			preLoaderRoute: typeof StringCompressorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/string-case-converter': {
-			id: '/string-case-converter';
-			path: '/string-case-converter';
-			fullPath: '/string-case-converter';
-			preLoaderRoute: typeof StringCaseConverterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/ssh-key-generator': {
-			id: '/ssh-key-generator';
-			path: '/ssh-key-generator';
-			fullPath: '/ssh-key-generator';
-			preLoaderRoute: typeof SshKeyGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/sql-formatter': {
-			id: '/sql-formatter';
-			path: '/sql-formatter';
-			fullPath: '/sql-formatter';
-			preLoaderRoute: typeof SqlFormatterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/settings': {
-			id: '/settings';
-			path: '/settings';
-			fullPath: '/settings';
-			preLoaderRoute: typeof SettingsRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/semver-tools': {
-			id: '/semver-tools';
-			path: '/semver-tools';
-			fullPath: '/semver-tools';
-			preLoaderRoute: typeof SemverToolsRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/rsa-tools': {
-			id: '/rsa-tools';
-			path: '/rsa-tools';
-			fullPath: '/rsa-tools';
-			preLoaderRoute: typeof RsaToolsRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/regex-tester': {
-			id: '/regex-tester';
-			path: '/regex-tester';
-			fullPath: '/regex-tester';
-			preLoaderRoute: typeof RegexTesterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/qr-code-generator': {
-			id: '/qr-code-generator';
-			path: '/qr-code-generator';
-			fullPath: '/qr-code-generator';
-			preLoaderRoute: typeof QrCodeGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/password-generator': {
-			id: '/password-generator';
-			path: '/password-generator';
-			fullPath: '/password-generator';
-			preLoaderRoute: typeof PasswordGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/number-base-converter': {
-			id: '/number-base-converter';
-			path: '/number-base-converter';
-			fullPath: '/number-base-converter';
-			preLoaderRoute: typeof NumberBaseConverterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/network-scanner': {
-			id: '/network-scanner';
-			path: '/network-scanner';
-			fullPath: '/network-scanner';
-			preLoaderRoute: typeof NetworkScannerRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/network-interfaces': {
-			id: '/network-interfaces';
-			path: '/network-interfaces';
-			fullPath: '/network-interfaces';
-			preLoaderRoute: typeof NetworkInterfacesRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/mime-types': {
-			id: '/mime-types';
-			path: '/mime-types';
-			fullPath: '/mime-types';
-			preLoaderRoute: typeof MimeTypesRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/markdown-editor': {
-			id: '/markdown-editor';
-			path: '/markdown-editor';
-			fullPath: '/markdown-editor';
-			preLoaderRoute: typeof MarkdownEditorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/lorem-ipsum': {
-			id: '/lorem-ipsum';
-			path: '/lorem-ipsum';
-			fullPath: '/lorem-ipsum';
-			preLoaderRoute: typeof LoremIpsumRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/list-comparer': {
-			id: '/list-comparer';
-			path: '/list-comparer';
-			fullPath: '/list-comparer';
-			preLoaderRoute: typeof ListComparerRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/jwt-decoder': {
-			id: '/jwt-decoder';
-			path: '/jwt-decoder';
-			fullPath: '/jwt-decoder';
-			preLoaderRoute: typeof JwtDecoderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/json-formatter': {
-			id: '/json-formatter';
-			path: '/json-formatter';
-			fullPath: '/json-formatter';
-			preLoaderRoute: typeof JsonFormatterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/ip-converter': {
-			id: '/ip-converter';
-			path: '/ip-converter';
-			fullPath: '/ip-converter';
-			preLoaderRoute: typeof IpConverterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/image-converter': {
-			id: '/image-converter';
-			path: '/image-converter';
-			fullPath: '/image-converter';
-			preLoaderRoute: typeof ImageConverterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/hash-generator': {
-			id: '/hash-generator';
-			path: '/hash-generator';
-			fullPath: '/hash-generator';
-			preLoaderRoute: typeof HashGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/gpg-key-generator': {
-			id: '/gpg-key-generator';
-			path: '/gpg-key-generator';
-			fullPath: '/gpg-key-generator';
-			preLoaderRoute: typeof GpgKeyGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/escape-tool': {
-			id: '/escape-tool';
-			path: '/escape-tool';
-			fullPath: '/escape-tool';
-			preLoaderRoute: typeof EscapeToolRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/diff-viewer': {
-			id: '/diff-viewer';
-			path: '/diff-viewer';
-			fullPath: '/diff-viewer';
-			preLoaderRoute: typeof DiffViewerRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/date-timestamp-converter': {
-			id: '/date-timestamp-converter';
-			path: '/date-timestamp-converter';
-			fullPath: '/date-timestamp-converter';
-			preLoaderRoute: typeof DateTimestampConverterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/curl-builder': {
-			id: '/curl-builder';
-			path: '/curl-builder';
-			fullPath: '/curl-builder';
-			preLoaderRoute: typeof CurlBuilderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/cron-expression-builder': {
-			id: '/cron-expression-builder';
-			path: '/cron-expression-builder';
-			fullPath: '/cron-expression-builder';
-			preLoaderRoute: typeof CronExpressionBuilderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/cidr-calculator': {
-			id: '/cidr-calculator';
-			path: '/cidr-calculator';
-			fullPath: '/cidr-calculator';
-			preLoaderRoute: typeof CidrCalculatorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/bcrypt-generator': {
-			id: '/bcrypt-generator';
-			path: '/bcrypt-generator';
-			fullPath: '/bcrypt-generator';
-			preLoaderRoute: typeof BcryptGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/base64-encoder': {
-			id: '/base64-encoder';
-			path: '/base64-encoder';
-			fullPath: '/base64-encoder';
-			preLoaderRoute: typeof Base64EncoderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/': {
-			id: '/';
-			path: '/';
-			fullPath: '/';
-			preLoaderRoute: typeof IndexRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-	}
+  interface FileRoutesByPath {
+    '/yaml-formatter': {
+      id: '/yaml-formatter'
+      path: '/yaml-formatter'
+      fullPath: '/yaml-formatter'
+      preLoaderRoute: typeof YamlFormatterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/xml-formatter': {
+      id: '/xml-formatter'
+      path: '/xml-formatter'
+      fullPath: '/xml-formatter'
+      preLoaderRoute: typeof XmlFormatterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/x509-decoder': {
+      id: '/x509-decoder'
+      path: '/x509-decoder'
+      fullPath: '/x509-decoder'
+      preLoaderRoute: typeof X509DecoderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/uuid-generator': {
+      id: '/uuid-generator'
+      path: '/uuid-generator'
+      fullPath: '/uuid-generator'
+      preLoaderRoute: typeof UuidGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/url-encoder': {
+      id: '/url-encoder'
+      path: '/url-encoder'
+      fullPath: '/url-encoder'
+      preLoaderRoute: typeof UrlEncoderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/string-compressor': {
+      id: '/string-compressor'
+      path: '/string-compressor'
+      fullPath: '/string-compressor'
+      preLoaderRoute: typeof StringCompressorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/string-case-converter': {
+      id: '/string-case-converter'
+      path: '/string-case-converter'
+      fullPath: '/string-case-converter'
+      preLoaderRoute: typeof StringCaseConverterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/ssh-key-generator': {
+      id: '/ssh-key-generator'
+      path: '/ssh-key-generator'
+      fullPath: '/ssh-key-generator'
+      preLoaderRoute: typeof SshKeyGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sql-formatter': {
+      id: '/sql-formatter'
+      path: '/sql-formatter'
+      fullPath: '/sql-formatter'
+      preLoaderRoute: typeof SqlFormatterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/semver-tools': {
+      id: '/semver-tools'
+      path: '/semver-tools'
+      fullPath: '/semver-tools'
+      preLoaderRoute: typeof SemverToolsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/rsa-tools': {
+      id: '/rsa-tools'
+      path: '/rsa-tools'
+      fullPath: '/rsa-tools'
+      preLoaderRoute: typeof RsaToolsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/regex-tester': {
+      id: '/regex-tester'
+      path: '/regex-tester'
+      fullPath: '/regex-tester'
+      preLoaderRoute: typeof RegexTesterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/qr-code-generator': {
+      id: '/qr-code-generator'
+      path: '/qr-code-generator'
+      fullPath: '/qr-code-generator'
+      preLoaderRoute: typeof QrCodeGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/password-generator': {
+      id: '/password-generator'
+      path: '/password-generator'
+      fullPath: '/password-generator'
+      preLoaderRoute: typeof PasswordGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/number-base-converter': {
+      id: '/number-base-converter'
+      path: '/number-base-converter'
+      fullPath: '/number-base-converter'
+      preLoaderRoute: typeof NumberBaseConverterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/network-scanner': {
+      id: '/network-scanner'
+      path: '/network-scanner'
+      fullPath: '/network-scanner'
+      preLoaderRoute: typeof NetworkScannerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/network-interfaces': {
+      id: '/network-interfaces'
+      path: '/network-interfaces'
+      fullPath: '/network-interfaces'
+      preLoaderRoute: typeof NetworkInterfacesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mime-types': {
+      id: '/mime-types'
+      path: '/mime-types'
+      fullPath: '/mime-types'
+      preLoaderRoute: typeof MimeTypesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/markdown-editor': {
+      id: '/markdown-editor'
+      path: '/markdown-editor'
+      fullPath: '/markdown-editor'
+      preLoaderRoute: typeof MarkdownEditorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/lorem-ipsum': {
+      id: '/lorem-ipsum'
+      path: '/lorem-ipsum'
+      fullPath: '/lorem-ipsum'
+      preLoaderRoute: typeof LoremIpsumRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/list-comparer': {
+      id: '/list-comparer'
+      path: '/list-comparer'
+      fullPath: '/list-comparer'
+      preLoaderRoute: typeof ListComparerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/jwt-decoder': {
+      id: '/jwt-decoder'
+      path: '/jwt-decoder'
+      fullPath: '/jwt-decoder'
+      preLoaderRoute: typeof JwtDecoderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/json-formatter': {
+      id: '/json-formatter'
+      path: '/json-formatter'
+      fullPath: '/json-formatter'
+      preLoaderRoute: typeof JsonFormatterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/ip-converter': {
+      id: '/ip-converter'
+      path: '/ip-converter'
+      fullPath: '/ip-converter'
+      preLoaderRoute: typeof IpConverterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/image-converter': {
+      id: '/image-converter'
+      path: '/image-converter'
+      fullPath: '/image-converter'
+      preLoaderRoute: typeof ImageConverterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/http-status-codes': {
+      id: '/http-status-codes'
+      path: '/http-status-codes'
+      fullPath: '/http-status-codes'
+      preLoaderRoute: typeof HttpStatusCodesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/hash-generator': {
+      id: '/hash-generator'
+      path: '/hash-generator'
+      fullPath: '/hash-generator'
+      preLoaderRoute: typeof HashGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/gpg-key-generator': {
+      id: '/gpg-key-generator'
+      path: '/gpg-key-generator'
+      fullPath: '/gpg-key-generator'
+      preLoaderRoute: typeof GpgKeyGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/escape-tool': {
+      id: '/escape-tool'
+      path: '/escape-tool'
+      fullPath: '/escape-tool'
+      preLoaderRoute: typeof EscapeToolRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/diff-viewer': {
+      id: '/diff-viewer'
+      path: '/diff-viewer'
+      fullPath: '/diff-viewer'
+      preLoaderRoute: typeof DiffViewerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/date-timestamp-converter': {
+      id: '/date-timestamp-converter'
+      path: '/date-timestamp-converter'
+      fullPath: '/date-timestamp-converter'
+      preLoaderRoute: typeof DateTimestampConverterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/curl-builder': {
+      id: '/curl-builder'
+      path: '/curl-builder'
+      fullPath: '/curl-builder'
+      preLoaderRoute: typeof CurlBuilderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/cron-expression-builder': {
+      id: '/cron-expression-builder'
+      path: '/cron-expression-builder'
+      fullPath: '/cron-expression-builder'
+      preLoaderRoute: typeof CronExpressionBuilderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/cidr-calculator': {
+      id: '/cidr-calculator'
+      path: '/cidr-calculator'
+      fullPath: '/cidr-calculator'
+      preLoaderRoute: typeof CidrCalculatorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/bcrypt-generator': {
+      id: '/bcrypt-generator'
+      path: '/bcrypt-generator'
+      fullPath: '/bcrypt-generator'
+      preLoaderRoute: typeof BcryptGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/base64-encoder': {
+      id: '/base64-encoder'
+      path: '/base64-encoder'
+      fullPath: '/base64-encoder'
+      preLoaderRoute: typeof Base64EncoderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+  }
 }
 
 const rootRouteChildren: RootRouteChildren = {
-	IndexRoute: IndexRoute,
-	Base64EncoderRoute: Base64EncoderRoute,
-	BcryptGeneratorRoute: BcryptGeneratorRoute,
-	CidrCalculatorRoute: CidrCalculatorRoute,
-	CronExpressionBuilderRoute: CronExpressionBuilderRoute,
-	CurlBuilderRoute: CurlBuilderRoute,
-	DateTimestampConverterRoute: DateTimestampConverterRoute,
-	DiffViewerRoute: DiffViewerRoute,
-	EscapeToolRoute: EscapeToolRoute,
-	GpgKeyGeneratorRoute: GpgKeyGeneratorRoute,
-	HashGeneratorRoute: HashGeneratorRoute,
-	ImageConverterRoute: ImageConverterRoute,
-	IpConverterRoute: IpConverterRoute,
-	JsonFormatterRoute: JsonFormatterRoute,
-	JwtDecoderRoute: JwtDecoderRoute,
-	ListComparerRoute: ListComparerRoute,
-	LoremIpsumRoute: LoremIpsumRoute,
-	MarkdownEditorRoute: MarkdownEditorRoute,
-	MimeTypesRoute: MimeTypesRoute,
-	NetworkInterfacesRoute: NetworkInterfacesRoute,
-	NetworkScannerRoute: NetworkScannerRoute,
-	NumberBaseConverterRoute: NumberBaseConverterRoute,
-	PasswordGeneratorRoute: PasswordGeneratorRoute,
-	QrCodeGeneratorRoute: QrCodeGeneratorRoute,
-	RegexTesterRoute: RegexTesterRoute,
-	RsaToolsRoute: RsaToolsRoute,
-	SemverToolsRoute: SemverToolsRoute,
-	SettingsRoute: SettingsRoute,
-	SqlFormatterRoute: SqlFormatterRoute,
-	SshKeyGeneratorRoute: SshKeyGeneratorRoute,
-	StringCaseConverterRoute: StringCaseConverterRoute,
-	StringCompressorRoute: StringCompressorRoute,
-	UrlEncoderRoute: UrlEncoderRoute,
-	UuidGeneratorRoute: UuidGeneratorRoute,
-	X509DecoderRoute: X509DecoderRoute,
-	XmlFormatterRoute: XmlFormatterRoute,
-	YamlFormatterRoute: YamlFormatterRoute,
-};
+  IndexRoute: IndexRoute,
+  Base64EncoderRoute: Base64EncoderRoute,
+  BcryptGeneratorRoute: BcryptGeneratorRoute,
+  CidrCalculatorRoute: CidrCalculatorRoute,
+  CronExpressionBuilderRoute: CronExpressionBuilderRoute,
+  CurlBuilderRoute: CurlBuilderRoute,
+  DateTimestampConverterRoute: DateTimestampConverterRoute,
+  DiffViewerRoute: DiffViewerRoute,
+  EscapeToolRoute: EscapeToolRoute,
+  GpgKeyGeneratorRoute: GpgKeyGeneratorRoute,
+  HashGeneratorRoute: HashGeneratorRoute,
+  HttpStatusCodesRoute: HttpStatusCodesRoute,
+  ImageConverterRoute: ImageConverterRoute,
+  IpConverterRoute: IpConverterRoute,
+  JsonFormatterRoute: JsonFormatterRoute,
+  JwtDecoderRoute: JwtDecoderRoute,
+  ListComparerRoute: ListComparerRoute,
+  LoremIpsumRoute: LoremIpsumRoute,
+  MarkdownEditorRoute: MarkdownEditorRoute,
+  MimeTypesRoute: MimeTypesRoute,
+  NetworkInterfacesRoute: NetworkInterfacesRoute,
+  NetworkScannerRoute: NetworkScannerRoute,
+  NumberBaseConverterRoute: NumberBaseConverterRoute,
+  PasswordGeneratorRoute: PasswordGeneratorRoute,
+  QrCodeGeneratorRoute: QrCodeGeneratorRoute,
+  RegexTesterRoute: RegexTesterRoute,
+  RsaToolsRoute: RsaToolsRoute,
+  SemverToolsRoute: SemverToolsRoute,
+  SettingsRoute: SettingsRoute,
+  SqlFormatterRoute: SqlFormatterRoute,
+  SshKeyGeneratorRoute: SshKeyGeneratorRoute,
+  StringCaseConverterRoute: StringCaseConverterRoute,
+  StringCompressorRoute: StringCompressorRoute,
+  UrlEncoderRoute: UrlEncoderRoute,
+  UuidGeneratorRoute: UuidGeneratorRoute,
+  X509DecoderRoute: X509DecoderRoute,
+  XmlFormatterRoute: XmlFormatterRoute,
+  YamlFormatterRoute: YamlFormatterRoute,
+}
 export const routeTree = rootRouteImport
-	._addFileChildren(rootRouteChildren)
-	._addFileTypes<FileRouteTypes>();
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()

--- a/src/routes/http-status-codes.tsx
+++ b/src/routes/http-status-codes.tsx
@@ -1,0 +1,564 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { AlertTriangle, BookOpen, ExternalLink, Search, X } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import { ActionButton, CopyButton } from '@/lib/components/action';
+import { FormCheckbox, FormCheckboxGroup, FormInfo, FormInput, FormSection } from '@/lib/components/form';
+import { ToolShell } from '@/lib/components/shell';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { Badge } from '@/lib/components/ui/badge';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { ToneBadge } from '@/lib/components/ui/tone-badge';
+import { useDocumentTitle } from '@/lib/hooks';
+import {
+	ALL_CATEGORIES,
+	CATEGORY_LABELS,
+	CATEGORY_TONES,
+	type FilterOptions,
+	filterStatusCodes,
+	getStatusCode,
+	IANA_REGISTRY_URL,
+	type StatusCategory,
+	type StatusCode,
+	STATUS_CODES,
+	TOTAL_CODES,
+} from '@/lib/services/http-status';
+import { createToolOptionsStore } from '@/lib/stores';
+import { cn } from '@/lib/utils';
+
+interface HttpStatusOptions {
+	readonly query: string;
+	readonly categories: readonly StatusCategory[];
+	readonly includeNonStandard: boolean;
+	readonly misuseOnly: boolean;
+	readonly selectedCode: number | null;
+}
+
+const DEFAULTS: HttpStatusOptions = {
+	query: '',
+	categories: ALL_CATEGORIES,
+	includeNonStandard: false,
+	misuseOnly: false,
+	selectedCode: null,
+};
+
+const useHttpStatusOptions = createToolOptionsStore<HttpStatusOptions>(
+	'http-status-codes',
+	DEFAULTS
+);
+
+export const Route = createFileRoute('/http-status-codes')({
+	component: HttpStatusCodesPage,
+});
+
+function HttpStatusCodesPage() {
+	useDocumentTitle('HTTP Status Codes');
+
+	const { value: options, patch } = useHttpStatusOptions();
+	const { query, categories, includeNonStandard, misuseOnly, selectedCode } = options;
+
+	const [showRail, setShowRail] = useState(true);
+	const [debouncedQuery, setDebouncedQuery] = useState(query);
+
+	// Debounce text input by 100ms so typing does not thrash the grid.
+	useEffect(() => {
+		const handle = window.setTimeout(() => setDebouncedQuery(query), 100);
+		return () => window.clearTimeout(handle);
+	}, [query]);
+
+	const categorySet = useMemo<ReadonlySet<StatusCategory>>(
+		() => new Set(categories),
+		[categories]
+	);
+
+	const filterOptions = useMemo<FilterOptions>(
+		() => ({
+			query: debouncedQuery,
+			categories: categorySet,
+			includeNonStandard,
+			misuseOnly,
+		}),
+		[debouncedQuery, categorySet, includeNonStandard, misuseOnly]
+	);
+
+	const filtered = useMemo(
+		() => filterStatusCodes(STATUS_CODES, filterOptions),
+		[filterOptions]
+	);
+
+	const selectedEntry = useMemo(
+		() => (selectedCode === null ? null : (getStatusCode(selectedCode) ?? null)),
+		[selectedCode]
+	);
+
+	const toggleCategory = (category: StatusCategory) => {
+		const set = new Set(categories);
+		if (set.has(category)) set.delete(category);
+		else set.add(category);
+		patch({ categories: ALL_CATEGORIES.filter((c) => set.has(c)) });
+	};
+
+	const setCategories = (next: readonly StatusCategory[]) => {
+		patch({ categories: ALL_CATEGORIES.filter((c) => next.includes(c)) });
+	};
+
+	const setSelectedCode = (code: number | null) => patch({ selectedCode: code });
+
+	const standardCount = useMemo(() => STATUS_CODES.filter((c) => c.standard).length, []);
+
+	return (
+		<ToolShell
+			showRail={showRail}
+			onShowRailChange={setShowRail}
+			statusContent={
+				<>
+					<StatItem label="Visible" value={filtered.length} />
+					<StatItem label="Total" value={TOTAL_CODES} />
+					<StatItem label="Standard" value={standardCount} />
+					{selectedEntry ? <StatItem label="Selected" value={selectedEntry.code} /> : null}
+				</>
+			}
+			rail={
+				<>
+					<FormSection title="Search">
+						<FormInfo>
+							Search by code (e.g. <code className="font-mono">401</code>,{' '}
+							<code className="font-mono">4</code>) or text (e.g.{' '}
+							<code className="font-mono">unauth</code>).
+						</FormInfo>
+						{query.length > 0 ? (
+							<ActionButton label="Clear search" variant="outline" onClick={() => patch({ query: '' })} />
+						) : null}
+					</FormSection>
+
+					<FormSection title="Categories">
+						<FormCheckboxGroup>
+							{ALL_CATEGORIES.map((category) => (
+								<FormCheckbox
+									key={category}
+									label={CATEGORY_LABELS[category]}
+									checked={categorySet.has(category)}
+									onCheckedChange={() => toggleCategory(category)}
+								/>
+							))}
+						</FormCheckboxGroup>
+					</FormSection>
+
+					<FormSection title="Non-standard codes">
+						<FormCheckbox
+							label="Include non-standard (418, 499, 520-527, ...)"
+							checked={includeNonStandard}
+							onCheckedChange={(checked) => patch({ includeNonStandard: checked })}
+						/>
+					</FormSection>
+
+					<FormSection title="Quick filters">
+						<div className="grid grid-cols-2 gap-1">
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={() =>
+									patch({
+										query: '',
+										categories: ALL_CATEGORIES,
+										includeNonStandard: true,
+										misuseOnly: false,
+									})
+								}
+							>
+								All
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={() =>
+									patch({
+										query: '',
+										categories: ALL_CATEGORIES,
+										includeNonStandard: false,
+										misuseOnly: false,
+									})
+								}
+							>
+								Only standard
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={() => patch({ misuseOnly: !misuseOnly })}
+							>
+								{misuseOnly ? 'Show all' : 'Misuse warnings'}
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={() => setCategories(['3xx'])}
+							>
+								Only redirects
+							</Button>
+						</div>
+					</FormSection>
+
+					<FormSection title="About">
+						<FormInfo>
+							Status codes are primarily defined in RFC 9110 (HTTP Semantics, June 2022). WebDAV
+							additions come from RFC 4918 / 5842; the IANA registry is the authoritative source.
+						</FormInfo>
+					</FormSection>
+				</>
+			}
+		>
+			<div className="flex h-full flex-col overflow-auto p-3">
+				<div className="space-y-3">
+					<Card density="compact">
+						<CardContent className="space-y-2">
+							<div className="relative">
+								<Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+								<FormInput
+									label="Search status codes"
+									value={query}
+									onValueChange={(value) => patch({ query: value })}
+									placeholder="Search by code or text (e.g. 401, 4, unauth)"
+									size="default"
+									className="pl-8"
+								/>
+							</div>
+							<ActiveFilterChips
+								categories={categorySet}
+								includeNonStandard={includeNonStandard}
+								misuseOnly={misuseOnly}
+								query={debouncedQuery}
+								onRemoveCategory={toggleCategory}
+								onToggleNonStandard={() => patch({ includeNonStandard: false })}
+								onToggleMisuseOnly={() => patch({ misuseOnly: false })}
+								onClearQuery={() => patch({ query: '' })}
+							/>
+						</CardContent>
+					</Card>
+
+					{filtered.length === 0 ? (
+						<Card density="compact">
+							<CardContent>
+								<EmbeddedEmptyState
+									icon={BookOpen}
+									title="No status codes match the current filters"
+									description="Try widening the categories, enabling non-standard codes, or clearing the search query."
+								/>
+							</CardContent>
+						</Card>
+					) : (
+						<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+							{filtered.map((entry) => (
+								<StatusCard
+									key={entry.code}
+									entry={entry}
+									isSelected={entry.code === selectedCode}
+									onSelect={() => setSelectedCode(entry.code === selectedCode ? null : entry.code)}
+								/>
+							))}
+						</div>
+					)}
+
+					{selectedEntry ? (
+						<DetailPanel
+							entry={selectedEntry}
+							onClose={() => setSelectedCode(null)}
+							onSelectRelated={(code) => setSelectedCode(code)}
+						/>
+					) : null}
+				</div>
+			</div>
+		</ToolShell>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface ActiveFilterChipsProps {
+	readonly categories: ReadonlySet<StatusCategory>;
+	readonly includeNonStandard: boolean;
+	readonly misuseOnly: boolean;
+	readonly query: string;
+	readonly onRemoveCategory: (category: StatusCategory) => void;
+	readonly onToggleNonStandard: () => void;
+	readonly onToggleMisuseOnly: () => void;
+	readonly onClearQuery: () => void;
+}
+
+function ActiveFilterChips({
+	categories,
+	includeNonStandard,
+	misuseOnly,
+	query,
+	onRemoveCategory,
+	onToggleNonStandard,
+	onToggleMisuseOnly,
+	onClearQuery,
+}: ActiveFilterChipsProps) {
+	const allOn = categories.size === ALL_CATEGORIES.length;
+	if (allOn && !includeNonStandard && !misuseOnly && query.trim().length === 0) {
+		return null;
+	}
+
+	return (
+		<div className="flex flex-wrap gap-1.5">
+			{!allOn
+				? ALL_CATEGORIES.filter((c) => categories.has(c)).map((category) => (
+						<RemovableChip
+							key={category}
+							label={CATEGORY_LABELS[category]}
+							tone={CATEGORY_TONES[category]}
+							onRemove={() => onRemoveCategory(category)}
+						/>
+					))
+				: null}
+			{includeNonStandard ? (
+				<RemovableChip label="Non-standard" tone="info" onRemove={onToggleNonStandard} />
+			) : null}
+			{misuseOnly ? (
+				<RemovableChip label="Misuse warnings" tone="warning" onRemove={onToggleMisuseOnly} />
+			) : null}
+			{query.trim().length > 0 ? (
+				<RemovableChip
+					label={`"${query.trim()}"`}
+					tone="info"
+					onRemove={onClearQuery}
+				/>
+			) : null}
+		</div>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface RemovableChipProps {
+	readonly label: string;
+	readonly tone: 'success' | 'warning' | 'info' | 'destructive';
+	readonly onRemove: () => void;
+}
+
+function RemovableChip({ label, tone, onRemove }: RemovableChipProps) {
+	return (
+		<ToneBadge tone={tone} className="cursor-pointer pr-1">
+			{label}
+			<button
+				type="button"
+				className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-foreground/10"
+				onClick={onRemove}
+				aria-label={`Remove ${label} filter`}
+			>
+				<X className="h-3 w-3" />
+			</button>
+		</ToneBadge>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface StatusCardProps {
+	readonly entry: StatusCode;
+	readonly isSelected: boolean;
+	readonly onSelect: () => void;
+}
+
+function StatusCard({ entry, isSelected, onSelect }: StatusCardProps) {
+	const tone = CATEGORY_TONES[entry.category];
+	const copyText = `${entry.code} ${entry.phrase}`;
+
+	return (
+		<Card
+			density="compact"
+			className={cn(
+				'cursor-pointer transition-colors hover:bg-muted/40',
+				isSelected && 'border-primary ring-1 ring-primary/40'
+			)}
+			onClick={onSelect}
+		>
+			<CardHeader className="pb-2">
+				<div className="flex items-start justify-between gap-2">
+					<div className="flex min-w-0 flex-col gap-1">
+						<div className="flex items-baseline gap-2">
+							<span className="font-mono text-2xl font-semibold tabular-nums leading-none">
+								{entry.code}
+							</span>
+							{entry.misuse ? (
+								<AlertTriangle className="h-3.5 w-3.5 shrink-0 text-warning" />
+							) : null}
+						</div>
+						<CardTitle className="truncate text-sm">{entry.phrase}</CardTitle>
+					</div>
+					<div className="flex flex-col items-end gap-1.5">
+						<ToneBadge tone={tone} className="text-2xs">
+							{entry.category}
+						</ToneBadge>
+						{!entry.standard ? (
+							<Badge variant="outline" className="text-2xs">
+								Non-standard
+							</Badge>
+						) : null}
+					</div>
+				</div>
+			</CardHeader>
+			<CardContent className="space-y-2">
+				<p className="line-clamp-2 text-xs text-muted-foreground">{entry.summary}</p>
+				<div className="flex items-center justify-between gap-2">
+					<span className="truncate text-2xs text-muted-foreground">{entry.rfc ?? 'No RFC'}</span>
+					<div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+						<CopyButton
+							text={copyText}
+							toastLabel={`${entry.code} ${entry.phrase}`}
+							label="Copy"
+							size="sm"
+							variant="outline"
+						/>
+					</div>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface DetailPanelProps {
+	readonly entry: StatusCode;
+	readonly onClose: () => void;
+	readonly onSelectRelated: (code: number) => void;
+}
+
+function DetailPanel({ entry, onClose, onSelectRelated }: DetailPanelProps) {
+	const tone = CATEGORY_TONES[entry.category];
+
+	const handleOpenRfc = async () => {
+		if (!entry.rfcUrl) return;
+		try {
+			const { openUrl } = await import('@tauri-apps/plugin-opener');
+			await openUrl(entry.rfcUrl);
+		} catch {
+			window.open(entry.rfcUrl, '_blank', 'noopener,noreferrer');
+		}
+	};
+
+	const handleOpenIana = async () => {
+		try {
+			const { openUrl } = await import('@tauri-apps/plugin-opener');
+			await openUrl(IANA_REGISTRY_URL);
+		} catch {
+			window.open(IANA_REGISTRY_URL, '_blank', 'noopener,noreferrer');
+		}
+	};
+
+	return (
+		<Card density="compact" className="border-primary/40">
+			<CardHeader className="pb-2">
+				<div className="flex flex-wrap items-start justify-between gap-3">
+					<div className="flex min-w-0 flex-col gap-1.5">
+						<div className="flex items-baseline gap-3">
+							<span className="font-mono text-4xl font-semibold tabular-nums leading-none">
+								{entry.code}
+							</span>
+							<CardTitle className="text-xl">{entry.phrase}</CardTitle>
+						</div>
+						<div className="flex flex-wrap items-center gap-2">
+							<ToneBadge tone={tone}>{entry.category}</ToneBadge>
+							{!entry.standard ? <Badge variant="outline">Non-standard</Badge> : null}
+							{entry.rfc ? (
+								<Badge variant="outline" className="font-mono text-2xs">
+									{entry.rfc}
+								</Badge>
+							) : null}
+						</div>
+					</div>
+					<div className="flex items-center gap-1.5">
+						<CopyButton
+							text={`${entry.code} ${entry.phrase}`}
+							label={`Copy ${entry.code} ${entry.phrase}`}
+							toastLabel={`${entry.code} ${entry.phrase}`}
+							size="sm"
+							variant="outline"
+						/>
+						<Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close detail panel">
+							<X className="h-4 w-4" />
+						</Button>
+					</div>
+				</div>
+			</CardHeader>
+			<CardContent className="space-y-3">
+				<section className="space-y-1.5">
+					<h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+						Summary
+					</h3>
+					<p className="text-sm text-foreground/90">{entry.summary}</p>
+				</section>
+
+				{entry.whenToUse ? (
+					<section className="space-y-1.5">
+						<h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+							When to use
+						</h3>
+						<p className="text-sm text-foreground/90">{entry.whenToUse}</p>
+					</section>
+				) : null}
+
+				{entry.misuse ? (
+					<section className="rounded-md border border-warning/40 bg-warning/5 p-3">
+						<div className="flex items-start gap-2">
+							<AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+							<div className="space-y-0.5">
+								<div className="text-xs font-semibold uppercase tracking-wide text-warning">
+									Common misuse
+								</div>
+								<p className="text-sm text-foreground/90">{entry.misuse}</p>
+							</div>
+						</div>
+					</section>
+				) : null}
+
+				{entry.related && entry.related.length > 0 ? (
+					<section className="space-y-1.5">
+						<h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+							Related codes
+						</h3>
+						<div className="flex flex-wrap gap-1.5">
+							{entry.related.map((code) => {
+								const related = getStatusCode(code);
+								if (!related) return null;
+								const relatedTone = CATEGORY_TONES[related.category];
+								return (
+									<button
+										key={code}
+										type="button"
+										onClick={() => onSelectRelated(code)}
+										className="inline-flex items-center"
+									>
+										<ToneBadge
+											tone={relatedTone}
+											className="cursor-pointer transition-colors hover:bg-foreground/10"
+										>
+											<span className="font-mono font-semibold">{related.code}</span>
+											<span className="ml-1">{related.phrase}</span>
+										</ToneBadge>
+									</button>
+								);
+							})}
+						</div>
+					</section>
+				) : null}
+
+				<section className="flex flex-wrap items-center gap-2 border-t border-border/40 pt-3">
+					{entry.rfcUrl ? (
+						<Button variant="outline" size="sm" onClick={handleOpenRfc}>
+							<ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+							Open RFC reference
+						</Button>
+					) : null}
+					<Button variant="ghost" size="sm" onClick={handleOpenIana}>
+						<ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+						IANA registry
+					</Button>
+				</section>
+			</CardContent>
+		</Card>
+	);
+}


### PR DESCRIPTION
## Summary
Add a searchable HTTP Status Code Reference under **Network** covering codes 100–599 with RFC citations, semantic categorization, and misuse warnings. Closes #230.

## Features
- **Complete catalog**: all IANA-registered codes plus widely-used non-standard codes (418, 499, 520-527, …)
- **Search by number or text**: `401` / `4` (prefix) / `unauth` (substring) all work
- **Category chips**: 1xx / 2xx / 3xx / 4xx / 5xx tone-coded badges
- **Include non-standard** toggle
- **Misuse warnings** on commonly-confused codes (401 vs 403, 301 vs 302, 307 vs 308, 422 vs 400, 404 for empty collection)
- **Related codes** chips on the detail panel (e.g. 301 ↔ 302 ↔ 307 ↔ 308)
- **One-click copy** for `Code Phrase` (`404 Not Found`)
- All client-side; pure data + filter

## Changes
### Added
- `src/routes/http-status-codes.tsx`
- `src/lib/services/http-status.ts` (catalog + filter)
- Page registration in `src/lib/services/pages.ts`

## Test plan
- [x] `bun run check` green
- [x] `bun run lint` no new errors
- [x] `bun run format` clean
- [ ] Manual: search `unauth` → 401 surfaces
- [ ] Manual: search `4` → all 4xx
- [ ] Manual: select 301 → related chips include 302/307/308
- [ ] Manual: select 401 → misuse warning explains 401 vs 403
- [ ] Manual: enable non-standard → 418, 499, 520-527 appear

Closes #230
