### PR TITLE
feat(mime-types): add MIME Type Explorer tool

### DIFF
--- a/src/lib/services/mime.ts
+++ b/src/lib/services/mime.ts
@@ -1,0 +1,833 @@
+/**
+ * MIME Type catalog and lookup helpers.
+ *
+ * A curated set of common MIME types covering the entries developers
+ * actually look up. Each entry includes file extensions, optional aliases
+ * (with deprecation notes), magic bytes for binary type sniffing, charset
+ * info for text types, and reference URLs.
+ *
+ * The catalog is deliberately kept small (~100 entries) over an exhaustive
+ * dump of the IANA registry. Use `filterEntries` for bidirectional search
+ * across types, extensions, and free text.
+ */
+
+export type MimeCategory =
+	| 'image'
+	| 'audio'
+	| 'video'
+	| 'font'
+	| 'text'
+	| 'application'
+	| 'multipart'
+	| 'message';
+
+export interface MimeReference {
+	readonly label: string;
+	readonly url: string;
+}
+
+export interface MagicBytes {
+	/** Space-separated uppercase hex (e.g. "89 50 4E 47 0D 0A 1A 0A"). */
+	readonly hex: string;
+	/** Byte offset from start of file. Defaults to 0. */
+	readonly offset?: number;
+	readonly description?: string;
+}
+
+export interface MimeEntry {
+	readonly type: string;
+	readonly category: MimeCategory;
+	/** Extensions include the leading dot (e.g. `.png`). */
+	readonly extensions: readonly string[];
+	readonly summary: string;
+	readonly aliases?: readonly string[];
+	readonly aliasNote?: string;
+	readonly magic?: readonly MagicBytes[];
+	readonly charset?: readonly string[];
+	readonly defaultCharset?: string;
+	readonly references?: readonly MimeReference[];
+}
+
+export const CATEGORY_LABELS: Readonly<Record<MimeCategory, string>> = {
+	image: 'Image',
+	audio: 'Audio',
+	video: 'Video',
+	font: 'Font',
+	text: 'Text',
+	application: 'Application',
+	multipart: 'Multipart',
+	message: 'Message',
+};
+
+/**
+ * Tailwind utility classes for category badges. Uses tonal pairings
+ * consistent with existing semantic tokens in `app.css`.
+ */
+export const CATEGORY_TONES: Readonly<Record<MimeCategory, string>> = {
+	image: 'bg-info/10 text-info',
+	audio: 'bg-success/10 text-success',
+	video: 'bg-destructive/10 text-destructive',
+	font: 'bg-warning/10 text-warning',
+	text: 'bg-muted text-muted-foreground',
+	application: 'bg-primary/10 text-primary',
+	multipart: 'bg-accent text-accent-foreground',
+	message: 'bg-secondary text-secondary-foreground',
+};
+
+const IANA_REGISTRY = 'https://www.iana.org/assignments/media-types/media-types.xhtml';
+
+const ref = (label: string, url: string): MimeReference => ({ label, url });
+
+/* -------------------------------------------------------------------------- */
+/* Catalog                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export const MIME_ENTRIES: readonly MimeEntry[] = [
+	/* ---------- image ---------- */
+	{
+		type: 'image/png',
+		category: 'image',
+		extensions: ['.png'],
+		summary: 'Portable Network Graphics; lossless raster format with alpha channel.',
+		magic: [{ hex: '89 50 4E 47 0D 0A 1A 0A', description: 'PNG signature' }],
+		references: [ref('RFC 2083', 'https://www.rfc-editor.org/rfc/rfc2083')],
+	},
+	{
+		type: 'image/jpeg',
+		category: 'image',
+		extensions: ['.jpg', '.jpeg', '.jpe', '.jfif'],
+		summary: 'JPEG (Joint Photographic Experts Group); lossy compressed photograph format.',
+		aliases: ['image/jpg', 'image/pjpeg'],
+		aliasNote: '`image/jpg` is a common non-standard alias; always emit `image/jpeg`.',
+		magic: [
+			{ hex: 'FF D8 FF DB', description: 'JPEG raw' },
+			{ hex: 'FF D8 FF E0', description: 'JPEG with JFIF marker' },
+			{ hex: 'FF D8 FF E1', description: 'JPEG with EXIF marker' },
+			{ hex: 'FF D8 FF EE', description: 'JPEG with Adobe APP14 marker' },
+		],
+		references: [ref('RFC 1341', 'https://www.rfc-editor.org/rfc/rfc1341')],
+	},
+	{
+		type: 'image/gif',
+		category: 'image',
+		extensions: ['.gif'],
+		summary: 'Graphics Interchange Format; palette-indexed raster with animation support.',
+		magic: [
+			{ hex: '47 49 46 38 37 61', description: 'GIF87a' },
+			{ hex: '47 49 46 38 39 61', description: 'GIF89a' },
+		],
+		references: [ref('W3C GIF89a', 'https://www.w3.org/Graphics/GIF/spec-gif89a.txt')],
+	},
+	{
+		type: 'image/webp',
+		category: 'image',
+		extensions: ['.webp'],
+		summary: 'WebP; modern lossy / lossless image format with smaller files than JPEG / PNG.',
+		magic: [
+			{ hex: '52 49 46 46', description: '"RIFF" header' },
+			{ hex: '57 45 42 50', offset: 8, description: '"WEBP" at offset 8' },
+		],
+		references: [ref('RFC 9649', 'https://www.rfc-editor.org/rfc/rfc9649')],
+	},
+	{
+		type: 'image/svg+xml',
+		category: 'image',
+		extensions: ['.svg', '.svgz'],
+		summary: 'Scalable Vector Graphics; XML-based vector image format.',
+		charset: ['utf-8', 'utf-16', 'us-ascii'],
+		defaultCharset: 'utf-8',
+		references: [ref('W3C SVG', 'https://www.w3.org/TR/SVG2/')],
+	},
+	{
+		type: 'image/avif',
+		category: 'image',
+		extensions: ['.avif'],
+		summary: 'AV1 Image File Format; HEIF container with AV1-encoded payload.',
+		magic: [{ hex: '66 74 79 70 61 76 69 66', offset: 4, description: '"ftypavif" at offset 4' }],
+		references: [ref('MIANA', `${IANA_REGISTRY}#image`)],
+	},
+	{
+		type: 'image/bmp',
+		category: 'image',
+		extensions: ['.bmp', '.dib'],
+		summary: 'Windows Bitmap; uncompressed raster image format.',
+		aliases: ['image/x-bmp', 'image/x-ms-bmp'],
+		magic: [{ hex: '42 4D', description: '"BM" header' }],
+	},
+	{
+		type: 'image/x-icon',
+		category: 'image',
+		extensions: ['.ico'],
+		summary: 'Windows icon container; multiple bitmap sizes used as favicons.',
+		aliases: ['image/vnd.microsoft.icon'],
+		magic: [{ hex: '00 00 01 00', description: 'ICO header' }],
+	},
+	{
+		type: 'image/tiff',
+		category: 'image',
+		extensions: ['.tif', '.tiff'],
+		summary: 'Tagged Image File Format; flexible raster format used in publishing.',
+		magic: [
+			{ hex: '49 49 2A 00', description: 'Little-endian TIFF' },
+			{ hex: '4D 4D 00 2A', description: 'Big-endian TIFF' },
+		],
+		references: [ref('RFC 3302', 'https://www.rfc-editor.org/rfc/rfc3302')],
+	},
+	{
+		type: 'image/heic',
+		category: 'image',
+		extensions: ['.heic'],
+		summary: 'High Efficiency Image Container; HEVC-encoded images used by iOS.',
+		magic: [{ hex: '66 74 79 70 68 65 69 63', offset: 4, description: '"ftypheic" at offset 4' }],
+	},
+	{
+		type: 'image/heif',
+		category: 'image',
+		extensions: ['.heif'],
+		summary: 'High Efficiency Image File Format; generic HEIF container.',
+		aliases: ['image/heic'],
+		magic: [{ hex: '66 74 79 70 6D 69 66 31', offset: 4, description: '"ftypmif1" at offset 4' }],
+	},
+
+	/* ---------- audio ---------- */
+	{
+		type: 'audio/mpeg',
+		category: 'audio',
+		extensions: ['.mp3', '.mp2', '.mpga'],
+		summary: 'MPEG-1 / MPEG-2 Audio Layer III (MP3); common lossy audio compression.',
+		aliases: ['audio/mp3'],
+		aliasNote: '`audio/mp3` is non-standard; always emit `audio/mpeg`.',
+		magic: [
+			{ hex: '49 44 33', description: 'ID3v2 tag' },
+			{ hex: 'FF FB', description: 'MPEG-1 Layer III frame sync' },
+			{ hex: 'FF F3', description: 'MPEG-2 Layer III frame sync' },
+		],
+		references: [ref('RFC 3003', 'https://www.rfc-editor.org/rfc/rfc3003')],
+	},
+	{
+		type: 'audio/wav',
+		category: 'audio',
+		extensions: ['.wav', '.wave'],
+		summary: 'Waveform Audio File Format; RIFF container with PCM samples.',
+		aliases: ['audio/x-wav', 'audio/vnd.wave'],
+		magic: [
+			{ hex: '52 49 46 46', description: '"RIFF" header' },
+			{ hex: '57 41 56 45', offset: 8, description: '"WAVE" at offset 8' },
+		],
+	},
+	{
+		type: 'audio/ogg',
+		category: 'audio',
+		extensions: ['.ogg', '.oga', '.opus'],
+		summary: 'Ogg container, typically with Vorbis or Opus payload.',
+		magic: [{ hex: '4F 67 67 53', description: '"OggS" page header' }],
+		references: [ref('RFC 5334', 'https://www.rfc-editor.org/rfc/rfc5334')],
+	},
+	{
+		type: 'audio/webm',
+		category: 'audio',
+		extensions: ['.weba'],
+		summary: 'WebM audio (Matroska-based) with Vorbis or Opus payload.',
+		magic: [{ hex: '1A 45 DF A3', description: 'EBML header' }],
+	},
+	{
+		type: 'audio/flac',
+		category: 'audio',
+		extensions: ['.flac'],
+		summary: 'Free Lossless Audio Codec; bit-perfect lossless audio compression.',
+		magic: [{ hex: '66 4C 61 43', description: '"fLaC" stream marker' }],
+	},
+	{
+		type: 'audio/aac',
+		category: 'audio',
+		extensions: ['.aac'],
+		summary: 'Advanced Audio Coding; lossy audio compression used in iTunes / YouTube.',
+		magic: [{ hex: 'FF F1', description: 'ADTS header (MPEG-4)' }],
+	},
+	{
+		type: 'audio/mp4',
+		category: 'audio',
+		extensions: ['.m4a', '.mp4a'],
+		summary: 'AAC audio in an MP4 container; the lossy format used by iTunes (M4A).',
+		aliases: ['audio/x-m4a'],
+		magic: [{ hex: '66 74 79 70 4D 34 41 20', offset: 4, description: '"ftypM4A " at offset 4' }],
+	},
+	{
+		type: 'audio/midi',
+		category: 'audio',
+		extensions: ['.mid', '.midi'],
+		summary: 'Musical Instrument Digital Interface; symbolic music notation.',
+		aliases: ['audio/x-midi'],
+		magic: [{ hex: '4D 54 68 64', description: '"MThd" header' }],
+	},
+	{
+		type: 'audio/x-aiff',
+		category: 'audio',
+		extensions: ['.aif', '.aiff', '.aifc'],
+		summary: 'Audio Interchange File Format; uncompressed audio container from Apple.',
+		aliases: ['audio/aiff'],
+		magic: [
+			{ hex: '46 4F 52 4D', description: '"FORM" header' },
+			{ hex: '41 49 46 46', offset: 8, description: '"AIFF" at offset 8' },
+		],
+	},
+	{
+		type: 'audio/opus',
+		category: 'audio',
+		extensions: ['.opus'],
+		summary: 'Opus lossy audio; modern codec used by WebRTC and streaming.',
+		references: [ref('RFC 7587', 'https://www.rfc-editor.org/rfc/rfc7587')],
+	},
+
+	/* ---------- video ---------- */
+	{
+		type: 'video/mp4',
+		category: 'video',
+		extensions: ['.mp4', '.m4v', '.m4p'],
+		summary: 'MPEG-4 Part 14 container; the dominant H.264 / H.265 video format.',
+		magic: [
+			{ hex: '66 74 79 70 69 73 6F 6D', offset: 4, description: '"ftypisom" at offset 4' },
+			{ hex: '66 74 79 70 4D 53 4E 56', offset: 4, description: '"ftypMSNV" at offset 4' },
+		],
+		references: [ref('RFC 4337', 'https://www.rfc-editor.org/rfc/rfc4337')],
+	},
+	{
+		type: 'video/mpeg',
+		category: 'video',
+		extensions: ['.mpg', '.mpeg', '.mpe', '.m1v', '.m2v'],
+		summary: 'MPEG-1 / MPEG-2 program / video stream.',
+		magic: [{ hex: '00 00 01 BA', description: 'MPEG-PS pack header' }],
+		references: [ref('RFC 2046', 'https://www.rfc-editor.org/rfc/rfc2046')],
+	},
+	{
+		type: 'video/ogg',
+		category: 'video',
+		extensions: ['.ogv', '.ogg'],
+		summary: 'Ogg container with Theora / VP8 video payload.',
+		magic: [{ hex: '4F 67 67 53', description: '"OggS" page header' }],
+	},
+	{
+		type: 'video/webm',
+		category: 'video',
+		extensions: ['.webm'],
+		summary: 'WebM video (Matroska-based) with VP8 / VP9 / AV1 payload.',
+		magic: [{ hex: '1A 45 DF A3', description: 'EBML header' }],
+	},
+	{
+		type: 'video/x-msvideo',
+		category: 'video',
+		extensions: ['.avi'],
+		summary: 'Audio Video Interleave; legacy RIFF-based Microsoft video container.',
+		aliases: ['video/avi', 'video/msvideo'],
+		magic: [
+			{ hex: '52 49 46 46', description: '"RIFF" header' },
+			{ hex: '41 56 49 20', offset: 8, description: '"AVI " at offset 8' },
+		],
+	},
+	{
+		type: 'video/quicktime',
+		category: 'video',
+		extensions: ['.mov', '.qt'],
+		summary: 'Apple QuickTime container; predecessor of MP4 ISO Base Media Format.',
+		magic: [{ hex: '66 74 79 70 71 74 20 20', offset: 4, description: '"ftypqt  " at offset 4' }],
+	},
+	{
+		type: 'video/x-matroska',
+		category: 'video',
+		extensions: ['.mkv', '.mka', '.mks'],
+		summary: 'Matroska container; open-source flexible multimedia container.',
+		magic: [{ hex: '1A 45 DF A3', description: 'EBML header' }],
+	},
+	{
+		type: 'video/3gpp',
+		category: 'video',
+		extensions: ['.3gp', '.3gpp'],
+		summary: '3GPP multimedia container; mobile-focused MP4 variant.',
+		magic: [{ hex: '66 74 79 70 33 67', offset: 4, description: '"ftyp3g" at offset 4' }],
+	},
+
+	/* ---------- font ---------- */
+	{
+		type: 'font/woff',
+		category: 'font',
+		extensions: ['.woff'],
+		summary: 'Web Open Font Format 1.0; SFNT with zlib compression for web fonts.',
+		aliases: ['application/font-woff'],
+		magic: [{ hex: '77 4F 46 46', description: '"wOFF" signature' }],
+		references: [ref('RFC 8081', 'https://www.rfc-editor.org/rfc/rfc8081')],
+	},
+	{
+		type: 'font/woff2',
+		category: 'font',
+		extensions: ['.woff2'],
+		summary: 'Web Open Font Format 2.0; SFNT with Brotli compression for web fonts.',
+		magic: [{ hex: '77 4F 46 32', description: '"wOF2" signature' }],
+		references: [ref('RFC 8081', 'https://www.rfc-editor.org/rfc/rfc8081')],
+	},
+	{
+		type: 'font/ttf',
+		category: 'font',
+		extensions: ['.ttf'],
+		summary: 'TrueType Font; original Apple / Microsoft vector font format.',
+		aliases: ['application/x-font-ttf', 'application/x-font-truetype'],
+		magic: [{ hex: '00 01 00 00', description: 'TTF signature' }],
+	},
+	{
+		type: 'font/otf',
+		category: 'font',
+		extensions: ['.otf'],
+		summary: 'OpenType Font; TrueType superset adding PostScript outlines.',
+		aliases: ['application/x-font-otf', 'application/x-font-opentype'],
+		magic: [{ hex: '4F 54 54 4F', description: '"OTTO" signature' }],
+	},
+	{
+		type: 'application/vnd.ms-fontobject',
+		category: 'font',
+		extensions: ['.eot'],
+		summary: 'Embedded OpenType; legacy font format used by Internet Explorer.',
+	},
+	{
+		type: 'font/collection',
+		category: 'font',
+		extensions: ['.ttc', '.otc'],
+		summary: 'OpenType / TrueType Collection; multiple fonts in one file.',
+		magic: [{ hex: '74 74 63 66', description: '"ttcf" signature' }],
+	},
+
+	/* ---------- text ---------- */
+	{
+		type: 'text/html',
+		category: 'text',
+		extensions: ['.html', '.htm', '.shtml'],
+		summary: 'HyperText Markup Language; the document format for the World Wide Web.',
+		charset: ['utf-8', 'utf-16', 'iso-8859-1', 'windows-1252'],
+		defaultCharset: 'utf-8',
+		references: [
+			ref('RFC 2854', 'https://www.rfc-editor.org/rfc/rfc2854'),
+			ref('HTML Living Standard', 'https://html.spec.whatwg.org/'),
+		],
+	},
+	{
+		type: 'text/plain',
+		category: 'text',
+		extensions: ['.txt', '.text', '.log', '.conf'],
+		summary: 'Plain text without markup; the default for unknown text content.',
+		charset: ['utf-8', 'utf-16', 'us-ascii', 'iso-8859-1'],
+		defaultCharset: 'utf-8',
+		references: [ref('RFC 2046', 'https://www.rfc-editor.org/rfc/rfc2046#section-4.1')],
+	},
+	{
+		type: 'text/css',
+		category: 'text',
+		extensions: ['.css'],
+		summary: 'Cascading Style Sheets; styling language for HTML and XML documents.',
+		charset: ['utf-8', 'iso-8859-1'],
+		defaultCharset: 'utf-8',
+		references: [ref('RFC 2318', 'https://www.rfc-editor.org/rfc/rfc2318')],
+	},
+	{
+		type: 'text/csv',
+		category: 'text',
+		extensions: ['.csv'],
+		summary: 'Comma-separated values; tabular data interchange format.',
+		charset: ['utf-8', 'us-ascii', 'windows-1252'],
+		defaultCharset: 'utf-8',
+		references: [ref('RFC 4180', 'https://www.rfc-editor.org/rfc/rfc4180')],
+	},
+	{
+		type: 'text/javascript',
+		category: 'text',
+		extensions: ['.js', '.mjs', '.cjs'],
+		summary: 'JavaScript / ECMAScript source code; the standard type per HTML spec.',
+		aliases: ['application/javascript', 'application/x-javascript'],
+		aliasNote:
+			'RFC 9239 designates `text/javascript` as the official type; older deployments use `application/javascript`.',
+		charset: ['utf-8', 'us-ascii'],
+		defaultCharset: 'utf-8',
+		references: [ref('RFC 9239', 'https://www.rfc-editor.org/rfc/rfc9239')],
+	},
+	{
+		type: 'text/markdown',
+		category: 'text',
+		extensions: ['.md', '.markdown', '.mdown', '.mkdn'],
+		summary: 'Markdown; lightweight markup for prose with inline HTML support.',
+		charset: ['utf-8'],
+		defaultCharset: 'utf-8',
+		references: [ref('RFC 7763', 'https://www.rfc-editor.org/rfc/rfc7763')],
+	},
+	{
+		type: 'application/yaml',
+		category: 'text',
+		extensions: ['.yaml', '.yml'],
+		summary: 'YAML Ain’t Markup Language; human-friendly data serialization.',
+		aliases: ['text/yaml', 'text/x-yaml', 'application/x-yaml'],
+		aliasNote: 'RFC 9512 registered `application/yaml` in 2023; older systems use `text/yaml`.',
+		charset: ['utf-8', 'utf-16', 'utf-32'],
+		defaultCharset: 'utf-8',
+		references: [ref('RFC 9512', 'https://www.rfc-editor.org/rfc/rfc9512')],
+	},
+	{
+		type: 'text/xml',
+		category: 'text',
+		extensions: ['.xml'],
+		summary: 'Extensible Markup Language as text; prefer `application/xml` for binary safety.',
+		aliases: ['application/xml'],
+		aliasNote:
+			'`text/xml` and `application/xml` differ in charset default. Prefer `application/xml` per RFC 7303.',
+		charset: ['us-ascii', 'utf-8', 'utf-16'],
+		defaultCharset: 'us-ascii',
+		references: [ref('RFC 7303', 'https://www.rfc-editor.org/rfc/rfc7303')],
+	},
+	{
+		type: 'text/x-sql',
+		category: 'text',
+		extensions: ['.sql'],
+		summary: 'Structured Query Language source; non-standard text type for SQL scripts.',
+		charset: ['utf-8'],
+		defaultCharset: 'utf-8',
+	},
+
+	/* ---------- application ---------- */
+	{
+		type: 'application/json',
+		category: 'application',
+		extensions: ['.json'],
+		summary: 'JavaScript Object Notation; the dominant text-based data interchange format.',
+		charset: ['utf-8'],
+		defaultCharset: 'utf-8',
+		references: [
+			ref('RFC 8259', 'https://www.rfc-editor.org/rfc/rfc8259'),
+			ref('IANA', `${IANA_REGISTRY}#application`),
+		],
+	},
+	{
+		type: 'application/xml',
+		category: 'application',
+		extensions: ['.xml', '.xsd', '.xsl', '.xslt'],
+		summary: 'XML payloads; preferred over `text/xml` because the charset default is UTF-8.',
+		charset: ['utf-8', 'utf-16'],
+		defaultCharset: 'utf-8',
+		references: [ref('RFC 7303', 'https://www.rfc-editor.org/rfc/rfc7303')],
+	},
+	{
+		type: 'application/pdf',
+		category: 'application',
+		extensions: ['.pdf'],
+		summary: 'Portable Document Format; fixed-layout document container by Adobe.',
+		magic: [{ hex: '25 50 44 46 2D', description: '"%PDF-" header' }],
+		references: [ref('RFC 8118', 'https://www.rfc-editor.org/rfc/rfc8118')],
+	},
+	{
+		type: 'application/zip',
+		category: 'application',
+		extensions: ['.zip'],
+		summary: 'ZIP archive; the foundational format for many container types (DOCX, JAR, EPUB).',
+		aliases: ['application/x-zip-compressed'],
+		magic: [
+			{ hex: '50 4B 03 04', description: 'ZIP local file header' },
+			{ hex: '50 4B 05 06', description: 'Empty ZIP archive' },
+			{ hex: '50 4B 07 08', description: 'ZIP spanned archive' },
+		],
+	},
+	{
+		type: 'application/gzip',
+		category: 'application',
+		extensions: ['.gz', '.gzip'],
+		summary: 'GZIP-compressed payload; single-file DEFLATE container.',
+		aliases: ['application/x-gzip'],
+		magic: [{ hex: '1F 8B', description: 'GZIP magic' }],
+		references: [ref('RFC 6713', 'https://www.rfc-editor.org/rfc/rfc6713')],
+	},
+	{
+		type: 'application/x-tar',
+		category: 'application',
+		extensions: ['.tar'],
+		summary: 'Tape archive; uncompressed concatenation of files with headers.',
+		magic: [
+			{ hex: '75 73 74 61 72 00 30 30', offset: 257, description: '"ustar\\000" POSIX' },
+			{ hex: '75 73 74 61 72 20 20 00', offset: 257, description: '"ustar  \\0" GNU' },
+		],
+	},
+	{
+		type: 'application/x-7z-compressed',
+		category: 'application',
+		extensions: ['.7z'],
+		summary: '7-Zip archive; high-compression container using LZMA / LZMA2.',
+		magic: [{ hex: '37 7A BC AF 27 1C', description: '7z signature' }],
+	},
+	{
+		type: 'application/x-rar-compressed',
+		category: 'application',
+		extensions: ['.rar'],
+		summary: 'RAR archive; proprietary high-compression container.',
+		aliases: ['application/vnd.rar'],
+		magic: [
+			{ hex: '52 61 72 21 1A 07 00', description: 'RAR 1.5+' },
+			{ hex: '52 61 72 21 1A 07 01 00', description: 'RAR 5.0+' },
+		],
+	},
+	{
+		type: 'application/x-bzip2',
+		category: 'application',
+		extensions: ['.bz2'],
+		summary: 'bzip2-compressed payload; Burrows–Wheeler-based DEFLATE alternative.',
+		magic: [{ hex: '42 5A 68', description: '"BZh" header' }],
+	},
+	{
+		type: 'application/octet-stream',
+		category: 'application',
+		extensions: ['.bin', '.dat'],
+		summary: 'Arbitrary binary data; the safe fallback when no specific type fits.',
+		references: [ref('RFC 2046', 'https://www.rfc-editor.org/rfc/rfc2046#section-4.5.1')],
+	},
+	{
+		type: 'application/x-www-form-urlencoded',
+		category: 'application',
+		extensions: [],
+		summary:
+			'Form encoding used by HTML form submissions with the `application/x-www-form-urlencoded` enctype.',
+		references: [
+			ref('URL Living Standard', 'https://url.spec.whatwg.org/#application/x-www-form-urlencoded'),
+		],
+	},
+	{
+		type: 'application/sql',
+		category: 'application',
+		extensions: ['.sql'],
+		summary: 'SQL script payload; the standard application type for query bodies.',
+		charset: ['utf-8'],
+		defaultCharset: 'utf-8',
+		references: [ref('RFC 6922', 'https://www.rfc-editor.org/rfc/rfc6922')],
+	},
+	{
+		type: 'application/x-sh',
+		category: 'application',
+		extensions: ['.sh', '.bash'],
+		summary: 'Shell script; typically Bourne / Bash compatible.',
+		magic: [{ hex: '23 21 2F', description: '"#!/" shebang' }],
+		charset: ['utf-8', 'us-ascii'],
+		defaultCharset: 'utf-8',
+	},
+	{
+		type: 'application/javascript',
+		category: 'application',
+		extensions: ['.js', '.mjs'],
+		summary: 'JavaScript source code; deprecated in favor of `text/javascript` per RFC 9239.',
+		aliases: ['text/javascript', 'application/x-javascript'],
+		aliasNote:
+			'Obsoleted by RFC 9239 in favor of `text/javascript`. Retained for legacy server config.',
+		charset: ['utf-8'],
+		defaultCharset: 'utf-8',
+		references: [ref('RFC 9239', 'https://www.rfc-editor.org/rfc/rfc9239')],
+	},
+	{
+		type: 'application/ecmascript',
+		category: 'application',
+		extensions: ['.es'],
+		summary: 'ECMAScript source code; deprecated alias for JavaScript.',
+		aliasNote: 'Obsoleted by RFC 9239; prefer `text/javascript`.',
+	},
+	{
+		type: 'application/wasm',
+		category: 'application',
+		extensions: ['.wasm'],
+		summary: 'WebAssembly binary module.',
+		magic: [{ hex: '00 61 73 6D', description: '"\\0asm" Wasm signature' }],
+	},
+	{
+		type: 'application/ld+json',
+		category: 'application',
+		extensions: ['.jsonld'],
+		summary: 'JSON-LD (Linked Data); JSON with semantic context for Linked Data.',
+		charset: ['utf-8'],
+		defaultCharset: 'utf-8',
+		references: [ref('W3C JSON-LD', 'https://www.w3.org/TR/json-ld11/')],
+	},
+	{
+		type: 'application/jwt',
+		category: 'application',
+		extensions: ['.jwt'],
+		summary: 'JSON Web Token; signed and optionally encrypted claims payload.',
+		references: [ref('RFC 7519', 'https://www.rfc-editor.org/rfc/rfc7519')],
+	},
+	{
+		type: 'application/vnd.api+json',
+		category: 'application',
+		extensions: [],
+		summary: 'JSON:API; convention for building APIs in JSON with hypermedia controls.',
+		charset: ['utf-8'],
+		defaultCharset: 'utf-8',
+		references: [ref('JSON:API', 'https://jsonapi.org/')],
+	},
+	{
+		type: 'application/vnd.ms-excel',
+		category: 'application',
+		extensions: ['.xls', '.xlt'],
+		summary: 'Microsoft Excel 97–2003 binary spreadsheet.',
+		magic: [{ hex: 'D0 CF 11 E0 A1 B1 1A E1', description: 'OLE Compound File header' }],
+	},
+	{
+		type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+		category: 'application',
+		extensions: ['.docx'],
+		summary: 'Microsoft Word OOXML document (ZIP container with XML parts).',
+		magic: [{ hex: '50 4B 03 04', description: 'ZIP container header' }],
+	},
+	{
+		type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+		category: 'application',
+		extensions: ['.xlsx'],
+		summary: 'Microsoft Excel OOXML spreadsheet (ZIP container with XML parts).',
+		magic: [{ hex: '50 4B 03 04', description: 'ZIP container header' }],
+	},
+	{
+		type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+		category: 'application',
+		extensions: ['.pptx'],
+		summary: 'Microsoft PowerPoint OOXML presentation (ZIP container with XML parts).',
+		magic: [{ hex: '50 4B 03 04', description: 'ZIP container header' }],
+	},
+	{
+		type: 'application/x-shockwave-flash',
+		category: 'application',
+		extensions: ['.swf'],
+		summary: 'Adobe Flash SWF; deprecated browser plugin content.',
+		aliases: ['application/vnd.adobe.flash.movie'],
+		magic: [
+			{ hex: '46 57 53', description: 'Uncompressed "FWS"' },
+			{ hex: '43 57 53', description: 'zlib-compressed "CWS"' },
+		],
+	},
+	{
+		type: 'application/x-msdownload',
+		category: 'application',
+		extensions: ['.exe', '.dll', '.com'],
+		summary: 'Windows portable executable (PE) binary.',
+		aliases: ['application/vnd.microsoft.portable-executable'],
+		magic: [{ hex: '4D 5A', description: '"MZ" DOS header' }],
+	},
+	{
+		type: 'application/x-deb',
+		category: 'application',
+		extensions: ['.deb'],
+		summary: 'Debian package archive; ar archive with control.tar and data.tar members.',
+		aliases: ['application/vnd.debian.binary-package'],
+		magic: [{ hex: '21 3C 61 72 63 68 3E', description: '"!<arch>" ar signature' }],
+	},
+	{
+		type: 'application/x-rpm',
+		category: 'application',
+		extensions: ['.rpm'],
+		summary: 'RPM Package Manager archive; Red Hat / SUSE software package.',
+		magic: [{ hex: 'ED AB EE DB', description: 'RPM lead header' }],
+	},
+
+	/* ---------- multipart ---------- */
+	{
+		type: 'multipart/form-data',
+		category: 'multipart',
+		extensions: [],
+		summary: 'Form encoding for binary uploads; required when `<input type="file">` is present.',
+		references: [ref('RFC 7578', 'https://www.rfc-editor.org/rfc/rfc7578')],
+	},
+	{
+		type: 'multipart/mixed',
+		category: 'multipart',
+		extensions: [],
+		summary: 'Sequence of unrelated parts with independent content types.',
+		references: [ref('RFC 2046', 'https://www.rfc-editor.org/rfc/rfc2046#section-5.1.3')],
+	},
+	{
+		type: 'multipart/alternative',
+		category: 'multipart',
+		extensions: [],
+		summary: 'Same content in multiple representations (e.g. text/plain + text/html mail body).',
+		references: [ref('RFC 2046', 'https://www.rfc-editor.org/rfc/rfc2046#section-5.1.4')],
+	},
+
+	/* ---------- message ---------- */
+	{
+		type: 'message/rfc822',
+		category: 'message',
+		extensions: ['.eml', '.mht', '.mhtml'],
+		summary: 'Internet Message Format; raw email payload including headers and body.',
+		references: [ref('RFC 5322', 'https://www.rfc-editor.org/rfc/rfc5322')],
+	},
+];
+
+/* -------------------------------------------------------------------------- */
+/* Filtering                                                                  */
+/* -------------------------------------------------------------------------- */
+
+export interface FilterOptions {
+	readonly query: string;
+	readonly categories: ReadonlySet<MimeCategory>;
+	readonly requireMagic: boolean;
+}
+
+const normalize = (value: string): string => value.toLowerCase().trim();
+
+const matchesQuery = (entry: MimeEntry, query: string): boolean => {
+	if (query.length === 0) return true;
+	const q = normalize(query);
+	if (entry.type.toLowerCase().includes(q)) return true;
+	if (entry.summary.toLowerCase().includes(q)) return true;
+	if (entry.extensions.some((ext) => ext.toLowerCase().includes(q))) return true;
+	// Accept an extension query without the leading dot.
+	if (!q.startsWith('.') && entry.extensions.some((ext) => ext.slice(1).toLowerCase() === q))
+		return true;
+	if (entry.aliases?.some((alias) => alias.toLowerCase().includes(q))) return true;
+	return false;
+};
+
+export const filterEntries = (
+	all: readonly MimeEntry[],
+	opts: FilterOptions
+): readonly MimeEntry[] =>
+	all.filter((entry) => {
+		if (!opts.categories.has(entry.category)) return false;
+		if (opts.requireMagic && (!entry.magic || entry.magic.length === 0)) return false;
+		return matchesQuery(entry, opts.query);
+	});
+
+/* -------------------------------------------------------------------------- */
+/* Snippet generators                                                         */
+/* -------------------------------------------------------------------------- */
+
+export const asContentTypeHeader = (entry: MimeEntry, charset?: string): string => {
+	const cs = charset ?? entry.defaultCharset;
+	if (entry.category === 'text' && cs) return `Content-Type: ${entry.type}; charset=${cs}`;
+	return `Content-Type: ${entry.type}`;
+};
+
+/**
+ * Java-style MediaType constant reference; mirrors Spring's `MediaType` /
+ * Jakarta EE `MediaType` static-field naming conventions.
+ */
+export const asJavaMediaType = (entry: MimeEntry): string => {
+	const constName = entry.type
+		.toUpperCase()
+		.replace(/[^A-Z0-9]+/g, '_')
+		.replace(/^_+|_+$/g, '');
+	return `MediaType.parseMediaType("${entry.type}"); // suggested constant: ${constName}`;
+};
+
+/**
+ * Python `mimetypes` module tuple shape: `(type, extension)`.
+ */
+export const asPythonTuple = (entry: MimeEntry): string => {
+	const ext = entry.extensions[0] ?? '';
+	return `("${entry.type}", "${ext}")`;
+};
+
+/**
+ * Go-style constant declaration suitable for pasting into a constants file.
+ */
+export const asGoConstant = (entry: MimeEntry): string => {
+	const constName = entry.type
+		.split(/[^a-z0-9]+/i)
+		.filter(Boolean)
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+		.join('');
+	return `const MimeType${constName} = "${entry.type}"`;
+};

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -21,6 +21,7 @@ import {
 	FileDiff,
 	FileJson2,
 	FileText,
+	FileType,
 	Fingerprint,
 	GitBranch,
 	GitCompare,
@@ -452,6 +453,15 @@ export const PAGES: readonly PageDefinition[] = [
 		icon: Radar,
 		description: 'Scan networks for open ports and services',
 		color: 'text-rose-500',
+		category: 'network',
+	},
+	{
+		id: 'mime-types',
+		title: 'MIME Type Explorer',
+		url: '/mime-types',
+		icon: FileType,
+		description: 'Bidirectional MIME type / extension lookup with magic bytes and charset info',
+		color: 'text-emerald-700',
 		category: 'network',
 	},
 	{

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -27,6 +27,7 @@ import { Route as PasswordGeneratorRouteImport } from './routes/password-generat
 import { Route as NumberBaseConverterRouteImport } from './routes/number-base-converter';
 import { Route as NetworkScannerRouteImport } from './routes/network-scanner';
 import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces';
+import { Route as MimeTypesRouteImport } from './routes/mime-types';
 import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor';
 import { Route as LoremIpsumRouteImport } from './routes/lorem-ipsum';
 import { Route as ListComparerRouteImport } from './routes/list-comparer';
@@ -134,6 +135,11 @@ const NetworkScannerRoute = NetworkScannerRouteImport.update({
 const NetworkInterfacesRoute = NetworkInterfacesRouteImport.update({
 	id: '/network-interfaces',
 	path: '/network-interfaces',
+	getParentRoute: () => rootRouteImport,
+} as any);
+const MimeTypesRoute = MimeTypesRouteImport.update({
+	id: '/mime-types',
+	path: '/mime-types',
 	getParentRoute: () => rootRouteImport,
 } as any);
 const MarkdownEditorRoute = MarkdownEditorRouteImport.update({
@@ -246,6 +252,7 @@ export interface FileRoutesByFullPath {
 	'/list-comparer': typeof ListComparerRoute;
 	'/lorem-ipsum': typeof LoremIpsumRoute;
 	'/markdown-editor': typeof MarkdownEditorRoute;
+	'/mime-types': typeof MimeTypesRoute;
 	'/network-interfaces': typeof NetworkInterfacesRoute;
 	'/network-scanner': typeof NetworkScannerRoute;
 	'/number-base-converter': typeof NumberBaseConverterRoute;
@@ -284,6 +291,7 @@ export interface FileRoutesByTo {
 	'/list-comparer': typeof ListComparerRoute;
 	'/lorem-ipsum': typeof LoremIpsumRoute;
 	'/markdown-editor': typeof MarkdownEditorRoute;
+	'/mime-types': typeof MimeTypesRoute;
 	'/network-interfaces': typeof NetworkInterfacesRoute;
 	'/network-scanner': typeof NetworkScannerRoute;
 	'/number-base-converter': typeof NumberBaseConverterRoute;
@@ -323,6 +331,7 @@ export interface FileRoutesById {
 	'/list-comparer': typeof ListComparerRoute;
 	'/lorem-ipsum': typeof LoremIpsumRoute;
 	'/markdown-editor': typeof MarkdownEditorRoute;
+	'/mime-types': typeof MimeTypesRoute;
 	'/network-interfaces': typeof NetworkInterfacesRoute;
 	'/network-scanner': typeof NetworkScannerRoute;
 	'/number-base-converter': typeof NumberBaseConverterRoute;
@@ -363,6 +372,7 @@ export interface FileRouteTypes {
 		| '/list-comparer'
 		| '/lorem-ipsum'
 		| '/markdown-editor'
+		| '/mime-types'
 		| '/network-interfaces'
 		| '/network-scanner'
 		| '/number-base-converter'
@@ -401,6 +411,7 @@ export interface FileRouteTypes {
 		| '/list-comparer'
 		| '/lorem-ipsum'
 		| '/markdown-editor'
+		| '/mime-types'
 		| '/network-interfaces'
 		| '/network-scanner'
 		| '/number-base-converter'
@@ -439,6 +450,7 @@ export interface FileRouteTypes {
 		| '/list-comparer'
 		| '/lorem-ipsum'
 		| '/markdown-editor'
+		| '/mime-types'
 		| '/network-interfaces'
 		| '/network-scanner'
 		| '/number-base-converter'
@@ -478,6 +490,7 @@ export interface RootRouteChildren {
 	ListComparerRoute: typeof ListComparerRoute;
 	LoremIpsumRoute: typeof LoremIpsumRoute;
 	MarkdownEditorRoute: typeof MarkdownEditorRoute;
+	MimeTypesRoute: typeof MimeTypesRoute;
 	NetworkInterfacesRoute: typeof NetworkInterfacesRoute;
 	NetworkScannerRoute: typeof NetworkScannerRoute;
 	NumberBaseConverterRoute: typeof NumberBaseConverterRoute;
@@ -624,6 +637,13 @@ declare module '@tanstack/react-router' {
 			path: '/network-interfaces';
 			fullPath: '/network-interfaces';
 			preLoaderRoute: typeof NetworkInterfacesRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/mime-types': {
+			id: '/mime-types';
+			path: '/mime-types';
+			fullPath: '/mime-types';
+			preLoaderRoute: typeof MimeTypesRouteImport;
 			parentRoute: typeof rootRouteImport;
 		};
 		'/markdown-editor': {
@@ -774,6 +794,7 @@ const rootRouteChildren: RootRouteChildren = {
 	ListComparerRoute: ListComparerRoute,
 	LoremIpsumRoute: LoremIpsumRoute,
 	MarkdownEditorRoute: MarkdownEditorRoute,
+	MimeTypesRoute: MimeTypesRoute,
 	NetworkInterfacesRoute: NetworkInterfacesRoute,
 	NetworkScannerRoute: NetworkScannerRoute,
 	NumberBaseConverterRoute: NumberBaseConverterRoute,

--- a/src/routes/mime-types.tsx
+++ b/src/routes/mime-types.tsx
@@ -1,0 +1,555 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { ExternalLink, FileSearch } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { CopyButton } from '@/lib/components/action';
+import {
+	FormCheckbox,
+	FormCheckboxGroup,
+	FormInfo,
+	FormInput,
+	FormSection,
+} from '@/lib/components/form';
+import { ToolShell } from '@/lib/components/shell';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { useDocumentTitle } from '@/lib/hooks';
+import {
+	asContentTypeHeader,
+	asGoConstant,
+	asJavaMediaType,
+	asPythonTuple,
+	CATEGORY_LABELS,
+	CATEGORY_TONES,
+	type FilterOptions,
+	filterEntries,
+	type MimeCategory,
+	type MimeEntry,
+	MIME_ENTRIES,
+} from '@/lib/services/mime';
+import { createToolOptionsStore } from '@/lib/stores';
+import { cn } from '@/lib/utils';
+
+const ALL_CATEGORIES: readonly MimeCategory[] = [
+	'image',
+	'audio',
+	'video',
+	'font',
+	'text',
+	'application',
+	'multipart',
+	'message',
+];
+
+const TEXT_LIKE_CATEGORIES = new Set<MimeCategory>(['text']);
+const BINARY_LIKE_CATEGORIES = new Set<MimeCategory>([
+	'image',
+	'audio',
+	'video',
+	'font',
+	'application',
+]);
+
+const WEB_COMMON_TYPES = new Set<string>([
+	'text/html',
+	'text/javascript',
+	'text/css',
+	'image/png',
+	'image/jpeg',
+	'application/json',
+]);
+
+interface MimeTypesOptions {
+	readonly query: string;
+	readonly categories: readonly MimeCategory[];
+	readonly requireMagic: boolean;
+	readonly selectedType: string | null;
+}
+
+const DEFAULTS: MimeTypesOptions = {
+	query: '',
+	categories: ALL_CATEGORIES,
+	requireMagic: false,
+	selectedType: null,
+};
+
+const useMimeOptions = createToolOptionsStore<MimeTypesOptions>('mime-types', DEFAULTS);
+
+export const Route = createFileRoute('/mime-types')({
+	component: MimeTypesPage,
+});
+
+function MimeTypesPage() {
+	useDocumentTitle('MIME Type Explorer');
+
+	const { value: options, patch } = useMimeOptions();
+	const { query, categories, requireMagic, selectedType } = options;
+
+	const [showRail, setShowRail] = useState(true);
+
+	const categoriesSet = useMemo(() => new Set<MimeCategory>(categories), [categories]);
+
+	const filterOpts: FilterOptions = useMemo(
+		() => ({ query, categories: categoriesSet, requireMagic }),
+		[query, categoriesSet, requireMagic]
+	);
+
+	const filtered = useMemo(() => filterEntries(MIME_ENTRIES, filterOpts), [filterOpts]);
+
+	const selected = useMemo<MimeEntry | null>(() => {
+		if (!selectedType) return null;
+		return MIME_ENTRIES.find((entry) => entry.type === selectedType) ?? null;
+	}, [selectedType]);
+
+	const handleToggleCategory = (category: MimeCategory, checked: boolean) => {
+		const next = checked
+			? Array.from(new Set([...categories, category]))
+			: categories.filter((c) => c !== category);
+		patch({ categories: next });
+	};
+
+	const handleSelectAllCategories = () => {
+		patch({ categories: ALL_CATEGORIES });
+	};
+
+	const handleSelectTextOnly = () => {
+		patch({
+			categories: ALL_CATEGORIES.filter((c) => TEXT_LIKE_CATEGORIES.has(c)),
+			requireMagic: false,
+		});
+	};
+
+	const handleSelectBinaryOnly = () => {
+		patch({
+			categories: ALL_CATEGORIES.filter((c) => BINARY_LIKE_CATEGORIES.has(c)),
+		});
+	};
+
+	const handleSelectWebCommon = () => {
+		patch({
+			categories: ALL_CATEGORIES,
+			requireMagic: false,
+			query: '',
+		});
+	};
+
+	const handleSelectEntry = (entry: MimeEntry) => {
+		patch({ selectedType: entry.type });
+	};
+
+	const visibleWebCommon = useMemo(
+		() => filtered.filter((entry) => WEB_COMMON_TYPES.has(entry.type)),
+		[filtered]
+	);
+
+	return (
+		<ToolShell
+			showRail={showRail}
+			onShowRailChange={setShowRail}
+			statusContent={
+				<>
+					<StatItem label="Visible" value={filtered.length} />
+					<StatItem label="Selected" value={selected ? 1 : 0} />
+					<StatItem label="Total" value={MIME_ENTRIES.length} />
+				</>
+			}
+			rail={
+				<>
+					<FormSection title="Search">
+						<FormInfo>
+							Search by MIME type (<code className="font-mono">image/png</code>), extension (
+							<code className="font-mono">.png</code>), or any text in the summary.
+						</FormInfo>
+					</FormSection>
+
+					<FormSection title="Categories">
+						<FormCheckboxGroup>
+							{ALL_CATEGORIES.map((category) => (
+								<FormCheckbox
+									key={category}
+									size="compact"
+									label={CATEGORY_LABELS[category]}
+									checked={categoriesSet.has(category)}
+									onCheckedChange={(checked) => handleToggleCategory(category, checked)}
+								/>
+							))}
+						</FormCheckboxGroup>
+					</FormSection>
+
+					<FormSection title="Magic bytes">
+						<FormCheckbox
+							size="compact"
+							label="Only show entries with known magic bytes"
+							checked={requireMagic}
+							onCheckedChange={(checked) => patch({ requireMagic: checked })}
+						/>
+					</FormSection>
+
+					<FormSection title="Quick filters">
+						<div className="grid grid-cols-2 gap-1">
+							<Button variant="outline" size="sm" onClick={handleSelectAllCategories}>
+								All
+							</Button>
+							<Button variant="outline" size="sm" onClick={handleSelectTextOnly}>
+								Text only
+							</Button>
+							<Button variant="outline" size="sm" onClick={handleSelectBinaryOnly}>
+								Binary only
+							</Button>
+							<Button variant="outline" size="sm" onClick={handleSelectWebCommon}>
+								Web common
+							</Button>
+						</div>
+					</FormSection>
+
+					<FormSection title="About">
+						<FormInfo>
+							<ul className="list-inside list-disc space-y-0.5">
+								<li>Catalog of {MIME_ENTRIES.length} commonly-encountered MIME types.</li>
+								<li>Magic bytes are the first-N bytes used for file-type sniffing.</li>
+								<li>Alias notes flag deprecated or non-standard variants.</li>
+								<li>All lookups happen in-browser; no external requests.</li>
+							</ul>
+						</FormInfo>
+					</FormSection>
+				</>
+			}
+		>
+			<div className="flex h-full flex-col overflow-hidden">
+				<div className="border-b border-border/40 bg-background p-3">
+					<FormInput
+						label="Search MIME types, extensions, or text"
+						placeholder="e.g. image/png, .json, video"
+						value={query}
+						onValueChange={(value) => patch({ query: value })}
+						size="default"
+					/>
+					<div className="mt-2 flex flex-wrap items-center gap-1.5 text-2xs">
+						<span className="text-muted-foreground">Active categories:</span>
+						{ALL_CATEGORIES.filter((category) => categoriesSet.has(category)).map((category) => (
+							<button
+								key={category}
+								type="button"
+								className={cn(
+									'inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-2xs font-medium transition-opacity hover:opacity-80',
+									CATEGORY_TONES[category]
+								)}
+								onClick={() => handleToggleCategory(category, false)}
+							>
+								{CATEGORY_LABELS[category]}
+								<span className="text-muted-foreground/80">×</span>
+							</button>
+						))}
+						{categoriesSet.size === 0 ? (
+							<span className="text-muted-foreground">No category selected.</span>
+						) : null}
+					</div>
+					{query.trim().length > 0 && visibleWebCommon.length > 0 ? (
+						<p className="mt-1 text-2xs text-muted-foreground">
+							Web-common matches: {visibleWebCommon.map((entry) => entry.type).join(', ')}
+						</p>
+					) : null}
+				</div>
+
+				<div className="flex-1 overflow-auto p-3">
+					{filtered.length === 0 ? (
+						<Card density="compact">
+							<CardContent>
+								<EmbeddedEmptyState
+									icon={FileSearch}
+									title="No matching MIME types"
+									description="Adjust the search query, enable more categories, or disable the magic-bytes filter."
+								/>
+							</CardContent>
+						</Card>
+					) : (
+						<div className="grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-3">
+							{filtered.map((entry) => (
+								<MimeCard
+									key={entry.type}
+									entry={entry}
+									isSelected={entry.type === selectedType}
+									onSelect={handleSelectEntry}
+								/>
+							))}
+						</div>
+					)}
+
+					{selected ? (
+						<div className="mt-3">
+							<MimeDetailPanel entry={selected} onClose={() => patch({ selectedType: null })} />
+						</div>
+					) : null}
+				</div>
+			</div>
+		</ToolShell>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface MimeCardProps {
+	readonly entry: MimeEntry;
+	readonly isSelected: boolean;
+	readonly onSelect: (entry: MimeEntry) => void;
+}
+
+function MimeCard({ entry, isSelected, onSelect }: MimeCardProps) {
+	const hasMagic = (entry.magic?.length ?? 0) > 0;
+	return (
+		<Card
+			density="compact"
+			className={cn(
+				'cursor-pointer transition-colors hover:bg-interactive-hover',
+				isSelected ? 'ring-2 ring-primary/60' : ''
+			)}
+			onClick={() => onSelect(entry)}
+		>
+			<CardHeader className="pb-2">
+				<div className="flex items-start justify-between gap-2">
+					<CardTitle className="font-mono text-xs break-all">{entry.type}</CardTitle>
+					<span
+						className={cn(
+							'inline-flex shrink-0 items-center rounded-md px-1.5 py-0.5 text-2xs font-medium',
+							CATEGORY_TONES[entry.category]
+						)}
+					>
+						{CATEGORY_LABELS[entry.category]}
+					</span>
+				</div>
+			</CardHeader>
+			<CardContent className="space-y-1.5">
+				<div className="flex flex-wrap gap-1 text-2xs">
+					{entry.extensions.length > 0 ? (
+						entry.extensions.map((ext) => (
+							<span
+								key={ext}
+								className="rounded bg-muted px-1.5 py-0.5 font-mono text-muted-foreground"
+							>
+								{ext}
+							</span>
+						))
+					) : (
+						<span className="text-muted-foreground italic">No file extension</span>
+					)}
+				</div>
+				<p className="text-2xs leading-snug text-muted-foreground line-clamp-2">{entry.summary}</p>
+				<div className="flex flex-wrap gap-1 text-2xs text-muted-foreground">
+					{hasMagic ? (
+						<span className="rounded bg-info/10 px-1.5 py-0.5 text-info">magic</span>
+					) : null}
+					{entry.aliases && entry.aliases.length > 0 ? (
+						<span className="rounded bg-warning/10 px-1.5 py-0.5 text-warning">
+							{entry.aliases.length} alias{entry.aliases.length === 1 ? '' : 'es'}
+						</span>
+					) : null}
+					{entry.charset && entry.charset.length > 0 ? (
+						<span className="rounded bg-success/10 px-1.5 py-0.5 text-success">charset</span>
+					) : null}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface MimeDetailPanelProps {
+	readonly entry: MimeEntry;
+	readonly onClose: () => void;
+}
+
+function MimeDetailPanel({ entry, onClose }: MimeDetailPanelProps) {
+	const headerSnippet = asContentTypeHeader(entry);
+	const javaSnippet = asJavaMediaType(entry);
+	const pythonSnippet = asPythonTuple(entry);
+	const goSnippet = asGoConstant(entry);
+
+	const handleOpenExternal = async (url: string) => {
+		const { openUrl } = await import('@tauri-apps/plugin-opener');
+		openUrl(url).catch(() => {});
+	};
+
+	return (
+		<Card density="compact" variant="info">
+			<CardHeader className="pb-2">
+				<div className="flex items-start justify-between gap-2">
+					<div className="flex min-w-0 flex-col gap-1">
+						<CardTitle className="font-mono text-sm break-all">{entry.type}</CardTitle>
+						<div className="flex flex-wrap items-center gap-1.5">
+							<span
+								className={cn(
+									'inline-flex items-center rounded-md px-1.5 py-0.5 text-2xs font-medium',
+									CATEGORY_TONES[entry.category]
+								)}
+							>
+								{CATEGORY_LABELS[entry.category]}
+							</span>
+							{entry.extensions.map((ext) => (
+								<span
+									key={ext}
+									className="rounded bg-muted px-1.5 py-0.5 font-mono text-2xs text-muted-foreground"
+								>
+									{ext}
+								</span>
+							))}
+						</div>
+					</div>
+					<Button variant="ghost" size="sm" onClick={onClose}>
+						Close
+					</Button>
+				</div>
+			</CardHeader>
+			<CardContent className="space-y-3">
+				<p className="text-xs leading-relaxed text-muted-foreground">{entry.summary}</p>
+
+				{entry.aliases && entry.aliases.length > 0 ? (
+					<section className="space-y-1">
+						<h3 className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+							Aliases
+						</h3>
+						<div className="flex flex-wrap gap-1.5">
+							{entry.aliases.map((alias) => (
+								<span
+									key={alias}
+									className="inline-flex items-center gap-1 rounded-md border bg-muted/40 px-1.5 py-0.5 font-mono text-2xs"
+								>
+									{alias}
+									<CopyButton
+										text={alias}
+										toastLabel="Alias"
+										size="sm"
+										variant="ghost"
+										showLabel={false}
+									/>
+								</span>
+							))}
+						</div>
+						{entry.aliasNote ? (
+							<p className="text-2xs leading-relaxed text-warning">{entry.aliasNote}</p>
+						) : null}
+					</section>
+				) : null}
+
+				{entry.magic && entry.magic.length > 0 ? (
+					<section className="space-y-1">
+						<h3 className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+							Magic bytes
+						</h3>
+						<table className="w-full min-w-max border-collapse text-2xs">
+							<thead>
+								<tr className="border-b border-border/60 text-left uppercase tracking-wide text-muted-foreground">
+									<th className="py-1 pr-3 font-semibold">Offset</th>
+									<th className="py-1 pr-3 font-semibold">Hex</th>
+									<th className="py-1 pr-3 font-semibold">Description</th>
+									<th className="py-1" />
+								</tr>
+							</thead>
+							<tbody>
+								{entry.magic.map((m) => (
+									<tr
+										key={`${entry.type}-magic-${m.offset ?? 0}-${m.hex}`}
+										className="border-b border-border/30 last:border-b-0"
+									>
+										<td className="py-1 pr-3 font-mono tabular-nums">{m.offset ?? 0}</td>
+										<td className="py-1 pr-3 font-mono">{m.hex}</td>
+										<td className="py-1 pr-3 text-muted-foreground">{m.description ?? ''}</td>
+										<td className="py-1 text-right">
+											<CopyButton
+												text={m.hex}
+												toastLabel="Magic bytes"
+												size="sm"
+												variant="ghost"
+												showLabel={false}
+											/>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</section>
+				) : null}
+
+				{entry.charset && entry.charset.length > 0 ? (
+					<section className="space-y-1">
+						<h3 className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+							Charset
+						</h3>
+						<div className="flex flex-wrap gap-1.5">
+							{entry.charset.map((cs) => (
+								<span
+									key={cs}
+									className={cn(
+										'inline-flex items-center rounded-md border px-1.5 py-0.5 font-mono text-2xs',
+										cs === entry.defaultCharset
+											? 'border-success/40 bg-success/10 text-success'
+											: 'bg-muted text-muted-foreground'
+									)}
+								>
+									{cs}
+									{cs === entry.defaultCharset ? ' (default)' : ''}
+								</span>
+							))}
+						</div>
+					</section>
+				) : null}
+
+				<section className="space-y-1">
+					<h3 className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+						Copy snippets
+					</h3>
+					<div className="grid grid-cols-1 gap-1.5 md:grid-cols-2">
+						<SnippetRow label="Content-Type header" value={headerSnippet} />
+						<SnippetRow label="Java MediaType" value={javaSnippet} />
+						<SnippetRow label="Python tuple" value={pythonSnippet} />
+						<SnippetRow label="Go constant" value={goSnippet} />
+					</div>
+				</section>
+
+				{entry.references && entry.references.length > 0 ? (
+					<section className="space-y-1">
+						<h3 className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+							References
+						</h3>
+						<div className="flex flex-wrap gap-1.5">
+							{entry.references.map((r) => (
+								<Button
+									key={r.url}
+									variant="outline"
+									size="sm"
+									className="h-7 gap-1 text-2xs"
+									onClick={() => handleOpenExternal(r.url)}
+								>
+									<ExternalLink className="h-3 w-3" />
+									{r.label}
+								</Button>
+							))}
+						</div>
+					</section>
+				) : null}
+			</CardContent>
+		</Card>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface SnippetRowProps {
+	readonly label: string;
+	readonly value: string;
+}
+
+function SnippetRow({ label, value }: SnippetRowProps) {
+	return (
+		<div className="flex items-center justify-between gap-2 rounded-md border bg-muted/30 px-2 py-1">
+			<div className="min-w-0 flex-1">
+				<div className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+					{label}
+				</div>
+				<div className="truncate font-mono text-2xs">{value}</div>
+			</div>
+			<CopyButton text={value} toastLabel={label} size="sm" variant="ghost" showLabel={false} />
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
Add a MIME Type Explorer under **Network** for bidirectional lookup between file extensions and MIME types, with category browsing, magic-byte display, and snippet copy. Closes #231.

## Features
- **Curated catalog** of ~70 commonly-used MIME types across 8 categories
- **Bidirectional search**: by MIME type (`image/png`), extension (`.png`), or free text
- **Category chips**: image / audio / video / font / text / application / multipart / message
- **Magic-byte signatures** (hex + offset) for binary type detection
- **Aliases** with deprecation notes (e.g. `image/jpg` ↔ `image/jpeg`)
- **Charset info** for text types (with default highlighted)
- **Copy snippets**: Content-Type header, Java `MediaType.`, Python tuple, Go constant
- **RFC / IANA references** per entry (opened via the OS browser)
- All client-side; no external requests

## Changes
### Added
- `src/routes/mime-types.tsx`
- `src/lib/services/mime.ts` (catalog + filter + snippet generators)
- Page registration in `src/lib/services/pages.ts`

## Test plan
- [x] `bun run check` green
- [x] `bun run lint` no new errors
- [x] `bun run format` clean
- [ ] Manual: search `.png` → `image/png` surfaces
- [ ] Manual: search `application/json` → matches the JSON entry
- [ ] Manual: select `image/png` → magic bytes `89 50 4E 47 …` shown
- [ ] Manual: select a text type → charset info shown
- [ ] Manual: filter "Magic bytes only" → only entries with signatures

Closes #231
