### PR TITLE
feat(mac-lookup): add MAC Address / OUI Lookup tool

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -466,6 +466,8 @@ pub fn run() {
             cancel_discovery,
             get_discovery_methods,
             check_discovery_privilege,
+            network::oui::lookup_oui_vendor,
+            network::oui::get_oui_database_info,
             settings::get_settings,
             settings::update_settings,
             settings::reset_settings,

--- a/src-tauri/src/network/mod.rs
+++ b/src-tauri/src/network/mod.rs
@@ -60,7 +60,7 @@ pub mod discovery;
 pub mod interfaces;
 mod llmnr;
 mod netbios;
-mod oui;
+pub mod oui;
 mod ports;
 pub mod scanner;
 mod snmp;

--- a/src-tauri/src/network/oui.rs
+++ b/src-tauri/src/network/oui.rs
@@ -1514,6 +1514,69 @@ pub fn lookup_vendor(mac: &str) -> Option<&'static str> {
     OUI_DATABASE.get(prefix).copied()
 }
 
+/// Vendor lookup result for the frontend OUI tool.
+///
+/// `prefix` is the matched 3-octet OUI in colon-uppercase form (e.g. `00:1B:63`),
+/// or `None` when no match was found.
+#[derive(serde::Serialize)]
+pub struct OuiLookupResult {
+    pub vendor: Option<String>,
+    pub prefix: Option<String>,
+}
+
+/// Metadata about the bundled OUI database surfaced in the UI.
+#[derive(serde::Serialize)]
+pub struct OuiDatabaseInfo {
+    /// Number of OUI prefixes contained in the database.
+    pub entries: usize,
+    /// Last-updated marker for the bundled snapshot (UTC date in `YYYY-MM-DD`).
+    pub updated: &'static str,
+    /// Short human-readable source description.
+    pub source: &'static str,
+}
+
+/// Bundled snapshot date for the OUI database. Bump when the dataset is
+/// refreshed against the IEEE registry.
+const OUI_UPDATED: &str = "2025-09-01";
+const OUI_SOURCE: &str = "IEEE OUI registry (curated subset)";
+
+/// Look up the vendor for a MAC address from the bundled IEEE OUI database.
+///
+/// Returns the vendor name and matched 3-octet prefix when found.
+#[tauri::command]
+pub fn lookup_oui_vendor(mac: String) -> OuiLookupResult {
+    let normalized = mac.to_uppercase();
+    let prefix = if normalized.len() >= 8 {
+        normalized[..8].to_string()
+    } else {
+        return OuiLookupResult {
+            vendor: None,
+            prefix: None,
+        };
+    };
+
+    OUI_DATABASE.get(prefix.as_str()).map_or_else(
+        || OuiLookupResult {
+            vendor: None,
+            prefix: None,
+        },
+        |vendor| OuiLookupResult {
+            vendor: Some((*vendor).to_string()),
+            prefix: Some(prefix),
+        },
+    )
+}
+
+/// Return metadata about the bundled OUI database for the freshness badge.
+#[tauri::command]
+pub fn get_oui_database_info() -> OuiDatabaseInfo {
+    OuiDatabaseInfo {
+        entries: OUI_DATABASE.len(),
+        updated: OUI_UPDATED,
+        source: OUI_SOURCE,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib/services/mac.ts
+++ b/src/lib/services/mac.ts
@@ -1,0 +1,284 @@
+/**
+ * MAC address parsing, formatting, vendor lookup, and derived encodings.
+ *
+ * Vendor lookup is delegated to the Rust backend via the
+ * `lookup_oui_vendor` Tauri command so the bundled IEEE OUI table never
+ * ships in the JS bundle.
+ */
+import { invoke } from '@tauri-apps/api/core';
+
+export type MacFormat = 'colon' | 'dash' | 'dot' | 'bare';
+
+export interface ParsedMac {
+	readonly bytes: readonly number[];
+	readonly canonical: string;
+}
+
+export type ParseResult =
+	| { readonly ok: true; readonly mac: ParsedMac }
+	| { readonly ok: false; readonly error: string };
+
+const HEX_CHARS = /^[0-9a-fA-F]+$/;
+const BARE_RE = /^[0-9a-fA-F]{12}$/;
+const COLON_RE = /^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$/;
+const DASH_RE = /^([0-9a-fA-F]{2}-){5}[0-9a-fA-F]{2}$/;
+const DOT_RE = /^([0-9a-fA-F]{4}\.){2}[0-9a-fA-F]{4}$/;
+
+const toHex = (n: number, upper: boolean): string => {
+	const s = n.toString(16).padStart(2, '0');
+	return upper ? s.toUpperCase() : s;
+};
+
+const parseHexBytes = (hex: string): number[] => {
+	const bytes: number[] = [];
+	for (let i = 0; i < 12; i += 2) {
+		bytes.push(Number.parseInt(hex.slice(i, i + 2), 16));
+	}
+	return bytes;
+};
+
+const bytesToCanonical = (bytes: readonly number[]): string =>
+	bytes.map((b) => toHex(b, false)).join(':');
+
+/**
+ * Parse a MAC address from one of the canonical notations.
+ *
+ * Accepts colon (`aa:bb:cc:dd:ee:ff`), dash (`AA-BB-CC-DD-EE-FF`),
+ * dot/Cisco (`aabb.ccdd.eeff`), and bare-hex (`aabbccddeeff`).
+ * The check is case-insensitive.
+ */
+export const parseMac = (input: string): ParseResult => {
+	const trimmed = input.trim();
+	if (trimmed.length === 0) return { ok: false, error: 'Input is empty' };
+
+	const compact = trimmed.replace(/[:\-.]/g, '');
+	if (!HEX_CHARS.test(compact)) {
+		return { ok: false, error: 'MAC address must contain only hex digits and separators' };
+	}
+	if (compact.length !== 12) {
+		return { ok: false, error: 'MAC address must contain exactly 12 hex digits (6 bytes)' };
+	}
+
+	const matchesKnown =
+		COLON_RE.test(trimmed) ||
+		DASH_RE.test(trimmed) ||
+		DOT_RE.test(trimmed) ||
+		BARE_RE.test(trimmed);
+	if (!matchesKnown) {
+		return {
+			ok: false,
+			error: 'Unrecognized format. Use colon, dash, dot, or bare-hex notation.',
+		};
+	}
+
+	const bytes = parseHexBytes(compact);
+	return { ok: true, mac: { bytes, canonical: bytesToCanonical(bytes) } };
+};
+
+/**
+ * Render a parsed MAC in the requested notation.
+ */
+export const formatMac = (mac: ParsedMac, format: MacFormat, upper = false): string => {
+	const hex = mac.bytes.map((b) => toHex(b, upper));
+	const [b0 = '00', b1 = '00', b2 = '00', b3 = '00', b4 = '00', b5 = '00'] = hex;
+	switch (format) {
+		case 'colon':
+			return hex.join(':');
+		case 'dash':
+			return hex.join('-');
+		case 'dot':
+			return `${b0}${b1}.${b2}${b3}.${b4}${b5}`;
+		case 'bare':
+			return hex.join('');
+	}
+};
+
+/**
+ * Render the OUI (first 3 bytes) in colon-uppercase form.
+ */
+export const formatPrefix = (bytes: readonly number[]): string =>
+	bytes
+		.slice(0, 3)
+		.map((b) => toHex(b, true))
+		.join(':');
+
+export interface MacFlags {
+	readonly local: boolean;
+	readonly multicast: boolean;
+	readonly broadcast: boolean;
+	readonly nullAddress: boolean;
+}
+
+/**
+ * Inspect the first-byte transmission bits and special-case the broadcast
+ * and null addresses.
+ *
+ * - Bit 0 (LSB) of byte 0 — I/G: 0 = unicast, 1 = multicast.
+ * - Bit 1 of byte 0 — U/L: 0 = universally administered, 1 = locally
+ *   administered.
+ */
+export const macFlags = (mac: ParsedMac): MacFlags => {
+	const first = mac.bytes[0] ?? 0;
+	const multicast = (first & 0x01) === 0x01;
+	const local = (first & 0x02) === 0x02;
+	const broadcast = mac.bytes.every((b) => b === 0xff);
+	const nullAddress = mac.bytes.every((b) => b === 0x00);
+	return { local, multicast, broadcast, nullAddress };
+};
+
+/**
+ * Modified EUI-64 derived interface identifier.
+ *
+ * Inserts `FF:FE` between the OUI and NIC halves and flips the
+ * universal/local bit in byte 0 (RFC 4291 § 2.5.1).
+ */
+export const toEui64Bytes = (mac: ParsedMac): readonly number[] => {
+	const [b0 = 0, b1 = 0, b2 = 0, b3 = 0, b4 = 0, b5 = 0] = mac.bytes;
+	const flipped = b0 ^ 0x02;
+	return [flipped, b1, b2, 0xff, 0xfe, b3, b4, b5];
+};
+
+const formatEui64Colon = (bytes: readonly number[], upper: boolean): string =>
+	bytes.map((b) => toHex(b, upper)).join(':');
+
+/**
+ * Modified EUI-64 in colon-hex notation.
+ */
+export const toEui64 = (mac: ParsedMac, upper = false): string =>
+	formatEui64Colon(toEui64Bytes(mac), upper);
+
+const compressIpv6 = (groups: readonly string[]): string => {
+	// Find the longest run of "0" groups (>= 2) to collapse to `::`.
+	let bestStart = -1;
+	let bestLen = 0;
+	let curStart = -1;
+	let curLen = 0;
+	groups.forEach((g, idx) => {
+		if (g === '0') {
+			if (curStart === -1) curStart = idx;
+			curLen += 1;
+			if (curLen > bestLen) {
+				bestStart = curStart;
+				bestLen = curLen;
+			}
+		} else {
+			curStart = -1;
+			curLen = 0;
+		}
+	});
+	if (bestLen < 2) return groups.join(':');
+	const left = groups.slice(0, bestStart).join(':');
+	const right = groups.slice(bestStart + bestLen).join(':');
+	return `${left}::${right}`;
+};
+
+/**
+ * IPv6 link-local address derived from the MAC via modified EUI-64.
+ *
+ * Format: `fe80::` followed by the EUI-64 interface identifier rendered as
+ * four 16-bit groups with leading zeros stripped and consecutive zero groups
+ * collapsed per RFC 5952.
+ */
+export const toIpv6LinkLocal = (mac: ParsedMac): string => {
+	const eui = toEui64Bytes(mac);
+	const groups: string[] = [];
+	for (let i = 0; i < eui.length; i += 2) {
+		const high = eui[i] ?? 0;
+		const low = eui[i + 1] ?? 0;
+		const value = (high << 8) | low;
+		groups.push(value.toString(16));
+	}
+	const linkLocalGroups: string[] = ['fe80', '0', '0', '0', ...groups];
+	return compressIpv6(linkLocalGroups);
+};
+
+export interface VendorResult {
+	readonly vendor: string | null;
+	readonly matchedPrefix: string | null;
+}
+
+interface RawVendorResult {
+	readonly vendor: string | null;
+	readonly prefix: string | null;
+}
+
+/**
+ * Resolve the OUI vendor via the Rust backend.
+ *
+ * Falls back to `null` on transport failure so the UI keeps rendering the
+ * rest of the result cards.
+ */
+export const lookupVendor = async (mac: ParsedMac): Promise<VendorResult> => {
+	try {
+		const raw = await invoke<RawVendorResult>('lookup_oui_vendor', { mac: mac.canonical });
+		return { vendor: raw.vendor, matchedPrefix: raw.prefix };
+	} catch {
+		return { vendor: null, matchedPrefix: null };
+	}
+};
+
+export interface OuiDatabaseInfo {
+	readonly entries: number;
+	readonly updated: string;
+	readonly source: string;
+}
+
+/**
+ * Fetch metadata about the bundled OUI database for the freshness badge.
+ */
+export const getOuiDatabaseInfo = async (): Promise<OuiDatabaseInfo | null> => {
+	try {
+		return await invoke<OuiDatabaseInfo>('get_oui_database_info');
+	} catch {
+		return null;
+	}
+};
+
+export interface RandomMacOptions {
+	readonly locallyAdministered: boolean;
+	readonly vendorPrefix?: string;
+}
+
+const randomByte = (): number => Math.floor(Math.random() * 256);
+
+const parsePrefixBytes = (prefix: string): readonly number[] | null => {
+	const clean = prefix.replace(/[:\-.\s]/g, '');
+	if (!/^[0-9a-fA-F]{6}$/.test(clean)) return null;
+	const slice = (start: number) => Number.parseInt(clean.slice(start, start + 2), 16);
+	return [slice(0), slice(2), slice(4)];
+};
+
+/**
+ * Generate a random MAC address suitable for testing.
+ *
+ * - When `vendorPrefix` is provided, the first three bytes are taken from it
+ *   verbatim. The locally-administered bit is only set when no vendor prefix
+ *   is supplied; vendor OUIs are by definition universally administered.
+ * - The multicast (I/G) bit is always cleared so the result is a valid
+ *   unicast address.
+ */
+export const generateRandomMac = (opts: RandomMacOptions): ParsedMac => {
+	const tail = [randomByte(), randomByte(), randomByte()];
+	const prefixBytes = opts.vendorPrefix ? parsePrefixBytes(opts.vendorPrefix) : null;
+
+	const head: readonly number[] = prefixBytes
+		? prefixBytes
+		: (() => {
+				const initial = randomByte();
+				// Always clear multicast bit so the random MAC stays unicast;
+				// honour locallyAdministered for U/L.
+				const cleared = initial & 0xfe;
+				const flagged = opts.locallyAdministered ? cleared | 0x02 : cleared & 0xfd;
+				return [flagged, randomByte(), randomByte()];
+			})();
+
+	const bytes = [...head, ...tail];
+	return { bytes, canonical: bytesToCanonical(bytes) };
+};
+
+/**
+ * Sample MACs used by the "Load sample" affordance.
+ */
+export const SAMPLE_MAC = '00:1B:63:84:45:E6';
+export const SAMPLE_LOCAL_MAC = '02:42:AC:11:00:02';
+export const SAMPLE_BROADCAST = 'FF:FF:FF:FF:FF:FF';

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -10,6 +10,7 @@ import {
 	Binary,
 	BookOpen,
 	Braces,
+	Cable,
 	Calculator,
 	CalendarClock,
 	CaseSensitive,
@@ -436,6 +437,15 @@ export const PAGES: readonly PageDefinition[] = [
 		description:
 			'Convert between IPv4 and IPv6 with IPv4-mapped / 6to4 / Teredo embeddings and notation normalizer',
 		color: 'text-sky-600',
+		category: 'network',
+	},
+	{
+		id: 'mac-lookup',
+		title: 'MAC Address Lookup',
+		url: '/mac-lookup',
+		icon: Cable,
+		description: 'Identify MAC address vendor (OUI) and convert between notations',
+		color: 'text-stone-700',
 		category: 'network',
 	},
 	{

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -29,6 +29,7 @@ import { Route as NetworkScannerRouteImport } from './routes/network-scanner'
 import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces'
 import { Route as MimeTypesRouteImport } from './routes/mime-types'
 import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor'
+import { Route as MacLookupRouteImport } from './routes/mac-lookup'
 import { Route as LoremIpsumRouteImport } from './routes/lorem-ipsum'
 import { Route as ListComparerRouteImport } from './routes/list-comparer'
 import { Route as JwtDecoderRouteImport } from './routes/jwt-decoder'
@@ -148,6 +149,11 @@ const MarkdownEditorRoute = MarkdownEditorRouteImport.update({
   path: '/markdown-editor',
   getParentRoute: () => rootRouteImport,
 } as any)
+const MacLookupRoute = MacLookupRouteImport.update({
+  id: '/mac-lookup',
+  path: '/mac-lookup',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LoremIpsumRoute = LoremIpsumRouteImport.update({
   id: '/lorem-ipsum',
   path: '/lorem-ipsum',
@@ -258,6 +264,7 @@ export interface FileRoutesByFullPath {
   '/jwt-decoder': typeof JwtDecoderRoute
   '/list-comparer': typeof ListComparerRoute
   '/lorem-ipsum': typeof LoremIpsumRoute
+  '/mac-lookup': typeof MacLookupRoute
   '/markdown-editor': typeof MarkdownEditorRoute
   '/mime-types': typeof MimeTypesRoute
   '/network-interfaces': typeof NetworkInterfacesRoute
@@ -298,6 +305,7 @@ export interface FileRoutesByTo {
   '/jwt-decoder': typeof JwtDecoderRoute
   '/list-comparer': typeof ListComparerRoute
   '/lorem-ipsum': typeof LoremIpsumRoute
+  '/mac-lookup': typeof MacLookupRoute
   '/markdown-editor': typeof MarkdownEditorRoute
   '/mime-types': typeof MimeTypesRoute
   '/network-interfaces': typeof NetworkInterfacesRoute
@@ -339,6 +347,7 @@ export interface FileRoutesById {
   '/jwt-decoder': typeof JwtDecoderRoute
   '/list-comparer': typeof ListComparerRoute
   '/lorem-ipsum': typeof LoremIpsumRoute
+  '/mac-lookup': typeof MacLookupRoute
   '/markdown-editor': typeof MarkdownEditorRoute
   '/mime-types': typeof MimeTypesRoute
   '/network-interfaces': typeof NetworkInterfacesRoute
@@ -381,6 +390,7 @@ export interface FileRouteTypes {
     | '/jwt-decoder'
     | '/list-comparer'
     | '/lorem-ipsum'
+    | '/mac-lookup'
     | '/markdown-editor'
     | '/mime-types'
     | '/network-interfaces'
@@ -421,6 +431,7 @@ export interface FileRouteTypes {
     | '/jwt-decoder'
     | '/list-comparer'
     | '/lorem-ipsum'
+    | '/mac-lookup'
     | '/markdown-editor'
     | '/mime-types'
     | '/network-interfaces'
@@ -461,6 +472,7 @@ export interface FileRouteTypes {
     | '/jwt-decoder'
     | '/list-comparer'
     | '/lorem-ipsum'
+    | '/mac-lookup'
     | '/markdown-editor'
     | '/mime-types'
     | '/network-interfaces'
@@ -502,6 +514,7 @@ export interface RootRouteChildren {
   JwtDecoderRoute: typeof JwtDecoderRoute
   ListComparerRoute: typeof ListComparerRoute
   LoremIpsumRoute: typeof LoremIpsumRoute
+  MacLookupRoute: typeof MacLookupRoute
   MarkdownEditorRoute: typeof MarkdownEditorRoute
   MimeTypesRoute: typeof MimeTypesRoute
   NetworkInterfacesRoute: typeof NetworkInterfacesRoute
@@ -666,6 +679,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MarkdownEditorRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/mac-lookup': {
+      id: '/mac-lookup'
+      path: '/mac-lookup'
+      fullPath: '/mac-lookup'
+      preLoaderRoute: typeof MacLookupRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/lorem-ipsum': {
       id: '/lorem-ipsum'
       path: '/lorem-ipsum'
@@ -814,6 +834,7 @@ const rootRouteChildren: RootRouteChildren = {
   JwtDecoderRoute: JwtDecoderRoute,
   ListComparerRoute: ListComparerRoute,
   LoremIpsumRoute: LoremIpsumRoute,
+  MacLookupRoute: MacLookupRoute,
   MarkdownEditorRoute: MarkdownEditorRoute,
   MimeTypesRoute: MimeTypesRoute,
   NetworkInterfacesRoute: NetworkInterfacesRoute,

--- a/src/routes/mac-lookup.tsx
+++ b/src/routes/mac-lookup.tsx
@@ -1,0 +1,578 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { Cable, Database, Dice5, Network } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import { ActionButton, CopyButton } from '@/lib/components/action';
+import {
+	FormCheckbox,
+	FormError,
+	FormInfo,
+	FormInput,
+	FormMode,
+	FormSection,
+} from '@/lib/components/form';
+import { ToolShell } from '@/lib/components/shell';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { ToneBadge } from '@/lib/components/ui/tone-badge';
+import { useDocumentTitle } from '@/lib/hooks';
+import {
+	formatMac,
+	formatPrefix,
+	generateRandomMac,
+	getOuiDatabaseInfo,
+	lookupVendor,
+	type MacFlags,
+	type MacFormat,
+	macFlags,
+	type OuiDatabaseInfo,
+	type ParsedMac,
+	parseMac,
+	SAMPLE_BROADCAST,
+	SAMPLE_LOCAL_MAC,
+	SAMPLE_MAC,
+	toEui64,
+	toIpv6LinkLocal,
+	type VendorResult,
+} from '@/lib/services/mac';
+import { createToolOptionsStore } from '@/lib/stores';
+
+interface MacLookupOptions {
+	readonly displayFormat: MacFormat;
+	readonly upperCase: boolean;
+	readonly randomLocalOnly: boolean;
+	readonly randomVendorOui: string;
+}
+
+const DEFAULTS: MacLookupOptions = {
+	displayFormat: 'colon',
+	upperCase: false,
+	randomLocalOnly: true,
+	randomVendorOui: '',
+};
+
+const useMacLookupOptions = createToolOptionsStore<MacLookupOptions>('mac-lookup', DEFAULTS);
+
+const FORMAT_OPTIONS: readonly { readonly value: MacFormat; readonly label: string }[] = [
+	{ value: 'colon', label: 'Colon' },
+	{ value: 'dash', label: 'Dash' },
+	{ value: 'dot', label: 'Dot' },
+	{ value: 'bare', label: 'Bare' },
+];
+
+export const Route = createFileRoute('/mac-lookup')({
+	component: MacLookupPage,
+});
+
+function MacLookupPage() {
+	useDocumentTitle('MAC Address Lookup');
+
+	const { value: options, patch } = useMacLookupOptions();
+	const { displayFormat, upperCase, randomLocalOnly, randomVendorOui } = options;
+
+	const [input, setInput] = useState<string>(SAMPLE_MAC);
+	const [vendor, setVendor] = useState<VendorResult | null>(null);
+	const [vendorLoading, setVendorLoading] = useState<boolean>(false);
+	const [dbInfo, setDbInfo] = useState<OuiDatabaseInfo | null>(null);
+	const [showRail, setShowRail] = useState(true);
+
+	const parseResult = useMemo(() => parseMac(input), [input]);
+	const trimmed = input.trim();
+
+	// Resolve vendor whenever the parsed MAC changes. Render-effect because
+	// the lookup is an out-of-band IPC roundtrip that cannot be derived
+	// synchronously.
+	useEffect(() => {
+		if (!parseResult.ok) {
+			setVendor(null);
+			setVendorLoading(false);
+			return;
+		}
+		let cancelled = false;
+		setVendorLoading(true);
+		lookupVendor(parseResult.mac).then((result) => {
+			if (cancelled) return;
+			setVendor(result);
+			setVendorLoading(false);
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [parseResult]);
+
+	// One-shot fetch of bundled database metadata for the freshness badge.
+	useEffect(() => {
+		let cancelled = false;
+		getOuiDatabaseInfo().then((info) => {
+			if (!cancelled) setDbInfo(info);
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	const flags: MacFlags | null = parseResult.ok ? macFlags(parseResult.mac) : null;
+
+	const validity: boolean | null = trimmed.length === 0 ? null : parseResult.ok;
+	const error = !parseResult.ok && trimmed.length > 0 ? parseResult.error : undefined;
+
+	const handleGenerateRandom = () => {
+		const mac = generateRandomMac({
+			locallyAdministered: randomLocalOnly,
+			vendorPrefix: randomVendorOui.trim().length > 0 ? randomVendorOui : undefined,
+		});
+		setInput(formatMac(mac, displayFormat, upperCase));
+	};
+
+	return (
+		<ToolShell
+			valid={validity}
+			error={error}
+			showRail={showRail}
+			onShowRailChange={setShowRail}
+			statusContent={
+				<MacLookupStatus parseResult={parseResult} vendor={vendor} flags={flags} dbInfo={dbInfo} />
+			}
+			rail={
+				<MacLookupRail
+					displayFormat={displayFormat}
+					upperCase={upperCase}
+					randomLocalOnly={randomLocalOnly}
+					randomVendorOui={randomVendorOui}
+					dbInfo={dbInfo}
+					onLoadSample={setInput}
+					onClear={() => setInput('')}
+					onPatch={patch}
+					onGenerateRandom={handleGenerateRandom}
+				/>
+			}
+		>
+			<MacLookupMain
+				input={input}
+				onInputChange={setInput}
+				parseResult={parseResult}
+				vendor={vendor}
+				vendorLoading={vendorLoading}
+				flags={flags}
+				displayFormat={displayFormat}
+				upperCase={upperCase}
+				dbInfo={dbInfo}
+			/>
+		</ToolShell>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface StatusProps {
+	readonly parseResult: ReturnType<typeof parseMac>;
+	readonly vendor: VendorResult | null;
+	readonly flags: MacFlags | null;
+	readonly dbInfo: OuiDatabaseInfo | null;
+}
+
+function MacLookupStatus({ parseResult, vendor, flags, dbInfo }: StatusProps) {
+	if (!parseResult.ok || !flags) {
+		return dbInfo ? <StatItem label="OUI entries" value={dbInfo.entries.toLocaleString()} /> : null;
+	}
+	const typeLabel = flags.broadcast ? 'Broadcast' : flags.multicast ? 'Multicast' : 'Unicast';
+	const adminLabel = flags.local ? 'Local' : 'Universal';
+	return (
+		<>
+			<StatItem label="Vendor" value={vendor?.vendor ?? 'Unknown'} />
+			<StatItem label="Type" value={typeLabel} />
+			<StatItem label="Admin" value={adminLabel} />
+		</>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface RailProps {
+	readonly displayFormat: MacFormat;
+	readonly upperCase: boolean;
+	readonly randomLocalOnly: boolean;
+	readonly randomVendorOui: string;
+	readonly dbInfo: OuiDatabaseInfo | null;
+	readonly onLoadSample: (value: string) => void;
+	readonly onClear: () => void;
+	readonly onPatch: (delta: Partial<MacLookupOptions>) => void;
+	readonly onGenerateRandom: () => void;
+}
+
+function MacLookupRail({
+	displayFormat,
+	upperCase,
+	randomLocalOnly,
+	randomVendorOui,
+	dbInfo,
+	onLoadSample,
+	onClear,
+	onPatch,
+	onGenerateRandom,
+}: RailProps) {
+	return (
+		<>
+			<FormSection title="Input">
+				<FormInfo>
+					Paste any MAC address in colon (<code className="font-mono">aa:bb:cc:dd:ee:ff</code>),
+					dash, dot/Cisco (<code className="font-mono">aabb.ccdd.eeff</code>), or bare-hex form.
+				</FormInfo>
+				<div className="grid grid-cols-2 gap-1">
+					<Button variant="outline" size="sm" onClick={() => onLoadSample(SAMPLE_MAC)}>
+						Vendor sample
+					</Button>
+					<Button variant="outline" size="sm" onClick={() => onLoadSample(SAMPLE_LOCAL_MAC)}>
+						Local sample
+					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						className="col-span-2"
+						onClick={() => onLoadSample(SAMPLE_BROADCAST)}
+					>
+						Broadcast sample
+					</Button>
+				</div>
+				<ActionButton label="Clear" variant="outline" onClick={onClear} />
+			</FormSection>
+
+			<FormSection title="Format preference">
+				<FormMode<MacFormat>
+					label="Notation"
+					value={displayFormat}
+					options={FORMAT_OPTIONS}
+					layout="stacked"
+					onValueChange={(v) => onPatch({ displayFormat: v })}
+				/>
+				<FormCheckbox
+					label="Uppercase hex"
+					checked={upperCase}
+					onCheckedChange={(checked) => onPatch({ upperCase: checked })}
+				/>
+			</FormSection>
+
+			<FormSection title="Random generator">
+				<FormInfo>
+					Produces a locally-administered MAC for testing. Provide a 6-hex-char OUI to inherit a
+					vendor prefix instead.
+				</FormInfo>
+				<FormCheckbox
+					label="Locally-administered (sets U/L bit)"
+					checked={randomLocalOnly}
+					onCheckedChange={(checked) => onPatch({ randomLocalOnly: checked })}
+				/>
+				<FormInput
+					label="Vendor OUI (optional)"
+					value={randomVendorOui}
+					placeholder="e.g. 001B63"
+					size="compact"
+					onValueChange={(v) => onPatch({ randomVendorOui: v })}
+				/>
+				<Button variant="default" size="sm" className="w-full" onClick={onGenerateRandom}>
+					<Dice5 className="mr-1.5 h-3.5 w-3.5" />
+					Generate random
+				</Button>
+			</FormSection>
+
+			<FormSection title="About">
+				<FormInfo>
+					Vendor lookup uses the bundled IEEE OUI database via a Tauri command. All processing
+					happens locally; no network calls.
+				</FormInfo>
+				{dbInfo ? (
+					<div className="flex items-center gap-2 text-xs text-muted-foreground">
+						<Database className="h-3.5 w-3.5" />
+						<span>
+							{dbInfo.entries.toLocaleString()} entries — updated {dbInfo.updated}
+						</span>
+					</div>
+				) : null}
+			</FormSection>
+		</>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface MainProps {
+	readonly input: string;
+	readonly onInputChange: (value: string) => void;
+	readonly parseResult: ReturnType<typeof parseMac>;
+	readonly vendor: VendorResult | null;
+	readonly vendorLoading: boolean;
+	readonly flags: MacFlags | null;
+	readonly displayFormat: MacFormat;
+	readonly upperCase: boolean;
+	readonly dbInfo: OuiDatabaseInfo | null;
+}
+
+function MacLookupMain({
+	input,
+	onInputChange,
+	parseResult,
+	vendor,
+	vendorLoading,
+	flags,
+	displayFormat,
+	upperCase,
+	dbInfo,
+}: MainProps) {
+	const trimmed = input.trim();
+	const isEmpty = trimmed.length === 0;
+	const showResults = parseResult.ok;
+
+	return (
+		<div className="flex h-full flex-col overflow-auto p-3">
+			<div className="space-y-3">
+				<InputCard
+					input={input}
+					onInputChange={onInputChange}
+					hasError={!parseResult.ok && !isEmpty}
+					error={!parseResult.ok && !isEmpty ? parseResult.error : null}
+					displayFormat={displayFormat}
+					upperCase={upperCase}
+				/>
+				{isEmpty ? (
+					<EmptyCard />
+				) : showResults && parseResult.ok && flags ? (
+					<>
+						<VendorCard vendor={vendor} loading={vendorLoading} dbInfo={dbInfo} />
+						<FlagsCard flags={flags} />
+						<NormalizedFormsCard
+							mac={parseResult.mac}
+							displayFormat={displayFormat}
+							upperCase={upperCase}
+						/>
+					</>
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+function EmptyCard() {
+	return (
+		<Card density="compact">
+			<CardContent>
+				<EmbeddedEmptyState
+					icon={Network}
+					title="Enter a MAC address"
+					description="Paste a MAC in any notation to identify its vendor (OUI), inspect its address-type bits, and see every canonical rendering."
+				/>
+			</CardContent>
+		</Card>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface InputCardProps {
+	readonly input: string;
+	readonly onInputChange: (value: string) => void;
+	readonly hasError: boolean;
+	readonly error: string | null;
+	readonly displayFormat: MacFormat;
+	readonly upperCase: boolean;
+}
+
+function InputCard({ input, onInputChange, hasError, error }: InputCardProps) {
+	return (
+		<Card density="compact">
+			<CardHeader className="pb-2">
+				<CardTitle>MAC Address</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<FormInput
+					label="MAC address"
+					value={input}
+					onValueChange={onInputChange}
+					placeholder="aa:bb:cc:dd:ee:ff"
+				/>
+				{hasError && error ? <FormError message={error} className="mt-2" /> : null}
+			</CardContent>
+		</Card>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface VendorCardProps {
+	readonly vendor: VendorResult | null;
+	readonly loading: boolean;
+	readonly dbInfo: OuiDatabaseInfo | null;
+}
+
+function VendorCard({ vendor, loading, dbInfo }: VendorCardProps) {
+	const knownVendor = vendor?.vendor ?? null;
+	const matchedPrefix = vendor?.matchedPrefix ?? null;
+
+	return (
+		<Card density="compact">
+			<CardHeader className="pb-2">
+				<div className="flex items-center justify-between gap-2">
+					<CardTitle className="flex items-center gap-2">
+						<Cable className="h-4 w-4 text-muted-foreground" />
+						Vendor
+					</CardTitle>
+					{dbInfo ? (
+						<span className="text-2xs text-muted-foreground">DB updated {dbInfo.updated}</span>
+					) : null}
+				</div>
+			</CardHeader>
+			<CardContent className="space-y-2">
+				{loading ? (
+					<p className="text-sm text-muted-foreground">Looking up vendor…</p>
+				) : knownVendor ? (
+					<>
+						<div className="text-lg font-semibold">{knownVendor}</div>
+						{matchedPrefix ? (
+							<div className="flex items-center gap-2">
+								<span className="text-xs text-muted-foreground">Matched OUI prefix:</span>
+								<code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+									{matchedPrefix}
+								</code>
+								<CopyButton
+									text={matchedPrefix}
+									toastLabel="OUI prefix"
+									size="sm"
+									variant="ghost"
+									showLabel={false}
+								/>
+							</div>
+						) : null}
+					</>
+				) : (
+					<>
+						<div className="text-sm font-medium text-muted-foreground">Unknown vendor</div>
+						<p className="text-xs text-muted-foreground">
+							The OUI prefix is not in the bundled database. The address may be locally
+							administered, randomized, or assigned outside the curated subset.
+						</p>
+					</>
+				)}
+			</CardContent>
+		</Card>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface FlagsCardProps {
+	readonly flags: MacFlags;
+}
+
+function FlagsCard({ flags }: FlagsCardProps) {
+	return (
+		<Card density="compact">
+			<CardHeader className="pb-2">
+				<CardTitle>Address Flags</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<div className="flex flex-wrap gap-1.5">
+					<ToneBadge tone={flags.local ? 'warning' : 'success'}>
+						{flags.local ? 'Locally administered' : 'Universally administered'}
+					</ToneBadge>
+					<ToneBadge tone={flags.multicast ? 'info' : 'success'}>
+						{flags.multicast ? 'Multicast' : 'Unicast'}
+					</ToneBadge>
+					{flags.broadcast ? <ToneBadge tone="destructive">Broadcast</ToneBadge> : null}
+					{flags.nullAddress ? <ToneBadge tone="destructive">Null address</ToneBadge> : null}
+				</div>
+				<p className="mt-2 text-2xs text-muted-foreground">
+					Address-type bits live in the least-significant two bits of byte 0: bit 0 (I/G) selects
+					unicast vs multicast; bit 1 (U/L) selects universal vs local administration.
+				</p>
+			</CardContent>
+		</Card>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface NormalizedFormsCardProps {
+	readonly mac: ParsedMac;
+	readonly displayFormat: MacFormat;
+	readonly upperCase: boolean;
+}
+
+interface NormalizedRow {
+	readonly key: string;
+	readonly label: string;
+	readonly value: string;
+	readonly hint?: string;
+}
+
+function NormalizedFormsCard({ mac, displayFormat, upperCase }: NormalizedFormsCardProps) {
+	const rows: readonly NormalizedRow[] = useMemo(() => {
+		const colon = formatMac(mac, 'colon', upperCase);
+		const dash = formatMac(mac, 'dash', upperCase);
+		const dot = formatMac(mac, 'dot', upperCase);
+		const bare = formatMac(mac, 'bare', upperCase);
+		const eui64 = toEui64(mac, upperCase);
+		const ipv6 = toIpv6LinkLocal(mac);
+		return [
+			{ key: 'colon', label: 'Colon', value: colon },
+			{ key: 'dash', label: 'Dash', value: dash },
+			{ key: 'dot', label: 'Dot (Cisco)', value: dot },
+			{ key: 'bare', label: 'Bare hex', value: bare },
+			{
+				key: 'eui64',
+				label: 'Modified EUI-64',
+				value: eui64,
+				hint: 'Inserts FF:FE and flips the U/L bit (RFC 4291 §2.5.1).',
+			},
+			{
+				key: 'ipv6',
+				label: 'IPv6 link-local',
+				value: ipv6,
+				hint: 'fe80::/10 prefix + EUI-64 interface identifier.',
+			},
+		];
+	}, [mac, upperCase]);
+
+	return (
+		<Card density="compact">
+			<CardHeader className="pb-2">
+				<div className="flex items-center justify-between gap-2">
+					<CardTitle>Normalized Forms</CardTitle>
+					<span className="text-2xs text-muted-foreground">
+						Preferred: {FORMAT_OPTIONS.find((o) => o.value === displayFormat)?.label}
+						{upperCase ? ' · UPPER' : ''}
+					</span>
+				</div>
+			</CardHeader>
+			<CardContent>
+				<div className="grid grid-cols-1 gap-2">
+					{rows.map((row) => (
+						<div
+							key={row.key}
+							className="flex items-center justify-between gap-2 rounded-md border bg-muted/30 px-2.5 py-1.5"
+						>
+							<div className="min-w-0">
+								<div className="text-2xs uppercase tracking-wide text-muted-foreground">
+									{row.label}
+								</div>
+								<div className="font-mono text-sm break-all tabular-nums">{row.value}</div>
+								{row.hint ? (
+									<p className="mt-0.5 text-2xs text-muted-foreground">{row.hint}</p>
+								) : null}
+							</div>
+							<CopyButton
+								text={row.value}
+								toastLabel={row.label}
+								size="sm"
+								variant="ghost"
+								showLabel={false}
+							/>
+						</div>
+					))}
+				</div>
+				<p className="mt-3 text-2xs text-muted-foreground">
+					Matched prefix used for vendor lookup: {formatPrefix(mac.bytes)}
+				</p>
+			</CardContent>
+		</Card>
+	);
+}


### PR DESCRIPTION
## Summary
Add a MAC Address / OUI Lookup under **Network** that identifies the network-card vendor using the existing in-tree IEEE OUI database, plus format normalization, address-type flags, EUI-64 / IPv6 link-local derivation, and a random MAC generator. Closes #232.

## Features
- **Accepts** colon / dash / dot / bare hex notations (case-insensitive)
- **Vendor lookup** via `src-tauri/src/network/oui.rs` (exposed as new Tauri command `lookup_oui_vendor`)
- **Address-type flags**: locally vs universally administered, unicast vs multicast, broadcast
- **Six simultaneous renderings**: colon, dash, dot, bare, EUI-64-derived, IPv6 link-local interface ID
- **Random MAC generator**: locally-administered bit + optional vendor-OUI inheritance
- **One-click copy** for any rendering
- **Database freshness badge** (entry count + snapshot date) via new `get_oui_database_info` command

## Changes
### Added
- `src/routes/mac-lookup.tsx`
- `src/lib/services/mac.ts`
- New Tauri commands `lookup_oui_vendor` and `get_oui_database_info` (thin wrappers over the existing `lookup_vendor` table)
- Page registration in `src/lib/services/pages.ts`

### Modified
- `src-tauri/src/network/oui.rs` — added `#[tauri::command]` wrappers + serde types
- `src-tauri/src/network/mod.rs` — promoted `oui` to `pub mod` so the commands are reachable
- `src-tauri/src/lib.rs` — added to `invoke_handler`
- `src/route-tree.gen.ts` — regenerated for the new `/mac-lookup` route

## Test plan
- [x] `bun run check` green
- [x] `bun run lint` no new errors on changed files
- [x] `bun run format` clean for changed files
- [x] `cargo check` + `cargo clippy --all-targets` clean
- [ ] Manual: paste `00:1B:63:84:45:E6` -> Apple vendor surfaces
- [ ] Manual: cycle notations -> colon / dash / dot / bare match
- [ ] Manual: EUI-64 inserts `FF:FE` mid-way and flips the U/L bit
- [ ] Manual: IPv6 link-local prefix `fe80::` rendered
- [ ] Manual: Generate random MAC -> U/L bit set when "Locally-administered" is on
- [ ] Manual: broadcast `FF:FF:FF:FF:FF:FF` -> broadcast badge

Closes #232
