### PR TITLE
feat(tls-inspector): add SSL / TLS Inspector (MVP)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3277,6 +3277,7 @@ dependencies = [
 name = "kogu"
 version = "0.0.6"
 dependencies = [
+ "base64 0.22.1",
  "bcrypt",
  "csnmp",
  "dns-lookup",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -79,6 +79,7 @@ quick-xml = "0.40"
 rustls = { version = "0.23", features = ["ring"] }
 tokio-rustls = "0.26"
 x509-parser = "0.18"
+base64 = "0.22"
 
 # DNS PTR Reverse Lookup
 hickory-resolver = { version = "0.26", features = ["tokio", "system-config"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,7 @@ mod menu;
 mod network;
 mod rest_client;
 mod settings;
+mod tls_inspect;
 mod websocket;
 
 use tauri::Manager;
@@ -477,6 +478,7 @@ pub fn run() {
             websocket::ws_send,
             websocket::ws_close,
             dns_lookup::dns_lookup,
+            tls_inspect::tls_inspect,
             settings::get_settings,
             settings::update_settings,
             settings::reset_settings,

--- a/src-tauri/src/tls_inspect.rs
+++ b/src-tauri/src/tls_inspect.rs
@@ -157,8 +157,7 @@ pub async fn tls_inspect(req: TlsInspectRequest) -> Result<TlsInspectResult, Str
     let config = build_client_config()?;
     let connector = TlsConnector::from(Arc::new(config));
 
-    let server_name = ServerName::try_from(sni.clone())
-        .map_err(|e| format!("Invalid SNI: {e}"))?;
+    let server_name = ServerName::try_from(sni.clone()).map_err(|e| format!("Invalid SNI: {e}"))?;
 
     let addr = format!("{}:{}", req.host, req.port);
     let stream = timeout(timeout_duration, TcpStream::connect(&addr))
@@ -228,6 +227,9 @@ mod tests {
 
     #[test]
     fn resolve_sni_prefers_override_when_present() {
-        assert_eq!(resolve_sni(Some("alt.example.com"), "example.com"), "alt.example.com");
+        assert_eq!(
+            resolve_sni(Some("alt.example.com"), "example.com"),
+            "alt.example.com"
+        );
     }
 }

--- a/src-tauri/src/tls_inspect.rs
+++ b/src-tauri/src/tls_inspect.rs
@@ -1,0 +1,233 @@
+//! TLS handshake inspector command.
+//!
+//! Performs a real TLS handshake against a `host:port` and returns the
+//! negotiated parameters together with the full peer certificate chain.
+//!
+//! The connection deliberately uses a custom certificate verifier that
+//! accepts every certificate. This lets the inspector surface expired,
+//! self-signed, and otherwise invalid certificates instead of failing the
+//! handshake. The result is therefore unsafe for any trust decision.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use base64::Engine as _;
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{ClientConfig, DigitallySignedStruct, SignatureScheme};
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+use tokio_rustls::TlsConnector;
+
+/// Request payload sent from the frontend.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TlsInspectRequest {
+    /// Target host (DNS name or IP literal).
+    pub host: String,
+    /// Target TCP port.
+    pub port: u16,
+    /// Optional SNI override. Defaults to `host` when `None` or empty.
+    pub sni: Option<String>,
+    /// Combined TCP-connect and TLS-handshake timeout in milliseconds.
+    pub timeout_ms: u32,
+}
+
+/// Successful inspection result.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TlsInspectResult {
+    /// Echo of the requested host.
+    pub host: String,
+    /// Echo of the requested port.
+    pub port: u16,
+    /// Effective SNI sent in the `ClientHello`.
+    pub sni: String,
+    /// Negotiated TLS protocol version (e.g. `TLSv1_3`).
+    pub negotiated_version: String,
+    /// Negotiated cipher suite name (e.g. `TLS13_AES_256_GCM_SHA384`).
+    pub cipher_suite: String,
+    /// Negotiated ALPN protocol, if any.
+    pub alpn: Option<String>,
+    /// Peer certificate chain as base64-encoded DER blobs, leaf first.
+    pub peer_chain_base64: Vec<String>,
+    /// Wall-clock elapsed time from start of TCP connect to handshake completion.
+    pub elapsed_ms: u128,
+}
+
+/// Certificate verifier that accepts every certificate without validation.
+///
+/// Used exclusively for inspection. The inspector must surface broken
+/// certificates (expired / self-signed / wrong host), which the default
+/// verifier rejects before the chain is delivered to the application.
+#[derive(Debug)]
+struct AcceptAllVerifier;
+
+impl ServerCertVerifier for AcceptAllVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            SignatureScheme::ECDSA_NISTP521_SHA512,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::ED25519,
+        ]
+    }
+}
+
+/// Build a permissive TLS client config so the inspector can observe broken
+/// certificates without the default verifier rejecting them.
+fn build_client_config() -> Result<ClientConfig, String> {
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let mut config = ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| format!("Failed to build TLS config: {e}"))?
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(AcceptAllVerifier))
+        .with_no_client_auth();
+    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    Ok(config)
+}
+
+/// Resolve the effective SNI value, falling back to the host when missing or empty.
+fn resolve_sni(sni: Option<&str>, host: &str) -> String {
+    sni.map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map_or_else(|| host.to_string(), str::to_string)
+}
+
+/// Format the negotiated protocol version using the rustls `Debug` representation.
+fn format_protocol_version(version: rustls::ProtocolVersion) -> String {
+    format!("{version:?}")
+}
+
+/// Format the negotiated cipher suite using the rustls `Debug` representation.
+fn format_cipher_suite(suite: rustls::SupportedCipherSuite) -> String {
+    format!("{:?}", suite.suite())
+}
+
+/// Inspect a TLS endpoint and return the negotiated parameters and chain.
+///
+/// # Errors
+///
+/// Returns a human-readable error string for invalid SNI, TCP connect failures,
+/// handshake failures, or operation timeouts.
+#[tauri::command]
+pub async fn tls_inspect(req: TlsInspectRequest) -> Result<TlsInspectResult, String> {
+    let started = Instant::now();
+    let timeout_duration = Duration::from_millis(u64::from(req.timeout_ms));
+    let sni = resolve_sni(req.sni.as_deref(), &req.host);
+
+    let config = build_client_config()?;
+    let connector = TlsConnector::from(Arc::new(config));
+
+    let server_name = ServerName::try_from(sni.clone())
+        .map_err(|e| format!("Invalid SNI: {e}"))?;
+
+    let addr = format!("{}:{}", req.host, req.port);
+    let stream = timeout(timeout_duration, TcpStream::connect(&addr))
+        .await
+        .map_err(|_| "Connection timed out".to_string())?
+        .map_err(|e| format!("TCP connect: {e}"))?;
+
+    let tls_stream = timeout(timeout_duration, connector.connect(server_name, stream))
+        .await
+        .map_err(|_| "TLS handshake timed out".to_string())?
+        .map_err(|e| format!("TLS handshake: {e}"))?;
+
+    let elapsed_ms = started.elapsed().as_millis();
+
+    let (negotiated_version, cipher_suite, alpn, peer_chain_der) = {
+        let (_, session) = tls_stream.get_ref();
+        let version = session
+            .protocol_version()
+            .map_or_else(|| "Unknown".to_string(), format_protocol_version);
+        let cipher = session
+            .negotiated_cipher_suite()
+            .map_or_else(|| "Unknown".to_string(), format_cipher_suite);
+        let alpn = session
+            .alpn_protocol()
+            .map(|p| String::from_utf8_lossy(p).into_owned());
+        let chain: Vec<Vec<u8>> = session
+            .peer_certificates()
+            .map(|certs| certs.iter().map(|c| c.as_ref().to_vec()).collect())
+            .unwrap_or_default();
+        (version, cipher, alpn, chain)
+    };
+
+    // Best-effort graceful close; we already captured everything we need.
+    let mut tls_stream = tls_stream;
+    let _ = tls_stream.shutdown().await;
+
+    let peer_chain_base64: Vec<String> = peer_chain_der
+        .iter()
+        .map(|der| base64::engine::general_purpose::STANDARD.encode(der))
+        .collect();
+
+    Ok(TlsInspectResult {
+        host: req.host,
+        port: req.port,
+        sni,
+        negotiated_version,
+        cipher_suite,
+        alpn,
+        peer_chain_base64,
+        elapsed_ms,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_sni_uses_host_when_override_missing() {
+        assert_eq!(resolve_sni(None, "example.com"), "example.com");
+    }
+
+    #[test]
+    fn resolve_sni_uses_host_when_override_blank() {
+        assert_eq!(resolve_sni(Some("   "), "example.com"), "example.com");
+    }
+
+    #[test]
+    fn resolve_sni_prefers_override_when_present() {
+        assert_eq!(resolve_sni(Some("alt.example.com"), "example.com"), "alt.example.com");
+    }
+}

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -507,6 +507,15 @@ export const PAGES: readonly PageDefinition[] = [
 		category: 'network',
 	},
 	{
+		id: 'tls-inspector',
+		title: 'SSL / TLS Inspector',
+		url: '/tls-inspector',
+		icon: Lock,
+		description: 'Inspect TLS handshake details and certificate chain for any host:port',
+		color: 'text-purple-700',
+		category: 'network',
+	},
+	{
 		id: 'websocket-tester',
 		title: 'WebSocket Tester',
 		url: '/websocket-tester',

--- a/src/lib/services/tls.ts
+++ b/src/lib/services/tls.ts
@@ -1,0 +1,76 @@
+/**
+ * TLS handshake inspector service.
+ *
+ * Bridges the `tls_inspect` Tauri command and decodes the returned
+ * certificate chain via the in-browser X.509 parser. The handshake itself
+ * runs in the Rust backend with a permissive verifier so expired,
+ * self-signed, and otherwise broken chains can still be inspected.
+ */
+import { invoke } from '@tauri-apps/api/core';
+
+import { parseCertificates, type ParseResult } from '@/lib/services/x509';
+
+export interface TlsInspectRequest {
+	readonly host: string;
+	readonly port: number;
+	readonly sni?: string;
+	readonly timeoutMs: number;
+}
+
+export interface TlsInspectResult {
+	readonly host: string;
+	readonly port: number;
+	readonly sni: string;
+	readonly negotiatedVersion: string;
+	readonly cipherSuite: string;
+	readonly alpn: string | null;
+	readonly peerChainBase64: readonly string[];
+	readonly elapsedMs: number;
+}
+
+export const SAMPLE_HOST = 'example.com';
+export const SAMPLE_PORT = 443;
+export const EXPIRED_SAMPLE_HOST = 'expired.badssl.com';
+export const SELF_SIGNED_SAMPLE_HOST = 'self-signed.badssl.com';
+
+export const PORT_PRESETS: readonly number[] = [443, 8443, 465, 993];
+
+export const TIMEOUT_MIN_MS = 1000;
+export const TIMEOUT_MAX_MS = 30000;
+export const TIMEOUT_STEP_MS = 500;
+export const TIMEOUT_DEFAULT_MS = 5000;
+
+/**
+ * Invoke the Rust backend to perform a TLS handshake against `host:port`.
+ */
+export const inspectTls = (req: TlsInspectRequest): Promise<TlsInspectResult> =>
+	invoke<TlsInspectResult>('tls_inspect', { req });
+
+/**
+ * Wrap a single base64 DER blob in a PEM `CERTIFICATE` envelope with 64-column
+ * line wrapping per RFC 7468.
+ */
+const wrapAsPem = (base64Der: string): string => {
+	const wrapped = base64Der.match(/.{1,64}/g)?.join('\n') ?? base64Der;
+	return `-----BEGIN CERTIFICATE-----\n${wrapped}\n-----END CERTIFICATE-----`;
+};
+
+/**
+ * Wrap each base64 DER blob in a PEM envelope and concatenate the results
+ * into a single chain bundle (leaf first).
+ */
+export const buildPemBundle = (base64Chain: readonly string[]): string =>
+	base64Chain.map(wrapAsPem).join('\n');
+
+/**
+ * Build the PEM representation of a single certificate from its base64 DER blob.
+ */
+export const buildPemFromBase64 = (base64Der: string): string => wrapAsPem(base64Der);
+
+/**
+ * Decode every entry of `base64Chain` via the X.509 parser used elsewhere in
+ * the app. The returned `ParseResult` keeps any per-entry parse errors so the
+ * UI can flag them without aborting the whole chain.
+ */
+export const decodeChain = (base64Chain: readonly string[]): Promise<ParseResult> =>
+	parseCertificates(buildPemBundle(base64Chain));

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -8,917 +8,938 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root';
-import { Route as YamlFormatterRouteImport } from './routes/yaml-formatter';
-import { Route as XmlFormatterRouteImport } from './routes/xml-formatter';
-import { Route as X509DecoderRouteImport } from './routes/x509-decoder';
-import { Route as WebsocketTesterRouteImport } from './routes/websocket-tester';
-import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator';
-import { Route as UrlEncoderRouteImport } from './routes/url-encoder';
-import { Route as StringCompressorRouteImport } from './routes/string-compressor';
-import { Route as StringCaseConverterRouteImport } from './routes/string-case-converter';
-import { Route as SshKeyGeneratorRouteImport } from './routes/ssh-key-generator';
-import { Route as SqlFormatterRouteImport } from './routes/sql-formatter';
-import { Route as SettingsRouteImport } from './routes/settings';
-import { Route as SemverToolsRouteImport } from './routes/semver-tools';
-import { Route as RsaToolsRouteImport } from './routes/rsa-tools';
-import { Route as RestClientRouteImport } from './routes/rest-client';
-import { Route as RegexTesterRouteImport } from './routes/regex-tester';
-import { Route as QrCodeGeneratorRouteImport } from './routes/qr-code-generator';
-import { Route as PasswordGeneratorRouteImport } from './routes/password-generator';
-import { Route as NumberBaseConverterRouteImport } from './routes/number-base-converter';
-import { Route as NetworkScannerRouteImport } from './routes/network-scanner';
-import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces';
-import { Route as MimeTypesRouteImport } from './routes/mime-types';
-import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor';
-import { Route as MacLookupRouteImport } from './routes/mac-lookup';
-import { Route as LoremIpsumRouteImport } from './routes/lorem-ipsum';
-import { Route as ListComparerRouteImport } from './routes/list-comparer';
-import { Route as JwtDecoderRouteImport } from './routes/jwt-decoder';
-import { Route as JsonFormatterRouteImport } from './routes/json-formatter';
-import { Route as IpConverterRouteImport } from './routes/ip-converter';
-import { Route as ImageConverterRouteImport } from './routes/image-converter';
-import { Route as HttpStatusCodesRouteImport } from './routes/http-status-codes';
-import { Route as HashGeneratorRouteImport } from './routes/hash-generator';
-import { Route as GpgKeyGeneratorRouteImport } from './routes/gpg-key-generator';
-import { Route as EscapeToolRouteImport } from './routes/escape-tool';
-import { Route as DnsLookupRouteImport } from './routes/dns-lookup';
-import { Route as DiffViewerRouteImport } from './routes/diff-viewer';
-import { Route as DateTimestampConverterRouteImport } from './routes/date-timestamp-converter';
-import { Route as CurlBuilderRouteImport } from './routes/curl-builder';
-import { Route as CronExpressionBuilderRouteImport } from './routes/cron-expression-builder';
-import { Route as CidrCalculatorRouteImport } from './routes/cidr-calculator';
-import { Route as BcryptGeneratorRouteImport } from './routes/bcrypt-generator';
-import { Route as Base64EncoderRouteImport } from './routes/base64-encoder';
-import { Route as IndexRouteImport } from './routes/index';
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as YamlFormatterRouteImport } from './routes/yaml-formatter'
+import { Route as XmlFormatterRouteImport } from './routes/xml-formatter'
+import { Route as X509DecoderRouteImport } from './routes/x509-decoder'
+import { Route as WebsocketTesterRouteImport } from './routes/websocket-tester'
+import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator'
+import { Route as UrlEncoderRouteImport } from './routes/url-encoder'
+import { Route as TlsInspectorRouteImport } from './routes/tls-inspector'
+import { Route as StringCompressorRouteImport } from './routes/string-compressor'
+import { Route as StringCaseConverterRouteImport } from './routes/string-case-converter'
+import { Route as SshKeyGeneratorRouteImport } from './routes/ssh-key-generator'
+import { Route as SqlFormatterRouteImport } from './routes/sql-formatter'
+import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as SemverToolsRouteImport } from './routes/semver-tools'
+import { Route as RsaToolsRouteImport } from './routes/rsa-tools'
+import { Route as RestClientRouteImport } from './routes/rest-client'
+import { Route as RegexTesterRouteImport } from './routes/regex-tester'
+import { Route as QrCodeGeneratorRouteImport } from './routes/qr-code-generator'
+import { Route as PasswordGeneratorRouteImport } from './routes/password-generator'
+import { Route as NumberBaseConverterRouteImport } from './routes/number-base-converter'
+import { Route as NetworkScannerRouteImport } from './routes/network-scanner'
+import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces'
+import { Route as MimeTypesRouteImport } from './routes/mime-types'
+import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor'
+import { Route as MacLookupRouteImport } from './routes/mac-lookup'
+import { Route as LoremIpsumRouteImport } from './routes/lorem-ipsum'
+import { Route as ListComparerRouteImport } from './routes/list-comparer'
+import { Route as JwtDecoderRouteImport } from './routes/jwt-decoder'
+import { Route as JsonFormatterRouteImport } from './routes/json-formatter'
+import { Route as IpConverterRouteImport } from './routes/ip-converter'
+import { Route as ImageConverterRouteImport } from './routes/image-converter'
+import { Route as HttpStatusCodesRouteImport } from './routes/http-status-codes'
+import { Route as HashGeneratorRouteImport } from './routes/hash-generator'
+import { Route as GpgKeyGeneratorRouteImport } from './routes/gpg-key-generator'
+import { Route as EscapeToolRouteImport } from './routes/escape-tool'
+import { Route as DnsLookupRouteImport } from './routes/dns-lookup'
+import { Route as DiffViewerRouteImport } from './routes/diff-viewer'
+import { Route as DateTimestampConverterRouteImport } from './routes/date-timestamp-converter'
+import { Route as CurlBuilderRouteImport } from './routes/curl-builder'
+import { Route as CronExpressionBuilderRouteImport } from './routes/cron-expression-builder'
+import { Route as CidrCalculatorRouteImport } from './routes/cidr-calculator'
+import { Route as BcryptGeneratorRouteImport } from './routes/bcrypt-generator'
+import { Route as Base64EncoderRouteImport } from './routes/base64-encoder'
+import { Route as IndexRouteImport } from './routes/index'
 
 const YamlFormatterRoute = YamlFormatterRouteImport.update({
-	id: '/yaml-formatter',
-	path: '/yaml-formatter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/yaml-formatter',
+  path: '/yaml-formatter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const XmlFormatterRoute = XmlFormatterRouteImport.update({
-	id: '/xml-formatter',
-	path: '/xml-formatter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/xml-formatter',
+  path: '/xml-formatter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const X509DecoderRoute = X509DecoderRouteImport.update({
-	id: '/x509-decoder',
-	path: '/x509-decoder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/x509-decoder',
+  path: '/x509-decoder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const WebsocketTesterRoute = WebsocketTesterRouteImport.update({
-	id: '/websocket-tester',
-	path: '/websocket-tester',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/websocket-tester',
+  path: '/websocket-tester',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const UuidGeneratorRoute = UuidGeneratorRouteImport.update({
-	id: '/uuid-generator',
-	path: '/uuid-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/uuid-generator',
+  path: '/uuid-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const UrlEncoderRoute = UrlEncoderRouteImport.update({
-	id: '/url-encoder',
-	path: '/url-encoder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/url-encoder',
+  path: '/url-encoder',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TlsInspectorRoute = TlsInspectorRouteImport.update({
+  id: '/tls-inspector',
+  path: '/tls-inspector',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const StringCompressorRoute = StringCompressorRouteImport.update({
-	id: '/string-compressor',
-	path: '/string-compressor',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/string-compressor',
+  path: '/string-compressor',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const StringCaseConverterRoute = StringCaseConverterRouteImport.update({
-	id: '/string-case-converter',
-	path: '/string-case-converter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/string-case-converter',
+  path: '/string-case-converter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SshKeyGeneratorRoute = SshKeyGeneratorRouteImport.update({
-	id: '/ssh-key-generator',
-	path: '/ssh-key-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/ssh-key-generator',
+  path: '/ssh-key-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SqlFormatterRoute = SqlFormatterRouteImport.update({
-	id: '/sql-formatter',
-	path: '/sql-formatter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/sql-formatter',
+  path: '/sql-formatter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SettingsRoute = SettingsRouteImport.update({
-	id: '/settings',
-	path: '/settings',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SemverToolsRoute = SemverToolsRouteImport.update({
-	id: '/semver-tools',
-	path: '/semver-tools',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/semver-tools',
+  path: '/semver-tools',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const RsaToolsRoute = RsaToolsRouteImport.update({
-	id: '/rsa-tools',
-	path: '/rsa-tools',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/rsa-tools',
+  path: '/rsa-tools',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const RestClientRoute = RestClientRouteImport.update({
-	id: '/rest-client',
-	path: '/rest-client',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/rest-client',
+  path: '/rest-client',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const RegexTesterRoute = RegexTesterRouteImport.update({
-	id: '/regex-tester',
-	path: '/regex-tester',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/regex-tester',
+  path: '/regex-tester',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const QrCodeGeneratorRoute = QrCodeGeneratorRouteImport.update({
-	id: '/qr-code-generator',
-	path: '/qr-code-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/qr-code-generator',
+  path: '/qr-code-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const PasswordGeneratorRoute = PasswordGeneratorRouteImport.update({
-	id: '/password-generator',
-	path: '/password-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/password-generator',
+  path: '/password-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const NumberBaseConverterRoute = NumberBaseConverterRouteImport.update({
-	id: '/number-base-converter',
-	path: '/number-base-converter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/number-base-converter',
+  path: '/number-base-converter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const NetworkScannerRoute = NetworkScannerRouteImport.update({
-	id: '/network-scanner',
-	path: '/network-scanner',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/network-scanner',
+  path: '/network-scanner',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const NetworkInterfacesRoute = NetworkInterfacesRouteImport.update({
-	id: '/network-interfaces',
-	path: '/network-interfaces',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/network-interfaces',
+  path: '/network-interfaces',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MimeTypesRoute = MimeTypesRouteImport.update({
-	id: '/mime-types',
-	path: '/mime-types',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/mime-types',
+  path: '/mime-types',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MarkdownEditorRoute = MarkdownEditorRouteImport.update({
-	id: '/markdown-editor',
-	path: '/markdown-editor',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/markdown-editor',
+  path: '/markdown-editor',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MacLookupRoute = MacLookupRouteImport.update({
-	id: '/mac-lookup',
-	path: '/mac-lookup',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/mac-lookup',
+  path: '/mac-lookup',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LoremIpsumRoute = LoremIpsumRouteImport.update({
-	id: '/lorem-ipsum',
-	path: '/lorem-ipsum',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/lorem-ipsum',
+  path: '/lorem-ipsum',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ListComparerRoute = ListComparerRouteImport.update({
-	id: '/list-comparer',
-	path: '/list-comparer',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/list-comparer',
+  path: '/list-comparer',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const JwtDecoderRoute = JwtDecoderRouteImport.update({
-	id: '/jwt-decoder',
-	path: '/jwt-decoder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/jwt-decoder',
+  path: '/jwt-decoder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const JsonFormatterRoute = JsonFormatterRouteImport.update({
-	id: '/json-formatter',
-	path: '/json-formatter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/json-formatter',
+  path: '/json-formatter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IpConverterRoute = IpConverterRouteImport.update({
-	id: '/ip-converter',
-	path: '/ip-converter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/ip-converter',
+  path: '/ip-converter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ImageConverterRoute = ImageConverterRouteImport.update({
-	id: '/image-converter',
-	path: '/image-converter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/image-converter',
+  path: '/image-converter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const HttpStatusCodesRoute = HttpStatusCodesRouteImport.update({
-	id: '/http-status-codes',
-	path: '/http-status-codes',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/http-status-codes',
+  path: '/http-status-codes',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const HashGeneratorRoute = HashGeneratorRouteImport.update({
-	id: '/hash-generator',
-	path: '/hash-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/hash-generator',
+  path: '/hash-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const GpgKeyGeneratorRoute = GpgKeyGeneratorRouteImport.update({
-	id: '/gpg-key-generator',
-	path: '/gpg-key-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/gpg-key-generator',
+  path: '/gpg-key-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const EscapeToolRoute = EscapeToolRouteImport.update({
-	id: '/escape-tool',
-	path: '/escape-tool',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/escape-tool',
+  path: '/escape-tool',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DnsLookupRoute = DnsLookupRouteImport.update({
-	id: '/dns-lookup',
-	path: '/dns-lookup',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/dns-lookup',
+  path: '/dns-lookup',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DiffViewerRoute = DiffViewerRouteImport.update({
-	id: '/diff-viewer',
-	path: '/diff-viewer',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/diff-viewer',
+  path: '/diff-viewer',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DateTimestampConverterRoute = DateTimestampConverterRouteImport.update({
-	id: '/date-timestamp-converter',
-	path: '/date-timestamp-converter',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/date-timestamp-converter',
+  path: '/date-timestamp-converter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CurlBuilderRoute = CurlBuilderRouteImport.update({
-	id: '/curl-builder',
-	path: '/curl-builder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/curl-builder',
+  path: '/curl-builder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CronExpressionBuilderRoute = CronExpressionBuilderRouteImport.update({
-	id: '/cron-expression-builder',
-	path: '/cron-expression-builder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/cron-expression-builder',
+  path: '/cron-expression-builder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CidrCalculatorRoute = CidrCalculatorRouteImport.update({
-	id: '/cidr-calculator',
-	path: '/cidr-calculator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/cidr-calculator',
+  path: '/cidr-calculator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const BcryptGeneratorRoute = BcryptGeneratorRouteImport.update({
-	id: '/bcrypt-generator',
-	path: '/bcrypt-generator',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/bcrypt-generator',
+  path: '/bcrypt-generator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const Base64EncoderRoute = Base64EncoderRouteImport.update({
-	id: '/base64-encoder',
-	path: '/base64-encoder',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/base64-encoder',
+  path: '/base64-encoder',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
-	id: '/',
-	path: '/',
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
-	'/': typeof IndexRoute;
-	'/base64-encoder': typeof Base64EncoderRoute;
-	'/bcrypt-generator': typeof BcryptGeneratorRoute;
-	'/cidr-calculator': typeof CidrCalculatorRoute;
-	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
-	'/curl-builder': typeof CurlBuilderRoute;
-	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
-	'/diff-viewer': typeof DiffViewerRoute;
-	'/dns-lookup': typeof DnsLookupRoute;
-	'/escape-tool': typeof EscapeToolRoute;
-	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
-	'/hash-generator': typeof HashGeneratorRoute;
-	'/http-status-codes': typeof HttpStatusCodesRoute;
-	'/image-converter': typeof ImageConverterRoute;
-	'/ip-converter': typeof IpConverterRoute;
-	'/json-formatter': typeof JsonFormatterRoute;
-	'/jwt-decoder': typeof JwtDecoderRoute;
-	'/list-comparer': typeof ListComparerRoute;
-	'/lorem-ipsum': typeof LoremIpsumRoute;
-	'/mac-lookup': typeof MacLookupRoute;
-	'/markdown-editor': typeof MarkdownEditorRoute;
-	'/mime-types': typeof MimeTypesRoute;
-	'/network-interfaces': typeof NetworkInterfacesRoute;
-	'/network-scanner': typeof NetworkScannerRoute;
-	'/number-base-converter': typeof NumberBaseConverterRoute;
-	'/password-generator': typeof PasswordGeneratorRoute;
-	'/qr-code-generator': typeof QrCodeGeneratorRoute;
-	'/regex-tester': typeof RegexTesterRoute;
-	'/rest-client': typeof RestClientRoute;
-	'/rsa-tools': typeof RsaToolsRoute;
-	'/semver-tools': typeof SemverToolsRoute;
-	'/settings': typeof SettingsRoute;
-	'/sql-formatter': typeof SqlFormatterRoute;
-	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
-	'/string-case-converter': typeof StringCaseConverterRoute;
-	'/string-compressor': typeof StringCompressorRoute;
-	'/url-encoder': typeof UrlEncoderRoute;
-	'/uuid-generator': typeof UuidGeneratorRoute;
-	'/websocket-tester': typeof WebsocketTesterRoute;
-	'/x509-decoder': typeof X509DecoderRoute;
-	'/xml-formatter': typeof XmlFormatterRoute;
-	'/yaml-formatter': typeof YamlFormatterRoute;
+  '/': typeof IndexRoute
+  '/base64-encoder': typeof Base64EncoderRoute
+  '/bcrypt-generator': typeof BcryptGeneratorRoute
+  '/cidr-calculator': typeof CidrCalculatorRoute
+  '/cron-expression-builder': typeof CronExpressionBuilderRoute
+  '/curl-builder': typeof CurlBuilderRoute
+  '/date-timestamp-converter': typeof DateTimestampConverterRoute
+  '/diff-viewer': typeof DiffViewerRoute
+  '/dns-lookup': typeof DnsLookupRoute
+  '/escape-tool': typeof EscapeToolRoute
+  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
+  '/hash-generator': typeof HashGeneratorRoute
+  '/http-status-codes': typeof HttpStatusCodesRoute
+  '/image-converter': typeof ImageConverterRoute
+  '/ip-converter': typeof IpConverterRoute
+  '/json-formatter': typeof JsonFormatterRoute
+  '/jwt-decoder': typeof JwtDecoderRoute
+  '/list-comparer': typeof ListComparerRoute
+  '/lorem-ipsum': typeof LoremIpsumRoute
+  '/mac-lookup': typeof MacLookupRoute
+  '/markdown-editor': typeof MarkdownEditorRoute
+  '/mime-types': typeof MimeTypesRoute
+  '/network-interfaces': typeof NetworkInterfacesRoute
+  '/network-scanner': typeof NetworkScannerRoute
+  '/number-base-converter': typeof NumberBaseConverterRoute
+  '/password-generator': typeof PasswordGeneratorRoute
+  '/qr-code-generator': typeof QrCodeGeneratorRoute
+  '/regex-tester': typeof RegexTesterRoute
+  '/rest-client': typeof RestClientRoute
+  '/rsa-tools': typeof RsaToolsRoute
+  '/semver-tools': typeof SemverToolsRoute
+  '/settings': typeof SettingsRoute
+  '/sql-formatter': typeof SqlFormatterRoute
+  '/ssh-key-generator': typeof SshKeyGeneratorRoute
+  '/string-case-converter': typeof StringCaseConverterRoute
+  '/string-compressor': typeof StringCompressorRoute
+  '/tls-inspector': typeof TlsInspectorRoute
+  '/url-encoder': typeof UrlEncoderRoute
+  '/uuid-generator': typeof UuidGeneratorRoute
+  '/websocket-tester': typeof WebsocketTesterRoute
+  '/x509-decoder': typeof X509DecoderRoute
+  '/xml-formatter': typeof XmlFormatterRoute
+  '/yaml-formatter': typeof YamlFormatterRoute
 }
 export interface FileRoutesByTo {
-	'/': typeof IndexRoute;
-	'/base64-encoder': typeof Base64EncoderRoute;
-	'/bcrypt-generator': typeof BcryptGeneratorRoute;
-	'/cidr-calculator': typeof CidrCalculatorRoute;
-	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
-	'/curl-builder': typeof CurlBuilderRoute;
-	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
-	'/diff-viewer': typeof DiffViewerRoute;
-	'/dns-lookup': typeof DnsLookupRoute;
-	'/escape-tool': typeof EscapeToolRoute;
-	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
-	'/hash-generator': typeof HashGeneratorRoute;
-	'/http-status-codes': typeof HttpStatusCodesRoute;
-	'/image-converter': typeof ImageConverterRoute;
-	'/ip-converter': typeof IpConverterRoute;
-	'/json-formatter': typeof JsonFormatterRoute;
-	'/jwt-decoder': typeof JwtDecoderRoute;
-	'/list-comparer': typeof ListComparerRoute;
-	'/lorem-ipsum': typeof LoremIpsumRoute;
-	'/mac-lookup': typeof MacLookupRoute;
-	'/markdown-editor': typeof MarkdownEditorRoute;
-	'/mime-types': typeof MimeTypesRoute;
-	'/network-interfaces': typeof NetworkInterfacesRoute;
-	'/network-scanner': typeof NetworkScannerRoute;
-	'/number-base-converter': typeof NumberBaseConverterRoute;
-	'/password-generator': typeof PasswordGeneratorRoute;
-	'/qr-code-generator': typeof QrCodeGeneratorRoute;
-	'/regex-tester': typeof RegexTesterRoute;
-	'/rest-client': typeof RestClientRoute;
-	'/rsa-tools': typeof RsaToolsRoute;
-	'/semver-tools': typeof SemverToolsRoute;
-	'/settings': typeof SettingsRoute;
-	'/sql-formatter': typeof SqlFormatterRoute;
-	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
-	'/string-case-converter': typeof StringCaseConverterRoute;
-	'/string-compressor': typeof StringCompressorRoute;
-	'/url-encoder': typeof UrlEncoderRoute;
-	'/uuid-generator': typeof UuidGeneratorRoute;
-	'/websocket-tester': typeof WebsocketTesterRoute;
-	'/x509-decoder': typeof X509DecoderRoute;
-	'/xml-formatter': typeof XmlFormatterRoute;
-	'/yaml-formatter': typeof YamlFormatterRoute;
+  '/': typeof IndexRoute
+  '/base64-encoder': typeof Base64EncoderRoute
+  '/bcrypt-generator': typeof BcryptGeneratorRoute
+  '/cidr-calculator': typeof CidrCalculatorRoute
+  '/cron-expression-builder': typeof CronExpressionBuilderRoute
+  '/curl-builder': typeof CurlBuilderRoute
+  '/date-timestamp-converter': typeof DateTimestampConverterRoute
+  '/diff-viewer': typeof DiffViewerRoute
+  '/dns-lookup': typeof DnsLookupRoute
+  '/escape-tool': typeof EscapeToolRoute
+  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
+  '/hash-generator': typeof HashGeneratorRoute
+  '/http-status-codes': typeof HttpStatusCodesRoute
+  '/image-converter': typeof ImageConverterRoute
+  '/ip-converter': typeof IpConverterRoute
+  '/json-formatter': typeof JsonFormatterRoute
+  '/jwt-decoder': typeof JwtDecoderRoute
+  '/list-comparer': typeof ListComparerRoute
+  '/lorem-ipsum': typeof LoremIpsumRoute
+  '/mac-lookup': typeof MacLookupRoute
+  '/markdown-editor': typeof MarkdownEditorRoute
+  '/mime-types': typeof MimeTypesRoute
+  '/network-interfaces': typeof NetworkInterfacesRoute
+  '/network-scanner': typeof NetworkScannerRoute
+  '/number-base-converter': typeof NumberBaseConverterRoute
+  '/password-generator': typeof PasswordGeneratorRoute
+  '/qr-code-generator': typeof QrCodeGeneratorRoute
+  '/regex-tester': typeof RegexTesterRoute
+  '/rest-client': typeof RestClientRoute
+  '/rsa-tools': typeof RsaToolsRoute
+  '/semver-tools': typeof SemverToolsRoute
+  '/settings': typeof SettingsRoute
+  '/sql-formatter': typeof SqlFormatterRoute
+  '/ssh-key-generator': typeof SshKeyGeneratorRoute
+  '/string-case-converter': typeof StringCaseConverterRoute
+  '/string-compressor': typeof StringCompressorRoute
+  '/tls-inspector': typeof TlsInspectorRoute
+  '/url-encoder': typeof UrlEncoderRoute
+  '/uuid-generator': typeof UuidGeneratorRoute
+  '/websocket-tester': typeof WebsocketTesterRoute
+  '/x509-decoder': typeof X509DecoderRoute
+  '/xml-formatter': typeof XmlFormatterRoute
+  '/yaml-formatter': typeof YamlFormatterRoute
 }
 export interface FileRoutesById {
-	__root__: typeof rootRouteImport;
-	'/': typeof IndexRoute;
-	'/base64-encoder': typeof Base64EncoderRoute;
-	'/bcrypt-generator': typeof BcryptGeneratorRoute;
-	'/cidr-calculator': typeof CidrCalculatorRoute;
-	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
-	'/curl-builder': typeof CurlBuilderRoute;
-	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
-	'/diff-viewer': typeof DiffViewerRoute;
-	'/dns-lookup': typeof DnsLookupRoute;
-	'/escape-tool': typeof EscapeToolRoute;
-	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
-	'/hash-generator': typeof HashGeneratorRoute;
-	'/http-status-codes': typeof HttpStatusCodesRoute;
-	'/image-converter': typeof ImageConverterRoute;
-	'/ip-converter': typeof IpConverterRoute;
-	'/json-formatter': typeof JsonFormatterRoute;
-	'/jwt-decoder': typeof JwtDecoderRoute;
-	'/list-comparer': typeof ListComparerRoute;
-	'/lorem-ipsum': typeof LoremIpsumRoute;
-	'/mac-lookup': typeof MacLookupRoute;
-	'/markdown-editor': typeof MarkdownEditorRoute;
-	'/mime-types': typeof MimeTypesRoute;
-	'/network-interfaces': typeof NetworkInterfacesRoute;
-	'/network-scanner': typeof NetworkScannerRoute;
-	'/number-base-converter': typeof NumberBaseConverterRoute;
-	'/password-generator': typeof PasswordGeneratorRoute;
-	'/qr-code-generator': typeof QrCodeGeneratorRoute;
-	'/regex-tester': typeof RegexTesterRoute;
-	'/rest-client': typeof RestClientRoute;
-	'/rsa-tools': typeof RsaToolsRoute;
-	'/semver-tools': typeof SemverToolsRoute;
-	'/settings': typeof SettingsRoute;
-	'/sql-formatter': typeof SqlFormatterRoute;
-	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
-	'/string-case-converter': typeof StringCaseConverterRoute;
-	'/string-compressor': typeof StringCompressorRoute;
-	'/url-encoder': typeof UrlEncoderRoute;
-	'/uuid-generator': typeof UuidGeneratorRoute;
-	'/websocket-tester': typeof WebsocketTesterRoute;
-	'/x509-decoder': typeof X509DecoderRoute;
-	'/xml-formatter': typeof XmlFormatterRoute;
-	'/yaml-formatter': typeof YamlFormatterRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/base64-encoder': typeof Base64EncoderRoute
+  '/bcrypt-generator': typeof BcryptGeneratorRoute
+  '/cidr-calculator': typeof CidrCalculatorRoute
+  '/cron-expression-builder': typeof CronExpressionBuilderRoute
+  '/curl-builder': typeof CurlBuilderRoute
+  '/date-timestamp-converter': typeof DateTimestampConverterRoute
+  '/diff-viewer': typeof DiffViewerRoute
+  '/dns-lookup': typeof DnsLookupRoute
+  '/escape-tool': typeof EscapeToolRoute
+  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
+  '/hash-generator': typeof HashGeneratorRoute
+  '/http-status-codes': typeof HttpStatusCodesRoute
+  '/image-converter': typeof ImageConverterRoute
+  '/ip-converter': typeof IpConverterRoute
+  '/json-formatter': typeof JsonFormatterRoute
+  '/jwt-decoder': typeof JwtDecoderRoute
+  '/list-comparer': typeof ListComparerRoute
+  '/lorem-ipsum': typeof LoremIpsumRoute
+  '/mac-lookup': typeof MacLookupRoute
+  '/markdown-editor': typeof MarkdownEditorRoute
+  '/mime-types': typeof MimeTypesRoute
+  '/network-interfaces': typeof NetworkInterfacesRoute
+  '/network-scanner': typeof NetworkScannerRoute
+  '/number-base-converter': typeof NumberBaseConverterRoute
+  '/password-generator': typeof PasswordGeneratorRoute
+  '/qr-code-generator': typeof QrCodeGeneratorRoute
+  '/regex-tester': typeof RegexTesterRoute
+  '/rest-client': typeof RestClientRoute
+  '/rsa-tools': typeof RsaToolsRoute
+  '/semver-tools': typeof SemverToolsRoute
+  '/settings': typeof SettingsRoute
+  '/sql-formatter': typeof SqlFormatterRoute
+  '/ssh-key-generator': typeof SshKeyGeneratorRoute
+  '/string-case-converter': typeof StringCaseConverterRoute
+  '/string-compressor': typeof StringCompressorRoute
+  '/tls-inspector': typeof TlsInspectorRoute
+  '/url-encoder': typeof UrlEncoderRoute
+  '/uuid-generator': typeof UuidGeneratorRoute
+  '/websocket-tester': typeof WebsocketTesterRoute
+  '/x509-decoder': typeof X509DecoderRoute
+  '/xml-formatter': typeof XmlFormatterRoute
+  '/yaml-formatter': typeof YamlFormatterRoute
 }
 export interface FileRouteTypes {
-	fileRoutesByFullPath: FileRoutesByFullPath;
-	fullPaths:
-		| '/'
-		| '/base64-encoder'
-		| '/bcrypt-generator'
-		| '/cidr-calculator'
-		| '/cron-expression-builder'
-		| '/curl-builder'
-		| '/date-timestamp-converter'
-		| '/diff-viewer'
-		| '/dns-lookup'
-		| '/escape-tool'
-		| '/gpg-key-generator'
-		| '/hash-generator'
-		| '/http-status-codes'
-		| '/image-converter'
-		| '/ip-converter'
-		| '/json-formatter'
-		| '/jwt-decoder'
-		| '/list-comparer'
-		| '/lorem-ipsum'
-		| '/mac-lookup'
-		| '/markdown-editor'
-		| '/mime-types'
-		| '/network-interfaces'
-		| '/network-scanner'
-		| '/number-base-converter'
-		| '/password-generator'
-		| '/qr-code-generator'
-		| '/regex-tester'
-		| '/rest-client'
-		| '/rsa-tools'
-		| '/semver-tools'
-		| '/settings'
-		| '/sql-formatter'
-		| '/ssh-key-generator'
-		| '/string-case-converter'
-		| '/string-compressor'
-		| '/url-encoder'
-		| '/uuid-generator'
-		| '/websocket-tester'
-		| '/x509-decoder'
-		| '/xml-formatter'
-		| '/yaml-formatter';
-	fileRoutesByTo: FileRoutesByTo;
-	to:
-		| '/'
-		| '/base64-encoder'
-		| '/bcrypt-generator'
-		| '/cidr-calculator'
-		| '/cron-expression-builder'
-		| '/curl-builder'
-		| '/date-timestamp-converter'
-		| '/diff-viewer'
-		| '/dns-lookup'
-		| '/escape-tool'
-		| '/gpg-key-generator'
-		| '/hash-generator'
-		| '/http-status-codes'
-		| '/image-converter'
-		| '/ip-converter'
-		| '/json-formatter'
-		| '/jwt-decoder'
-		| '/list-comparer'
-		| '/lorem-ipsum'
-		| '/mac-lookup'
-		| '/markdown-editor'
-		| '/mime-types'
-		| '/network-interfaces'
-		| '/network-scanner'
-		| '/number-base-converter'
-		| '/password-generator'
-		| '/qr-code-generator'
-		| '/regex-tester'
-		| '/rest-client'
-		| '/rsa-tools'
-		| '/semver-tools'
-		| '/settings'
-		| '/sql-formatter'
-		| '/ssh-key-generator'
-		| '/string-case-converter'
-		| '/string-compressor'
-		| '/url-encoder'
-		| '/uuid-generator'
-		| '/websocket-tester'
-		| '/x509-decoder'
-		| '/xml-formatter'
-		| '/yaml-formatter';
-	id:
-		| '__root__'
-		| '/'
-		| '/base64-encoder'
-		| '/bcrypt-generator'
-		| '/cidr-calculator'
-		| '/cron-expression-builder'
-		| '/curl-builder'
-		| '/date-timestamp-converter'
-		| '/diff-viewer'
-		| '/dns-lookup'
-		| '/escape-tool'
-		| '/gpg-key-generator'
-		| '/hash-generator'
-		| '/http-status-codes'
-		| '/image-converter'
-		| '/ip-converter'
-		| '/json-formatter'
-		| '/jwt-decoder'
-		| '/list-comparer'
-		| '/lorem-ipsum'
-		| '/mac-lookup'
-		| '/markdown-editor'
-		| '/mime-types'
-		| '/network-interfaces'
-		| '/network-scanner'
-		| '/number-base-converter'
-		| '/password-generator'
-		| '/qr-code-generator'
-		| '/regex-tester'
-		| '/rest-client'
-		| '/rsa-tools'
-		| '/semver-tools'
-		| '/settings'
-		| '/sql-formatter'
-		| '/ssh-key-generator'
-		| '/string-case-converter'
-		| '/string-compressor'
-		| '/url-encoder'
-		| '/uuid-generator'
-		| '/websocket-tester'
-		| '/x509-decoder'
-		| '/xml-formatter'
-		| '/yaml-formatter';
-	fileRoutesById: FileRoutesById;
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/base64-encoder'
+    | '/bcrypt-generator'
+    | '/cidr-calculator'
+    | '/cron-expression-builder'
+    | '/curl-builder'
+    | '/date-timestamp-converter'
+    | '/diff-viewer'
+    | '/dns-lookup'
+    | '/escape-tool'
+    | '/gpg-key-generator'
+    | '/hash-generator'
+    | '/http-status-codes'
+    | '/image-converter'
+    | '/ip-converter'
+    | '/json-formatter'
+    | '/jwt-decoder'
+    | '/list-comparer'
+    | '/lorem-ipsum'
+    | '/mac-lookup'
+    | '/markdown-editor'
+    | '/mime-types'
+    | '/network-interfaces'
+    | '/network-scanner'
+    | '/number-base-converter'
+    | '/password-generator'
+    | '/qr-code-generator'
+    | '/regex-tester'
+    | '/rest-client'
+    | '/rsa-tools'
+    | '/semver-tools'
+    | '/settings'
+    | '/sql-formatter'
+    | '/ssh-key-generator'
+    | '/string-case-converter'
+    | '/string-compressor'
+    | '/tls-inspector'
+    | '/url-encoder'
+    | '/uuid-generator'
+    | '/websocket-tester'
+    | '/x509-decoder'
+    | '/xml-formatter'
+    | '/yaml-formatter'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/base64-encoder'
+    | '/bcrypt-generator'
+    | '/cidr-calculator'
+    | '/cron-expression-builder'
+    | '/curl-builder'
+    | '/date-timestamp-converter'
+    | '/diff-viewer'
+    | '/dns-lookup'
+    | '/escape-tool'
+    | '/gpg-key-generator'
+    | '/hash-generator'
+    | '/http-status-codes'
+    | '/image-converter'
+    | '/ip-converter'
+    | '/json-formatter'
+    | '/jwt-decoder'
+    | '/list-comparer'
+    | '/lorem-ipsum'
+    | '/mac-lookup'
+    | '/markdown-editor'
+    | '/mime-types'
+    | '/network-interfaces'
+    | '/network-scanner'
+    | '/number-base-converter'
+    | '/password-generator'
+    | '/qr-code-generator'
+    | '/regex-tester'
+    | '/rest-client'
+    | '/rsa-tools'
+    | '/semver-tools'
+    | '/settings'
+    | '/sql-formatter'
+    | '/ssh-key-generator'
+    | '/string-case-converter'
+    | '/string-compressor'
+    | '/tls-inspector'
+    | '/url-encoder'
+    | '/uuid-generator'
+    | '/websocket-tester'
+    | '/x509-decoder'
+    | '/xml-formatter'
+    | '/yaml-formatter'
+  id:
+    | '__root__'
+    | '/'
+    | '/base64-encoder'
+    | '/bcrypt-generator'
+    | '/cidr-calculator'
+    | '/cron-expression-builder'
+    | '/curl-builder'
+    | '/date-timestamp-converter'
+    | '/diff-viewer'
+    | '/dns-lookup'
+    | '/escape-tool'
+    | '/gpg-key-generator'
+    | '/hash-generator'
+    | '/http-status-codes'
+    | '/image-converter'
+    | '/ip-converter'
+    | '/json-formatter'
+    | '/jwt-decoder'
+    | '/list-comparer'
+    | '/lorem-ipsum'
+    | '/mac-lookup'
+    | '/markdown-editor'
+    | '/mime-types'
+    | '/network-interfaces'
+    | '/network-scanner'
+    | '/number-base-converter'
+    | '/password-generator'
+    | '/qr-code-generator'
+    | '/regex-tester'
+    | '/rest-client'
+    | '/rsa-tools'
+    | '/semver-tools'
+    | '/settings'
+    | '/sql-formatter'
+    | '/ssh-key-generator'
+    | '/string-case-converter'
+    | '/string-compressor'
+    | '/tls-inspector'
+    | '/url-encoder'
+    | '/uuid-generator'
+    | '/websocket-tester'
+    | '/x509-decoder'
+    | '/xml-formatter'
+    | '/yaml-formatter'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-	IndexRoute: typeof IndexRoute;
-	Base64EncoderRoute: typeof Base64EncoderRoute;
-	BcryptGeneratorRoute: typeof BcryptGeneratorRoute;
-	CidrCalculatorRoute: typeof CidrCalculatorRoute;
-	CronExpressionBuilderRoute: typeof CronExpressionBuilderRoute;
-	CurlBuilderRoute: typeof CurlBuilderRoute;
-	DateTimestampConverterRoute: typeof DateTimestampConverterRoute;
-	DiffViewerRoute: typeof DiffViewerRoute;
-	DnsLookupRoute: typeof DnsLookupRoute;
-	EscapeToolRoute: typeof EscapeToolRoute;
-	GpgKeyGeneratorRoute: typeof GpgKeyGeneratorRoute;
-	HashGeneratorRoute: typeof HashGeneratorRoute;
-	HttpStatusCodesRoute: typeof HttpStatusCodesRoute;
-	ImageConverterRoute: typeof ImageConverterRoute;
-	IpConverterRoute: typeof IpConverterRoute;
-	JsonFormatterRoute: typeof JsonFormatterRoute;
-	JwtDecoderRoute: typeof JwtDecoderRoute;
-	ListComparerRoute: typeof ListComparerRoute;
-	LoremIpsumRoute: typeof LoremIpsumRoute;
-	MacLookupRoute: typeof MacLookupRoute;
-	MarkdownEditorRoute: typeof MarkdownEditorRoute;
-	MimeTypesRoute: typeof MimeTypesRoute;
-	NetworkInterfacesRoute: typeof NetworkInterfacesRoute;
-	NetworkScannerRoute: typeof NetworkScannerRoute;
-	NumberBaseConverterRoute: typeof NumberBaseConverterRoute;
-	PasswordGeneratorRoute: typeof PasswordGeneratorRoute;
-	QrCodeGeneratorRoute: typeof QrCodeGeneratorRoute;
-	RegexTesterRoute: typeof RegexTesterRoute;
-	RestClientRoute: typeof RestClientRoute;
-	RsaToolsRoute: typeof RsaToolsRoute;
-	SemverToolsRoute: typeof SemverToolsRoute;
-	SettingsRoute: typeof SettingsRoute;
-	SqlFormatterRoute: typeof SqlFormatterRoute;
-	SshKeyGeneratorRoute: typeof SshKeyGeneratorRoute;
-	StringCaseConverterRoute: typeof StringCaseConverterRoute;
-	StringCompressorRoute: typeof StringCompressorRoute;
-	UrlEncoderRoute: typeof UrlEncoderRoute;
-	UuidGeneratorRoute: typeof UuidGeneratorRoute;
-	WebsocketTesterRoute: typeof WebsocketTesterRoute;
-	X509DecoderRoute: typeof X509DecoderRoute;
-	XmlFormatterRoute: typeof XmlFormatterRoute;
-	YamlFormatterRoute: typeof YamlFormatterRoute;
+  IndexRoute: typeof IndexRoute
+  Base64EncoderRoute: typeof Base64EncoderRoute
+  BcryptGeneratorRoute: typeof BcryptGeneratorRoute
+  CidrCalculatorRoute: typeof CidrCalculatorRoute
+  CronExpressionBuilderRoute: typeof CronExpressionBuilderRoute
+  CurlBuilderRoute: typeof CurlBuilderRoute
+  DateTimestampConverterRoute: typeof DateTimestampConverterRoute
+  DiffViewerRoute: typeof DiffViewerRoute
+  DnsLookupRoute: typeof DnsLookupRoute
+  EscapeToolRoute: typeof EscapeToolRoute
+  GpgKeyGeneratorRoute: typeof GpgKeyGeneratorRoute
+  HashGeneratorRoute: typeof HashGeneratorRoute
+  HttpStatusCodesRoute: typeof HttpStatusCodesRoute
+  ImageConverterRoute: typeof ImageConverterRoute
+  IpConverterRoute: typeof IpConverterRoute
+  JsonFormatterRoute: typeof JsonFormatterRoute
+  JwtDecoderRoute: typeof JwtDecoderRoute
+  ListComparerRoute: typeof ListComparerRoute
+  LoremIpsumRoute: typeof LoremIpsumRoute
+  MacLookupRoute: typeof MacLookupRoute
+  MarkdownEditorRoute: typeof MarkdownEditorRoute
+  MimeTypesRoute: typeof MimeTypesRoute
+  NetworkInterfacesRoute: typeof NetworkInterfacesRoute
+  NetworkScannerRoute: typeof NetworkScannerRoute
+  NumberBaseConverterRoute: typeof NumberBaseConverterRoute
+  PasswordGeneratorRoute: typeof PasswordGeneratorRoute
+  QrCodeGeneratorRoute: typeof QrCodeGeneratorRoute
+  RegexTesterRoute: typeof RegexTesterRoute
+  RestClientRoute: typeof RestClientRoute
+  RsaToolsRoute: typeof RsaToolsRoute
+  SemverToolsRoute: typeof SemverToolsRoute
+  SettingsRoute: typeof SettingsRoute
+  SqlFormatterRoute: typeof SqlFormatterRoute
+  SshKeyGeneratorRoute: typeof SshKeyGeneratorRoute
+  StringCaseConverterRoute: typeof StringCaseConverterRoute
+  StringCompressorRoute: typeof StringCompressorRoute
+  TlsInspectorRoute: typeof TlsInspectorRoute
+  UrlEncoderRoute: typeof UrlEncoderRoute
+  UuidGeneratorRoute: typeof UuidGeneratorRoute
+  WebsocketTesterRoute: typeof WebsocketTesterRoute
+  X509DecoderRoute: typeof X509DecoderRoute
+  XmlFormatterRoute: typeof XmlFormatterRoute
+  YamlFormatterRoute: typeof YamlFormatterRoute
 }
 
 declare module '@tanstack/react-router' {
-	interface FileRoutesByPath {
-		'/yaml-formatter': {
-			id: '/yaml-formatter';
-			path: '/yaml-formatter';
-			fullPath: '/yaml-formatter';
-			preLoaderRoute: typeof YamlFormatterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/xml-formatter': {
-			id: '/xml-formatter';
-			path: '/xml-formatter';
-			fullPath: '/xml-formatter';
-			preLoaderRoute: typeof XmlFormatterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/x509-decoder': {
-			id: '/x509-decoder';
-			path: '/x509-decoder';
-			fullPath: '/x509-decoder';
-			preLoaderRoute: typeof X509DecoderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/websocket-tester': {
-			id: '/websocket-tester';
-			path: '/websocket-tester';
-			fullPath: '/websocket-tester';
-			preLoaderRoute: typeof WebsocketTesterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/uuid-generator': {
-			id: '/uuid-generator';
-			path: '/uuid-generator';
-			fullPath: '/uuid-generator';
-			preLoaderRoute: typeof UuidGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/url-encoder': {
-			id: '/url-encoder';
-			path: '/url-encoder';
-			fullPath: '/url-encoder';
-			preLoaderRoute: typeof UrlEncoderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/string-compressor': {
-			id: '/string-compressor';
-			path: '/string-compressor';
-			fullPath: '/string-compressor';
-			preLoaderRoute: typeof StringCompressorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/string-case-converter': {
-			id: '/string-case-converter';
-			path: '/string-case-converter';
-			fullPath: '/string-case-converter';
-			preLoaderRoute: typeof StringCaseConverterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/ssh-key-generator': {
-			id: '/ssh-key-generator';
-			path: '/ssh-key-generator';
-			fullPath: '/ssh-key-generator';
-			preLoaderRoute: typeof SshKeyGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/sql-formatter': {
-			id: '/sql-formatter';
-			path: '/sql-formatter';
-			fullPath: '/sql-formatter';
-			preLoaderRoute: typeof SqlFormatterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/settings': {
-			id: '/settings';
-			path: '/settings';
-			fullPath: '/settings';
-			preLoaderRoute: typeof SettingsRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/semver-tools': {
-			id: '/semver-tools';
-			path: '/semver-tools';
-			fullPath: '/semver-tools';
-			preLoaderRoute: typeof SemverToolsRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/rsa-tools': {
-			id: '/rsa-tools';
-			path: '/rsa-tools';
-			fullPath: '/rsa-tools';
-			preLoaderRoute: typeof RsaToolsRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/rest-client': {
-			id: '/rest-client';
-			path: '/rest-client';
-			fullPath: '/rest-client';
-			preLoaderRoute: typeof RestClientRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/regex-tester': {
-			id: '/regex-tester';
-			path: '/regex-tester';
-			fullPath: '/regex-tester';
-			preLoaderRoute: typeof RegexTesterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/qr-code-generator': {
-			id: '/qr-code-generator';
-			path: '/qr-code-generator';
-			fullPath: '/qr-code-generator';
-			preLoaderRoute: typeof QrCodeGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/password-generator': {
-			id: '/password-generator';
-			path: '/password-generator';
-			fullPath: '/password-generator';
-			preLoaderRoute: typeof PasswordGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/number-base-converter': {
-			id: '/number-base-converter';
-			path: '/number-base-converter';
-			fullPath: '/number-base-converter';
-			preLoaderRoute: typeof NumberBaseConverterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/network-scanner': {
-			id: '/network-scanner';
-			path: '/network-scanner';
-			fullPath: '/network-scanner';
-			preLoaderRoute: typeof NetworkScannerRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/network-interfaces': {
-			id: '/network-interfaces';
-			path: '/network-interfaces';
-			fullPath: '/network-interfaces';
-			preLoaderRoute: typeof NetworkInterfacesRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/mime-types': {
-			id: '/mime-types';
-			path: '/mime-types';
-			fullPath: '/mime-types';
-			preLoaderRoute: typeof MimeTypesRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/markdown-editor': {
-			id: '/markdown-editor';
-			path: '/markdown-editor';
-			fullPath: '/markdown-editor';
-			preLoaderRoute: typeof MarkdownEditorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/mac-lookup': {
-			id: '/mac-lookup';
-			path: '/mac-lookup';
-			fullPath: '/mac-lookup';
-			preLoaderRoute: typeof MacLookupRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/lorem-ipsum': {
-			id: '/lorem-ipsum';
-			path: '/lorem-ipsum';
-			fullPath: '/lorem-ipsum';
-			preLoaderRoute: typeof LoremIpsumRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/list-comparer': {
-			id: '/list-comparer';
-			path: '/list-comparer';
-			fullPath: '/list-comparer';
-			preLoaderRoute: typeof ListComparerRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/jwt-decoder': {
-			id: '/jwt-decoder';
-			path: '/jwt-decoder';
-			fullPath: '/jwt-decoder';
-			preLoaderRoute: typeof JwtDecoderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/json-formatter': {
-			id: '/json-formatter';
-			path: '/json-formatter';
-			fullPath: '/json-formatter';
-			preLoaderRoute: typeof JsonFormatterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/ip-converter': {
-			id: '/ip-converter';
-			path: '/ip-converter';
-			fullPath: '/ip-converter';
-			preLoaderRoute: typeof IpConverterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/image-converter': {
-			id: '/image-converter';
-			path: '/image-converter';
-			fullPath: '/image-converter';
-			preLoaderRoute: typeof ImageConverterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/http-status-codes': {
-			id: '/http-status-codes';
-			path: '/http-status-codes';
-			fullPath: '/http-status-codes';
-			preLoaderRoute: typeof HttpStatusCodesRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/hash-generator': {
-			id: '/hash-generator';
-			path: '/hash-generator';
-			fullPath: '/hash-generator';
-			preLoaderRoute: typeof HashGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/gpg-key-generator': {
-			id: '/gpg-key-generator';
-			path: '/gpg-key-generator';
-			fullPath: '/gpg-key-generator';
-			preLoaderRoute: typeof GpgKeyGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/escape-tool': {
-			id: '/escape-tool';
-			path: '/escape-tool';
-			fullPath: '/escape-tool';
-			preLoaderRoute: typeof EscapeToolRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/dns-lookup': {
-			id: '/dns-lookup';
-			path: '/dns-lookup';
-			fullPath: '/dns-lookup';
-			preLoaderRoute: typeof DnsLookupRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/diff-viewer': {
-			id: '/diff-viewer';
-			path: '/diff-viewer';
-			fullPath: '/diff-viewer';
-			preLoaderRoute: typeof DiffViewerRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/date-timestamp-converter': {
-			id: '/date-timestamp-converter';
-			path: '/date-timestamp-converter';
-			fullPath: '/date-timestamp-converter';
-			preLoaderRoute: typeof DateTimestampConverterRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/curl-builder': {
-			id: '/curl-builder';
-			path: '/curl-builder';
-			fullPath: '/curl-builder';
-			preLoaderRoute: typeof CurlBuilderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/cron-expression-builder': {
-			id: '/cron-expression-builder';
-			path: '/cron-expression-builder';
-			fullPath: '/cron-expression-builder';
-			preLoaderRoute: typeof CronExpressionBuilderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/cidr-calculator': {
-			id: '/cidr-calculator';
-			path: '/cidr-calculator';
-			fullPath: '/cidr-calculator';
-			preLoaderRoute: typeof CidrCalculatorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/bcrypt-generator': {
-			id: '/bcrypt-generator';
-			path: '/bcrypt-generator';
-			fullPath: '/bcrypt-generator';
-			preLoaderRoute: typeof BcryptGeneratorRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/base64-encoder': {
-			id: '/base64-encoder';
-			path: '/base64-encoder';
-			fullPath: '/base64-encoder';
-			preLoaderRoute: typeof Base64EncoderRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		'/': {
-			id: '/';
-			path: '/';
-			fullPath: '/';
-			preLoaderRoute: typeof IndexRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-	}
+  interface FileRoutesByPath {
+    '/yaml-formatter': {
+      id: '/yaml-formatter'
+      path: '/yaml-formatter'
+      fullPath: '/yaml-formatter'
+      preLoaderRoute: typeof YamlFormatterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/xml-formatter': {
+      id: '/xml-formatter'
+      path: '/xml-formatter'
+      fullPath: '/xml-formatter'
+      preLoaderRoute: typeof XmlFormatterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/x509-decoder': {
+      id: '/x509-decoder'
+      path: '/x509-decoder'
+      fullPath: '/x509-decoder'
+      preLoaderRoute: typeof X509DecoderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/websocket-tester': {
+      id: '/websocket-tester'
+      path: '/websocket-tester'
+      fullPath: '/websocket-tester'
+      preLoaderRoute: typeof WebsocketTesterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/uuid-generator': {
+      id: '/uuid-generator'
+      path: '/uuid-generator'
+      fullPath: '/uuid-generator'
+      preLoaderRoute: typeof UuidGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/url-encoder': {
+      id: '/url-encoder'
+      path: '/url-encoder'
+      fullPath: '/url-encoder'
+      preLoaderRoute: typeof UrlEncoderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tls-inspector': {
+      id: '/tls-inspector'
+      path: '/tls-inspector'
+      fullPath: '/tls-inspector'
+      preLoaderRoute: typeof TlsInspectorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/string-compressor': {
+      id: '/string-compressor'
+      path: '/string-compressor'
+      fullPath: '/string-compressor'
+      preLoaderRoute: typeof StringCompressorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/string-case-converter': {
+      id: '/string-case-converter'
+      path: '/string-case-converter'
+      fullPath: '/string-case-converter'
+      preLoaderRoute: typeof StringCaseConverterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/ssh-key-generator': {
+      id: '/ssh-key-generator'
+      path: '/ssh-key-generator'
+      fullPath: '/ssh-key-generator'
+      preLoaderRoute: typeof SshKeyGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sql-formatter': {
+      id: '/sql-formatter'
+      path: '/sql-formatter'
+      fullPath: '/sql-formatter'
+      preLoaderRoute: typeof SqlFormatterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/semver-tools': {
+      id: '/semver-tools'
+      path: '/semver-tools'
+      fullPath: '/semver-tools'
+      preLoaderRoute: typeof SemverToolsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/rsa-tools': {
+      id: '/rsa-tools'
+      path: '/rsa-tools'
+      fullPath: '/rsa-tools'
+      preLoaderRoute: typeof RsaToolsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/rest-client': {
+      id: '/rest-client'
+      path: '/rest-client'
+      fullPath: '/rest-client'
+      preLoaderRoute: typeof RestClientRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/regex-tester': {
+      id: '/regex-tester'
+      path: '/regex-tester'
+      fullPath: '/regex-tester'
+      preLoaderRoute: typeof RegexTesterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/qr-code-generator': {
+      id: '/qr-code-generator'
+      path: '/qr-code-generator'
+      fullPath: '/qr-code-generator'
+      preLoaderRoute: typeof QrCodeGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/password-generator': {
+      id: '/password-generator'
+      path: '/password-generator'
+      fullPath: '/password-generator'
+      preLoaderRoute: typeof PasswordGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/number-base-converter': {
+      id: '/number-base-converter'
+      path: '/number-base-converter'
+      fullPath: '/number-base-converter'
+      preLoaderRoute: typeof NumberBaseConverterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/network-scanner': {
+      id: '/network-scanner'
+      path: '/network-scanner'
+      fullPath: '/network-scanner'
+      preLoaderRoute: typeof NetworkScannerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/network-interfaces': {
+      id: '/network-interfaces'
+      path: '/network-interfaces'
+      fullPath: '/network-interfaces'
+      preLoaderRoute: typeof NetworkInterfacesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mime-types': {
+      id: '/mime-types'
+      path: '/mime-types'
+      fullPath: '/mime-types'
+      preLoaderRoute: typeof MimeTypesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/markdown-editor': {
+      id: '/markdown-editor'
+      path: '/markdown-editor'
+      fullPath: '/markdown-editor'
+      preLoaderRoute: typeof MarkdownEditorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mac-lookup': {
+      id: '/mac-lookup'
+      path: '/mac-lookup'
+      fullPath: '/mac-lookup'
+      preLoaderRoute: typeof MacLookupRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/lorem-ipsum': {
+      id: '/lorem-ipsum'
+      path: '/lorem-ipsum'
+      fullPath: '/lorem-ipsum'
+      preLoaderRoute: typeof LoremIpsumRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/list-comparer': {
+      id: '/list-comparer'
+      path: '/list-comparer'
+      fullPath: '/list-comparer'
+      preLoaderRoute: typeof ListComparerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/jwt-decoder': {
+      id: '/jwt-decoder'
+      path: '/jwt-decoder'
+      fullPath: '/jwt-decoder'
+      preLoaderRoute: typeof JwtDecoderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/json-formatter': {
+      id: '/json-formatter'
+      path: '/json-formatter'
+      fullPath: '/json-formatter'
+      preLoaderRoute: typeof JsonFormatterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/ip-converter': {
+      id: '/ip-converter'
+      path: '/ip-converter'
+      fullPath: '/ip-converter'
+      preLoaderRoute: typeof IpConverterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/image-converter': {
+      id: '/image-converter'
+      path: '/image-converter'
+      fullPath: '/image-converter'
+      preLoaderRoute: typeof ImageConverterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/http-status-codes': {
+      id: '/http-status-codes'
+      path: '/http-status-codes'
+      fullPath: '/http-status-codes'
+      preLoaderRoute: typeof HttpStatusCodesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/hash-generator': {
+      id: '/hash-generator'
+      path: '/hash-generator'
+      fullPath: '/hash-generator'
+      preLoaderRoute: typeof HashGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/gpg-key-generator': {
+      id: '/gpg-key-generator'
+      path: '/gpg-key-generator'
+      fullPath: '/gpg-key-generator'
+      preLoaderRoute: typeof GpgKeyGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/escape-tool': {
+      id: '/escape-tool'
+      path: '/escape-tool'
+      fullPath: '/escape-tool'
+      preLoaderRoute: typeof EscapeToolRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dns-lookup': {
+      id: '/dns-lookup'
+      path: '/dns-lookup'
+      fullPath: '/dns-lookup'
+      preLoaderRoute: typeof DnsLookupRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/diff-viewer': {
+      id: '/diff-viewer'
+      path: '/diff-viewer'
+      fullPath: '/diff-viewer'
+      preLoaderRoute: typeof DiffViewerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/date-timestamp-converter': {
+      id: '/date-timestamp-converter'
+      path: '/date-timestamp-converter'
+      fullPath: '/date-timestamp-converter'
+      preLoaderRoute: typeof DateTimestampConverterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/curl-builder': {
+      id: '/curl-builder'
+      path: '/curl-builder'
+      fullPath: '/curl-builder'
+      preLoaderRoute: typeof CurlBuilderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/cron-expression-builder': {
+      id: '/cron-expression-builder'
+      path: '/cron-expression-builder'
+      fullPath: '/cron-expression-builder'
+      preLoaderRoute: typeof CronExpressionBuilderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/cidr-calculator': {
+      id: '/cidr-calculator'
+      path: '/cidr-calculator'
+      fullPath: '/cidr-calculator'
+      preLoaderRoute: typeof CidrCalculatorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/bcrypt-generator': {
+      id: '/bcrypt-generator'
+      path: '/bcrypt-generator'
+      fullPath: '/bcrypt-generator'
+      preLoaderRoute: typeof BcryptGeneratorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/base64-encoder': {
+      id: '/base64-encoder'
+      path: '/base64-encoder'
+      fullPath: '/base64-encoder'
+      preLoaderRoute: typeof Base64EncoderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+  }
 }
 
 const rootRouteChildren: RootRouteChildren = {
-	IndexRoute: IndexRoute,
-	Base64EncoderRoute: Base64EncoderRoute,
-	BcryptGeneratorRoute: BcryptGeneratorRoute,
-	CidrCalculatorRoute: CidrCalculatorRoute,
-	CronExpressionBuilderRoute: CronExpressionBuilderRoute,
-	CurlBuilderRoute: CurlBuilderRoute,
-	DateTimestampConverterRoute: DateTimestampConverterRoute,
-	DiffViewerRoute: DiffViewerRoute,
-	DnsLookupRoute: DnsLookupRoute,
-	EscapeToolRoute: EscapeToolRoute,
-	GpgKeyGeneratorRoute: GpgKeyGeneratorRoute,
-	HashGeneratorRoute: HashGeneratorRoute,
-	HttpStatusCodesRoute: HttpStatusCodesRoute,
-	ImageConverterRoute: ImageConverterRoute,
-	IpConverterRoute: IpConverterRoute,
-	JsonFormatterRoute: JsonFormatterRoute,
-	JwtDecoderRoute: JwtDecoderRoute,
-	ListComparerRoute: ListComparerRoute,
-	LoremIpsumRoute: LoremIpsumRoute,
-	MacLookupRoute: MacLookupRoute,
-	MarkdownEditorRoute: MarkdownEditorRoute,
-	MimeTypesRoute: MimeTypesRoute,
-	NetworkInterfacesRoute: NetworkInterfacesRoute,
-	NetworkScannerRoute: NetworkScannerRoute,
-	NumberBaseConverterRoute: NumberBaseConverterRoute,
-	PasswordGeneratorRoute: PasswordGeneratorRoute,
-	QrCodeGeneratorRoute: QrCodeGeneratorRoute,
-	RegexTesterRoute: RegexTesterRoute,
-	RestClientRoute: RestClientRoute,
-	RsaToolsRoute: RsaToolsRoute,
-	SemverToolsRoute: SemverToolsRoute,
-	SettingsRoute: SettingsRoute,
-	SqlFormatterRoute: SqlFormatterRoute,
-	SshKeyGeneratorRoute: SshKeyGeneratorRoute,
-	StringCaseConverterRoute: StringCaseConverterRoute,
-	StringCompressorRoute: StringCompressorRoute,
-	UrlEncoderRoute: UrlEncoderRoute,
-	UuidGeneratorRoute: UuidGeneratorRoute,
-	WebsocketTesterRoute: WebsocketTesterRoute,
-	X509DecoderRoute: X509DecoderRoute,
-	XmlFormatterRoute: XmlFormatterRoute,
-	YamlFormatterRoute: YamlFormatterRoute,
-};
+  IndexRoute: IndexRoute,
+  Base64EncoderRoute: Base64EncoderRoute,
+  BcryptGeneratorRoute: BcryptGeneratorRoute,
+  CidrCalculatorRoute: CidrCalculatorRoute,
+  CronExpressionBuilderRoute: CronExpressionBuilderRoute,
+  CurlBuilderRoute: CurlBuilderRoute,
+  DateTimestampConverterRoute: DateTimestampConverterRoute,
+  DiffViewerRoute: DiffViewerRoute,
+  DnsLookupRoute: DnsLookupRoute,
+  EscapeToolRoute: EscapeToolRoute,
+  GpgKeyGeneratorRoute: GpgKeyGeneratorRoute,
+  HashGeneratorRoute: HashGeneratorRoute,
+  HttpStatusCodesRoute: HttpStatusCodesRoute,
+  ImageConverterRoute: ImageConverterRoute,
+  IpConverterRoute: IpConverterRoute,
+  JsonFormatterRoute: JsonFormatterRoute,
+  JwtDecoderRoute: JwtDecoderRoute,
+  ListComparerRoute: ListComparerRoute,
+  LoremIpsumRoute: LoremIpsumRoute,
+  MacLookupRoute: MacLookupRoute,
+  MarkdownEditorRoute: MarkdownEditorRoute,
+  MimeTypesRoute: MimeTypesRoute,
+  NetworkInterfacesRoute: NetworkInterfacesRoute,
+  NetworkScannerRoute: NetworkScannerRoute,
+  NumberBaseConverterRoute: NumberBaseConverterRoute,
+  PasswordGeneratorRoute: PasswordGeneratorRoute,
+  QrCodeGeneratorRoute: QrCodeGeneratorRoute,
+  RegexTesterRoute: RegexTesterRoute,
+  RestClientRoute: RestClientRoute,
+  RsaToolsRoute: RsaToolsRoute,
+  SemverToolsRoute: SemverToolsRoute,
+  SettingsRoute: SettingsRoute,
+  SqlFormatterRoute: SqlFormatterRoute,
+  SshKeyGeneratorRoute: SshKeyGeneratorRoute,
+  StringCaseConverterRoute: StringCaseConverterRoute,
+  StringCompressorRoute: StringCompressorRoute,
+  TlsInspectorRoute: TlsInspectorRoute,
+  UrlEncoderRoute: UrlEncoderRoute,
+  UuidGeneratorRoute: UuidGeneratorRoute,
+  WebsocketTesterRoute: WebsocketTesterRoute,
+  X509DecoderRoute: X509DecoderRoute,
+  XmlFormatterRoute: XmlFormatterRoute,
+  YamlFormatterRoute: YamlFormatterRoute,
+}
 export const routeTree = rootRouteImport
-	._addFileChildren(rootRouteChildren)
-	._addFileTypes<FileRouteTypes>();
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()

--- a/src/routes/tls-inspector.tsx
+++ b/src/routes/tls-inspector.tsx
@@ -1,0 +1,556 @@
+import { createFileRoute } from '@tanstack/react-router';
+import {
+	FlaskConical,
+	KeyRound,
+	Layers,
+	Loader2,
+	Lock,
+	ShieldAlert,
+	ShieldCheck,
+} from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
+import { CopyButton } from '@/lib/components/action';
+import { FormError, FormInfo, FormInput, FormSection, FormSlider } from '@/lib/components/form';
+import { SectionLabel } from '@/lib/components/layout';
+import { ToolShell } from '@/lib/components/shell';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { Badge } from '@/lib/components/ui/badge';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { Input } from '@/lib/components/ui/input';
+import { Label } from '@/lib/components/ui/label';
+import { useDocumentTitle } from '@/lib/hooks';
+import {
+	buildPemBundle,
+	buildPemFromBase64,
+	decodeChain,
+	EXPIRED_SAMPLE_HOST,
+	inspectTls,
+	PORT_PRESETS,
+	SAMPLE_HOST,
+	SAMPLE_PORT,
+	SELF_SIGNED_SAMPLE_HOST,
+	TIMEOUT_DEFAULT_MS,
+	TIMEOUT_MAX_MS,
+	TIMEOUT_MIN_MS,
+	TIMEOUT_STEP_MS,
+	type TlsInspectResult,
+} from '@/lib/services/tls';
+import {
+	daysUntilExpiry,
+	getSubjectLabel,
+	isExpired,
+	isNotYetValid,
+	type ParsedCertificate,
+	type SanEntry,
+	type SanType,
+} from '@/lib/services/x509';
+import { createToolOptionsStore } from '@/lib/stores';
+import { cn, getErrorMessage } from '@/lib/utils';
+
+interface TlsInspectorOptions {
+	readonly host: string;
+	readonly port: number;
+	readonly sni: string;
+	readonly timeoutMs: number;
+}
+
+const DEFAULT_OPTIONS: TlsInspectorOptions = {
+	host: '',
+	port: SAMPLE_PORT,
+	sni: '',
+	timeoutMs: TIMEOUT_DEFAULT_MS,
+};
+
+const useTlsInspectorOptions = createToolOptionsStore<TlsInspectorOptions>(
+	'tls-inspector',
+	DEFAULT_OPTIONS
+);
+
+const SAN_TYPE_TONE: Readonly<
+	Record<SanType, { readonly label: string; readonly className: string }>
+> = {
+	dns: { label: 'DNS', className: 'bg-success/10 text-success border-success/30' },
+	ip: { label: 'IP', className: 'bg-info/10 text-info border-info/30' },
+	uri: { label: 'URI', className: 'bg-warning/10 text-warning border-warning/30' },
+	email: { label: 'Email', className: 'bg-primary/10 text-primary border-primary/30' },
+	dirName: { label: 'DirName', className: 'bg-muted text-foreground' },
+	other: { label: 'Other', className: 'bg-muted text-muted-foreground' },
+};
+
+type ExpiryTone = 'success' | 'info' | 'warning' | 'destructive';
+
+const TONE_BADGE_CLASS: Readonly<Record<ExpiryTone, string>> = {
+	success: 'bg-success/10 text-success border-success/30',
+	info: 'bg-info/10 text-info border-info/30',
+	warning: 'bg-warning/10 text-warning border-warning/30',
+	destructive: 'bg-destructive/10 text-destructive border-destructive/30',
+};
+
+const formatDate = (date: Date): string => date.toLocaleString();
+
+interface ExpiryBadge {
+	readonly label: string;
+	readonly tone: ExpiryTone;
+}
+
+const buildExpiryBadge = (cert: ParsedCertificate, now: Date): ExpiryBadge => {
+	if (isNotYetValid(cert, now)) {
+		return { label: 'Not yet valid', tone: 'info' };
+	}
+	if (isExpired(cert, now)) {
+		const days = Math.abs(daysUntilExpiry(cert, now));
+		return { label: `Expired ${days} days ago`, tone: 'destructive' };
+	}
+	const days = daysUntilExpiry(cert, now);
+	if (days <= 7) return { label: `Expires in ${days} days`, tone: 'destructive' };
+	if (days <= 30) return { label: `Expires in ${days} days`, tone: 'warning' };
+	return { label: `Valid (${days} days left)`, tone: 'success' };
+};
+
+const clampPort = (value: string): number => {
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed)) return SAMPLE_PORT;
+	return Math.max(1, Math.min(65535, parsed));
+};
+
+export const Route = createFileRoute('/tls-inspector')({
+	component: TlsInspectorPage,
+});
+
+function TlsInspectorPage() {
+	useDocumentTitle('SSL / TLS Inspector');
+
+	const { value: options, patch } = useTlsInspectorOptions();
+	const { host, port, sni, timeoutMs } = options;
+
+	const [result, setResult] = useState<TlsInspectResult | null>(null);
+	const [parsedChain, setParsedChain] = useState<readonly ParsedCertificate[]>([]);
+	const [error, setError] = useState<string | null>(null);
+	const [running, setRunning] = useState(false);
+	const [showRail, setShowRail] = useState(true);
+
+	const canRun = host.trim().length > 0 && !running;
+
+	const handleRun = async () => {
+		const trimmedHost = host.trim();
+		if (trimmedHost.length === 0) return;
+		setRunning(true);
+		setError(null);
+		try {
+			const next = await inspectTls({
+				host: trimmedHost,
+				port,
+				sni: sni.trim().length > 0 ? sni.trim() : undefined,
+				timeoutMs,
+			});
+			setResult(next);
+			const parsed = await decodeChain(next.peerChainBase64);
+			setParsedChain(parsed.certificates);
+			if (parsed.errors.length > 0) {
+				toast.error(`Failed to parse ${parsed.errors.length} certificate(s) in chain`);
+			}
+		} catch (e) {
+			setError(getErrorMessage(e, 'Inspection failed'));
+			setResult(null);
+			setParsedChain([]);
+		} finally {
+			setRunning(false);
+		}
+	};
+
+	const loadSample = (sampleHost: string) => {
+		patch({ host: sampleHost, port: SAMPLE_PORT, sni: '' });
+		setResult(null);
+		setParsedChain([]);
+		setError(null);
+	};
+
+	const handleCopyChain = async () => {
+		if (!result) return;
+		try {
+			await navigator.clipboard.writeText(buildPemBundle(result.peerChainBase64));
+			toast.success('Full chain PEM copied to clipboard');
+		} catch {
+			toast.error('Failed to copy to clipboard');
+		}
+	};
+
+	const now = useMemo(() => new Date(), [result]);
+
+	return (
+		<ToolShell
+			showRail={showRail}
+			onShowRailChange={setShowRail}
+			statusContent={
+				<>
+					<StatItem label="Version" value={result?.negotiatedVersion ?? '—'} />
+					<StatItem label="Cipher" value={result?.cipherSuite ?? '—'} />
+					<StatItem label="Certs" value={result?.peerChainBase64.length ?? 0} />
+					<StatItem label="Elapsed" value={result ? `${result.elapsedMs} ms` : '—'} />
+				</>
+			}
+			rail={
+				<>
+					<FormSection title="Run">
+						<Button onClick={handleRun} disabled={!canRun} className="w-full">
+							{running ? (
+								<Loader2 className="h-4 w-4 animate-spin" />
+							) : (
+								<ShieldCheck className="h-4 w-4" />
+							)}
+							{running ? 'Inspecting…' : 'Inspect'}
+						</Button>
+					</FormSection>
+
+					<FormSection title="SNI override">
+						<FormInput
+							label="SNI hostname"
+							value={sni}
+							placeholder="leave empty to use host"
+							onValueChange={(value) => patch({ sni: value })}
+							hint="Server Name Indication sent in the ClientHello."
+						/>
+					</FormSection>
+
+					<FormSection title="Options">
+						<FormSlider
+							label="Timeout (ms)"
+							value={timeoutMs}
+							min={TIMEOUT_MIN_MS}
+							max={TIMEOUT_MAX_MS}
+							step={TIMEOUT_STEP_MS}
+							onValueChange={(value) => patch({ timeoutMs: value })}
+						/>
+					</FormSection>
+
+					<FormSection title="Samples">
+						<div className="flex flex-col gap-2">
+							<Button variant="outline" size="sm" onClick={() => loadSample(SAMPLE_HOST)}>
+								<FlaskConical className="h-3.5 w-3.5" />
+								{SAMPLE_HOST}:{SAMPLE_PORT}
+							</Button>
+							<Button variant="outline" size="sm" onClick={() => loadSample(EXPIRED_SAMPLE_HOST)}>
+								<FlaskConical className="h-3.5 w-3.5" />
+								Expired ({EXPIRED_SAMPLE_HOST})
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={() => loadSample(SELF_SIGNED_SAMPLE_HOST)}
+							>
+								<FlaskConical className="h-3.5 w-3.5" />
+								Self-signed ({SELF_SIGNED_SAMPLE_HOST})
+							</Button>
+						</div>
+					</FormSection>
+
+					<FormSection title="Export">
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={handleCopyChain}
+							disabled={!result || result.peerChainBase64.length === 0}
+							className="w-full"
+						>
+							Copy full chain as PEM
+						</Button>
+					</FormSection>
+
+					<FormSection title="About">
+						<FormInfo>
+							Performs a TLS handshake and dumps the certificate chain. Accepts invalid / expired /
+							self-signed certs for inspection — connections are NOT verified.
+						</FormInfo>
+					</FormSection>
+				</>
+			}
+		>
+			<div className="flex h-full flex-col overflow-hidden">
+				<div className="shrink-0 border-b bg-surface-2 p-4">
+					<HostPortInputBar
+						host={host}
+						port={port}
+						running={running}
+						canRun={canRun}
+						onHostChange={(value) => patch({ host: value })}
+						onPortChange={(value) => patch({ port: value })}
+						onRun={handleRun}
+					/>
+				</div>
+
+				<div className="flex-1 overflow-auto">
+					{error ? (
+						<div className="p-4">
+							<FormError message={error} />
+						</div>
+					) : null}
+
+					{!result && !error ? (
+						<div className="flex h-full items-center justify-center p-4">
+							<EmbeddedEmptyState
+								icon={Lock}
+								title="Inspect a TLS endpoint"
+								description="Enter a host and port, then click Inspect. The peer's certificate chain is rendered below — even when the chain is expired, self-signed, or otherwise invalid."
+							/>
+						</div>
+					) : null}
+
+					{result ? (
+						<div className="space-y-4 p-4">
+							<HandshakeSummaryCard result={result} />
+							<ChainCards chain={parsedChain} base64Chain={result.peerChainBase64} now={now} />
+						</div>
+					) : null}
+				</div>
+			</div>
+		</ToolShell>
+	);
+}
+
+interface HostPortInputBarProps {
+	readonly host: string;
+	readonly port: number;
+	readonly running: boolean;
+	readonly canRun: boolean;
+	readonly onHostChange: (value: string) => void;
+	readonly onPortChange: (value: number) => void;
+	readonly onRun: () => void;
+}
+
+function HostPortInputBar({
+	host,
+	port,
+	running,
+	canRun,
+	onHostChange,
+	onPortChange,
+	onRun,
+}: HostPortInputBarProps) {
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === 'Enter' && canRun) onRun();
+	};
+
+	return (
+		<div className="space-y-2">
+			<div className="grid grid-cols-[1fr_120px_auto] gap-2">
+				<div className="space-y-1">
+					<Label className="text-sm font-medium">Host</Label>
+					<Input
+						value={host}
+						placeholder="example.com"
+						onChange={(e) => onHostChange(e.target.value)}
+						onKeyDown={handleKeyDown}
+						className="h-9 bg-background text-sm"
+					/>
+				</div>
+				<div className="space-y-1">
+					<Label className="text-sm font-medium">Port</Label>
+					<Input
+						type="number"
+						min={1}
+						max={65535}
+						value={port}
+						onChange={(e) => onPortChange(clampPort(e.target.value))}
+						onKeyDown={handleKeyDown}
+						className="h-9 bg-background text-sm"
+					/>
+				</div>
+				<div className="flex flex-col justify-end">
+					<Button onClick={onRun} disabled={!canRun}>
+						{running ? (
+							<Loader2 className="h-4 w-4 animate-spin" />
+						) : (
+							<ShieldCheck className="h-4 w-4" />
+						)}
+						Inspect
+					</Button>
+				</div>
+			</div>
+			<div className="flex flex-wrap gap-1.5">
+				<span className="text-xs text-muted-foreground">Port presets:</span>
+				{PORT_PRESETS.map((preset) => (
+					<Button
+						key={preset}
+						variant={port === preset ? 'default' : 'outline'}
+						size="sm"
+						className="h-6 px-2 text-xs"
+						onClick={() => onPortChange(preset)}
+					>
+						{preset}
+					</Button>
+				))}
+			</div>
+		</div>
+	);
+}
+
+interface HandshakeSummaryCardProps {
+	readonly result: TlsInspectResult;
+}
+
+function HandshakeSummaryCard({ result }: HandshakeSummaryCardProps) {
+	return (
+		<Card density="compact">
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2 text-sm font-medium">
+					<KeyRound className="h-4 w-4 text-muted-foreground" />
+					Handshake summary
+					<Badge variant="outline" className="font-mono text-2xs">
+						{result.host}:{result.port}
+					</Badge>
+				</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<dl className="grid grid-cols-[140px_1fr] gap-x-3 gap-y-1 text-xs">
+					<SummaryRow label="Negotiated version" value={result.negotiatedVersion} />
+					<SummaryRow label="Cipher suite" value={result.cipherSuite} />
+					<SummaryRow label="ALPN" value={result.alpn ?? '(none)'} />
+					<SummaryRow label="SNI" value={result.sni} />
+					<SummaryRow label="Peer chain" value={`${result.peerChainBase64.length} certs`} />
+					<SummaryRow label="Elapsed" value={`${result.elapsedMs} ms`} />
+				</dl>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface SummaryRowProps {
+	readonly label: string;
+	readonly value: string;
+}
+
+function SummaryRow({ label, value }: SummaryRowProps) {
+	return (
+		<>
+			<dt className="font-mono text-muted-foreground">{label}</dt>
+			<dd className="break-all font-mono">{value}</dd>
+		</>
+	);
+}
+
+interface ChainCardsProps {
+	readonly chain: readonly ParsedCertificate[];
+	readonly base64Chain: readonly string[];
+	readonly now: Date;
+}
+
+function ChainCards({ chain, base64Chain, now }: ChainCardsProps) {
+	if (chain.length === 0) {
+		return (
+			<Card density="compact">
+				<CardContent>
+					<p className="text-xs text-muted-foreground">Peer did not present a certificate chain.</p>
+				</CardContent>
+			</Card>
+		);
+	}
+
+	return (
+		<div className="space-y-3">
+			<SectionLabel icon={Layers}>Certificate chain ({chain.length}) — leaf first</SectionLabel>
+			{chain.map((cert, idx) => (
+				<ChainCertificateCard
+					key={cert.fingerprints.sha256}
+					cert={cert}
+					base64Der={base64Chain[idx] ?? ''}
+					role={
+						idx === 0
+							? 'leaf'
+							: idx === chain.length - 1 && chain.length > 1
+								? 'root'
+								: 'intermediate'
+					}
+					now={now}
+				/>
+			))}
+		</div>
+	);
+}
+
+interface ChainCertificateCardProps {
+	readonly cert: ParsedCertificate;
+	readonly base64Der: string;
+	readonly role: 'leaf' | 'intermediate' | 'root';
+	readonly now: Date;
+}
+
+function ChainCertificateCard({ cert, base64Der, role, now }: ChainCertificateCardProps) {
+	const badge = buildExpiryBadge(cert, now);
+	const subjectLabel = getSubjectLabel(cert);
+	const issuerLabel = cert.issuer.components.map((c) => `${c.shortName}=${c.value}`).join(', ');
+	const pem = base64Der.length > 0 ? buildPemFromBase64(base64Der) : cert.pem;
+
+	const roleClass: Record<typeof role, string> = {
+		leaf: 'border-success/40',
+		intermediate: 'border-warning/40',
+		root: 'border-info/40',
+	};
+
+	return (
+		<Card density="compact" className={cn('border-l-4', roleClass[role])}>
+			<CardHeader>
+				<div className="flex flex-wrap items-center justify-between gap-2">
+					<div className="flex min-w-0 items-center gap-2">
+						<Badge variant="outline" className="font-mono text-2xs uppercase">
+							{role}
+						</Badge>
+						<CardTitle className="truncate text-sm font-medium">{subjectLabel}</CardTitle>
+						{cert.selfSigned ? (
+							<Badge variant="outline" className="font-mono text-2xs">
+								Self-signed
+							</Badge>
+						) : null}
+					</div>
+					<div className="flex items-center gap-2">
+						<Badge className={cn('font-medium', TONE_BADGE_CLASS[badge.tone])}>{badge.label}</Badge>
+						<CopyButton text={pem} toastLabel="Certificate PEM" size="sm" />
+					</div>
+				</div>
+			</CardHeader>
+			<CardContent className="space-y-3">
+				<dl className="grid grid-cols-[80px_1fr] gap-x-3 gap-y-1 text-xs">
+					<SummaryRow label="Subject" value={subjectLabel} />
+					<SummaryRow label="Issuer" value={issuerLabel} />
+					<SummaryRow label="Not Before" value={formatDate(cert.notBefore)} />
+					<SummaryRow label="Not After" value={formatDate(cert.notAfter)} />
+					<SummaryRow label="Serial" value={cert.serialNumber} />
+					<SummaryRow label="Signature" value={cert.signatureAlgorithm} />
+				</dl>
+				{cert.subjectAlternativeNames.length > 0 ? (
+					<SanBadgeList entries={cert.subjectAlternativeNames} />
+				) : null}
+			</CardContent>
+		</Card>
+	);
+}
+
+interface SanBadgeListProps {
+	readonly entries: readonly SanEntry[];
+}
+
+function SanBadgeList({ entries }: SanBadgeListProps) {
+	return (
+		<div>
+			<SectionLabel icon={ShieldAlert} iconClass="h-3.5 w-3.5 text-muted-foreground">
+				Subject Alternative Names ({entries.length})
+			</SectionLabel>
+			<div className="flex flex-wrap gap-1.5">
+				{entries.map((entry) => {
+					const tone = SAN_TYPE_TONE[entry.type];
+					return (
+						<Badge
+							key={`${entry.type}-${entry.value}`}
+							variant="outline"
+							className={cn('font-mono text-2xs', tone.className)}
+						>
+							{tone.label}: {entry.value}
+						</Badge>
+					);
+				})}
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
Add an MVP SSL / TLS Inspector under **Network** that performs a real TLS handshake against any host:port and dumps the negotiated parameters + certificate chain. Closes #235.

## MVP scope
- **host:port input** with port presets (443 / 8443 / 465 / 993)
- **Optional SNI override**
- **Backend**: new `tls_inspect` Tauri command using rustls with a permissive verifier so expired / self-signed / invalid certs can be inspected
- **Returns**: negotiated TLS version, cipher suite, ALPN, peer chain
- **Frontend**: reuses `src/lib/services/x509.ts` to decode chain into structured cert cards (subject / issuer / validity badge / SAN badges)
- **Copy** per-cert PEM and full-chain PEM
- **Samples**: `example.com:443`, `expired.badssl.com:443`, `self-signed.badssl.com:443`

## Deferred to follow-up PRs
- Cipher-suite verdict (weak / deprecated detection)
- OCSP / CRL fetching
- "Open in X.509 Decoder" deep-link
- TLS version override / cipher filter

## Changes
### Added
- `src/routes/tls-inspector.tsx`
- `src/lib/services/tls.ts`
- `src-tauri/src/tls_inspect.rs`
- Page registration in `src/lib/services/pages.ts`

### Modified
- `src-tauri/src/lib.rs` — `mod tls_inspect` + `invoke_handler!`
- `src-tauri/Cargo.toml` — added `base64` (rustls / tokio-rustls / x509-parser already present)

## Test plan
- [x] `bun run check` green
- [x] `bun run lint` no new errors
- [x] `cargo check` + `cargo clippy --all-targets` clean
- [x] `cargo test --lib tls_inspect` (3 unit tests for SNI resolution)
- [ ] Manual: `example.com:443` → TLS 1.3 + chain rendered
- [ ] Manual: `expired.badssl.com:443` → chain rendered with "Expired" badge
- [ ] Manual: `self-signed.badssl.com:443` → chain rendered (single cert, self-signed flag)
- [ ] Manual: invalid host → transport error
- [ ] Manual: "Copy full chain as PEM" produces valid PEM bundle

Closes #235
