### PR TITLE
feat(dns-lookup): add DNS Lookup tool (MVP)

### DIFF
--- a/src-tauri/src/dns_lookup.rs
+++ b/src-tauri/src/dns_lookup.rs
@@ -1,0 +1,252 @@
+//! DNS Lookup command.
+//!
+//! Async Tauri command backed by `hickory-resolver` that resolves a name
+//! against the system resolver, a public preset (Cloudflare / Google /
+//! Quad9), or a custom IP. Returns records grouped by type with TTL and
+//! the AD (authentic data, DNSSEC validated) flag from the upstream
+//! response header.
+//!
+//! Standard UDP/TCP only — encrypted transports (`DoH` / `DoT` / `DoQ`)
+//! are intentionally deferred to a follow-up.
+
+use std::net::IpAddr;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use hickory_resolver::config::{
+    NameServerConfig, ResolverConfig, ResolverOpts, CLOUDFLARE, GOOGLE, QUAD9,
+};
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
+use hickory_resolver::proto::rr::RecordType;
+use hickory_resolver::{Resolver, TokioResolver};
+use serde::{Deserialize, Serialize};
+
+/// User-supplied request for a DNS lookup.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DnsLookupRequest {
+    /// Name (or PTR-formatted reverse query) to resolve.
+    pub name: String,
+    /// Record types to query, e.g. `["A", "AAAA", "MX"]`.
+    pub record_types: Vec<String>,
+    /// Resolver selector: `"system"`, `"cloudflare"`, `"google"`, `"quad9"`,
+    /// or a bare IPv4 / IPv6 literal.
+    pub resolver: String,
+    /// Per-query timeout in milliseconds.
+    pub timeout_ms: u32,
+}
+
+/// One resource record returned by the resolver.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DnsRecord {
+    /// Record type label echoed from the request (e.g. `"A"`).
+    pub record_type: String,
+    /// Stringified rdata. For MX this includes the preference + exchange,
+    /// for SOA the seven SOA fields, etc.
+    pub value: String,
+    /// TTL reported by the upstream in seconds.
+    pub ttl: u32,
+}
+
+/// Per-record-type result block.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DnsTypeResult {
+    /// Record type label echoed from the request.
+    pub record_type: String,
+    /// Records returned for this type. Empty when the upstream returned
+    /// NXDOMAIN, NOERROR with no answers, or when a transport error
+    /// occurred (in which case `error` is also populated).
+    pub records: Vec<DnsRecord>,
+    /// Wallclock expiry derived from the smallest TTL in `records`. Zero
+    /// when `records` is empty.
+    pub ttl_expires_at_ms: u64,
+    /// AD (authentic data) flag from the upstream response header. `None`
+    /// when no answer was returned.
+    pub authentic_data: Option<bool>,
+    /// Transport / parse / resolver error string when the lookup failed.
+    pub error: Option<String>,
+}
+
+/// Aggregated result of one [`DnsLookupRequest`].
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DnsLookupResult {
+    /// Name echoed from the request.
+    pub name: String,
+    /// Resolver spec echoed from the request.
+    pub resolver: String,
+    /// Per-type result blocks in the order requested.
+    pub results: Vec<DnsTypeResult>,
+    /// Total wallclock duration of the whole lookup in milliseconds.
+    pub elapsed_ms: u128,
+}
+
+/// Map a string label to a hickory `RecordType`. Returns `None` for any
+/// label outside the MVP set so the caller can surface a clean error.
+fn parse_record_type(s: &str) -> Option<RecordType> {
+    match s.to_uppercase().as_str() {
+        "A" => Some(RecordType::A),
+        "AAAA" => Some(RecordType::AAAA),
+        "MX" => Some(RecordType::MX),
+        "TXT" => Some(RecordType::TXT),
+        "NS" => Some(RecordType::NS),
+        "CNAME" => Some(RecordType::CNAME),
+        "SOA" => Some(RecordType::SOA),
+        "PTR" => Some(RecordType::PTR),
+        _ => None,
+    }
+}
+
+/// Build resolver options with the caller-supplied timeout. `attempts` is
+/// pinned to 1 so a slow upstream surfaces a timeout instead of doubling
+/// the wallclock when the first probe fails.
+fn build_opts(timeout_ms: u32) -> ResolverOpts {
+    let mut opts = ResolverOpts::default();
+    opts.timeout = Duration::from_millis(u64::from(timeout_ms));
+    opts.attempts = 1;
+    opts
+}
+
+/// Build a [`TokioResolver`] for the requested `spec`. `"system"` reads
+/// the platform resolver configuration; the named presets resolve through
+/// the bundled IP set over UDP+TCP; any other value is parsed as a bare
+/// IPv4 / IPv6 literal that is wired up as both a UDP and a TCP server.
+fn build_resolver(spec: &str, timeout_ms: u32) -> Result<TokioResolver, String> {
+    let opts = build_opts(timeout_ms);
+
+    if spec == "system" {
+        let mut builder = Resolver::builder_tokio().map_err(|e| e.to_string())?;
+        *builder.options_mut() = opts;
+        return builder.build().map_err(|e| e.to_string());
+    }
+
+    let config = match spec {
+        "cloudflare" => ResolverConfig::udp_and_tcp(&CLOUDFLARE),
+        "google" => ResolverConfig::udp_and_tcp(&GOOGLE),
+        "quad9" => ResolverConfig::udp_and_tcp(&QUAD9),
+        custom => {
+            let ip: IpAddr = custom
+                .parse()
+                .map_err(|e: std::net::AddrParseError| format!("Invalid resolver IP: {e}"))?;
+            ResolverConfig::from_parts(None, vec![], vec![NameServerConfig::udp_and_tcp(ip)])
+        }
+    };
+
+    Resolver::builder_with_config(config, TokioRuntimeProvider::default())
+        .with_options(opts)
+        .build()
+        .map_err(|e| e.to_string())
+}
+
+/// Convert a smallest-TTL value to an absolute wallclock expiry in
+/// milliseconds since the Unix epoch. Returns 0 when the system clock is
+/// before the epoch (effectively never).
+fn ttl_expires_at_ms(ttl_seconds: u32) -> u64 {
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX));
+    now_ms.saturating_add(u64::from(ttl_seconds).saturating_mul(1000))
+}
+
+/// Run a single record-type lookup. Errors are folded into the result
+/// (with empty `records`) so the frontend can show per-type problems
+/// without aborting the whole query.
+async fn lookup_type(
+    resolver: &TokioResolver,
+    name: &str,
+    rt_label: &str,
+    rt: RecordType,
+) -> DnsTypeResult {
+    match resolver.lookup(name, rt).await {
+        Ok(lookup) => {
+            let records: Vec<DnsRecord> = lookup
+                .answers()
+                .iter()
+                .map(|r| DnsRecord {
+                    record_type: rt_label.to_string(),
+                    value: r.data.to_string(),
+                    ttl: r.ttl,
+                })
+                .collect();
+            let min_ttl = records.iter().map(|r| r.ttl).min().unwrap_or(0);
+            let authentic_data = Some(lookup.message().metadata.authentic_data);
+            DnsTypeResult {
+                record_type: rt_label.to_string(),
+                ttl_expires_at_ms: if records.is_empty() {
+                    0
+                } else {
+                    ttl_expires_at_ms(min_ttl)
+                },
+                records,
+                authentic_data,
+                error: None,
+            }
+        }
+        Err(e) => DnsTypeResult {
+            record_type: rt_label.to_string(),
+            records: vec![],
+            ttl_expires_at_ms: 0,
+            authentic_data: None,
+            error: Some(e.to_string()),
+        },
+    }
+}
+
+/// Resolve every requested record type against the chosen resolver and
+/// return the aggregated result.
+#[tauri::command]
+pub async fn dns_lookup(req: DnsLookupRequest) -> Result<DnsLookupResult, String> {
+    let started = std::time::Instant::now();
+    let resolver = build_resolver(&req.resolver, req.timeout_ms)?;
+
+    let mut results = Vec::with_capacity(req.record_types.len());
+    for rt_label in &req.record_types {
+        match parse_record_type(rt_label) {
+            Some(rt) => results.push(lookup_type(&resolver, &req.name, rt_label, rt).await),
+            None => results.push(DnsTypeResult {
+                record_type: rt_label.clone(),
+                records: vec![],
+                ttl_expires_at_ms: 0,
+                authentic_data: None,
+                error: Some(format!("Unsupported record type: {rt_label}")),
+            }),
+        }
+    }
+
+    Ok(DnsLookupResult {
+        name: req.name,
+        resolver: req.resolver,
+        results,
+        elapsed_ms: started.elapsed().as_millis(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_record_type_accepts_supported_types() {
+        assert_eq!(parse_record_type("A"), Some(RecordType::A));
+        assert_eq!(parse_record_type("aaaa"), Some(RecordType::AAAA));
+        assert_eq!(parse_record_type("Mx"), Some(RecordType::MX));
+        assert_eq!(parse_record_type("PTR"), Some(RecordType::PTR));
+    }
+
+    #[test]
+    fn parse_record_type_rejects_out_of_scope_types() {
+        assert_eq!(parse_record_type("CAA"), None);
+        assert_eq!(parse_record_type("SRV"), None);
+        assert_eq!(parse_record_type(""), None);
+    }
+
+    #[test]
+    fn ttl_expires_at_is_in_the_future_for_nonzero_ttl() {
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX));
+        let expires = ttl_expires_at_ms(60);
+        assert!(expires >= now_ms);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,6 +47,7 @@
 //! including AST parsing functionality for JSON, YAML, XML, and SQL.
 
 mod ast;
+mod dns_lookup;
 mod generators;
 #[cfg(target_os = "macos")]
 mod menu;
@@ -470,6 +471,7 @@ pub fn run() {
             network::oui::lookup_oui_vendor,
             network::oui::get_oui_database_info,
             rest_client::rest_client_send,
+            dns_lookup::dns_lookup,
             settings::get_settings,
             settings::update_settings,
             settings::reset_settings,

--- a/src/lib/services/dns.ts
+++ b/src/lib/services/dns.ts
@@ -1,0 +1,164 @@
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * Record types supported by the DNS Lookup MVP.
+ * DNSSEC-only types (DNSKEY / RRSIG / DS) and operationally adjacent
+ * types (CAA / SRV) are deferred to a follow-up.
+ */
+export type RecordType = 'A' | 'AAAA' | 'MX' | 'TXT' | 'NS' | 'CNAME' | 'SOA' | 'PTR';
+
+export const RECORD_TYPES: readonly RecordType[] = [
+	'A',
+	'AAAA',
+	'MX',
+	'TXT',
+	'NS',
+	'CNAME',
+	'SOA',
+	'PTR',
+];
+
+/**
+ * Resolver preset keyed by short label. `"custom"` is a UI sentinel that
+ * routes to a free-form IP input; the backend receives the literal IP
+ * string rather than the word "custom".
+ */
+export type ResolverPreset = 'system' | 'cloudflare' | 'google' | 'quad9' | 'custom';
+
+export interface ResolverPresetInfo {
+	readonly id: ResolverPreset;
+	readonly label: string;
+	readonly description: string;
+	readonly ip?: string;
+}
+
+export const RESOLVER_PRESETS: readonly ResolverPresetInfo[] = [
+	{ id: 'system', label: 'System', description: 'Use the resolver configured on this device' },
+	{ id: 'cloudflare', label: 'Cloudflare', description: '1.1.1.1', ip: '1.1.1.1' },
+	{ id: 'google', label: 'Google', description: '8.8.8.8', ip: '8.8.8.8' },
+	{ id: 'quad9', label: 'Quad9', description: '9.9.9.9', ip: '9.9.9.9' },
+	{ id: 'custom', label: 'Custom', description: 'Provide a custom resolver IP' },
+];
+
+export interface DnsLookupRequest {
+	readonly name: string;
+	readonly recordTypes: readonly RecordType[];
+	readonly resolver: string;
+	readonly timeoutMs: number;
+}
+
+export interface DnsRecord {
+	readonly recordType: string;
+	readonly value: string;
+	readonly ttl: number;
+}
+
+export interface DnsTypeResult {
+	readonly recordType: string;
+	readonly records: readonly DnsRecord[];
+	readonly ttlExpiresAtMs: number;
+	readonly authenticData: boolean | null;
+	readonly error: string | null;
+}
+
+export interface DnsLookupResult {
+	readonly name: string;
+	readonly resolver: string;
+	readonly results: readonly DnsTypeResult[];
+	readonly elapsedMs: number;
+}
+
+/** Invoke the Tauri `dns_lookup` command. */
+export const runDnsLookup = (req: DnsLookupRequest): Promise<DnsLookupResult> =>
+	invoke<DnsLookupResult>('dns_lookup', { req });
+
+const IPV4_RE = /^(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$/;
+// Permissive IPv6: accepts compressed (::) and fully expanded forms.
+// We rely on the Rust resolver for authoritative parsing; this guard
+// only needs to disambiguate "looks like an IP" from "looks like a name"
+// so the UI can auto-switch to PTR.
+const IPV6_RE = /^[0-9a-fA-F:]+$/;
+
+/**
+ * Return `true` when the trimmed input is a literal IPv4 or IPv6 address
+ * (used to auto-switch the query type to PTR for reverse lookups).
+ */
+export const isIpLiteral = (text: string): boolean => {
+	const trimmed = text.trim();
+	if (trimmed.length === 0) return false;
+	if (IPV4_RE.test(trimmed)) return true;
+	if (!IPV6_RE.test(trimmed)) return false;
+	// An IPv6 literal must contain a colon and be ≥ 2 characters.
+	return trimmed.includes(':') && trimmed.length >= 2;
+};
+
+/**
+ * Convert an IPv4 / IPv6 literal to its PTR-format reverse-DNS name.
+ * Returns the original input when it is not a recognized literal so the
+ * caller can pass it through unchanged.
+ */
+export const toReverseDnsName = (ip: string): string => {
+	const trimmed = ip.trim();
+	if (IPV4_RE.test(trimmed)) {
+		return `${trimmed.split('.').reverse().join('.')}.in-addr.arpa`;
+	}
+	if (!IPV6_RE.test(trimmed) || !trimmed.includes(':')) return trimmed;
+	const expanded = expandIpv6(trimmed);
+	if (expanded === null) return trimmed;
+	const nibbles = expanded
+		.split(':')
+		.map((group) => group.padStart(4, '0'))
+		.join('')
+		.split('')
+		.reverse()
+		.join('.');
+	return `${nibbles}.ip6.arpa`;
+};
+
+/**
+ * Expand a compressed IPv6 literal (`::` notation) to its full 8-group
+ * form. Returns `null` when the input cannot be parsed as IPv6.
+ */
+const expandIpv6 = (ip: string): string | null => {
+	const halves = ip.split('::');
+	if (halves.length > 2) return null;
+	const [leftRaw = '', rightRaw = ''] = halves;
+	const left = leftRaw.length > 0 ? leftRaw.split(':') : [];
+	const right = rightRaw.length > 0 ? rightRaw.split(':') : [];
+	const missing = 8 - left.length - right.length;
+	if (halves.length === 1) {
+		// No `::` — must already be 8 groups.
+		if (left.length !== 8) return null;
+		return left.join(':');
+	}
+	if (missing < 0) return null;
+	const filler = Array.from({ length: missing }, () => '0');
+	return [...left, ...filler, ...right].join(':');
+};
+
+/**
+ * Render the request as the equivalent `dig` invocation. Used for the
+ * "Copy as dig" export so the user can reproduce the lookup offline.
+ */
+export const exportAsDig = (req: DnsLookupRequest): string => {
+	const server = req.resolver === 'system' ? '' : ` @${resolverIpFor(req.resolver)}`;
+	const types = req.recordTypes.join(' ');
+	const name = req.name.trim().length > 0 ? req.name.trim() : 'example.com';
+	return `dig${server} ${name} ${types}`.trim();
+};
+
+/**
+ * Resolve a preset id (or a passthrough IP literal) to its display IP.
+ * Used by the `dig` export and the resolver chip subtitle.
+ */
+export const resolverIpFor = (spec: string): string => {
+	const preset = RESOLVER_PRESETS.find((p) => p.id === spec);
+	if (preset?.ip !== undefined) return preset.ip;
+	return spec;
+};
+
+/** Recommended bootstrap input shown on first load. */
+export const SAMPLE_DOMAIN = 'example.com';
+
+/** Default reverse-DNS sample for the "Load reverse sample" button. */
+export const SAMPLE_REVERSE_IP = '8.8.8.8';

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -46,6 +46,7 @@ import {
 	Radar,
 	Regex,
 	Search,
+	SearchCode,
 	Send,
 	Settings,
 	Shield,
@@ -474,6 +475,16 @@ export const PAGES: readonly PageDefinition[] = [
 		icon: FileType,
 		description: 'Bidirectional MIME type / extension lookup with magic bytes and charset info',
 		color: 'text-emerald-700',
+		category: 'network',
+	},
+	{
+		id: 'dns-lookup',
+		title: 'DNS Lookup',
+		url: '/dns-lookup',
+		icon: SearchCode,
+		description:
+			'Query DNS records (A / AAAA / MX / TXT / NS / SOA / CNAME / PTR) against selectable resolvers',
+		color: 'text-cyan-700',
 		category: 'network',
 	},
 	{

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -8,875 +8,896 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as YamlFormatterRouteImport } from './routes/yaml-formatter'
-import { Route as XmlFormatterRouteImport } from './routes/xml-formatter'
-import { Route as X509DecoderRouteImport } from './routes/x509-decoder'
-import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator'
-import { Route as UrlEncoderRouteImport } from './routes/url-encoder'
-import { Route as StringCompressorRouteImport } from './routes/string-compressor'
-import { Route as StringCaseConverterRouteImport } from './routes/string-case-converter'
-import { Route as SshKeyGeneratorRouteImport } from './routes/ssh-key-generator'
-import { Route as SqlFormatterRouteImport } from './routes/sql-formatter'
-import { Route as SettingsRouteImport } from './routes/settings'
-import { Route as SemverToolsRouteImport } from './routes/semver-tools'
-import { Route as RsaToolsRouteImport } from './routes/rsa-tools'
-import { Route as RestClientRouteImport } from './routes/rest-client'
-import { Route as RegexTesterRouteImport } from './routes/regex-tester'
-import { Route as QrCodeGeneratorRouteImport } from './routes/qr-code-generator'
-import { Route as PasswordGeneratorRouteImport } from './routes/password-generator'
-import { Route as NumberBaseConverterRouteImport } from './routes/number-base-converter'
-import { Route as NetworkScannerRouteImport } from './routes/network-scanner'
-import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces'
-import { Route as MimeTypesRouteImport } from './routes/mime-types'
-import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor'
-import { Route as MacLookupRouteImport } from './routes/mac-lookup'
-import { Route as LoremIpsumRouteImport } from './routes/lorem-ipsum'
-import { Route as ListComparerRouteImport } from './routes/list-comparer'
-import { Route as JwtDecoderRouteImport } from './routes/jwt-decoder'
-import { Route as JsonFormatterRouteImport } from './routes/json-formatter'
-import { Route as IpConverterRouteImport } from './routes/ip-converter'
-import { Route as ImageConverterRouteImport } from './routes/image-converter'
-import { Route as HttpStatusCodesRouteImport } from './routes/http-status-codes'
-import { Route as HashGeneratorRouteImport } from './routes/hash-generator'
-import { Route as GpgKeyGeneratorRouteImport } from './routes/gpg-key-generator'
-import { Route as EscapeToolRouteImport } from './routes/escape-tool'
-import { Route as DiffViewerRouteImport } from './routes/diff-viewer'
-import { Route as DateTimestampConverterRouteImport } from './routes/date-timestamp-converter'
-import { Route as CurlBuilderRouteImport } from './routes/curl-builder'
-import { Route as CronExpressionBuilderRouteImport } from './routes/cron-expression-builder'
-import { Route as CidrCalculatorRouteImport } from './routes/cidr-calculator'
-import { Route as BcryptGeneratorRouteImport } from './routes/bcrypt-generator'
-import { Route as Base64EncoderRouteImport } from './routes/base64-encoder'
-import { Route as IndexRouteImport } from './routes/index'
+import { Route as rootRouteImport } from './routes/__root';
+import { Route as YamlFormatterRouteImport } from './routes/yaml-formatter';
+import { Route as XmlFormatterRouteImport } from './routes/xml-formatter';
+import { Route as X509DecoderRouteImport } from './routes/x509-decoder';
+import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator';
+import { Route as UrlEncoderRouteImport } from './routes/url-encoder';
+import { Route as StringCompressorRouteImport } from './routes/string-compressor';
+import { Route as StringCaseConverterRouteImport } from './routes/string-case-converter';
+import { Route as SshKeyGeneratorRouteImport } from './routes/ssh-key-generator';
+import { Route as SqlFormatterRouteImport } from './routes/sql-formatter';
+import { Route as SettingsRouteImport } from './routes/settings';
+import { Route as SemverToolsRouteImport } from './routes/semver-tools';
+import { Route as RsaToolsRouteImport } from './routes/rsa-tools';
+import { Route as RestClientRouteImport } from './routes/rest-client';
+import { Route as RegexTesterRouteImport } from './routes/regex-tester';
+import { Route as QrCodeGeneratorRouteImport } from './routes/qr-code-generator';
+import { Route as PasswordGeneratorRouteImport } from './routes/password-generator';
+import { Route as NumberBaseConverterRouteImport } from './routes/number-base-converter';
+import { Route as NetworkScannerRouteImport } from './routes/network-scanner';
+import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces';
+import { Route as MimeTypesRouteImport } from './routes/mime-types';
+import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor';
+import { Route as MacLookupRouteImport } from './routes/mac-lookup';
+import { Route as LoremIpsumRouteImport } from './routes/lorem-ipsum';
+import { Route as ListComparerRouteImport } from './routes/list-comparer';
+import { Route as JwtDecoderRouteImport } from './routes/jwt-decoder';
+import { Route as JsonFormatterRouteImport } from './routes/json-formatter';
+import { Route as IpConverterRouteImport } from './routes/ip-converter';
+import { Route as ImageConverterRouteImport } from './routes/image-converter';
+import { Route as HttpStatusCodesRouteImport } from './routes/http-status-codes';
+import { Route as HashGeneratorRouteImport } from './routes/hash-generator';
+import { Route as GpgKeyGeneratorRouteImport } from './routes/gpg-key-generator';
+import { Route as EscapeToolRouteImport } from './routes/escape-tool';
+import { Route as DnsLookupRouteImport } from './routes/dns-lookup';
+import { Route as DiffViewerRouteImport } from './routes/diff-viewer';
+import { Route as DateTimestampConverterRouteImport } from './routes/date-timestamp-converter';
+import { Route as CurlBuilderRouteImport } from './routes/curl-builder';
+import { Route as CronExpressionBuilderRouteImport } from './routes/cron-expression-builder';
+import { Route as CidrCalculatorRouteImport } from './routes/cidr-calculator';
+import { Route as BcryptGeneratorRouteImport } from './routes/bcrypt-generator';
+import { Route as Base64EncoderRouteImport } from './routes/base64-encoder';
+import { Route as IndexRouteImport } from './routes/index';
 
 const YamlFormatterRoute = YamlFormatterRouteImport.update({
-  id: '/yaml-formatter',
-  path: '/yaml-formatter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/yaml-formatter',
+	path: '/yaml-formatter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const XmlFormatterRoute = XmlFormatterRouteImport.update({
-  id: '/xml-formatter',
-  path: '/xml-formatter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/xml-formatter',
+	path: '/xml-formatter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const X509DecoderRoute = X509DecoderRouteImport.update({
-  id: '/x509-decoder',
-  path: '/x509-decoder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/x509-decoder',
+	path: '/x509-decoder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const UuidGeneratorRoute = UuidGeneratorRouteImport.update({
-  id: '/uuid-generator',
-  path: '/uuid-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/uuid-generator',
+	path: '/uuid-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const UrlEncoderRoute = UrlEncoderRouteImport.update({
-  id: '/url-encoder',
-  path: '/url-encoder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/url-encoder',
+	path: '/url-encoder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const StringCompressorRoute = StringCompressorRouteImport.update({
-  id: '/string-compressor',
-  path: '/string-compressor',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/string-compressor',
+	path: '/string-compressor',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const StringCaseConverterRoute = StringCaseConverterRouteImport.update({
-  id: '/string-case-converter',
-  path: '/string-case-converter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/string-case-converter',
+	path: '/string-case-converter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const SshKeyGeneratorRoute = SshKeyGeneratorRouteImport.update({
-  id: '/ssh-key-generator',
-  path: '/ssh-key-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/ssh-key-generator',
+	path: '/ssh-key-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const SqlFormatterRoute = SqlFormatterRouteImport.update({
-  id: '/sql-formatter',
-  path: '/sql-formatter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/sql-formatter',
+	path: '/sql-formatter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const SettingsRoute = SettingsRouteImport.update({
-  id: '/settings',
-  path: '/settings',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/settings',
+	path: '/settings',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const SemverToolsRoute = SemverToolsRouteImport.update({
-  id: '/semver-tools',
-  path: '/semver-tools',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/semver-tools',
+	path: '/semver-tools',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const RsaToolsRoute = RsaToolsRouteImport.update({
-  id: '/rsa-tools',
-  path: '/rsa-tools',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/rsa-tools',
+	path: '/rsa-tools',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const RestClientRoute = RestClientRouteImport.update({
-  id: '/rest-client',
-  path: '/rest-client',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/rest-client',
+	path: '/rest-client',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const RegexTesterRoute = RegexTesterRouteImport.update({
-  id: '/regex-tester',
-  path: '/regex-tester',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/regex-tester',
+	path: '/regex-tester',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const QrCodeGeneratorRoute = QrCodeGeneratorRouteImport.update({
-  id: '/qr-code-generator',
-  path: '/qr-code-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/qr-code-generator',
+	path: '/qr-code-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const PasswordGeneratorRoute = PasswordGeneratorRouteImport.update({
-  id: '/password-generator',
-  path: '/password-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/password-generator',
+	path: '/password-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const NumberBaseConverterRoute = NumberBaseConverterRouteImport.update({
-  id: '/number-base-converter',
-  path: '/number-base-converter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/number-base-converter',
+	path: '/number-base-converter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const NetworkScannerRoute = NetworkScannerRouteImport.update({
-  id: '/network-scanner',
-  path: '/network-scanner',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/network-scanner',
+	path: '/network-scanner',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const NetworkInterfacesRoute = NetworkInterfacesRouteImport.update({
-  id: '/network-interfaces',
-  path: '/network-interfaces',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/network-interfaces',
+	path: '/network-interfaces',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const MimeTypesRoute = MimeTypesRouteImport.update({
-  id: '/mime-types',
-  path: '/mime-types',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/mime-types',
+	path: '/mime-types',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const MarkdownEditorRoute = MarkdownEditorRouteImport.update({
-  id: '/markdown-editor',
-  path: '/markdown-editor',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/markdown-editor',
+	path: '/markdown-editor',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const MacLookupRoute = MacLookupRouteImport.update({
-  id: '/mac-lookup',
-  path: '/mac-lookup',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/mac-lookup',
+	path: '/mac-lookup',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const LoremIpsumRoute = LoremIpsumRouteImport.update({
-  id: '/lorem-ipsum',
-  path: '/lorem-ipsum',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/lorem-ipsum',
+	path: '/lorem-ipsum',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const ListComparerRoute = ListComparerRouteImport.update({
-  id: '/list-comparer',
-  path: '/list-comparer',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/list-comparer',
+	path: '/list-comparer',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const JwtDecoderRoute = JwtDecoderRouteImport.update({
-  id: '/jwt-decoder',
-  path: '/jwt-decoder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/jwt-decoder',
+	path: '/jwt-decoder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const JsonFormatterRoute = JsonFormatterRouteImport.update({
-  id: '/json-formatter',
-  path: '/json-formatter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/json-formatter',
+	path: '/json-formatter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const IpConverterRoute = IpConverterRouteImport.update({
-  id: '/ip-converter',
-  path: '/ip-converter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/ip-converter',
+	path: '/ip-converter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const ImageConverterRoute = ImageConverterRouteImport.update({
-  id: '/image-converter',
-  path: '/image-converter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/image-converter',
+	path: '/image-converter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const HttpStatusCodesRoute = HttpStatusCodesRouteImport.update({
-  id: '/http-status-codes',
-  path: '/http-status-codes',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/http-status-codes',
+	path: '/http-status-codes',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const HashGeneratorRoute = HashGeneratorRouteImport.update({
-  id: '/hash-generator',
-  path: '/hash-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/hash-generator',
+	path: '/hash-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const GpgKeyGeneratorRoute = GpgKeyGeneratorRouteImport.update({
-  id: '/gpg-key-generator',
-  path: '/gpg-key-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/gpg-key-generator',
+	path: '/gpg-key-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const EscapeToolRoute = EscapeToolRouteImport.update({
-  id: '/escape-tool',
-  path: '/escape-tool',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/escape-tool',
+	path: '/escape-tool',
+	getParentRoute: () => rootRouteImport,
+} as any);
+const DnsLookupRoute = DnsLookupRouteImport.update({
+	id: '/dns-lookup',
+	path: '/dns-lookup',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const DiffViewerRoute = DiffViewerRouteImport.update({
-  id: '/diff-viewer',
-  path: '/diff-viewer',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/diff-viewer',
+	path: '/diff-viewer',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const DateTimestampConverterRoute = DateTimestampConverterRouteImport.update({
-  id: '/date-timestamp-converter',
-  path: '/date-timestamp-converter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/date-timestamp-converter',
+	path: '/date-timestamp-converter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const CurlBuilderRoute = CurlBuilderRouteImport.update({
-  id: '/curl-builder',
-  path: '/curl-builder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/curl-builder',
+	path: '/curl-builder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const CronExpressionBuilderRoute = CronExpressionBuilderRouteImport.update({
-  id: '/cron-expression-builder',
-  path: '/cron-expression-builder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/cron-expression-builder',
+	path: '/cron-expression-builder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const CidrCalculatorRoute = CidrCalculatorRouteImport.update({
-  id: '/cidr-calculator',
-  path: '/cidr-calculator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/cidr-calculator',
+	path: '/cidr-calculator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const BcryptGeneratorRoute = BcryptGeneratorRouteImport.update({
-  id: '/bcrypt-generator',
-  path: '/bcrypt-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/bcrypt-generator',
+	path: '/bcrypt-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const Base64EncoderRoute = Base64EncoderRouteImport.update({
-  id: '/base64-encoder',
-  path: '/base64-encoder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/base64-encoder',
+	path: '/base64-encoder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/',
+	path: '/',
+	getParentRoute: () => rootRouteImport,
+} as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/base64-encoder': typeof Base64EncoderRoute
-  '/bcrypt-generator': typeof BcryptGeneratorRoute
-  '/cidr-calculator': typeof CidrCalculatorRoute
-  '/cron-expression-builder': typeof CronExpressionBuilderRoute
-  '/curl-builder': typeof CurlBuilderRoute
-  '/date-timestamp-converter': typeof DateTimestampConverterRoute
-  '/diff-viewer': typeof DiffViewerRoute
-  '/escape-tool': typeof EscapeToolRoute
-  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
-  '/hash-generator': typeof HashGeneratorRoute
-  '/http-status-codes': typeof HttpStatusCodesRoute
-  '/image-converter': typeof ImageConverterRoute
-  '/ip-converter': typeof IpConverterRoute
-  '/json-formatter': typeof JsonFormatterRoute
-  '/jwt-decoder': typeof JwtDecoderRoute
-  '/list-comparer': typeof ListComparerRoute
-  '/lorem-ipsum': typeof LoremIpsumRoute
-  '/mac-lookup': typeof MacLookupRoute
-  '/markdown-editor': typeof MarkdownEditorRoute
-  '/mime-types': typeof MimeTypesRoute
-  '/network-interfaces': typeof NetworkInterfacesRoute
-  '/network-scanner': typeof NetworkScannerRoute
-  '/number-base-converter': typeof NumberBaseConverterRoute
-  '/password-generator': typeof PasswordGeneratorRoute
-  '/qr-code-generator': typeof QrCodeGeneratorRoute
-  '/regex-tester': typeof RegexTesterRoute
-  '/rest-client': typeof RestClientRoute
-  '/rsa-tools': typeof RsaToolsRoute
-  '/semver-tools': typeof SemverToolsRoute
-  '/settings': typeof SettingsRoute
-  '/sql-formatter': typeof SqlFormatterRoute
-  '/ssh-key-generator': typeof SshKeyGeneratorRoute
-  '/string-case-converter': typeof StringCaseConverterRoute
-  '/string-compressor': typeof StringCompressorRoute
-  '/url-encoder': typeof UrlEncoderRoute
-  '/uuid-generator': typeof UuidGeneratorRoute
-  '/x509-decoder': typeof X509DecoderRoute
-  '/xml-formatter': typeof XmlFormatterRoute
-  '/yaml-formatter': typeof YamlFormatterRoute
+	'/': typeof IndexRoute;
+	'/base64-encoder': typeof Base64EncoderRoute;
+	'/bcrypt-generator': typeof BcryptGeneratorRoute;
+	'/cidr-calculator': typeof CidrCalculatorRoute;
+	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
+	'/curl-builder': typeof CurlBuilderRoute;
+	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
+	'/diff-viewer': typeof DiffViewerRoute;
+	'/dns-lookup': typeof DnsLookupRoute;
+	'/escape-tool': typeof EscapeToolRoute;
+	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
+	'/hash-generator': typeof HashGeneratorRoute;
+	'/http-status-codes': typeof HttpStatusCodesRoute;
+	'/image-converter': typeof ImageConverterRoute;
+	'/ip-converter': typeof IpConverterRoute;
+	'/json-formatter': typeof JsonFormatterRoute;
+	'/jwt-decoder': typeof JwtDecoderRoute;
+	'/list-comparer': typeof ListComparerRoute;
+	'/lorem-ipsum': typeof LoremIpsumRoute;
+	'/mac-lookup': typeof MacLookupRoute;
+	'/markdown-editor': typeof MarkdownEditorRoute;
+	'/mime-types': typeof MimeTypesRoute;
+	'/network-interfaces': typeof NetworkInterfacesRoute;
+	'/network-scanner': typeof NetworkScannerRoute;
+	'/number-base-converter': typeof NumberBaseConverterRoute;
+	'/password-generator': typeof PasswordGeneratorRoute;
+	'/qr-code-generator': typeof QrCodeGeneratorRoute;
+	'/regex-tester': typeof RegexTesterRoute;
+	'/rest-client': typeof RestClientRoute;
+	'/rsa-tools': typeof RsaToolsRoute;
+	'/semver-tools': typeof SemverToolsRoute;
+	'/settings': typeof SettingsRoute;
+	'/sql-formatter': typeof SqlFormatterRoute;
+	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
+	'/string-case-converter': typeof StringCaseConverterRoute;
+	'/string-compressor': typeof StringCompressorRoute;
+	'/url-encoder': typeof UrlEncoderRoute;
+	'/uuid-generator': typeof UuidGeneratorRoute;
+	'/x509-decoder': typeof X509DecoderRoute;
+	'/xml-formatter': typeof XmlFormatterRoute;
+	'/yaml-formatter': typeof YamlFormatterRoute;
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/base64-encoder': typeof Base64EncoderRoute
-  '/bcrypt-generator': typeof BcryptGeneratorRoute
-  '/cidr-calculator': typeof CidrCalculatorRoute
-  '/cron-expression-builder': typeof CronExpressionBuilderRoute
-  '/curl-builder': typeof CurlBuilderRoute
-  '/date-timestamp-converter': typeof DateTimestampConverterRoute
-  '/diff-viewer': typeof DiffViewerRoute
-  '/escape-tool': typeof EscapeToolRoute
-  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
-  '/hash-generator': typeof HashGeneratorRoute
-  '/http-status-codes': typeof HttpStatusCodesRoute
-  '/image-converter': typeof ImageConverterRoute
-  '/ip-converter': typeof IpConverterRoute
-  '/json-formatter': typeof JsonFormatterRoute
-  '/jwt-decoder': typeof JwtDecoderRoute
-  '/list-comparer': typeof ListComparerRoute
-  '/lorem-ipsum': typeof LoremIpsumRoute
-  '/mac-lookup': typeof MacLookupRoute
-  '/markdown-editor': typeof MarkdownEditorRoute
-  '/mime-types': typeof MimeTypesRoute
-  '/network-interfaces': typeof NetworkInterfacesRoute
-  '/network-scanner': typeof NetworkScannerRoute
-  '/number-base-converter': typeof NumberBaseConverterRoute
-  '/password-generator': typeof PasswordGeneratorRoute
-  '/qr-code-generator': typeof QrCodeGeneratorRoute
-  '/regex-tester': typeof RegexTesterRoute
-  '/rest-client': typeof RestClientRoute
-  '/rsa-tools': typeof RsaToolsRoute
-  '/semver-tools': typeof SemverToolsRoute
-  '/settings': typeof SettingsRoute
-  '/sql-formatter': typeof SqlFormatterRoute
-  '/ssh-key-generator': typeof SshKeyGeneratorRoute
-  '/string-case-converter': typeof StringCaseConverterRoute
-  '/string-compressor': typeof StringCompressorRoute
-  '/url-encoder': typeof UrlEncoderRoute
-  '/uuid-generator': typeof UuidGeneratorRoute
-  '/x509-decoder': typeof X509DecoderRoute
-  '/xml-formatter': typeof XmlFormatterRoute
-  '/yaml-formatter': typeof YamlFormatterRoute
+	'/': typeof IndexRoute;
+	'/base64-encoder': typeof Base64EncoderRoute;
+	'/bcrypt-generator': typeof BcryptGeneratorRoute;
+	'/cidr-calculator': typeof CidrCalculatorRoute;
+	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
+	'/curl-builder': typeof CurlBuilderRoute;
+	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
+	'/diff-viewer': typeof DiffViewerRoute;
+	'/dns-lookup': typeof DnsLookupRoute;
+	'/escape-tool': typeof EscapeToolRoute;
+	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
+	'/hash-generator': typeof HashGeneratorRoute;
+	'/http-status-codes': typeof HttpStatusCodesRoute;
+	'/image-converter': typeof ImageConverterRoute;
+	'/ip-converter': typeof IpConverterRoute;
+	'/json-formatter': typeof JsonFormatterRoute;
+	'/jwt-decoder': typeof JwtDecoderRoute;
+	'/list-comparer': typeof ListComparerRoute;
+	'/lorem-ipsum': typeof LoremIpsumRoute;
+	'/mac-lookup': typeof MacLookupRoute;
+	'/markdown-editor': typeof MarkdownEditorRoute;
+	'/mime-types': typeof MimeTypesRoute;
+	'/network-interfaces': typeof NetworkInterfacesRoute;
+	'/network-scanner': typeof NetworkScannerRoute;
+	'/number-base-converter': typeof NumberBaseConverterRoute;
+	'/password-generator': typeof PasswordGeneratorRoute;
+	'/qr-code-generator': typeof QrCodeGeneratorRoute;
+	'/regex-tester': typeof RegexTesterRoute;
+	'/rest-client': typeof RestClientRoute;
+	'/rsa-tools': typeof RsaToolsRoute;
+	'/semver-tools': typeof SemverToolsRoute;
+	'/settings': typeof SettingsRoute;
+	'/sql-formatter': typeof SqlFormatterRoute;
+	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
+	'/string-case-converter': typeof StringCaseConverterRoute;
+	'/string-compressor': typeof StringCompressorRoute;
+	'/url-encoder': typeof UrlEncoderRoute;
+	'/uuid-generator': typeof UuidGeneratorRoute;
+	'/x509-decoder': typeof X509DecoderRoute;
+	'/xml-formatter': typeof XmlFormatterRoute;
+	'/yaml-formatter': typeof YamlFormatterRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/base64-encoder': typeof Base64EncoderRoute
-  '/bcrypt-generator': typeof BcryptGeneratorRoute
-  '/cidr-calculator': typeof CidrCalculatorRoute
-  '/cron-expression-builder': typeof CronExpressionBuilderRoute
-  '/curl-builder': typeof CurlBuilderRoute
-  '/date-timestamp-converter': typeof DateTimestampConverterRoute
-  '/diff-viewer': typeof DiffViewerRoute
-  '/escape-tool': typeof EscapeToolRoute
-  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
-  '/hash-generator': typeof HashGeneratorRoute
-  '/http-status-codes': typeof HttpStatusCodesRoute
-  '/image-converter': typeof ImageConverterRoute
-  '/ip-converter': typeof IpConverterRoute
-  '/json-formatter': typeof JsonFormatterRoute
-  '/jwt-decoder': typeof JwtDecoderRoute
-  '/list-comparer': typeof ListComparerRoute
-  '/lorem-ipsum': typeof LoremIpsumRoute
-  '/mac-lookup': typeof MacLookupRoute
-  '/markdown-editor': typeof MarkdownEditorRoute
-  '/mime-types': typeof MimeTypesRoute
-  '/network-interfaces': typeof NetworkInterfacesRoute
-  '/network-scanner': typeof NetworkScannerRoute
-  '/number-base-converter': typeof NumberBaseConverterRoute
-  '/password-generator': typeof PasswordGeneratorRoute
-  '/qr-code-generator': typeof QrCodeGeneratorRoute
-  '/regex-tester': typeof RegexTesterRoute
-  '/rest-client': typeof RestClientRoute
-  '/rsa-tools': typeof RsaToolsRoute
-  '/semver-tools': typeof SemverToolsRoute
-  '/settings': typeof SettingsRoute
-  '/sql-formatter': typeof SqlFormatterRoute
-  '/ssh-key-generator': typeof SshKeyGeneratorRoute
-  '/string-case-converter': typeof StringCaseConverterRoute
-  '/string-compressor': typeof StringCompressorRoute
-  '/url-encoder': typeof UrlEncoderRoute
-  '/uuid-generator': typeof UuidGeneratorRoute
-  '/x509-decoder': typeof X509DecoderRoute
-  '/xml-formatter': typeof XmlFormatterRoute
-  '/yaml-formatter': typeof YamlFormatterRoute
+	__root__: typeof rootRouteImport;
+	'/': typeof IndexRoute;
+	'/base64-encoder': typeof Base64EncoderRoute;
+	'/bcrypt-generator': typeof BcryptGeneratorRoute;
+	'/cidr-calculator': typeof CidrCalculatorRoute;
+	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
+	'/curl-builder': typeof CurlBuilderRoute;
+	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
+	'/diff-viewer': typeof DiffViewerRoute;
+	'/dns-lookup': typeof DnsLookupRoute;
+	'/escape-tool': typeof EscapeToolRoute;
+	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
+	'/hash-generator': typeof HashGeneratorRoute;
+	'/http-status-codes': typeof HttpStatusCodesRoute;
+	'/image-converter': typeof ImageConverterRoute;
+	'/ip-converter': typeof IpConverterRoute;
+	'/json-formatter': typeof JsonFormatterRoute;
+	'/jwt-decoder': typeof JwtDecoderRoute;
+	'/list-comparer': typeof ListComparerRoute;
+	'/lorem-ipsum': typeof LoremIpsumRoute;
+	'/mac-lookup': typeof MacLookupRoute;
+	'/markdown-editor': typeof MarkdownEditorRoute;
+	'/mime-types': typeof MimeTypesRoute;
+	'/network-interfaces': typeof NetworkInterfacesRoute;
+	'/network-scanner': typeof NetworkScannerRoute;
+	'/number-base-converter': typeof NumberBaseConverterRoute;
+	'/password-generator': typeof PasswordGeneratorRoute;
+	'/qr-code-generator': typeof QrCodeGeneratorRoute;
+	'/regex-tester': typeof RegexTesterRoute;
+	'/rest-client': typeof RestClientRoute;
+	'/rsa-tools': typeof RsaToolsRoute;
+	'/semver-tools': typeof SemverToolsRoute;
+	'/settings': typeof SettingsRoute;
+	'/sql-formatter': typeof SqlFormatterRoute;
+	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
+	'/string-case-converter': typeof StringCaseConverterRoute;
+	'/string-compressor': typeof StringCompressorRoute;
+	'/url-encoder': typeof UrlEncoderRoute;
+	'/uuid-generator': typeof UuidGeneratorRoute;
+	'/x509-decoder': typeof X509DecoderRoute;
+	'/xml-formatter': typeof XmlFormatterRoute;
+	'/yaml-formatter': typeof YamlFormatterRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths:
-    | '/'
-    | '/base64-encoder'
-    | '/bcrypt-generator'
-    | '/cidr-calculator'
-    | '/cron-expression-builder'
-    | '/curl-builder'
-    | '/date-timestamp-converter'
-    | '/diff-viewer'
-    | '/escape-tool'
-    | '/gpg-key-generator'
-    | '/hash-generator'
-    | '/http-status-codes'
-    | '/image-converter'
-    | '/ip-converter'
-    | '/json-formatter'
-    | '/jwt-decoder'
-    | '/list-comparer'
-    | '/lorem-ipsum'
-    | '/mac-lookup'
-    | '/markdown-editor'
-    | '/mime-types'
-    | '/network-interfaces'
-    | '/network-scanner'
-    | '/number-base-converter'
-    | '/password-generator'
-    | '/qr-code-generator'
-    | '/regex-tester'
-    | '/rest-client'
-    | '/rsa-tools'
-    | '/semver-tools'
-    | '/settings'
-    | '/sql-formatter'
-    | '/ssh-key-generator'
-    | '/string-case-converter'
-    | '/string-compressor'
-    | '/url-encoder'
-    | '/uuid-generator'
-    | '/x509-decoder'
-    | '/xml-formatter'
-    | '/yaml-formatter'
-  fileRoutesByTo: FileRoutesByTo
-  to:
-    | '/'
-    | '/base64-encoder'
-    | '/bcrypt-generator'
-    | '/cidr-calculator'
-    | '/cron-expression-builder'
-    | '/curl-builder'
-    | '/date-timestamp-converter'
-    | '/diff-viewer'
-    | '/escape-tool'
-    | '/gpg-key-generator'
-    | '/hash-generator'
-    | '/http-status-codes'
-    | '/image-converter'
-    | '/ip-converter'
-    | '/json-formatter'
-    | '/jwt-decoder'
-    | '/list-comparer'
-    | '/lorem-ipsum'
-    | '/mac-lookup'
-    | '/markdown-editor'
-    | '/mime-types'
-    | '/network-interfaces'
-    | '/network-scanner'
-    | '/number-base-converter'
-    | '/password-generator'
-    | '/qr-code-generator'
-    | '/regex-tester'
-    | '/rest-client'
-    | '/rsa-tools'
-    | '/semver-tools'
-    | '/settings'
-    | '/sql-formatter'
-    | '/ssh-key-generator'
-    | '/string-case-converter'
-    | '/string-compressor'
-    | '/url-encoder'
-    | '/uuid-generator'
-    | '/x509-decoder'
-    | '/xml-formatter'
-    | '/yaml-formatter'
-  id:
-    | '__root__'
-    | '/'
-    | '/base64-encoder'
-    | '/bcrypt-generator'
-    | '/cidr-calculator'
-    | '/cron-expression-builder'
-    | '/curl-builder'
-    | '/date-timestamp-converter'
-    | '/diff-viewer'
-    | '/escape-tool'
-    | '/gpg-key-generator'
-    | '/hash-generator'
-    | '/http-status-codes'
-    | '/image-converter'
-    | '/ip-converter'
-    | '/json-formatter'
-    | '/jwt-decoder'
-    | '/list-comparer'
-    | '/lorem-ipsum'
-    | '/mac-lookup'
-    | '/markdown-editor'
-    | '/mime-types'
-    | '/network-interfaces'
-    | '/network-scanner'
-    | '/number-base-converter'
-    | '/password-generator'
-    | '/qr-code-generator'
-    | '/regex-tester'
-    | '/rest-client'
-    | '/rsa-tools'
-    | '/semver-tools'
-    | '/settings'
-    | '/sql-formatter'
-    | '/ssh-key-generator'
-    | '/string-case-converter'
-    | '/string-compressor'
-    | '/url-encoder'
-    | '/uuid-generator'
-    | '/x509-decoder'
-    | '/xml-formatter'
-    | '/yaml-formatter'
-  fileRoutesById: FileRoutesById
+	fileRoutesByFullPath: FileRoutesByFullPath;
+	fullPaths:
+		| '/'
+		| '/base64-encoder'
+		| '/bcrypt-generator'
+		| '/cidr-calculator'
+		| '/cron-expression-builder'
+		| '/curl-builder'
+		| '/date-timestamp-converter'
+		| '/diff-viewer'
+		| '/dns-lookup'
+		| '/escape-tool'
+		| '/gpg-key-generator'
+		| '/hash-generator'
+		| '/http-status-codes'
+		| '/image-converter'
+		| '/ip-converter'
+		| '/json-formatter'
+		| '/jwt-decoder'
+		| '/list-comparer'
+		| '/lorem-ipsum'
+		| '/mac-lookup'
+		| '/markdown-editor'
+		| '/mime-types'
+		| '/network-interfaces'
+		| '/network-scanner'
+		| '/number-base-converter'
+		| '/password-generator'
+		| '/qr-code-generator'
+		| '/regex-tester'
+		| '/rest-client'
+		| '/rsa-tools'
+		| '/semver-tools'
+		| '/settings'
+		| '/sql-formatter'
+		| '/ssh-key-generator'
+		| '/string-case-converter'
+		| '/string-compressor'
+		| '/url-encoder'
+		| '/uuid-generator'
+		| '/x509-decoder'
+		| '/xml-formatter'
+		| '/yaml-formatter';
+	fileRoutesByTo: FileRoutesByTo;
+	to:
+		| '/'
+		| '/base64-encoder'
+		| '/bcrypt-generator'
+		| '/cidr-calculator'
+		| '/cron-expression-builder'
+		| '/curl-builder'
+		| '/date-timestamp-converter'
+		| '/diff-viewer'
+		| '/dns-lookup'
+		| '/escape-tool'
+		| '/gpg-key-generator'
+		| '/hash-generator'
+		| '/http-status-codes'
+		| '/image-converter'
+		| '/ip-converter'
+		| '/json-formatter'
+		| '/jwt-decoder'
+		| '/list-comparer'
+		| '/lorem-ipsum'
+		| '/mac-lookup'
+		| '/markdown-editor'
+		| '/mime-types'
+		| '/network-interfaces'
+		| '/network-scanner'
+		| '/number-base-converter'
+		| '/password-generator'
+		| '/qr-code-generator'
+		| '/regex-tester'
+		| '/rest-client'
+		| '/rsa-tools'
+		| '/semver-tools'
+		| '/settings'
+		| '/sql-formatter'
+		| '/ssh-key-generator'
+		| '/string-case-converter'
+		| '/string-compressor'
+		| '/url-encoder'
+		| '/uuid-generator'
+		| '/x509-decoder'
+		| '/xml-formatter'
+		| '/yaml-formatter';
+	id:
+		| '__root__'
+		| '/'
+		| '/base64-encoder'
+		| '/bcrypt-generator'
+		| '/cidr-calculator'
+		| '/cron-expression-builder'
+		| '/curl-builder'
+		| '/date-timestamp-converter'
+		| '/diff-viewer'
+		| '/dns-lookup'
+		| '/escape-tool'
+		| '/gpg-key-generator'
+		| '/hash-generator'
+		| '/http-status-codes'
+		| '/image-converter'
+		| '/ip-converter'
+		| '/json-formatter'
+		| '/jwt-decoder'
+		| '/list-comparer'
+		| '/lorem-ipsum'
+		| '/mac-lookup'
+		| '/markdown-editor'
+		| '/mime-types'
+		| '/network-interfaces'
+		| '/network-scanner'
+		| '/number-base-converter'
+		| '/password-generator'
+		| '/qr-code-generator'
+		| '/regex-tester'
+		| '/rest-client'
+		| '/rsa-tools'
+		| '/semver-tools'
+		| '/settings'
+		| '/sql-formatter'
+		| '/ssh-key-generator'
+		| '/string-case-converter'
+		| '/string-compressor'
+		| '/url-encoder'
+		| '/uuid-generator'
+		| '/x509-decoder'
+		| '/xml-formatter'
+		| '/yaml-formatter';
+	fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  Base64EncoderRoute: typeof Base64EncoderRoute
-  BcryptGeneratorRoute: typeof BcryptGeneratorRoute
-  CidrCalculatorRoute: typeof CidrCalculatorRoute
-  CronExpressionBuilderRoute: typeof CronExpressionBuilderRoute
-  CurlBuilderRoute: typeof CurlBuilderRoute
-  DateTimestampConverterRoute: typeof DateTimestampConverterRoute
-  DiffViewerRoute: typeof DiffViewerRoute
-  EscapeToolRoute: typeof EscapeToolRoute
-  GpgKeyGeneratorRoute: typeof GpgKeyGeneratorRoute
-  HashGeneratorRoute: typeof HashGeneratorRoute
-  HttpStatusCodesRoute: typeof HttpStatusCodesRoute
-  ImageConverterRoute: typeof ImageConverterRoute
-  IpConverterRoute: typeof IpConverterRoute
-  JsonFormatterRoute: typeof JsonFormatterRoute
-  JwtDecoderRoute: typeof JwtDecoderRoute
-  ListComparerRoute: typeof ListComparerRoute
-  LoremIpsumRoute: typeof LoremIpsumRoute
-  MacLookupRoute: typeof MacLookupRoute
-  MarkdownEditorRoute: typeof MarkdownEditorRoute
-  MimeTypesRoute: typeof MimeTypesRoute
-  NetworkInterfacesRoute: typeof NetworkInterfacesRoute
-  NetworkScannerRoute: typeof NetworkScannerRoute
-  NumberBaseConverterRoute: typeof NumberBaseConverterRoute
-  PasswordGeneratorRoute: typeof PasswordGeneratorRoute
-  QrCodeGeneratorRoute: typeof QrCodeGeneratorRoute
-  RegexTesterRoute: typeof RegexTesterRoute
-  RestClientRoute: typeof RestClientRoute
-  RsaToolsRoute: typeof RsaToolsRoute
-  SemverToolsRoute: typeof SemverToolsRoute
-  SettingsRoute: typeof SettingsRoute
-  SqlFormatterRoute: typeof SqlFormatterRoute
-  SshKeyGeneratorRoute: typeof SshKeyGeneratorRoute
-  StringCaseConverterRoute: typeof StringCaseConverterRoute
-  StringCompressorRoute: typeof StringCompressorRoute
-  UrlEncoderRoute: typeof UrlEncoderRoute
-  UuidGeneratorRoute: typeof UuidGeneratorRoute
-  X509DecoderRoute: typeof X509DecoderRoute
-  XmlFormatterRoute: typeof XmlFormatterRoute
-  YamlFormatterRoute: typeof YamlFormatterRoute
+	IndexRoute: typeof IndexRoute;
+	Base64EncoderRoute: typeof Base64EncoderRoute;
+	BcryptGeneratorRoute: typeof BcryptGeneratorRoute;
+	CidrCalculatorRoute: typeof CidrCalculatorRoute;
+	CronExpressionBuilderRoute: typeof CronExpressionBuilderRoute;
+	CurlBuilderRoute: typeof CurlBuilderRoute;
+	DateTimestampConverterRoute: typeof DateTimestampConverterRoute;
+	DiffViewerRoute: typeof DiffViewerRoute;
+	DnsLookupRoute: typeof DnsLookupRoute;
+	EscapeToolRoute: typeof EscapeToolRoute;
+	GpgKeyGeneratorRoute: typeof GpgKeyGeneratorRoute;
+	HashGeneratorRoute: typeof HashGeneratorRoute;
+	HttpStatusCodesRoute: typeof HttpStatusCodesRoute;
+	ImageConverterRoute: typeof ImageConverterRoute;
+	IpConverterRoute: typeof IpConverterRoute;
+	JsonFormatterRoute: typeof JsonFormatterRoute;
+	JwtDecoderRoute: typeof JwtDecoderRoute;
+	ListComparerRoute: typeof ListComparerRoute;
+	LoremIpsumRoute: typeof LoremIpsumRoute;
+	MacLookupRoute: typeof MacLookupRoute;
+	MarkdownEditorRoute: typeof MarkdownEditorRoute;
+	MimeTypesRoute: typeof MimeTypesRoute;
+	NetworkInterfacesRoute: typeof NetworkInterfacesRoute;
+	NetworkScannerRoute: typeof NetworkScannerRoute;
+	NumberBaseConverterRoute: typeof NumberBaseConverterRoute;
+	PasswordGeneratorRoute: typeof PasswordGeneratorRoute;
+	QrCodeGeneratorRoute: typeof QrCodeGeneratorRoute;
+	RegexTesterRoute: typeof RegexTesterRoute;
+	RestClientRoute: typeof RestClientRoute;
+	RsaToolsRoute: typeof RsaToolsRoute;
+	SemverToolsRoute: typeof SemverToolsRoute;
+	SettingsRoute: typeof SettingsRoute;
+	SqlFormatterRoute: typeof SqlFormatterRoute;
+	SshKeyGeneratorRoute: typeof SshKeyGeneratorRoute;
+	StringCaseConverterRoute: typeof StringCaseConverterRoute;
+	StringCompressorRoute: typeof StringCompressorRoute;
+	UrlEncoderRoute: typeof UrlEncoderRoute;
+	UuidGeneratorRoute: typeof UuidGeneratorRoute;
+	X509DecoderRoute: typeof X509DecoderRoute;
+	XmlFormatterRoute: typeof XmlFormatterRoute;
+	YamlFormatterRoute: typeof YamlFormatterRoute;
 }
 
 declare module '@tanstack/react-router' {
-  interface FileRoutesByPath {
-    '/yaml-formatter': {
-      id: '/yaml-formatter'
-      path: '/yaml-formatter'
-      fullPath: '/yaml-formatter'
-      preLoaderRoute: typeof YamlFormatterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/xml-formatter': {
-      id: '/xml-formatter'
-      path: '/xml-formatter'
-      fullPath: '/xml-formatter'
-      preLoaderRoute: typeof XmlFormatterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/x509-decoder': {
-      id: '/x509-decoder'
-      path: '/x509-decoder'
-      fullPath: '/x509-decoder'
-      preLoaderRoute: typeof X509DecoderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/uuid-generator': {
-      id: '/uuid-generator'
-      path: '/uuid-generator'
-      fullPath: '/uuid-generator'
-      preLoaderRoute: typeof UuidGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/url-encoder': {
-      id: '/url-encoder'
-      path: '/url-encoder'
-      fullPath: '/url-encoder'
-      preLoaderRoute: typeof UrlEncoderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/string-compressor': {
-      id: '/string-compressor'
-      path: '/string-compressor'
-      fullPath: '/string-compressor'
-      preLoaderRoute: typeof StringCompressorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/string-case-converter': {
-      id: '/string-case-converter'
-      path: '/string-case-converter'
-      fullPath: '/string-case-converter'
-      preLoaderRoute: typeof StringCaseConverterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/ssh-key-generator': {
-      id: '/ssh-key-generator'
-      path: '/ssh-key-generator'
-      fullPath: '/ssh-key-generator'
-      preLoaderRoute: typeof SshKeyGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/sql-formatter': {
-      id: '/sql-formatter'
-      path: '/sql-formatter'
-      fullPath: '/sql-formatter'
-      preLoaderRoute: typeof SqlFormatterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/settings': {
-      id: '/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof SettingsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/semver-tools': {
-      id: '/semver-tools'
-      path: '/semver-tools'
-      fullPath: '/semver-tools'
-      preLoaderRoute: typeof SemverToolsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/rsa-tools': {
-      id: '/rsa-tools'
-      path: '/rsa-tools'
-      fullPath: '/rsa-tools'
-      preLoaderRoute: typeof RsaToolsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/rest-client': {
-      id: '/rest-client'
-      path: '/rest-client'
-      fullPath: '/rest-client'
-      preLoaderRoute: typeof RestClientRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/regex-tester': {
-      id: '/regex-tester'
-      path: '/regex-tester'
-      fullPath: '/regex-tester'
-      preLoaderRoute: typeof RegexTesterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/qr-code-generator': {
-      id: '/qr-code-generator'
-      path: '/qr-code-generator'
-      fullPath: '/qr-code-generator'
-      preLoaderRoute: typeof QrCodeGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/password-generator': {
-      id: '/password-generator'
-      path: '/password-generator'
-      fullPath: '/password-generator'
-      preLoaderRoute: typeof PasswordGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/number-base-converter': {
-      id: '/number-base-converter'
-      path: '/number-base-converter'
-      fullPath: '/number-base-converter'
-      preLoaderRoute: typeof NumberBaseConverterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/network-scanner': {
-      id: '/network-scanner'
-      path: '/network-scanner'
-      fullPath: '/network-scanner'
-      preLoaderRoute: typeof NetworkScannerRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/network-interfaces': {
-      id: '/network-interfaces'
-      path: '/network-interfaces'
-      fullPath: '/network-interfaces'
-      preLoaderRoute: typeof NetworkInterfacesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/mime-types': {
-      id: '/mime-types'
-      path: '/mime-types'
-      fullPath: '/mime-types'
-      preLoaderRoute: typeof MimeTypesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/markdown-editor': {
-      id: '/markdown-editor'
-      path: '/markdown-editor'
-      fullPath: '/markdown-editor'
-      preLoaderRoute: typeof MarkdownEditorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/mac-lookup': {
-      id: '/mac-lookup'
-      path: '/mac-lookup'
-      fullPath: '/mac-lookup'
-      preLoaderRoute: typeof MacLookupRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/lorem-ipsum': {
-      id: '/lorem-ipsum'
-      path: '/lorem-ipsum'
-      fullPath: '/lorem-ipsum'
-      preLoaderRoute: typeof LoremIpsumRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/list-comparer': {
-      id: '/list-comparer'
-      path: '/list-comparer'
-      fullPath: '/list-comparer'
-      preLoaderRoute: typeof ListComparerRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/jwt-decoder': {
-      id: '/jwt-decoder'
-      path: '/jwt-decoder'
-      fullPath: '/jwt-decoder'
-      preLoaderRoute: typeof JwtDecoderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/json-formatter': {
-      id: '/json-formatter'
-      path: '/json-formatter'
-      fullPath: '/json-formatter'
-      preLoaderRoute: typeof JsonFormatterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/ip-converter': {
-      id: '/ip-converter'
-      path: '/ip-converter'
-      fullPath: '/ip-converter'
-      preLoaderRoute: typeof IpConverterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/image-converter': {
-      id: '/image-converter'
-      path: '/image-converter'
-      fullPath: '/image-converter'
-      preLoaderRoute: typeof ImageConverterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/http-status-codes': {
-      id: '/http-status-codes'
-      path: '/http-status-codes'
-      fullPath: '/http-status-codes'
-      preLoaderRoute: typeof HttpStatusCodesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/hash-generator': {
-      id: '/hash-generator'
-      path: '/hash-generator'
-      fullPath: '/hash-generator'
-      preLoaderRoute: typeof HashGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/gpg-key-generator': {
-      id: '/gpg-key-generator'
-      path: '/gpg-key-generator'
-      fullPath: '/gpg-key-generator'
-      preLoaderRoute: typeof GpgKeyGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/escape-tool': {
-      id: '/escape-tool'
-      path: '/escape-tool'
-      fullPath: '/escape-tool'
-      preLoaderRoute: typeof EscapeToolRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/diff-viewer': {
-      id: '/diff-viewer'
-      path: '/diff-viewer'
-      fullPath: '/diff-viewer'
-      preLoaderRoute: typeof DiffViewerRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/date-timestamp-converter': {
-      id: '/date-timestamp-converter'
-      path: '/date-timestamp-converter'
-      fullPath: '/date-timestamp-converter'
-      preLoaderRoute: typeof DateTimestampConverterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/curl-builder': {
-      id: '/curl-builder'
-      path: '/curl-builder'
-      fullPath: '/curl-builder'
-      preLoaderRoute: typeof CurlBuilderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/cron-expression-builder': {
-      id: '/cron-expression-builder'
-      path: '/cron-expression-builder'
-      fullPath: '/cron-expression-builder'
-      preLoaderRoute: typeof CronExpressionBuilderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/cidr-calculator': {
-      id: '/cidr-calculator'
-      path: '/cidr-calculator'
-      fullPath: '/cidr-calculator'
-      preLoaderRoute: typeof CidrCalculatorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/bcrypt-generator': {
-      id: '/bcrypt-generator'
-      path: '/bcrypt-generator'
-      fullPath: '/bcrypt-generator'
-      preLoaderRoute: typeof BcryptGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/base64-encoder': {
-      id: '/base64-encoder'
-      path: '/base64-encoder'
-      fullPath: '/base64-encoder'
-      preLoaderRoute: typeof Base64EncoderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-  }
+	interface FileRoutesByPath {
+		'/yaml-formatter': {
+			id: '/yaml-formatter';
+			path: '/yaml-formatter';
+			fullPath: '/yaml-formatter';
+			preLoaderRoute: typeof YamlFormatterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/xml-formatter': {
+			id: '/xml-formatter';
+			path: '/xml-formatter';
+			fullPath: '/xml-formatter';
+			preLoaderRoute: typeof XmlFormatterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/x509-decoder': {
+			id: '/x509-decoder';
+			path: '/x509-decoder';
+			fullPath: '/x509-decoder';
+			preLoaderRoute: typeof X509DecoderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/uuid-generator': {
+			id: '/uuid-generator';
+			path: '/uuid-generator';
+			fullPath: '/uuid-generator';
+			preLoaderRoute: typeof UuidGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/url-encoder': {
+			id: '/url-encoder';
+			path: '/url-encoder';
+			fullPath: '/url-encoder';
+			preLoaderRoute: typeof UrlEncoderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/string-compressor': {
+			id: '/string-compressor';
+			path: '/string-compressor';
+			fullPath: '/string-compressor';
+			preLoaderRoute: typeof StringCompressorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/string-case-converter': {
+			id: '/string-case-converter';
+			path: '/string-case-converter';
+			fullPath: '/string-case-converter';
+			preLoaderRoute: typeof StringCaseConverterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/ssh-key-generator': {
+			id: '/ssh-key-generator';
+			path: '/ssh-key-generator';
+			fullPath: '/ssh-key-generator';
+			preLoaderRoute: typeof SshKeyGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/sql-formatter': {
+			id: '/sql-formatter';
+			path: '/sql-formatter';
+			fullPath: '/sql-formatter';
+			preLoaderRoute: typeof SqlFormatterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/settings': {
+			id: '/settings';
+			path: '/settings';
+			fullPath: '/settings';
+			preLoaderRoute: typeof SettingsRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/semver-tools': {
+			id: '/semver-tools';
+			path: '/semver-tools';
+			fullPath: '/semver-tools';
+			preLoaderRoute: typeof SemverToolsRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/rsa-tools': {
+			id: '/rsa-tools';
+			path: '/rsa-tools';
+			fullPath: '/rsa-tools';
+			preLoaderRoute: typeof RsaToolsRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/rest-client': {
+			id: '/rest-client';
+			path: '/rest-client';
+			fullPath: '/rest-client';
+			preLoaderRoute: typeof RestClientRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/regex-tester': {
+			id: '/regex-tester';
+			path: '/regex-tester';
+			fullPath: '/regex-tester';
+			preLoaderRoute: typeof RegexTesterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/qr-code-generator': {
+			id: '/qr-code-generator';
+			path: '/qr-code-generator';
+			fullPath: '/qr-code-generator';
+			preLoaderRoute: typeof QrCodeGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/password-generator': {
+			id: '/password-generator';
+			path: '/password-generator';
+			fullPath: '/password-generator';
+			preLoaderRoute: typeof PasswordGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/number-base-converter': {
+			id: '/number-base-converter';
+			path: '/number-base-converter';
+			fullPath: '/number-base-converter';
+			preLoaderRoute: typeof NumberBaseConverterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/network-scanner': {
+			id: '/network-scanner';
+			path: '/network-scanner';
+			fullPath: '/network-scanner';
+			preLoaderRoute: typeof NetworkScannerRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/network-interfaces': {
+			id: '/network-interfaces';
+			path: '/network-interfaces';
+			fullPath: '/network-interfaces';
+			preLoaderRoute: typeof NetworkInterfacesRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/mime-types': {
+			id: '/mime-types';
+			path: '/mime-types';
+			fullPath: '/mime-types';
+			preLoaderRoute: typeof MimeTypesRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/markdown-editor': {
+			id: '/markdown-editor';
+			path: '/markdown-editor';
+			fullPath: '/markdown-editor';
+			preLoaderRoute: typeof MarkdownEditorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/mac-lookup': {
+			id: '/mac-lookup';
+			path: '/mac-lookup';
+			fullPath: '/mac-lookup';
+			preLoaderRoute: typeof MacLookupRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/lorem-ipsum': {
+			id: '/lorem-ipsum';
+			path: '/lorem-ipsum';
+			fullPath: '/lorem-ipsum';
+			preLoaderRoute: typeof LoremIpsumRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/list-comparer': {
+			id: '/list-comparer';
+			path: '/list-comparer';
+			fullPath: '/list-comparer';
+			preLoaderRoute: typeof ListComparerRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/jwt-decoder': {
+			id: '/jwt-decoder';
+			path: '/jwt-decoder';
+			fullPath: '/jwt-decoder';
+			preLoaderRoute: typeof JwtDecoderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/json-formatter': {
+			id: '/json-formatter';
+			path: '/json-formatter';
+			fullPath: '/json-formatter';
+			preLoaderRoute: typeof JsonFormatterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/ip-converter': {
+			id: '/ip-converter';
+			path: '/ip-converter';
+			fullPath: '/ip-converter';
+			preLoaderRoute: typeof IpConverterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/image-converter': {
+			id: '/image-converter';
+			path: '/image-converter';
+			fullPath: '/image-converter';
+			preLoaderRoute: typeof ImageConverterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/http-status-codes': {
+			id: '/http-status-codes';
+			path: '/http-status-codes';
+			fullPath: '/http-status-codes';
+			preLoaderRoute: typeof HttpStatusCodesRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/hash-generator': {
+			id: '/hash-generator';
+			path: '/hash-generator';
+			fullPath: '/hash-generator';
+			preLoaderRoute: typeof HashGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/gpg-key-generator': {
+			id: '/gpg-key-generator';
+			path: '/gpg-key-generator';
+			fullPath: '/gpg-key-generator';
+			preLoaderRoute: typeof GpgKeyGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/escape-tool': {
+			id: '/escape-tool';
+			path: '/escape-tool';
+			fullPath: '/escape-tool';
+			preLoaderRoute: typeof EscapeToolRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/dns-lookup': {
+			id: '/dns-lookup';
+			path: '/dns-lookup';
+			fullPath: '/dns-lookup';
+			preLoaderRoute: typeof DnsLookupRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/diff-viewer': {
+			id: '/diff-viewer';
+			path: '/diff-viewer';
+			fullPath: '/diff-viewer';
+			preLoaderRoute: typeof DiffViewerRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/date-timestamp-converter': {
+			id: '/date-timestamp-converter';
+			path: '/date-timestamp-converter';
+			fullPath: '/date-timestamp-converter';
+			preLoaderRoute: typeof DateTimestampConverterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/curl-builder': {
+			id: '/curl-builder';
+			path: '/curl-builder';
+			fullPath: '/curl-builder';
+			preLoaderRoute: typeof CurlBuilderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/cron-expression-builder': {
+			id: '/cron-expression-builder';
+			path: '/cron-expression-builder';
+			fullPath: '/cron-expression-builder';
+			preLoaderRoute: typeof CronExpressionBuilderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/cidr-calculator': {
+			id: '/cidr-calculator';
+			path: '/cidr-calculator';
+			fullPath: '/cidr-calculator';
+			preLoaderRoute: typeof CidrCalculatorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/bcrypt-generator': {
+			id: '/bcrypt-generator';
+			path: '/bcrypt-generator';
+			fullPath: '/bcrypt-generator';
+			preLoaderRoute: typeof BcryptGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/base64-encoder': {
+			id: '/base64-encoder';
+			path: '/base64-encoder';
+			fullPath: '/base64-encoder';
+			preLoaderRoute: typeof Base64EncoderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/': {
+			id: '/';
+			path: '/';
+			fullPath: '/';
+			preLoaderRoute: typeof IndexRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+	}
 }
 
 const rootRouteChildren: RootRouteChildren = {
-  IndexRoute: IndexRoute,
-  Base64EncoderRoute: Base64EncoderRoute,
-  BcryptGeneratorRoute: BcryptGeneratorRoute,
-  CidrCalculatorRoute: CidrCalculatorRoute,
-  CronExpressionBuilderRoute: CronExpressionBuilderRoute,
-  CurlBuilderRoute: CurlBuilderRoute,
-  DateTimestampConverterRoute: DateTimestampConverterRoute,
-  DiffViewerRoute: DiffViewerRoute,
-  EscapeToolRoute: EscapeToolRoute,
-  GpgKeyGeneratorRoute: GpgKeyGeneratorRoute,
-  HashGeneratorRoute: HashGeneratorRoute,
-  HttpStatusCodesRoute: HttpStatusCodesRoute,
-  ImageConverterRoute: ImageConverterRoute,
-  IpConverterRoute: IpConverterRoute,
-  JsonFormatterRoute: JsonFormatterRoute,
-  JwtDecoderRoute: JwtDecoderRoute,
-  ListComparerRoute: ListComparerRoute,
-  LoremIpsumRoute: LoremIpsumRoute,
-  MacLookupRoute: MacLookupRoute,
-  MarkdownEditorRoute: MarkdownEditorRoute,
-  MimeTypesRoute: MimeTypesRoute,
-  NetworkInterfacesRoute: NetworkInterfacesRoute,
-  NetworkScannerRoute: NetworkScannerRoute,
-  NumberBaseConverterRoute: NumberBaseConverterRoute,
-  PasswordGeneratorRoute: PasswordGeneratorRoute,
-  QrCodeGeneratorRoute: QrCodeGeneratorRoute,
-  RegexTesterRoute: RegexTesterRoute,
-  RestClientRoute: RestClientRoute,
-  RsaToolsRoute: RsaToolsRoute,
-  SemverToolsRoute: SemverToolsRoute,
-  SettingsRoute: SettingsRoute,
-  SqlFormatterRoute: SqlFormatterRoute,
-  SshKeyGeneratorRoute: SshKeyGeneratorRoute,
-  StringCaseConverterRoute: StringCaseConverterRoute,
-  StringCompressorRoute: StringCompressorRoute,
-  UrlEncoderRoute: UrlEncoderRoute,
-  UuidGeneratorRoute: UuidGeneratorRoute,
-  X509DecoderRoute: X509DecoderRoute,
-  XmlFormatterRoute: XmlFormatterRoute,
-  YamlFormatterRoute: YamlFormatterRoute,
-}
+	IndexRoute: IndexRoute,
+	Base64EncoderRoute: Base64EncoderRoute,
+	BcryptGeneratorRoute: BcryptGeneratorRoute,
+	CidrCalculatorRoute: CidrCalculatorRoute,
+	CronExpressionBuilderRoute: CronExpressionBuilderRoute,
+	CurlBuilderRoute: CurlBuilderRoute,
+	DateTimestampConverterRoute: DateTimestampConverterRoute,
+	DiffViewerRoute: DiffViewerRoute,
+	DnsLookupRoute: DnsLookupRoute,
+	EscapeToolRoute: EscapeToolRoute,
+	GpgKeyGeneratorRoute: GpgKeyGeneratorRoute,
+	HashGeneratorRoute: HashGeneratorRoute,
+	HttpStatusCodesRoute: HttpStatusCodesRoute,
+	ImageConverterRoute: ImageConverterRoute,
+	IpConverterRoute: IpConverterRoute,
+	JsonFormatterRoute: JsonFormatterRoute,
+	JwtDecoderRoute: JwtDecoderRoute,
+	ListComparerRoute: ListComparerRoute,
+	LoremIpsumRoute: LoremIpsumRoute,
+	MacLookupRoute: MacLookupRoute,
+	MarkdownEditorRoute: MarkdownEditorRoute,
+	MimeTypesRoute: MimeTypesRoute,
+	NetworkInterfacesRoute: NetworkInterfacesRoute,
+	NetworkScannerRoute: NetworkScannerRoute,
+	NumberBaseConverterRoute: NumberBaseConverterRoute,
+	PasswordGeneratorRoute: PasswordGeneratorRoute,
+	QrCodeGeneratorRoute: QrCodeGeneratorRoute,
+	RegexTesterRoute: RegexTesterRoute,
+	RestClientRoute: RestClientRoute,
+	RsaToolsRoute: RsaToolsRoute,
+	SemverToolsRoute: SemverToolsRoute,
+	SettingsRoute: SettingsRoute,
+	SqlFormatterRoute: SqlFormatterRoute,
+	SshKeyGeneratorRoute: SshKeyGeneratorRoute,
+	StringCaseConverterRoute: StringCaseConverterRoute,
+	StringCompressorRoute: StringCompressorRoute,
+	UrlEncoderRoute: UrlEncoderRoute,
+	UuidGeneratorRoute: UuidGeneratorRoute,
+	X509DecoderRoute: X509DecoderRoute,
+	XmlFormatterRoute: XmlFormatterRoute,
+	YamlFormatterRoute: YamlFormatterRoute,
+};
 export const routeTree = rootRouteImport
-  ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+	._addFileChildren(rootRouteChildren)
+	._addFileTypes<FileRouteTypes>();

--- a/src/routes/dns-lookup.tsx
+++ b/src/routes/dns-lookup.tsx
@@ -1,0 +1,500 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { AlertCircle, Globe, Search, ShieldCheck, Terminal } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
+import { ActionButton, CopyButton } from '@/lib/components/action';
+import {
+	FormCheckbox,
+	FormCheckboxGroup,
+	FormInfo,
+	FormInput,
+	FormSection,
+	FormSelect,
+	FormSlider,
+} from '@/lib/components/form';
+import { ToolShell } from '@/lib/components/shell';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { ToneBadge } from '@/lib/components/ui/tone-badge';
+import { useDocumentTitle } from '@/lib/hooks';
+import {
+	type DnsLookupRequest,
+	type DnsLookupResult,
+	type DnsTypeResult,
+	exportAsDig,
+	isIpLiteral,
+	RECORD_TYPES,
+	type RecordType,
+	resolverIpFor,
+	RESOLVER_PRESETS,
+	type ResolverPreset,
+	runDnsLookup,
+	SAMPLE_DOMAIN,
+	SAMPLE_REVERSE_IP,
+	toReverseDnsName,
+} from '@/lib/services/dns';
+import { createToolOptionsStore } from '@/lib/stores';
+
+interface DnsLookupOptions {
+	readonly recordTypes: readonly RecordType[];
+	readonly resolver: ResolverPreset;
+	readonly customResolver: string;
+	readonly timeoutMs: number;
+}
+
+const DEFAULT_TYPES: readonly RecordType[] = ['A', 'AAAA'];
+const PTR_ONLY: readonly RecordType[] = ['PTR'];
+
+const DEFAULTS: DnsLookupOptions = {
+	recordTypes: DEFAULT_TYPES,
+	resolver: 'system',
+	customResolver: '',
+	timeoutMs: 3000,
+};
+
+const useDnsLookupOptions = createToolOptionsStore<DnsLookupOptions>('dns-lookup', DEFAULTS);
+
+const RESOLVER_SELECT_OPTIONS = RESOLVER_PRESETS.map((preset) => ({
+	value: preset.id,
+	label: preset.label,
+	description: preset.description,
+}));
+
+export const Route = createFileRoute('/dns-lookup')({
+	component: DnsLookupPage,
+});
+
+function DnsLookupPage() {
+	useDocumentTitle('DNS Lookup');
+
+	const { value: options, patch, reset } = useDnsLookupOptions();
+	const { recordTypes, resolver, customResolver, timeoutMs } = options;
+
+	const [name, setName] = useState<string>(SAMPLE_DOMAIN);
+	const [result, setResult] = useState<DnsLookupResult | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [loading, setLoading] = useState<boolean>(false);
+	const [showRail, setShowRail] = useState(true);
+
+	const trimmedName = name.trim();
+	const reverseLookup = trimmedName.length > 0 && isIpLiteral(trimmedName);
+
+	// Effective request derives the resolver spec (preset id or literal IP)
+	// and forces PTR when the input is an IP literal so the user gets a
+	// reverse lookup without having to manually toggle chips.
+	const effectiveRequest = useMemo<DnsLookupRequest>(() => {
+		const resolverSpec = resolver === 'custom' ? customResolver.trim() : resolver;
+		const effectiveTypes = reverseLookup ? PTR_ONLY : recordTypes;
+		const effectiveName = reverseLookup ? toReverseDnsName(trimmedName) : trimmedName;
+		return {
+			name: effectiveName,
+			recordTypes: effectiveTypes,
+			resolver: resolverSpec,
+			timeoutMs,
+		};
+	}, [resolver, customResolver, recordTypes, reverseLookup, trimmedName, timeoutMs]);
+
+	const totalRecords = useMemo(
+		() => result?.results.reduce((sum, type) => sum + type.records.length, 0) ?? 0,
+		[result]
+	);
+
+	const errorCount = useMemo(
+		() => result?.results.filter((type) => type.error !== null).length ?? 0,
+		[result]
+	);
+
+	const handleLookup = async () => {
+		if (trimmedName.length === 0) {
+			setError('Enter a domain or IP to look up.');
+			return;
+		}
+		if (effectiveRequest.recordTypes.length === 0) {
+			setError('Select at least one record type.');
+			return;
+		}
+		if (resolver === 'custom' && customResolver.trim().length === 0) {
+			setError('Enter a custom resolver IP, or pick a preset.');
+			return;
+		}
+		setLoading(true);
+		setError(null);
+		try {
+			const next = await runDnsLookup(effectiveRequest);
+			setResult(next);
+		} catch (e) {
+			setError(e instanceof Error ? e.message : String(e));
+			setResult(null);
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	const handleToggleType = (type: RecordType, checked: boolean) => {
+		const next = checked
+			? [...recordTypes, type].filter((t, idx, arr) => arr.indexOf(t) === idx)
+			: recordTypes.filter((t) => t !== type);
+		// Preserve canonical order to keep result cards stable across toggles.
+		const ordered = RECORD_TYPES.filter((t) => next.includes(t));
+		patch({ recordTypes: ordered });
+	};
+
+	const handleCopyDig = async () => {
+		try {
+			await navigator.clipboard.writeText(exportAsDig(effectiveRequest));
+			toast.success('Copied dig command');
+		} catch {
+			toast.error('Failed to copy dig command');
+		}
+	};
+
+	const handleLoadSampleDomain = () => {
+		setName(SAMPLE_DOMAIN);
+		setResult(null);
+		setError(null);
+	};
+
+	const handleLoadReverseSample = () => {
+		setName(SAMPLE_REVERSE_IP);
+		setResult(null);
+		setError(null);
+	};
+
+	const validity: boolean | null =
+		trimmedName.length === 0 ? null : result === null ? null : errorCount === 0;
+
+	return (
+		<ToolShell
+			valid={validity}
+			error={error ?? undefined}
+			showRail={showRail}
+			onShowRailChange={setShowRail}
+			statusContent={
+				<DnsLookupStatus result={result} totalRecords={totalRecords} errorCount={errorCount} />
+			}
+			rail={
+				<DnsLookupRail
+					recordTypes={recordTypes}
+					resolver={resolver}
+					customResolver={customResolver}
+					timeoutMs={timeoutMs}
+					reverseLookup={reverseLookup}
+					onToggleType={handleToggleType}
+					onResolverChange={(v) => patch({ resolver: v })}
+					onCustomResolverChange={(v) => patch({ customResolver: v })}
+					onTimeoutChange={(v) => patch({ timeoutMs: v })}
+					onLoadSampleDomain={handleLoadSampleDomain}
+					onLoadReverseSample={handleLoadReverseSample}
+					onCopyDig={handleCopyDig}
+					onResetOptions={reset}
+				/>
+			}
+		>
+			<DnsLookupMain
+				name={name}
+				onNameChange={setName}
+				reverseLookup={reverseLookup}
+				effectiveRequest={effectiveRequest}
+				loading={loading}
+				error={error}
+				result={result}
+				onLookup={handleLookup}
+			/>
+		</ToolShell>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface StatusProps {
+	readonly result: DnsLookupResult | null;
+	readonly totalRecords: number;
+	readonly errorCount: number;
+}
+
+function DnsLookupStatus({ result, totalRecords, errorCount }: StatusProps) {
+	if (result === null) return null;
+	return (
+		<>
+			<StatItem label="Records" value={totalRecords} />
+			<StatItem label="Errors" value={errorCount} />
+			<StatItem label="Elapsed" value={`${result.elapsedMs} ms`} />
+		</>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface RailProps {
+	readonly recordTypes: readonly RecordType[];
+	readonly resolver: ResolverPreset;
+	readonly customResolver: string;
+	readonly timeoutMs: number;
+	readonly reverseLookup: boolean;
+	readonly onToggleType: (type: RecordType, checked: boolean) => void;
+	readonly onResolverChange: (value: ResolverPreset) => void;
+	readonly onCustomResolverChange: (value: string) => void;
+	readonly onTimeoutChange: (value: number) => void;
+	readonly onLoadSampleDomain: () => void;
+	readonly onLoadReverseSample: () => void;
+	readonly onCopyDig: () => void;
+	readonly onResetOptions: () => void;
+}
+
+function DnsLookupRail({
+	recordTypes,
+	resolver,
+	customResolver,
+	timeoutMs,
+	reverseLookup,
+	onToggleType,
+	onResolverChange,
+	onCustomResolverChange,
+	onTimeoutChange,
+	onLoadSampleDomain,
+	onLoadReverseSample,
+	onCopyDig,
+	onResetOptions,
+}: RailProps) {
+	return (
+		<>
+			<FormSection title="Resolver">
+				<FormSelect
+					label="Upstream"
+					value={resolver}
+					options={RESOLVER_SELECT_OPTIONS}
+					onValueChange={(v) => onResolverChange(v as ResolverPreset)}
+				/>
+				{resolver === 'custom' ? (
+					<FormInput
+						label="Custom resolver IP"
+						value={customResolver}
+						onValueChange={onCustomResolverChange}
+						placeholder="e.g. 1.0.0.1 or 2606:4700:4700::1111"
+						size="compact"
+					/>
+				) : null}
+			</FormSection>
+
+			<FormSection title="Record types">
+				{reverseLookup ? (
+					<FormInfo>
+						Reverse lookup detected — querying <code className="font-mono">PTR</code> only. Other
+						record-type toggles are ignored until the input is no longer an IP literal.
+					</FormInfo>
+				) : null}
+				<FormCheckboxGroup>
+					{RECORD_TYPES.map((type) => (
+						<FormCheckbox
+							key={type}
+							label={type}
+							size="compact"
+							checked={recordTypes.includes(type)}
+							disabled={reverseLookup}
+							onCheckedChange={(checked) => onToggleType(type, checked)}
+						/>
+					))}
+				</FormCheckboxGroup>
+			</FormSection>
+
+			<FormSection title="Options">
+				<FormSlider
+					label="Timeout"
+					min={500}
+					max={15000}
+					step={500}
+					value={timeoutMs}
+					valueLabel={`${timeoutMs} ms`}
+					onValueChange={onTimeoutChange}
+				/>
+				<ActionButton label="Reset options" variant="outline" onClick={onResetOptions} />
+			</FormSection>
+
+			<FormSection title="Samples">
+				<div className="grid grid-cols-1 gap-1">
+					<Button variant="outline" size="sm" onClick={onLoadSampleDomain}>
+						Load sample ({SAMPLE_DOMAIN})
+					</Button>
+					<Button variant="outline" size="sm" onClick={onLoadReverseSample}>
+						Load reverse sample ({SAMPLE_REVERSE_IP})
+					</Button>
+				</div>
+			</FormSection>
+
+			<FormSection title="Export">
+				<Button variant="outline" size="sm" className="w-full" onClick={onCopyDig}>
+					<Terminal className="mr-1.5 h-3.5 w-3.5" />
+					Copy as dig
+				</Button>
+			</FormSection>
+
+			<FormSection title="About">
+				<FormInfo>
+					Standard DNS over UDP / TCP. DNS-over-HTTPS, multi-resolver compare, and DNSSEC validation
+					are deferred to a follow-up. The AD badge mirrors the upstream{' '}
+					<code className="font-mono">ad</code> header bit — meaningful only when the upstream
+					itself validates.
+				</FormInfo>
+			</FormSection>
+		</>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface MainProps {
+	readonly name: string;
+	readonly onNameChange: (value: string) => void;
+	readonly reverseLookup: boolean;
+	readonly effectiveRequest: DnsLookupRequest;
+	readonly loading: boolean;
+	readonly error: string | null;
+	readonly result: DnsLookupResult | null;
+	readonly onLookup: () => void;
+}
+
+function DnsLookupMain({
+	name,
+	onNameChange,
+	reverseLookup,
+	effectiveRequest,
+	loading,
+	error,
+	result,
+	onLookup,
+}: MainProps) {
+	return (
+		<div className="flex h-full flex-col overflow-auto p-3">
+			<div className="space-y-3">
+				<Card density="compact">
+					<CardHeader className="pb-2">
+						<CardTitle>Query</CardTitle>
+					</CardHeader>
+					<CardContent className="space-y-2">
+						<div className="flex items-end gap-2">
+							<div className="flex-1">
+								<FormInput
+									label="Domain or IP"
+									value={name}
+									onValueChange={onNameChange}
+									placeholder="example.com or 8.8.8.8"
+								/>
+							</div>
+							<Button onClick={onLookup} disabled={loading || name.trim().length === 0}>
+								<Search className="mr-1.5 h-3.5 w-3.5" />
+								{loading ? 'Looking up...' : 'Lookup'}
+							</Button>
+						</div>
+						<div className="flex flex-wrap items-center gap-2 text-2xs text-muted-foreground">
+							<span>
+								Resolver:{' '}
+								<code className="font-mono">{resolverIpFor(effectiveRequest.resolver)}</code>
+							</span>
+							<span>·</span>
+							<span>
+								Types: <code className="font-mono">{effectiveRequest.recordTypes.join(', ')}</code>
+							</span>
+							{reverseLookup ? (
+								<>
+									<span>·</span>
+									<ToneBadge tone="info">Reverse (PTR)</ToneBadge>
+								</>
+							) : null}
+						</div>
+						{error ? (
+							<div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-2.5 py-1.5 text-xs text-destructive">
+								<AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+								<span>{error}</span>
+							</div>
+						) : null}
+					</CardContent>
+				</Card>
+
+				{result === null ? (
+					<Card density="compact">
+						<CardContent>
+							<EmbeddedEmptyState
+								icon={Globe}
+								title="No lookup yet"
+								description="Enter a domain or IP, pick the resolver and record types from the rail, then run the query."
+							/>
+						</CardContent>
+					</Card>
+				) : (
+					result.results.map((typeResult) => (
+						<TypeResultCard key={typeResult.recordType} typeResult={typeResult} />
+					))
+				)}
+			</div>
+		</div>
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+
+interface TypeResultCardProps {
+	readonly typeResult: DnsTypeResult;
+}
+
+function TypeResultCard({ typeResult }: TypeResultCardProps) {
+	const { recordType, records, error, authenticData } = typeResult;
+	const hasError = error !== null;
+	const showAd = authenticData === true;
+
+	return (
+		<Card density="compact">
+			<CardHeader className="pb-2">
+				<div className="flex flex-wrap items-center gap-2">
+					<CardTitle className="font-mono">{recordType}</CardTitle>
+					<ToneBadge tone={records.length > 0 ? 'success' : 'info'}>
+						{records.length} {records.length === 1 ? 'record' : 'records'}
+					</ToneBadge>
+					{hasError ? <ToneBadge tone="destructive">Error</ToneBadge> : null}
+					{showAd ? (
+						<ToneBadge tone="success">
+							<ShieldCheck className="mr-1 h-3 w-3" />
+							AD
+						</ToneBadge>
+					) : null}
+				</div>
+			</CardHeader>
+			<CardContent className="space-y-2">
+				{hasError ? (
+					<div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-2.5 py-1.5 text-xs text-destructive">
+						<AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+						<span className="break-all">{error}</span>
+					</div>
+				) : records.length === 0 ? (
+					<p className="text-xs text-muted-foreground">
+						No records returned for this type (NOERROR / NXDOMAIN).
+					</p>
+				) : (
+					<div className="grid grid-cols-1 gap-1.5">
+						{records.map((record) => (
+							<div
+								// Two records of the same type with identical rdata would
+								// be a server misconfiguration; the value is enough to key on.
+								key={`${record.recordType}-${record.value}`}
+								className="flex items-center justify-between gap-2 rounded-md border bg-muted/30 px-2.5 py-1.5"
+							>
+								<div className="min-w-0 flex-1 font-mono text-sm break-all">{record.value}</div>
+								<div className="flex shrink-0 items-center gap-2">
+									<ToneBadge tone="info">TTL {record.ttl}s</ToneBadge>
+									<CopyButton
+										text={record.value}
+										toastLabel={`${record.recordType} record`}
+										size="sm"
+										variant="ghost"
+										showLabel={false}
+									/>
+								</div>
+							</div>
+						))}
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+}


### PR DESCRIPTION
## Summary
Add an MVP DNS Lookup tool under **Network** backed by `hickory-resolver`. Closes #234.

## MVP scope
- **Record types**: A / AAAA / MX / TXT / NS / CNAME / SOA / PTR
- **Resolver presets**: System / Cloudflare (1.1.1.1) / Google (8.8.8.8) / Quad9 (9.9.9.9) + custom IP
- **Standard UDP/TCP** transport
- **Reverse DNS**: input an IP literal -> PTR auto-selected
- **Per-type result cards** with TTL chips and inline errors
- **Copy as dig** export

## Deferred
- DoH (DNS-over-HTTPS) transport
- Multi-resolver side-by-side compare
- DNSSEC validation / DNSKEY / RRSIG checks
- CAA / SRV / DNSKEY record types
- TTL countdown (live)

## Changes

### Added
- `src/routes/dns-lookup.tsx`
- `src/lib/services/dns.ts`
- `src-tauri/src/dns_lookup.rs`
- Page registration in `src/lib/services/pages.ts`

### Modified
- `src-tauri/src/lib.rs` — `mod dns_lookup` + `invoke_handler!`
- `src/route-tree.gen.ts` — regenerated for the new route

## Test plan
- [x] `bun run check` green (TypeScript + page validation + design audit)
- [x] `bun run format:check` clean
- [x] `bun run lint` no new errors (baseline unchanged at 9/24)
- [x] `cargo check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test dns_lookup` 3/3 pass
- [ ] Manual: lookup `example.com` for A -> IPv4 returned
- [ ] Manual: lookup `example.com` for MX -> MX records with priority
- [ ] Manual: lookup `8.8.8.8` (IP) -> PTR auto-selected, returns `dns.google`
- [ ] Manual: switch resolver Cloudflare / Google -> results consistent
- [ ] Manual: custom resolver `1.0.0.1` -> also works
- [ ] Manual: "Copy as dig" -> produces `dig @1.1.1.1 example.com A AAAA`

Closes #234
