### PR TITLE
feat(rest-client): add HTTP REST Client (MVP)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -51,6 +51,7 @@ mod generators;
 #[cfg(target_os = "macos")]
 mod menu;
 mod network;
+mod rest_client;
 mod settings;
 
 use tauri::Manager;
@@ -468,6 +469,7 @@ pub fn run() {
             check_discovery_privilege,
             network::oui::lookup_oui_vendor,
             network::oui::get_oui_database_info,
+            rest_client::rest_client_send,
             settings::get_settings,
             settings::update_settings,
             settings::reset_settings,

--- a/src-tauri/src/rest_client.rs
+++ b/src-tauri/src/rest_client.rs
@@ -1,0 +1,120 @@
+//! HTTP REST client command.
+//!
+//! Provides a single Tauri command, [`rest_client_send`], that performs an
+//! arbitrary HTTP request and returns the response captured as UTF-8 lossy
+//! text along with timing and size metadata. The client uses `rustls-tls`
+//! to avoid linking against system OpenSSL.
+
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+
+/// HTTP request payload sent from the frontend.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RestRequest {
+    /// HTTP method (e.g. `GET`, `POST`). Parsed with [`reqwest::Method`].
+    pub method: String,
+    /// Absolute request URL.
+    pub url: String,
+    /// Request headers as ordered key/value pairs.
+    pub headers: Vec<(String, String)>,
+    /// Optional request body. Empty bodies are not transmitted.
+    pub body: Option<String>,
+    /// Whether to follow HTTP redirects (capped at 10 hops when enabled).
+    pub follow_redirects: bool,
+    /// Total request timeout in milliseconds.
+    pub timeout_ms: u32,
+}
+
+/// HTTP response payload returned to the frontend.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RestResponse {
+    /// HTTP status code (e.g. 200, 404).
+    pub status: u16,
+    /// Canonical status reason phrase (e.g. "OK", "Not Found").
+    pub status_text: String,
+    /// Response headers in arrival order.
+    pub headers: Vec<(String, String)>,
+    /// Response body as UTF-8 lossy text.
+    pub body: String,
+    /// Total response body size in bytes.
+    pub bytes_received: u64,
+    /// Elapsed wall-clock time from request build to body read, in milliseconds.
+    pub elapsed_ms: u128,
+    /// Final URL after redirects (matches `url` when redirects are disabled).
+    pub final_url: String,
+}
+
+/// Send an arbitrary HTTP request and return the response.
+///
+/// # Errors
+///
+/// Returns an error string for invalid method names, client build failures,
+/// transport errors (DNS, TLS, timeout), or body reads that exceed the
+/// configured timeout.
+#[tauri::command]
+pub async fn rest_client_send(req: RestRequest) -> Result<RestResponse, String> {
+    let started = Instant::now();
+
+    let redirect_policy = if req.follow_redirects {
+        reqwest::redirect::Policy::limited(10)
+    } else {
+        reqwest::redirect::Policy::none()
+    };
+
+    let client = reqwest::Client::builder()
+        .redirect(redirect_policy)
+        .timeout(std::time::Duration::from_millis(u64::from(req.timeout_ms)))
+        .build()
+        .map_err(|e| format!("Failed to build HTTP client: {e}"))?;
+
+    let method = req
+        .method
+        .parse::<reqwest::Method>()
+        .map_err(|e| format!("Invalid HTTP method '{}': {e}", req.method))?;
+
+    let request_with_headers = req
+        .headers
+        .iter()
+        .fold(client.request(method, &req.url), |builder, (k, v)| {
+            builder.header(k, v)
+        });
+
+    let request = match req.body.as_ref().filter(|b| !b.is_empty()) {
+        Some(body) => request_with_headers.body(body.clone()),
+        None => request_with_headers,
+    };
+
+    let response = request
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {e}"))?;
+
+    let status = response.status();
+    let status_text = status.canonical_reason().unwrap_or("").to_string();
+    let headers: Vec<(String, String)> = response
+        .headers()
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect();
+    let final_url = response.url().to_string();
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| format!("Failed to read response body: {e}"))?;
+    let bytes_received = bytes.len() as u64;
+    let body = String::from_utf8_lossy(&bytes).into_owned();
+
+    Ok(RestResponse {
+        status: status.as_u16(),
+        status_text,
+        headers,
+        body,
+        bytes_received,
+        elapsed_ms: started.elapsed().as_millis(),
+        final_url,
+    })
+}

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -46,6 +46,7 @@ import {
 	Radar,
 	Regex,
 	Search,
+	Send,
 	Settings,
 	Shield,
 	ShieldCheck,
@@ -480,9 +481,17 @@ export const PAGES: readonly PageDefinition[] = [
 		title: 'HTTP Status Codes',
 		url: '/http-status-codes',
 		icon: BookOpen,
-		description:
-			'Searchable HTTP status code reference with RFC citations and misuse warnings',
+		description: 'Searchable HTTP status code reference with RFC citations and misuse warnings',
 		color: 'text-violet-600',
+		category: 'network',
+	},
+	{
+		id: 'rest-client',
+		title: 'HTTP REST Client',
+		url: '/rest-client',
+		icon: Send,
+		description: 'Build and send HTTP requests; view formatted responses',
+		color: 'text-blue-700',
 		category: 'network',
 	},
 	{

--- a/src/lib/services/rest-client.ts
+++ b/src/lib/services/rest-client.ts
@@ -1,0 +1,152 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
+
+export const HTTP_METHODS: readonly HttpMethod[] = [
+	'GET',
+	'POST',
+	'PUT',
+	'PATCH',
+	'DELETE',
+	'HEAD',
+	'OPTIONS',
+];
+
+const HTTP_METHOD_SET: ReadonlySet<HttpMethod> = new Set(HTTP_METHODS);
+
+export const isHttpMethod = (value: string): value is HttpMethod =>
+	HTTP_METHOD_SET.has(value as HttpMethod);
+
+/**
+ * Single header row owned by the UI. `enabled=false` keeps the row visible
+ * but excludes it from the request.
+ */
+export interface HeaderEntry {
+	readonly id: string;
+	readonly key: string;
+	readonly value: string;
+	readonly enabled: boolean;
+}
+
+/** Tuple form transmitted over IPC. */
+export type HeaderTuple = readonly [string, string];
+
+export interface RestRequest {
+	readonly method: HttpMethod | string;
+	readonly url: string;
+	readonly headers: readonly HeaderTuple[];
+	readonly body?: string;
+	readonly followRedirects: boolean;
+	readonly timeoutMs: number;
+}
+
+export interface RestResponse {
+	readonly status: number;
+	readonly statusText: string;
+	readonly headers: readonly HeaderTuple[];
+	readonly body: string;
+	readonly bytesReceived: number;
+	readonly elapsedMs: number;
+	readonly finalUrl: string;
+}
+
+/** Bounds on the timeout slider (milliseconds). */
+export const TIMEOUT_MIN_MS = 1_000;
+export const TIMEOUT_MAX_MS = 60_000;
+export const TIMEOUT_STEP_MS = 1_000;
+export const TIMEOUT_DEFAULT_MS = 10_000;
+
+/** Sample endpoints — public httpbin echo service. */
+export const SAMPLE_GET_URL = 'https://httpbin.org/json';
+export const SAMPLE_POST_URL = 'https://httpbin.org/post';
+export const SAMPLE_POST_BODY = `{
+  "hello": "world",
+  "count": 1
+}`;
+
+/** Send an HTTP request via the Tauri backend. */
+export const sendRequest = (req: RestRequest): Promise<RestResponse> =>
+	invoke<RestResponse>('rest_client_send', { req });
+
+/** Convert UI header rows to the tuple form expected by the backend. */
+export const headersToTuples = (entries: readonly HeaderEntry[]): readonly HeaderTuple[] =>
+	entries
+		.filter((h) => h.enabled && h.key.trim().length > 0)
+		.map((h) => [h.key.trim(), h.value] as const);
+
+/** Case-insensitive lookup for a header value. */
+export const headerValue = (headers: readonly HeaderTuple[], name: string): string | undefined => {
+	const lower = name.toLowerCase();
+	return headers.find(([k]) => k.toLowerCase() === lower)?.[1];
+};
+
+/**
+ * Pretty-print a response body when the Content-Type indicates JSON.
+ * Returns the original body unchanged for non-JSON or invalid JSON payloads.
+ */
+export const formatResponseBody = (body: string, contentType: string | undefined): string => {
+	if (!contentType) return body;
+	const lower = contentType.toLowerCase();
+	if (!lower.includes('application/json') && !lower.includes('+json')) return body;
+	try {
+		const parsed = JSON.parse(body) as unknown;
+		return JSON.stringify(parsed, null, 2);
+	} catch {
+		return body;
+	}
+};
+
+/** Tone classification used by the response status badge. */
+export type StatusTone = 'success' | 'info' | 'warning' | 'destructive';
+
+export const statusTone = (status: number): StatusTone => {
+	if (status >= 200 && status < 300) return 'success';
+	if (status >= 300 && status < 400) return 'info';
+	if (status >= 500 && status < 600) return 'destructive';
+	// Treat unknown / 1xx / 4xx all as warning tone for the response badge.
+	return 'warning';
+};
+
+/** Format a byte count for compact display in the status bar. */
+export const formatBytes = (bytes: number): string => {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+};
+
+const shellEscape = (input: string): string => `'${input.replace(/'/g, `'\\''`)}'`;
+
+/**
+ * Build a single-line cURL command equivalent to the supplied request.
+ * Useful for sharing or pasting into a terminal.
+ */
+export const exportAsCurl = (req: RestRequest): string => {
+	const parts: string[] = ['curl'];
+	const method = req.method.toUpperCase();
+	if (method !== 'GET') {
+		parts.push('-X', method);
+	}
+	for (const [key, value] of req.headers) {
+		parts.push('-H', shellEscape(`${key}: ${value}`));
+	}
+	if (req.body && req.body.length > 0) {
+		parts.push('--data', shellEscape(req.body));
+	}
+	if (req.followRedirects) {
+		parts.push('-L');
+	}
+	parts.push(shellEscape(req.url));
+	return parts.join(' ');
+};
+
+/** Generate a stable id for a new header row (used as a React key). */
+export const createHeaderId = (): string =>
+	`hdr_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+
+/** Empty header row factory. */
+export const createEmptyHeader = (): HeaderEntry => ({
+	id: createHeaderId(),
+	key: '',
+	value: '',
+	enabled: true,
+});

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -21,6 +21,7 @@ import { Route as SqlFormatterRouteImport } from './routes/sql-formatter'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as SemverToolsRouteImport } from './routes/semver-tools'
 import { Route as RsaToolsRouteImport } from './routes/rsa-tools'
+import { Route as RestClientRouteImport } from './routes/rest-client'
 import { Route as RegexTesterRouteImport } from './routes/regex-tester'
 import { Route as QrCodeGeneratorRouteImport } from './routes/qr-code-generator'
 import { Route as PasswordGeneratorRouteImport } from './routes/password-generator'
@@ -107,6 +108,11 @@ const SemverToolsRoute = SemverToolsRouteImport.update({
 const RsaToolsRoute = RsaToolsRouteImport.update({
   id: '/rsa-tools',
   path: '/rsa-tools',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const RestClientRoute = RestClientRouteImport.update({
+  id: '/rest-client',
+  path: '/rest-client',
   getParentRoute: () => rootRouteImport,
 } as any)
 const RegexTesterRoute = RegexTesterRouteImport.update({
@@ -273,6 +279,7 @@ export interface FileRoutesByFullPath {
   '/password-generator': typeof PasswordGeneratorRoute
   '/qr-code-generator': typeof QrCodeGeneratorRoute
   '/regex-tester': typeof RegexTesterRoute
+  '/rest-client': typeof RestClientRoute
   '/rsa-tools': typeof RsaToolsRoute
   '/semver-tools': typeof SemverToolsRoute
   '/settings': typeof SettingsRoute
@@ -314,6 +321,7 @@ export interface FileRoutesByTo {
   '/password-generator': typeof PasswordGeneratorRoute
   '/qr-code-generator': typeof QrCodeGeneratorRoute
   '/regex-tester': typeof RegexTesterRoute
+  '/rest-client': typeof RestClientRoute
   '/rsa-tools': typeof RsaToolsRoute
   '/semver-tools': typeof SemverToolsRoute
   '/settings': typeof SettingsRoute
@@ -356,6 +364,7 @@ export interface FileRoutesById {
   '/password-generator': typeof PasswordGeneratorRoute
   '/qr-code-generator': typeof QrCodeGeneratorRoute
   '/regex-tester': typeof RegexTesterRoute
+  '/rest-client': typeof RestClientRoute
   '/rsa-tools': typeof RsaToolsRoute
   '/semver-tools': typeof SemverToolsRoute
   '/settings': typeof SettingsRoute
@@ -399,6 +408,7 @@ export interface FileRouteTypes {
     | '/password-generator'
     | '/qr-code-generator'
     | '/regex-tester'
+    | '/rest-client'
     | '/rsa-tools'
     | '/semver-tools'
     | '/settings'
@@ -440,6 +450,7 @@ export interface FileRouteTypes {
     | '/password-generator'
     | '/qr-code-generator'
     | '/regex-tester'
+    | '/rest-client'
     | '/rsa-tools'
     | '/semver-tools'
     | '/settings'
@@ -481,6 +492,7 @@ export interface FileRouteTypes {
     | '/password-generator'
     | '/qr-code-generator'
     | '/regex-tester'
+    | '/rest-client'
     | '/rsa-tools'
     | '/semver-tools'
     | '/settings'
@@ -523,6 +535,7 @@ export interface RootRouteChildren {
   PasswordGeneratorRoute: typeof PasswordGeneratorRoute
   QrCodeGeneratorRoute: typeof QrCodeGeneratorRoute
   RegexTesterRoute: typeof RegexTesterRoute
+  RestClientRoute: typeof RestClientRoute
   RsaToolsRoute: typeof RsaToolsRoute
   SemverToolsRoute: typeof SemverToolsRoute
   SettingsRoute: typeof SettingsRoute
@@ -621,6 +634,13 @@ declare module '@tanstack/react-router' {
       path: '/rsa-tools'
       fullPath: '/rsa-tools'
       preLoaderRoute: typeof RsaToolsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/rest-client': {
+      id: '/rest-client'
+      path: '/rest-client'
+      fullPath: '/rest-client'
+      preLoaderRoute: typeof RestClientRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/regex-tester': {
@@ -843,6 +863,7 @@ const rootRouteChildren: RootRouteChildren = {
   PasswordGeneratorRoute: PasswordGeneratorRoute,
   QrCodeGeneratorRoute: QrCodeGeneratorRoute,
   RegexTesterRoute: RegexTesterRoute,
+  RestClientRoute: RestClientRoute,
   RsaToolsRoute: RsaToolsRoute,
   SemverToolsRoute: SemverToolsRoute,
   SettingsRoute: SettingsRoute,

--- a/src/routes/rest-client.tsx
+++ b/src/routes/rest-client.tsx
@@ -1,0 +1,763 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useMemo, useState, type ChangeEvent, type ReactNode } from 'react';
+import {
+	Code2,
+	FileText,
+	FlaskConical,
+	Globe,
+	Loader2,
+	Plus,
+	Send,
+	Settings2,
+	Trash2,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+import { CopyButton } from '@/lib/components/action';
+import {
+	FormCheckbox,
+	FormError,
+	FormInfo,
+	FormInput,
+	FormSection,
+	FormSelect,
+	FormSlider,
+} from '@/lib/components/form';
+import { ToolShell } from '@/lib/components/shell';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { Badge } from '@/lib/components/ui/badge';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { Checkbox } from '@/lib/components/ui/checkbox';
+import { Input } from '@/lib/components/ui/input';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/lib/components/ui/tabs';
+import { Textarea } from '@/lib/components/ui/textarea';
+import { ToneBadge } from '@/lib/components/ui/tone-badge';
+import { useDocumentTitle } from '@/lib/hooks';
+import {
+	createEmptyHeader,
+	createHeaderId,
+	exportAsCurl,
+	formatBytes,
+	formatResponseBody,
+	HTTP_METHODS,
+	type HeaderEntry,
+	type HttpMethod,
+	headerValue,
+	headersToTuples,
+	isHttpMethod,
+	type RestResponse,
+	SAMPLE_GET_URL,
+	SAMPLE_POST_BODY,
+	SAMPLE_POST_URL,
+	sendRequest,
+	statusTone,
+	TIMEOUT_DEFAULT_MS,
+	TIMEOUT_MAX_MS,
+	TIMEOUT_MIN_MS,
+	TIMEOUT_STEP_MS,
+} from '@/lib/services/rest-client';
+import { createToolOptionsStore } from '@/lib/stores';
+import { cn, getErrorMessage } from '@/lib/utils';
+
+interface RestClientOptions {
+	readonly method: HttpMethod;
+	readonly url: string;
+	readonly headers: readonly HeaderEntry[];
+	readonly body: string;
+	readonly followRedirects: boolean;
+	readonly timeoutMs: number;
+}
+
+const DEFAULT_HEADERS: readonly HeaderEntry[] = [
+	{ id: 'hdr_default_accept', key: 'Accept', value: '*/*', enabled: true },
+];
+
+const DEFAULTS: RestClientOptions = {
+	method: 'GET',
+	url: '',
+	headers: DEFAULT_HEADERS,
+	body: '',
+	followRedirects: true,
+	timeoutMs: TIMEOUT_DEFAULT_MS,
+};
+
+const useRestClientOptions = createToolOptionsStore<RestClientOptions>('rest-client', DEFAULTS);
+
+const METHOD_OPTIONS = HTTP_METHODS.map((m) => ({ value: m, label: m }));
+
+export const Route = createFileRoute('/rest-client')({
+	component: RestClientPage,
+});
+
+type RequestTab = 'headers' | 'body';
+type ResponseTab = 'body' | 'headers';
+
+function RestClientPage() {
+	const { value: options, patch } = useRestClientOptions();
+	const { method, url, headers, body, followRedirects, timeoutMs } = options;
+
+	const [response, setResponse] = useState<RestResponse | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [sending, setSending] = useState(false);
+	const [requestTab, setRequestTab] = useState<RequestTab>('headers');
+	const [responseTab, setResponseTab] = useState<ResponseTab>('body');
+
+	useDocumentTitle('HTTP REST Client');
+
+	const canSend = url.trim().length > 0 && !sending;
+
+	const enabledHeaderCount = useMemo(
+		() => headers.filter((h) => h.enabled && h.key.trim().length > 0).length,
+		[headers]
+	);
+
+	const handleMethodChange = (value: string) => {
+		if (isHttpMethod(value)) patch({ method: value });
+	};
+
+	const handleHeaderChange = (id: string, delta: Partial<HeaderEntry>) => {
+		patch({
+			headers: headers.map((h) => (h.id === id ? { ...h, ...delta } : h)),
+		});
+	};
+
+	const handleHeaderRemove = (id: string) => {
+		patch({ headers: headers.filter((h) => h.id !== id) });
+	};
+
+	const handleLoadGetSample = () => {
+		patch({ method: 'GET', url: SAMPLE_GET_URL, body: '' });
+		setRequestTab('headers');
+	};
+
+	const handleLoadPostSample = () => {
+		patch({
+			method: 'POST',
+			url: SAMPLE_POST_URL,
+			body: SAMPLE_POST_BODY,
+			headers: [
+				...headers.filter((h) => h.key.trim().toLowerCase() !== 'content-type' || !h.enabled),
+				{
+					id: createHeaderId(),
+					key: 'Content-Type',
+					value: 'application/json',
+					enabled: true,
+				},
+			],
+		});
+		setRequestTab('body');
+	};
+
+	const handleCopyCurl = async () => {
+		if (!url.trim()) {
+			toast.error('Enter a URL first');
+			return;
+		}
+		const command = exportAsCurl({
+			method,
+			url,
+			headers: headersToTuples(headers),
+			body,
+			followRedirects,
+			timeoutMs,
+		});
+		try {
+			await navigator.clipboard.writeText(command);
+			toast.success('cURL command copied to clipboard');
+		} catch {
+			toast.error('Failed to copy to clipboard');
+		}
+	};
+
+	const handleSend = async () => {
+		if (!canSend) return;
+		setSending(true);
+		setError(null);
+		try {
+			const res = await sendRequest({
+				method,
+				url,
+				headers: headersToTuples(headers),
+				body,
+				followRedirects,
+				timeoutMs,
+			});
+			setResponse(res);
+			setResponseTab('body');
+		} catch (e) {
+			setError(getErrorMessage(e));
+			setResponse(null);
+		} finally {
+			setSending(false);
+		}
+	};
+
+	const rail = (
+		<RestClientRail
+			sending={sending}
+			canSend={canSend}
+			followRedirects={followRedirects}
+			timeoutMs={timeoutMs}
+			onSend={handleSend}
+			onPatch={patch}
+			onLoadGetSample={handleLoadGetSample}
+			onLoadPostSample={handleLoadPostSample}
+			onCopyCurl={handleCopyCurl}
+		/>
+	);
+
+	const statusContent = <StatusBarContent response={response} />;
+
+	return (
+		<ToolShell
+			valid={error ? false : response ? true : null}
+			error={error ?? undefined}
+			rail={rail}
+			statusContent={statusContent}
+		>
+			<div className="flex h-full flex-col overflow-hidden">
+				<div className="flex-1 overflow-auto p-4">
+					<div className="mx-auto flex max-w-5xl flex-col gap-4">
+						<RequestBar
+							method={method}
+							url={url}
+							sending={sending}
+							canSend={canSend}
+							onMethodChange={handleMethodChange}
+							onUrlChange={(v) => patch({ url: v })}
+							onSend={handleSend}
+						/>
+
+						<RequestPanel
+							activeTab={requestTab}
+							onTabChange={setRequestTab}
+							headers={headers}
+							enabledHeaderCount={enabledHeaderCount}
+							body={body}
+							onHeaderChange={handleHeaderChange}
+							onHeaderRemove={handleHeaderRemove}
+							onHeaderAdd={() => patch({ headers: [...headers, createEmptyHeader()] })}
+							onBodyChange={(e) => patch({ body: e.target.value })}
+						/>
+
+						{error ? <ErrorCard message={error} /> : null}
+
+						<ResponseCard
+							response={response}
+							activeTab={responseTab}
+							onTabChange={setResponseTab}
+						/>
+					</div>
+				</div>
+			</div>
+		</ToolShell>
+	);
+}
+
+interface RestClientRailProps {
+	readonly sending: boolean;
+	readonly canSend: boolean;
+	readonly followRedirects: boolean;
+	readonly timeoutMs: number;
+	readonly onSend: () => void;
+	readonly onPatch: (delta: Partial<RestClientOptions>) => void;
+	readonly onLoadGetSample: () => void;
+	readonly onLoadPostSample: () => void;
+	readonly onCopyCurl: () => void;
+}
+
+function RestClientRail({
+	sending,
+	canSend,
+	followRedirects,
+	timeoutMs,
+	onSend,
+	onPatch,
+	onLoadGetSample,
+	onLoadPostSample,
+	onCopyCurl,
+}: RestClientRailProps) {
+	return (
+		<>
+			<FormSection title="Send">
+				<Button
+					type="button"
+					className="w-full"
+					onClick={onSend}
+					disabled={!canSend}
+					aria-label="Send HTTP request"
+				>
+					<SendButtonContent sending={sending} label="Send Request" />
+				</Button>
+			</FormSection>
+
+			<FormSection title="Options">
+				<FormCheckbox
+					label="Follow redirects"
+					hint="Cap of 10 hops when enabled."
+					checked={followRedirects}
+					onCheckedChange={(v) => onPatch({ followRedirects: v })}
+					size="compact"
+				/>
+				<FormSlider
+					label="Timeout (ms)"
+					value={timeoutMs}
+					min={TIMEOUT_MIN_MS}
+					max={TIMEOUT_MAX_MS}
+					step={TIMEOUT_STEP_MS}
+					valueLabel={`${timeoutMs.toLocaleString()} ms`}
+					size="compact"
+					onValueChange={(v) => onPatch({ timeoutMs: v })}
+				/>
+			</FormSection>
+
+			<FormSection title="Samples">
+				<Button variant="outline" size="sm" className="w-full" onClick={onLoadGetSample}>
+					<FlaskConical className="h-3.5 w-3.5" />
+					Load GET sample
+				</Button>
+				<Button variant="outline" size="sm" className="w-full" onClick={onLoadPostSample}>
+					<FlaskConical className="h-3.5 w-3.5" />
+					Load POST sample
+				</Button>
+			</FormSection>
+
+			<FormSection title="Export">
+				<Button variant="outline" size="sm" className="w-full" onClick={onCopyCurl}>
+					<Code2 className="h-3.5 w-3.5" />
+					Copy as cURL
+				</Button>
+			</FormSection>
+
+			<FormSection title="About">
+				<FormInfo>
+					Local HTTP client. Requests go directly from your machine; not proxied. CORS does not
+					apply (Tauri backend).
+				</FormInfo>
+			</FormSection>
+		</>
+	);
+}
+
+interface SendButtonContentProps {
+	readonly sending: boolean;
+	readonly label: string;
+}
+
+function SendButtonContent({ sending, label }: SendButtonContentProps) {
+	if (sending) {
+		return (
+			<>
+				<Loader2 className="h-4 w-4 animate-spin" />
+				Sending...
+			</>
+		);
+	}
+	return (
+		<>
+			<Send className="h-4 w-4" />
+			{label}
+		</>
+	);
+}
+
+interface RequestBarProps {
+	readonly method: string;
+	readonly url: string;
+	readonly sending: boolean;
+	readonly canSend: boolean;
+	readonly onMethodChange: (value: string) => void;
+	readonly onUrlChange: (value: string) => void;
+	readonly onSend: () => void;
+}
+
+function RequestBar({
+	method,
+	url,
+	sending,
+	canSend,
+	onMethodChange,
+	onUrlChange,
+	onSend,
+}: RequestBarProps) {
+	return (
+		<Card density="compact">
+			<CardHeader className="pb-3">
+				<div className="flex items-center gap-2">
+					<Globe className="h-4 w-4 text-muted-foreground" />
+					<CardTitle className="text-sm font-medium">Request</CardTitle>
+				</div>
+			</CardHeader>
+			<CardContent>
+				<div className="grid grid-cols-[120px_1fr_auto] items-end gap-2">
+					<FormSelect
+						label="Method"
+						value={method}
+						options={METHOD_OPTIONS}
+						onValueChange={onMethodChange}
+					/>
+					<FormInput
+						label="URL"
+						value={url}
+						placeholder="https://example.com/api"
+						onValueChange={onUrlChange}
+					/>
+					<Button
+						type="button"
+						className="h-9"
+						onClick={onSend}
+						disabled={!canSend}
+						aria-label="Send HTTP request"
+					>
+						<SendButtonContent sending={sending} label="Send" />
+					</Button>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface RequestPanelProps {
+	readonly activeTab: RequestTab;
+	readonly onTabChange: (tab: RequestTab) => void;
+	readonly headers: readonly HeaderEntry[];
+	readonly enabledHeaderCount: number;
+	readonly body: string;
+	readonly onHeaderChange: (id: string, delta: Partial<HeaderEntry>) => void;
+	readonly onHeaderRemove: (id: string) => void;
+	readonly onHeaderAdd: () => void;
+	readonly onBodyChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
+}
+
+function RequestPanel({
+	activeTab,
+	onTabChange,
+	headers,
+	enabledHeaderCount,
+	body,
+	onHeaderChange,
+	onHeaderRemove,
+	onHeaderAdd,
+	onBodyChange,
+}: RequestPanelProps) {
+	const handleValueChange = (v: string) => {
+		if (v === 'headers' || v === 'body') onTabChange(v);
+	};
+
+	return (
+		<Card density="compact">
+			<CardContent className="space-y-3">
+				<Tabs value={activeTab} onValueChange={handleValueChange}>
+					<TabsList className="grid w-full grid-cols-2">
+						<TabsTrigger value="headers" className="gap-2">
+							<Settings2 className="h-3.5 w-3.5" />
+							Headers
+							{enabledHeaderCount > 0 ? (
+								<Badge variant="secondary" className="ml-1 h-4 px-1.5 text-2xs">
+									{enabledHeaderCount}
+								</Badge>
+							) : null}
+						</TabsTrigger>
+						<TabsTrigger value="body" className="gap-2">
+							<FileText className="h-3.5 w-3.5" />
+							Body
+							{body.trim().length > 0 ? (
+								<Badge variant="secondary" className="ml-1 h-4 px-1.5 text-2xs">
+									{body.length}
+								</Badge>
+							) : null}
+						</TabsTrigger>
+					</TabsList>
+
+					<TabsContent value="headers" className="space-y-2 pt-3">
+						<HeadersEditor
+							headers={headers}
+							onHeaderChange={onHeaderChange}
+							onHeaderRemove={onHeaderRemove}
+							onHeaderAdd={onHeaderAdd}
+						/>
+					</TabsContent>
+
+					<TabsContent value="body" className="space-y-2 pt-3">
+						<Textarea
+							value={body}
+							placeholder='{"key": "value"}'
+							rows={10}
+							className="font-mono text-sm"
+							onChange={onBodyChange}
+						/>
+						<p className="text-xs text-muted-foreground">
+							Content-Type defaults to <code className="font-mono">text/plain</code> unless set in
+							Headers.
+						</p>
+					</TabsContent>
+				</Tabs>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface HeadersEditorProps {
+	readonly headers: readonly HeaderEntry[];
+	readonly onHeaderChange: (id: string, delta: Partial<HeaderEntry>) => void;
+	readonly onHeaderRemove: (id: string) => void;
+	readonly onHeaderAdd: () => void;
+}
+
+function HeadersEditor({
+	headers,
+	onHeaderChange,
+	onHeaderRemove,
+	onHeaderAdd,
+}: HeadersEditorProps) {
+	return (
+		<>
+			{headers.length === 0 ? (
+				<EmbeddedEmptyState
+					icon={Settings2}
+					title="No headers"
+					description="Add headers to send with this request."
+				/>
+			) : (
+				<div className="space-y-1.5">
+					{headers.map((entry) => (
+						<HeaderRow
+							key={entry.id}
+							entry={entry}
+							onChange={(delta) => onHeaderChange(entry.id, delta)}
+							onRemove={() => onHeaderRemove(entry.id)}
+						/>
+					))}
+				</div>
+			)}
+			<Button variant="outline" size="sm" onClick={onHeaderAdd}>
+				<Plus className="h-3.5 w-3.5" />
+				Add header
+			</Button>
+		</>
+	);
+}
+
+interface HeaderRowProps {
+	readonly entry: HeaderEntry;
+	readonly onChange: (delta: Partial<HeaderEntry>) => void;
+	readonly onRemove: () => void;
+}
+
+function HeaderRow({ entry, onChange, onRemove }: HeaderRowProps) {
+	return (
+		<div
+			className={cn(
+				'grid grid-cols-[auto_minmax(0,1fr)_minmax(0,2fr)_auto] items-center gap-2',
+				!entry.enabled && 'opacity-50'
+			)}
+		>
+			<Checkbox
+				checked={entry.enabled}
+				onCheckedChange={(v) => onChange({ enabled: Boolean(v) })}
+				aria-label="Include header"
+			/>
+			<Input
+				value={entry.key}
+				placeholder="Header"
+				className="h-8 font-mono text-xs"
+				onChange={(e) => onChange({ key: e.target.value })}
+			/>
+			<Input
+				value={entry.value}
+				placeholder="Value"
+				className="h-8 font-mono text-xs"
+				onChange={(e) => onChange({ value: e.target.value })}
+			/>
+			<Button
+				variant="ghost"
+				size="icon-sm"
+				className="h-8 w-8 text-muted-foreground hover:text-destructive"
+				onClick={onRemove}
+				aria-label="Remove header"
+			>
+				<Trash2 className="h-3.5 w-3.5" />
+			</Button>
+		</div>
+	);
+}
+
+interface ErrorCardProps {
+	readonly message: string;
+}
+
+function ErrorCard({ message }: ErrorCardProps) {
+	return (
+		<Card density="compact" variant="destructive">
+			<CardHeader className="pb-3">
+				<CardTitle className="text-sm font-medium text-destructive">Request failed</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<FormError message={message} />
+			</CardContent>
+		</Card>
+	);
+}
+
+interface ResponseCardProps {
+	readonly response: RestResponse | null;
+	readonly activeTab: ResponseTab;
+	readonly onTabChange: (tab: ResponseTab) => void;
+}
+
+function ResponseCard({ response, activeTab, onTabChange }: ResponseCardProps) {
+	return (
+		<Card density="compact">
+			<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
+				<div className="flex items-center gap-2">
+					<CardTitle className="text-sm font-medium">Response</CardTitle>
+					{response ? (
+						<ToneBadge tone={statusTone(response.status)} className="font-mono">
+							{response.status} {response.statusText}
+						</ToneBadge>
+					) : null}
+				</div>
+				{response ? (
+					<div className="flex items-center gap-3 text-xs text-muted-foreground">
+						<span>{response.elapsedMs} ms</span>
+						<span>{formatBytes(response.bytesReceived)}</span>
+					</div>
+				) : null}
+			</CardHeader>
+			<CardContent>
+				{response ? (
+					<ResponseTabs response={response} activeTab={activeTab} onTabChange={onTabChange} />
+				) : (
+					<EmbeddedEmptyState
+						icon={Send}
+						title="No response yet"
+						description="Send a request to see the response here."
+					/>
+				)}
+			</CardContent>
+		</Card>
+	);
+}
+
+interface ResponseTabsProps {
+	readonly response: RestResponse;
+	readonly activeTab: ResponseTab;
+	readonly onTabChange: (tab: ResponseTab) => void;
+}
+
+function ResponseTabs({ response, activeTab, onTabChange }: ResponseTabsProps) {
+	const contentType = headerValue(response.headers, 'content-type');
+	const formattedBody = formatResponseBody(response.body, contentType);
+
+	const handleValueChange = (v: string) => {
+		if (v === 'body' || v === 'headers') onTabChange(v);
+	};
+
+	return (
+		<Tabs value={activeTab} onValueChange={handleValueChange}>
+			<TabsList className="grid w-full grid-cols-2">
+				<TabsTrigger value="body" className="gap-2">
+					<FileText className="h-3.5 w-3.5" />
+					Body
+				</TabsTrigger>
+				<TabsTrigger value="headers" className="gap-2">
+					<Settings2 className="h-3.5 w-3.5" />
+					Headers
+					<Badge variant="secondary" className="ml-1 h-4 px-1.5 text-2xs">
+						{response.headers.length}
+					</Badge>
+				</TabsTrigger>
+			</TabsList>
+
+			<TabsContent value="body" className="pt-3">
+				<ResponseBody body={formattedBody} contentType={contentType} />
+			</TabsContent>
+
+			<TabsContent value="headers" className="pt-3">
+				<ResponseHeaders headers={response.headers} />
+			</TabsContent>
+		</Tabs>
+	);
+}
+
+interface ResponseBodyProps {
+	readonly body: string;
+	readonly contentType: string | undefined;
+}
+
+function ResponseBody({ body, contentType }: ResponseBodyProps) {
+	return (
+		<div className="space-y-2">
+			<div className="flex items-center justify-between gap-2">
+				<span className="font-mono text-xs text-muted-foreground">
+					{contentType ?? 'no content-type'}
+				</span>
+				<CopyButton text={body} toastLabel="Response body" size="sm" />
+			</div>
+			{body.length > 0 ? (
+				<pre className="max-h-96 overflow-auto rounded-md bg-muted p-3 font-mono text-xs">
+					{body}
+				</pre>
+			) : (
+				<p className="text-sm text-muted-foreground">Empty response body.</p>
+			)}
+		</div>
+	);
+}
+
+interface ResponseHeadersProps {
+	readonly headers: readonly (readonly [string, string])[];
+}
+
+function ResponseHeaders({ headers }: ResponseHeadersProps): ReactNode {
+	if (headers.length === 0) {
+		return <p className="text-sm text-muted-foreground">No response headers.</p>;
+	}
+	// Disambiguate duplicate header names (Set-Cookie, etc.) by counting
+	// occurrences so React keys are stable when re-rendering the same response.
+	const seen = new Map<string, number>();
+	const rows = headers.map(([key, value]) => {
+		const occurrence = (seen.get(key) ?? 0) + 1;
+		seen.set(key, occurrence);
+		return { id: `${key}#${occurrence}`, key, value };
+	});
+	return (
+		<div className="space-y-1">
+			{rows.map((row) => (
+				<div
+					key={row.id}
+					className="grid grid-cols-[minmax(0,1fr)_minmax(0,2fr)] gap-2 border-b px-2 py-1.5 last:border-b-0"
+				>
+					<span className="break-all font-mono text-xs font-medium">{row.key}</span>
+					<span className="break-all font-mono text-xs text-muted-foreground">{row.value}</span>
+				</div>
+			))}
+		</div>
+	);
+}
+
+interface StatusBarContentProps {
+	readonly response: RestResponse | null;
+}
+
+function StatusBarContent({ response }: StatusBarContentProps): ReactNode {
+	if (!response) return null;
+	const statusVariant: 'success' | 'warning' | 'error' =
+		response.status >= 200 && response.status < 400
+			? 'success'
+			: response.status >= 400 && response.status < 500
+				? 'warning'
+				: 'error';
+	return (
+		<>
+			<StatItem
+				label="Status"
+				value={`${response.status} ${response.statusText}`}
+				variant={statusVariant}
+			/>
+			<StatItem label="Elapsed" value={`${response.elapsedMs} ms`} />
+			<StatItem label="Size" value={formatBytes(response.bytesReceived)} />
+		</>
+	);
+}


### PR DESCRIPTION
## Summary
Add an MVP HTTP REST Client under **Network**. Local-first HTTP request builder backed by a new `rest_client_send` Tauri command (reqwest with rustls-tls). Closes #233.

## MVP scope
- **Method + URL bar**: GET / POST / PUT / PATCH / DELETE / HEAD / OPTIONS
- **Headers**: key/value grid with per-row enable toggle and add/remove
- **Body**: raw text editor (Content-Type controlled via Headers)
- **Send**: tauri command `rest_client_send` with configurable timeout and follow-redirects
- **Response**: status badge (tone-coded by 2xx/3xx/4xx/5xx), elapsed ms, bytes received
- **Auto-formatting**: pretty-prints `application/json` response bodies
- **Samples**: GET and POST loaders against the public echo service
- **Export**: one-click "Copy as cURL"

## Deferred to follow-up PRs
- History / collections / environment variables
- Multipart, form-urlencoded, binary body editors
- Auth tab (Basic / Bearer / OAuth)
- Timing breakdown (DNS / TCP / TLS / TTFB / download)
- Cookies tab
- Image / HTML response preview
- Streaming for large payloads

## Changes
### Added
- `src/routes/rest-client.tsx` — page
- `src/lib/services/rest-client.ts` — request/response shapes, cURL export
- `src-tauri/src/rest_client.rs` — new tauri command

### Modified
- `src/lib/services/pages.ts` — page registration under Network
- `src-tauri/src/lib.rs` — `mod rest_client` + `invoke_handler!` entry

## Test plan
- [x] `bun run check` green
- [x] `bun run lint` no new errors
- [x] `cargo check` + `cargo clippy --all-targets` clean
- [ ] Manual: GET against the JSON sample endpoint pretty-prints in the response body
- [ ] Manual: POST sample echoes the body back correctly
- [ ] Manual: Toggle "Follow redirects" off — 301/302 surface in the response
- [ ] Manual: Timeout slider at 1000 ms against a slow endpoint surfaces a transport error
- [ ] Manual: "Copy as cURL" produces a valid command

Closes #233
