### PR TITLE
feat(websocket-tester): add WebSocket Tester (MVP)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1487,7 +1487,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1842,7 +1842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3312,6 +3312,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "uuid",
@@ -3624,7 +3625,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4426,7 +4427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5445,7 +5446,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5504,7 +5505,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6062,7 +6063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6209,7 +6210,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6638,7 +6639,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 1.0.69",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "uuid",
  "webview2-com",
  "windows 0.61.3",
@@ -6831,7 +6832,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7001,7 +7002,23 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.28.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -7232,7 +7249,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7270,6 +7287,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "twofish"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7298,7 +7333,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7833,7 +7868,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -84,6 +84,9 @@ x509-parser = "0.18"
 hickory-resolver = { version = "0.26", features = ["tokio", "system-config"] }
 csnmp = "0.6.0"
 
+# WebSocket Client
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
+
 # Note: no direct `rand_core` dependency.
 #
 # The codebase only needs `OsRng` for `ssh-key` and `pgp` key generation,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,7 @@ mod menu;
 mod network;
 mod rest_client;
 mod settings;
+mod websocket;
 
 use tauri::Manager;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
@@ -401,6 +402,7 @@ pub fn run() {
     builder
         .manage(WorkerProcessState::new())
         .manage(NetworkScannerState::new())
+        .manage(websocket::WebSocketState::new())
         .setup(|app| {
             // Windows: enable Snap Layout support via the decorum overlay titlebar.
             // The same call on macOS injects transparent <div data-tauri-drag-region>
@@ -471,6 +473,9 @@ pub fn run() {
             network::oui::lookup_oui_vendor,
             network::oui::get_oui_database_info,
             rest_client::rest_client_send,
+            websocket::ws_connect,
+            websocket::ws_send,
+            websocket::ws_close,
             dns_lookup::dns_lookup,
             settings::get_settings,
             settings::update_settings,

--- a/src-tauri/src/websocket.rs
+++ b/src-tauri/src/websocket.rs
@@ -1,0 +1,445 @@
+//! WebSocket Tester backend.
+//!
+//! Provides Tauri commands and a per-connection state map that bridge a
+//! [`tokio_tungstenite`] WebSocket session to the frontend through Tauri
+//! events. Each active connection has a unique string id (chosen by the
+//! frontend, typically a UUID) that is used to address sends and closes.
+//!
+//! Custom request headers are deferred to a follow-up change: the MVP only
+//! supports plain `ws://` / `wss://` connections with an optional list of
+//! subprotocols.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use futures::{SinkExt, StreamExt};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager, State};
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::protocol::{Message, WebSocketConfig};
+
+/// Maximum number of bytes echoed back to the frontend per frame. Larger
+/// frames are truncated to keep the IPC payload bounded; the byte size is
+/// preserved separately in [`WsMessagePayload::size_bytes`].
+const MAX_FRAME_PREVIEW_BYTES: usize = 64 * 1024;
+
+/// Per-connection control channel. Send a [`ControlMessage`] to ask the
+/// connection task to either dispatch a frame or close the socket.
+#[derive(Debug)]
+enum ControlMessage {
+    /// Forward a frame to the WebSocket peer.
+    Send(Message),
+    /// Initiate a clean close.
+    Close,
+}
+
+/// Tauri-managed map of active connections. The mutex is uncontended in
+/// practice (one entry per active socket), so a [`std::sync::Mutex`] is
+/// sufficient and avoids dragging an async lock through command bodies.
+#[derive(Default)]
+pub struct WebSocketState {
+    connections: Mutex<HashMap<String, mpsc::Sender<ControlMessage>>>,
+}
+
+impl WebSocketState {
+    /// Construct an empty state map.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn insert(&self, conn_id: String, tx: mpsc::Sender<ControlMessage>) -> Result<(), String> {
+        self.connections
+            .lock()
+            .map_err(|e| format!("WebSocket state lock poisoned: {e}"))?
+            .insert(conn_id, tx);
+        Ok(())
+    }
+
+    fn take(&self, conn_id: &str) -> Result<Option<mpsc::Sender<ControlMessage>>, String> {
+        Ok(self
+            .connections
+            .lock()
+            .map_err(|e| format!("WebSocket state lock poisoned: {e}"))?
+            .remove(conn_id))
+    }
+
+    fn get(&self, conn_id: &str) -> Result<Option<mpsc::Sender<ControlMessage>>, String> {
+        Ok(self
+            .connections
+            .lock()
+            .map_err(|e| format!("WebSocket state lock poisoned: {e}"))?
+            .get(conn_id)
+            .cloned())
+    }
+}
+
+/// Event payload describing a single WebSocket frame, in either direction.
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct WsMessagePayload {
+    conn_id: String,
+    direction: &'static str,
+    kind: &'static str,
+    data: String,
+    size_bytes: u64,
+    timestamp_ms: u64,
+}
+
+/// Event payload describing a connection-state transition.
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct WsStatePayload {
+    conn_id: String,
+    state: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+}
+
+/// Decode a hex-encoded byte string. Whitespace and ASCII separator
+/// characters (`:`, `-`, `,`, `_`) are ignored so the caller can paste
+/// space-separated or `aa:bb:cc` style hex without preprocessing.
+fn decode_hex(hex: &str) -> Result<Vec<u8>, String> {
+    let cleaned: String = hex
+        .chars()
+        .filter(|c| !c.is_whitespace() && !matches!(c, ':' | '-' | ',' | '_'))
+        .collect();
+    if !cleaned.len().is_multiple_of(2) {
+        return Err("Hex string must have an even number of digits".to_string());
+    }
+    (0..cleaned.len())
+        .step_by(2)
+        .map(|i| {
+            cleaned
+                .get(i..i + 2)
+                .ok_or_else(|| "Hex string range error".to_string())
+                .and_then(|pair| {
+                    u8::from_str_radix(pair, 16)
+                        .map_err(|e| format!("Invalid hex pair '{pair}': {e}"))
+                })
+        })
+        .collect()
+}
+
+/// Encode bytes as a lowercase, separator-free hex string.
+fn encode_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut acc, b| {
+            let _ = write!(&mut acc, "{b:02x}");
+            acc
+        })
+}
+
+/// Current unix timestamp in milliseconds. Returns `0` if the system clock
+/// is set before the unix epoch, which should not happen in practice.
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+}
+
+/// Build a [`WsMessagePayload`] describing an outbound text or binary frame
+/// that the client is about to send to the peer.
+fn build_sent_payload(
+    conn_id: &str,
+    kind: &'static str,
+    data: String,
+    size_bytes: u64,
+) -> WsMessagePayload {
+    WsMessagePayload {
+        conn_id: conn_id.to_string(),
+        direction: "sent",
+        kind,
+        data,
+        size_bytes,
+        timestamp_ms: now_ms(),
+    }
+}
+
+/// Emit a [`WsStatePayload`] on the `ws_state` channel; logs (does not
+/// propagate) emit failures because state transitions are advisory.
+fn emit_state(app: &AppHandle, conn_id: &str, state: &'static str, reason: Option<String>) {
+    let payload = WsStatePayload {
+        conn_id: conn_id.to_string(),
+        state,
+        reason,
+    };
+    let _ = app.emit("ws_state", payload);
+}
+
+/// Emit a [`WsMessagePayload`] on the `ws_message` channel.
+fn emit_message(app: &AppHandle, payload: WsMessagePayload) {
+    let _ = app.emit("ws_message", payload);
+}
+
+/// Convert an inbound [`Message`] from the WebSocket peer into the JSON
+/// payload that the frontend renders as a chat bubble. Binary frames are
+/// hex-encoded; ping/pong/close frames carry a textual description.
+fn payload_from_received(conn_id: &str, msg: &Message) -> WsMessagePayload {
+    let (kind, data, size_bytes): (&'static str, String, u64) = match msg {
+        Message::Text(text) => {
+            let bytes = text.as_bytes();
+            let preview = if bytes.len() > MAX_FRAME_PREVIEW_BYTES {
+                String::from_utf8_lossy(&bytes[..MAX_FRAME_PREVIEW_BYTES]).into_owned()
+            } else {
+                text.to_string()
+            };
+            ("text", preview, bytes.len() as u64)
+        }
+        Message::Binary(bytes) => {
+            let slice = if bytes.len() > MAX_FRAME_PREVIEW_BYTES {
+                &bytes[..MAX_FRAME_PREVIEW_BYTES]
+            } else {
+                bytes.as_ref()
+            };
+            ("binary", encode_hex(slice), bytes.len() as u64)
+        }
+        Message::Ping(payload) => ("ping", encode_hex(payload), payload.len() as u64),
+        Message::Pong(payload) => ("pong", encode_hex(payload), payload.len() as u64),
+        Message::Close(frame) => {
+            let summary = frame.as_ref().map_or_else(
+                || "no close frame".to_string(),
+                |f| format!("{}: {}", u16::from(f.code), f.reason),
+            );
+            let len = summary.len() as u64;
+            ("close", summary, len)
+        }
+        // tungstenite::Message::Frame is reserved for raw frame relaying and
+        // is never produced by the high-level read API. Surface it as a
+        // placeholder so downstream consumers always see a valid kind.
+        Message::Frame(_) => ("binary", String::new(), 0),
+    };
+    WsMessagePayload {
+        conn_id: conn_id.to_string(),
+        direction: "received",
+        kind,
+        data,
+        size_bytes,
+        timestamp_ms: now_ms(),
+    }
+}
+
+/// Open a WebSocket connection to `url`. Connection state transitions are
+/// streamed to the frontend on the `ws_state` channel; received frames are
+/// streamed on `ws_message`.
+///
+/// `headers` is accepted for API stability but is currently ignored — custom
+/// header support is deferred to a follow-up change. `subprotocols` is
+/// joined into a `Sec-WebSocket-Protocol` request header when non-empty.
+#[tauri::command]
+pub async fn ws_connect(
+    state: State<'_, WebSocketState>,
+    app: AppHandle,
+    conn_id: String,
+    url: String,
+    headers: Vec<(String, String)>,
+    subprotocols: Vec<String>,
+) -> Result<(), String> {
+    // Custom headers are deferred; the parameter is accepted to keep the
+    // frontend API stable when we re-enable them.
+    let _ = headers;
+
+    emit_state(&app, &conn_id, "connecting", None);
+
+    let mut request = url
+        .as_str()
+        .into_client_request()
+        .map_err(|e| format!("Invalid WebSocket URL: {e}"))?;
+
+    if !subprotocols.is_empty() {
+        let joined = subprotocols.join(", ");
+        let header_value = joined
+            .parse()
+            .map_err(|e| format!("Invalid subprotocol list '{joined}': {e}"))?;
+        request
+            .headers_mut()
+            .insert("Sec-WebSocket-Protocol", header_value);
+    }
+
+    let config: Option<WebSocketConfig> = None;
+    let connect_result = tokio_tungstenite::connect_async_with_config(request, config, false).await;
+
+    let (ws_stream, _response) = match connect_result {
+        Ok(pair) => pair,
+        Err(e) => {
+            let reason = format!("{e}");
+            emit_state(&app, &conn_id, "closed", Some(reason.clone()));
+            return Err(reason);
+        }
+    };
+
+    emit_state(&app, &conn_id, "open", None);
+
+    let (mut writer, mut reader) = ws_stream.split();
+    let (tx, mut rx) = mpsc::channel::<ControlMessage>(32);
+    state.insert(conn_id.clone(), tx)?;
+
+    let app_for_task = app.clone();
+    let conn_id_for_task = conn_id.clone();
+
+    // The connection task cannot move the `State` directly (it borrows from
+    // the command's stack frame). Instead, it captures the AppHandle and
+    // looks up the managed `WebSocketState` from inside the task to remove
+    // its entry when the read loop ends.
+    tokio::spawn(async move {
+        let close_reason: Option<String> = loop {
+            tokio::select! {
+                control = rx.recv() => {
+                    match control {
+                        Some(ControlMessage::Send(msg)) => {
+                            if let Err(e) = writer.send(msg).await {
+                                break Some(format!("Send failed: {e}"));
+                            }
+                        }
+                        Some(ControlMessage::Close) => {
+                            emit_state(&app_for_task, &conn_id_for_task, "closing", None);
+                            let _ = writer.send(Message::Close(None)).await;
+                            break Some("client closed".to_string());
+                        }
+                        None => {
+                            // Channel dropped from the state map; treat as a
+                            // client-initiated close.
+                            break Some("connection handle dropped".to_string());
+                        }
+                    }
+                }
+                incoming = reader.next() => {
+                    match incoming {
+                        Some(Ok(msg)) => {
+                            let is_close = matches!(msg, Message::Close(_));
+                            emit_message(&app_for_task, payload_from_received(&conn_id_for_task, &msg));
+                            if is_close {
+                                break match msg {
+                                    Message::Close(Some(frame)) => Some(format!(
+                                        "peer closed: {} {}",
+                                        u16::from(frame.code),
+                                        frame.reason
+                                    )),
+                                    _ => Some("peer closed".to_string()),
+                                };
+                            }
+                        }
+                        Some(Err(e)) => {
+                            break Some(format!("Read error: {e}"));
+                        }
+                        None => {
+                            break Some("stream ended".to_string());
+                        }
+                    }
+                }
+            }
+        };
+
+        // Cleanup: remove the entry from the managed state map if it has not
+        // already been taken by ws_close.
+        if let Some(ws_state) = app_for_task.try_state::<WebSocketState>() {
+            let _ = ws_state.take(&conn_id_for_task);
+        }
+        emit_state(&app_for_task, &conn_id_for_task, "closed", close_reason);
+    });
+
+    Ok(())
+}
+
+/// Send a single frame on an open WebSocket connection. `kind` must be
+/// either `"text"` or `"binary"`; binary frames carry hex-encoded bytes in
+/// `data`.
+#[tauri::command]
+pub async fn ws_send(
+    state: State<'_, WebSocketState>,
+    app: AppHandle,
+    conn_id: String,
+    kind: String,
+    data: String,
+) -> Result<(), String> {
+    let tx = state
+        .get(&conn_id)?
+        .ok_or_else(|| format!("No active connection for id '{conn_id}'"))?;
+
+    let (message, payload) = match kind.as_str() {
+        "text" => {
+            let size = data.len() as u64;
+            (
+                Message::Text(data.clone().into()),
+                build_sent_payload(&conn_id, "text", data, size),
+            )
+        }
+        "binary" => {
+            let bytes = decode_hex(&data)?;
+            let size = bytes.len() as u64;
+            let preview = if bytes.len() > MAX_FRAME_PREVIEW_BYTES {
+                encode_hex(&bytes[..MAX_FRAME_PREVIEW_BYTES])
+            } else {
+                encode_hex(&bytes)
+            };
+            (
+                Message::Binary(bytes.into()),
+                build_sent_payload(&conn_id, "binary", preview, size),
+            )
+        }
+        other => return Err(format!("Unsupported frame kind '{other}'")),
+    };
+
+    tx.send(ControlMessage::Send(message))
+        .await
+        .map_err(|e| format!("Failed to enqueue send: {e}"))?;
+
+    // Reflect the outbound frame to the frontend so the chat log can show
+    // both sides without waiting for the writer to acknowledge.
+    emit_message(&app, payload);
+    Ok(())
+}
+
+/// Request an orderly close on an open WebSocket connection. The matching
+/// `ws_state` event with `state: "closed"` is emitted from the connection
+/// task once the close handshake finishes.
+#[tauri::command]
+pub async fn ws_close(state: State<'_, WebSocketState>, conn_id: String) -> Result<(), String> {
+    let tx = state
+        .take(&conn_id)?
+        .ok_or_else(|| format!("No active connection for id '{conn_id}'"))?;
+    tx.send(ControlMessage::Close)
+        .await
+        .map_err(|e| format!("Failed to enqueue close: {e}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_hex_accepts_lowercase() {
+        assert_eq!(decode_hex("48656c6c6f").unwrap(), b"Hello");
+    }
+
+    #[test]
+    fn test_decode_hex_accepts_uppercase_and_spaces() {
+        assert_eq!(decode_hex("48 65 6C 6C 6F").unwrap(), b"Hello");
+    }
+
+    #[test]
+    fn test_decode_hex_accepts_colon_separators() {
+        assert_eq!(decode_hex("aa:bb:cc").unwrap(), vec![0xaa, 0xbb, 0xcc]);
+    }
+
+    #[test]
+    fn test_decode_hex_rejects_odd_length() {
+        assert!(decode_hex("abc").is_err());
+    }
+
+    #[test]
+    fn test_decode_hex_rejects_invalid_digits() {
+        assert!(decode_hex("zz").is_err());
+    }
+
+    #[test]
+    fn test_encode_hex_roundtrip() {
+        let bytes = vec![0x00, 0x10, 0xff, 0xab];
+        assert_eq!(decode_hex(&encode_hex(&bytes)).unwrap(), bytes);
+    }
+}

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -41,6 +41,7 @@ import {
 	Network,
 	Pencil,
 	Play,
+	Plug,
 	QrCode,
 	Quote,
 	Radar,
@@ -503,6 +504,15 @@ export const PAGES: readonly PageDefinition[] = [
 		icon: Send,
 		description: 'Build and send HTTP requests; view formatted responses',
 		color: 'text-blue-700',
+		category: 'network',
+	},
+	{
+		id: 'websocket-tester',
+		title: 'WebSocket Tester',
+		url: '/websocket-tester',
+		icon: Plug,
+		description: 'Connect to ws:// or wss:// endpoints with a chat-style frame log',
+		color: 'text-fuchsia-700',
 		category: 'network',
 	},
 	{

--- a/src/lib/services/websocket.ts
+++ b/src/lib/services/websocket.ts
@@ -1,0 +1,150 @@
+/**
+ * WebSocket Tester service.
+ *
+ * Thin TypeScript wrapper around the Tauri `ws_connect` / `ws_send` /
+ * `ws_close` commands and the `ws_message` / `ws_state` event channels.
+ * The Rust backend keeps the active connection map; this module exposes
+ * type-safe entry points and a small set of helpers used by the UI.
+ */
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+
+/** Lifecycle state reported on the `ws_state` channel. `idle` is a frontend-
+ * only sentinel before the first connect attempt. */
+export type WsConnectionState = 'idle' | 'connecting' | 'open' | 'closing' | 'closed';
+
+/** Frame variant carried by a single bubble in the chat log. */
+export type WsFrameKind = 'text' | 'binary' | 'ping' | 'pong' | 'close';
+
+/** Bubble direction. `sent` is reflected back from the backend so both sides
+ * appear in the same stream. */
+export type WsDirection = 'sent' | 'received';
+
+/** Single frame as rendered in the log. */
+export interface WsFrame {
+	readonly connId: string;
+	readonly direction: WsDirection;
+	readonly kind: WsFrameKind;
+	/** Text payload, or hex-encoded bytes for `binary` / `ping` / `pong`. */
+	readonly data: string;
+	/** Original byte size before any preview truncation. */
+	readonly sizeBytes: number;
+	readonly timestampMs: number;
+}
+
+/** Connection-state transition. */
+export interface WsStateChange {
+	readonly connId: string;
+	readonly state: WsConnectionState;
+	readonly reason?: string;
+}
+
+/** Default sample URL exposed in the rail's "Samples" section. */
+export const SAMPLE_URL = 'wss://echo.websocket.events';
+
+/**
+ * Open a WebSocket connection. State and frame events are streamed back via
+ * [`onWsState`] and [`onWsMessage`]. Custom headers are accepted for API
+ * stability but currently ignored by the backend (MVP).
+ */
+export const wsConnect = (
+	connId: string,
+	url: string,
+	headers: readonly (readonly [string, string])[],
+	subprotocols: readonly string[]
+): Promise<void> =>
+	invoke('ws_connect', {
+		connId,
+		url,
+		headers: headers.map(([k, v]) => [k, v]),
+		subprotocols: [...subprotocols],
+	});
+
+/** Send a single frame. `kind` is `'text'` for a UTF-8 string or `'binary'`
+ * for a hex-encoded byte string. */
+export const wsSend = (connId: string, kind: 'text' | 'binary', data: string): Promise<void> =>
+	invoke('ws_send', { connId, kind, data });
+
+/** Initiate a clean close. The matching `closed` state is emitted on
+ * `ws_state` once the close handshake finishes. */
+export const wsClose = (connId: string): Promise<void> => invoke('ws_close', { connId });
+
+/** Subscribe to inbound frames. The returned function unsubscribes. */
+export const onWsMessage = (handler: (frame: WsFrame) => void): Promise<UnlistenFn> =>
+	listen<WsFrame>('ws_message', (event) => handler(event.payload));
+
+/** Subscribe to connection-state transitions. */
+export const onWsState = (handler: (change: WsStateChange) => void): Promise<UnlistenFn> =>
+	listen<WsStateChange>('ws_state', (event) => handler(event.payload));
+
+/**
+ * Decode a hex string into bytes. Whitespace and the common ASCII
+ * separators (`:`, `-`, `,`, `_`) are ignored so users can paste either
+ * `48 65 6c 6c 6f` or `48:65:6c:6c:6f` without preprocessing.
+ */
+export const hexToBytes = (hex: string): Uint8Array => {
+	const cleaned = hex.replace(/[\s:_,-]/g, '');
+	if (cleaned.length % 2 !== 0) {
+		throw new Error('Hex string must have an even number of digits');
+	}
+	const bytes = new Uint8Array(cleaned.length / 2);
+	for (let i = 0; i < cleaned.length; i += 2) {
+		const pair = cleaned.slice(i, i + 2);
+		const value = Number.parseInt(pair, 16);
+		if (Number.isNaN(value)) {
+			throw new Error(`Invalid hex pair: ${pair}`);
+		}
+		bytes[i / 2] = value;
+	}
+	return bytes;
+};
+
+/** Encode bytes as a lowercase, separator-free hex string. */
+export const bytesToHex = (bytes: Uint8Array): string =>
+	[...bytes].map((b) => b.toString(16).padStart(2, '0')).join('');
+
+/** Result of an attempted JSON pretty-print. `isJson` is `false` when the
+ * input did not parse as JSON; in that case `text` is returned unchanged. */
+export interface PrettyJsonResult {
+	readonly text: string;
+	readonly isJson: boolean;
+}
+
+/**
+ * Attempt to parse `text` as JSON and pretty-print it with 2-space indent.
+ * Returns the original text and `isJson: false` when parsing fails.
+ */
+export const tryPrettifyJson = (text: string): PrettyJsonResult => {
+	const trimmed = text.trim();
+	if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+		return { text, isJson: false };
+	}
+	try {
+		const parsed: unknown = JSON.parse(trimmed);
+		return { text: JSON.stringify(parsed, null, 2), isJson: true };
+	} catch {
+		return { text, isJson: false };
+	}
+};
+
+/** Split a comma-separated subprotocol string into a clean readonly list. */
+export const parseSubprotocols = (input: string): readonly string[] =>
+	input
+		.split(',')
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+
+/** Hex-dump a hex string to a space-separated, ASCII-paired layout. The
+ * first `maxBytes` bytes are rendered; longer payloads are truncated with
+ * a trailing `...` marker. */
+export const formatHexDump = (hex: string, maxBytes = 256): string => {
+	const cleaned = hex.replace(/\s/g, '');
+	const byteCount = Math.floor(cleaned.length / 2);
+	const renderBytes = Math.min(byteCount, maxBytes);
+	const groups: string[] = [];
+	for (let i = 0; i < renderBytes; i += 1) {
+		groups.push(cleaned.slice(i * 2, i * 2 + 2));
+	}
+	const grouped = groups.join(' ');
+	return byteCount > maxBytes ? `${grouped} ... (${byteCount - maxBytes} more bytes)` : grouped;
+};

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root';
 import { Route as YamlFormatterRouteImport } from './routes/yaml-formatter';
 import { Route as XmlFormatterRouteImport } from './routes/xml-formatter';
 import { Route as X509DecoderRouteImport } from './routes/x509-decoder';
+import { Route as WebsocketTesterRouteImport } from './routes/websocket-tester';
 import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator';
 import { Route as UrlEncoderRouteImport } from './routes/url-encoder';
 import { Route as StringCompressorRouteImport } from './routes/string-compressor';
@@ -64,6 +65,11 @@ const XmlFormatterRoute = XmlFormatterRouteImport.update({
 const X509DecoderRoute = X509DecoderRouteImport.update({
 	id: '/x509-decoder',
 	path: '/x509-decoder',
+	getParentRoute: () => rootRouteImport,
+} as any);
+const WebsocketTesterRoute = WebsocketTesterRouteImport.update({
+	id: '/websocket-tester',
+	path: '/websocket-tester',
 	getParentRoute: () => rootRouteImport,
 } as any);
 const UuidGeneratorRoute = UuidGeneratorRouteImport.update({
@@ -296,6 +302,7 @@ export interface FileRoutesByFullPath {
 	'/string-compressor': typeof StringCompressorRoute;
 	'/url-encoder': typeof UrlEncoderRoute;
 	'/uuid-generator': typeof UuidGeneratorRoute;
+	'/websocket-tester': typeof WebsocketTesterRoute;
 	'/x509-decoder': typeof X509DecoderRoute;
 	'/xml-formatter': typeof XmlFormatterRoute;
 	'/yaml-formatter': typeof YamlFormatterRoute;
@@ -339,6 +346,7 @@ export interface FileRoutesByTo {
 	'/string-compressor': typeof StringCompressorRoute;
 	'/url-encoder': typeof UrlEncoderRoute;
 	'/uuid-generator': typeof UuidGeneratorRoute;
+	'/websocket-tester': typeof WebsocketTesterRoute;
 	'/x509-decoder': typeof X509DecoderRoute;
 	'/xml-formatter': typeof XmlFormatterRoute;
 	'/yaml-formatter': typeof YamlFormatterRoute;
@@ -383,6 +391,7 @@ export interface FileRoutesById {
 	'/string-compressor': typeof StringCompressorRoute;
 	'/url-encoder': typeof UrlEncoderRoute;
 	'/uuid-generator': typeof UuidGeneratorRoute;
+	'/websocket-tester': typeof WebsocketTesterRoute;
 	'/x509-decoder': typeof X509DecoderRoute;
 	'/xml-formatter': typeof XmlFormatterRoute;
 	'/yaml-formatter': typeof YamlFormatterRoute;
@@ -428,6 +437,7 @@ export interface FileRouteTypes {
 		| '/string-compressor'
 		| '/url-encoder'
 		| '/uuid-generator'
+		| '/websocket-tester'
 		| '/x509-decoder'
 		| '/xml-formatter'
 		| '/yaml-formatter';
@@ -471,6 +481,7 @@ export interface FileRouteTypes {
 		| '/string-compressor'
 		| '/url-encoder'
 		| '/uuid-generator'
+		| '/websocket-tester'
 		| '/x509-decoder'
 		| '/xml-formatter'
 		| '/yaml-formatter';
@@ -514,6 +525,7 @@ export interface FileRouteTypes {
 		| '/string-compressor'
 		| '/url-encoder'
 		| '/uuid-generator'
+		| '/websocket-tester'
 		| '/x509-decoder'
 		| '/xml-formatter'
 		| '/yaml-formatter';
@@ -558,6 +570,7 @@ export interface RootRouteChildren {
 	StringCompressorRoute: typeof StringCompressorRoute;
 	UrlEncoderRoute: typeof UrlEncoderRoute;
 	UuidGeneratorRoute: typeof UuidGeneratorRoute;
+	WebsocketTesterRoute: typeof WebsocketTesterRoute;
 	X509DecoderRoute: typeof X509DecoderRoute;
 	XmlFormatterRoute: typeof XmlFormatterRoute;
 	YamlFormatterRoute: typeof YamlFormatterRoute;
@@ -584,6 +597,13 @@ declare module '@tanstack/react-router' {
 			path: '/x509-decoder';
 			fullPath: '/x509-decoder';
 			preLoaderRoute: typeof X509DecoderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/websocket-tester': {
+			id: '/websocket-tester';
+			path: '/websocket-tester';
+			fullPath: '/websocket-tester';
+			preLoaderRoute: typeof WebsocketTesterRouteImport;
 			parentRoute: typeof rootRouteImport;
 		};
 		'/uuid-generator': {
@@ -894,6 +914,7 @@ const rootRouteChildren: RootRouteChildren = {
 	StringCompressorRoute: StringCompressorRoute,
 	UrlEncoderRoute: UrlEncoderRoute,
 	UuidGeneratorRoute: UuidGeneratorRoute,
+	WebsocketTesterRoute: WebsocketTesterRoute,
 	X509DecoderRoute: X509DecoderRoute,
 	XmlFormatterRoute: XmlFormatterRoute,
 	YamlFormatterRoute: YamlFormatterRoute,

--- a/src/routes/websocket-tester.tsx
+++ b/src/routes/websocket-tester.tsx
@@ -1,0 +1,649 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { ArrowLeft, ArrowRight, FlaskConical, Plug, PlugZap, Send, Trash2 } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+import { ActionButton } from '@/lib/components/action';
+import {
+	FormCheckbox,
+	FormInfo,
+	FormInput,
+	FormMode,
+	FormSection,
+	FormTextarea,
+} from '@/lib/components/form';
+import { ToolShell } from '@/lib/components/shell';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { Badge } from '@/lib/components/ui/badge';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent } from '@/lib/components/ui/card';
+import { ToneBadge, type ToneBadgeTone } from '@/lib/components/ui/tone-badge';
+import { useDocumentTitle } from '@/lib/hooks';
+import {
+	formatHexDump,
+	onWsMessage,
+	onWsState,
+	parseSubprotocols,
+	SAMPLE_URL,
+	tryPrettifyJson,
+	wsClose,
+	wsConnect,
+	wsSend,
+	type WsConnectionState,
+	type WsDirection,
+	type WsFrame,
+	type WsFrameKind,
+} from '@/lib/services/websocket';
+import { createToolOptionsStore } from '@/lib/stores';
+import { cn, getErrorMessage } from '@/lib/utils';
+
+type ComposeKind = 'text' | 'binary';
+
+interface WebSocketTesterOptions {
+	readonly url: string;
+	readonly subprotocols: string;
+	readonly autoDecodeJson: boolean;
+	readonly composeKind: ComposeKind;
+	readonly composeText: string;
+	readonly composeHex: string;
+}
+
+const DEFAULTS: WebSocketTesterOptions = {
+	url: '',
+	subprotocols: '',
+	autoDecodeJson: true,
+	composeKind: 'text',
+	composeText: '',
+	composeHex: '',
+};
+
+const useWebSocketTesterOptions = createToolOptionsStore<WebSocketTesterOptions>(
+	'websocket-tester',
+	DEFAULTS
+);
+
+interface LogEntry extends WsFrame {
+	readonly logId: string;
+}
+
+const STATE_TONE: Record<WsConnectionState, ToneBadgeTone | null> = {
+	idle: null,
+	connecting: 'info',
+	open: 'success',
+	closing: 'warning',
+	closed: 'destructive',
+};
+
+const STATE_LABEL: Record<WsConnectionState, string> = {
+	idle: 'Idle',
+	connecting: 'Connecting...',
+	open: 'Open',
+	closing: 'Closing...',
+	closed: 'Closed',
+};
+
+const KIND_LABEL: Record<WsFrameKind, string> = {
+	text: 'text',
+	binary: 'binary',
+	ping: 'ping',
+	pong: 'pong',
+	close: 'close',
+};
+
+const formatTimestamp = (timestampMs: number): string => {
+	const date = new Date(timestampMs);
+	const hh = date.getHours().toString().padStart(2, '0');
+	const mm = date.getMinutes().toString().padStart(2, '0');
+	const ss = date.getSeconds().toString().padStart(2, '0');
+	const ms = date.getMilliseconds().toString().padStart(3, '0');
+	return `${hh}:${mm}:${ss}.${ms}`;
+};
+
+const formatBytes = (bytes: number): string => {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+	return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+};
+
+export const Route = createFileRoute('/websocket-tester')({
+	component: WebSocketTesterPage,
+});
+
+function WebSocketTesterPage() {
+	const { value: options, patch } = useWebSocketTesterOptions();
+	const { url, subprotocols, autoDecodeJson, composeKind, composeText, composeHex } = options;
+
+	const [connId, setConnId] = useState<string>(() => crypto.randomUUID());
+	const [state, setState] = useState<WsConnectionState>('idle');
+	const [closeReason, setCloseReason] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [frames, setFrames] = useState<readonly LogEntry[]>([]);
+
+	const connIdRef = useRef(connId);
+	connIdRef.current = connId;
+
+	const logRef = useRef<HTMLDivElement | null>(null);
+
+	useDocumentTitle('WebSocket Tester');
+
+	// Event subscriptions: register once on mount, unsubscribe on unmount.
+	useEffect(() => {
+		let unMessage: (() => void) | null = null;
+		let unState: (() => void) | null = null;
+		let cancelled = false;
+
+		const init = async () => {
+			const msgUnlisten = await onWsMessage((frame) => {
+				if (frame.connId !== connIdRef.current) return;
+				setFrames((prev) => [...prev, { ...frame, logId: `${frame.timestampMs}-${prev.length}` }]);
+			});
+			const stateUnlisten = await onWsState((change) => {
+				if (change.connId !== connIdRef.current) return;
+				setState(change.state);
+				if (change.state === 'closed') {
+					setCloseReason(change.reason ?? null);
+				} else {
+					setCloseReason(null);
+				}
+			});
+			if (cancelled) {
+				msgUnlisten();
+				stateUnlisten();
+				return;
+			}
+			unMessage = msgUnlisten;
+			unState = stateUnlisten;
+		};
+		init().catch(() => {
+			toast.error('Failed to subscribe to WebSocket events');
+		});
+
+		return () => {
+			cancelled = true;
+			unMessage?.();
+			unState?.();
+		};
+	}, []);
+
+	// Auto-scroll to bottom whenever new frames arrive.
+	useEffect(() => {
+		const el = logRef.current;
+		if (!el) return;
+		el.scrollTop = el.scrollHeight;
+	}, [frames]);
+
+	const canConnect = url.trim().length > 0 && (state === 'idle' || state === 'closed');
+	const canDisconnect = state === 'open' || state === 'connecting';
+	const canSend = state === 'open';
+
+	const sentCount = useMemo(() => frames.filter((f) => f.direction === 'sent').length, [frames]);
+	const receivedCount = useMemo(
+		() => frames.filter((f) => f.direction === 'received').length,
+		[frames]
+	);
+
+	const handleConnect = useCallback(async () => {
+		if (!canConnect) return;
+		setError(null);
+		setCloseReason(null);
+		// Use a fresh connection id so leftover events from a previous session
+		// (which already unsubscribed) cannot cross-contaminate this one.
+		const nextId = crypto.randomUUID();
+		setConnId(nextId);
+		try {
+			await wsConnect(nextId, url.trim(), [], parseSubprotocols(subprotocols));
+		} catch (e) {
+			const message = getErrorMessage(e);
+			setError(message);
+			toast.error('Connect failed', { description: message });
+		}
+	}, [canConnect, url, subprotocols]);
+
+	const handleDisconnect = useCallback(async () => {
+		if (!canDisconnect) return;
+		try {
+			await wsClose(connId);
+		} catch (e) {
+			toast.error('Disconnect failed', { description: getErrorMessage(e) });
+		}
+	}, [canDisconnect, connId]);
+
+	const handleSend = useCallback(async () => {
+		if (!canSend) return;
+		const payload = composeKind === 'text' ? composeText : composeHex;
+		if (payload.length === 0) {
+			toast.warning('Nothing to send', {
+				description: 'Enter a message before sending.',
+			});
+			return;
+		}
+		try {
+			await wsSend(connId, composeKind, payload);
+			if (composeKind === 'text') {
+				patch({ composeText: '' });
+			} else {
+				patch({ composeHex: '' });
+			}
+		} catch (e) {
+			toast.error('Send failed', { description: getErrorMessage(e) });
+		}
+	}, [canSend, composeKind, composeText, composeHex, connId, patch]);
+
+	const handleLoadSample = useCallback(() => {
+		patch({ url: SAMPLE_URL });
+		toast.success('Sample loaded', { description: SAMPLE_URL });
+	}, [patch]);
+
+	const handleClearLog = useCallback(() => {
+		setFrames([]);
+	}, []);
+
+	const stateTone = STATE_TONE[state];
+	const stateLabel =
+		state === 'closed' && closeReason
+			? `${STATE_LABEL.closed}: ${closeReason}`
+			: STATE_LABEL[state];
+
+	const rail = (
+		<WebSocketTesterRail
+			state={state}
+			canConnect={canConnect}
+			canDisconnect={canDisconnect}
+			subprotocols={subprotocols}
+			autoDecodeJson={autoDecodeJson}
+			onSubprotocolsChange={(v) => patch({ subprotocols: v })}
+			onAutoDecodeJsonChange={(v) => patch({ autoDecodeJson: v })}
+			onConnect={() => {
+				handleConnect().catch(() => {});
+			}}
+			onDisconnect={() => {
+				handleDisconnect().catch(() => {});
+			}}
+			onLoadSample={handleLoadSample}
+			onClearLog={handleClearLog}
+		/>
+	);
+
+	const statusContent = (
+		<>
+			<StatItem label="State" value={STATE_LABEL[state]} />
+			<StatItem label="Frames" value={frames.length} />
+			<StatItem label="Sent" value={sentCount} />
+			<StatItem label="Received" value={receivedCount} />
+		</>
+	);
+
+	return (
+		<ToolShell
+			valid={error ? false : state === 'open' ? true : null}
+			error={error ?? undefined}
+			rail={rail}
+			statusContent={statusContent}
+		>
+			<div className="flex h-full flex-col overflow-hidden">
+				<ConnectionBar
+					url={url}
+					state={state}
+					stateLabel={stateLabel}
+					stateTone={stateTone}
+					canConnect={canConnect}
+					canDisconnect={canDisconnect}
+					onUrlChange={(v) => patch({ url: v })}
+					onConnect={() => {
+						handleConnect().catch(() => {});
+					}}
+					onDisconnect={() => {
+						handleDisconnect().catch(() => {});
+					}}
+				/>
+
+				<div ref={logRef} className="flex-1 overflow-auto p-4">
+					<div className="mx-auto flex max-w-3xl flex-col gap-2">
+						{frames.length === 0 ? (
+							<EmbeddedEmptyState
+								icon={Plug}
+								title="No frames yet"
+								description="Connect to a WebSocket endpoint to start exchanging frames."
+							/>
+						) : (
+							frames.map((frame) => (
+								<FrameBubble key={frame.logId} frame={frame} autoDecodeJson={autoDecodeJson} />
+							))
+						)}
+					</div>
+				</div>
+
+				<ComposerBar
+					composeKind={composeKind}
+					composeText={composeText}
+					composeHex={composeHex}
+					canSend={canSend}
+					onKindChange={(v) => patch({ composeKind: v })}
+					onTextChange={(v) => patch({ composeText: v })}
+					onHexChange={(v) => patch({ composeHex: v })}
+					onSend={() => {
+						handleSend().catch(() => {});
+					}}
+				/>
+			</div>
+		</ToolShell>
+	);
+}
+
+interface WebSocketTesterRailProps {
+	readonly state: WsConnectionState;
+	readonly canConnect: boolean;
+	readonly canDisconnect: boolean;
+	readonly subprotocols: string;
+	readonly autoDecodeJson: boolean;
+	readonly onSubprotocolsChange: (value: string) => void;
+	readonly onAutoDecodeJsonChange: (value: boolean) => void;
+	readonly onConnect: () => void;
+	readonly onDisconnect: () => void;
+	readonly onLoadSample: () => void;
+	readonly onClearLog: () => void;
+}
+
+function WebSocketTesterRail({
+	state,
+	canConnect,
+	canDisconnect,
+	subprotocols,
+	autoDecodeJson,
+	onSubprotocolsChange,
+	onAutoDecodeJsonChange,
+	onConnect,
+	onDisconnect,
+	onLoadSample,
+	onClearLog,
+}: WebSocketTesterRailProps) {
+	const connecting = state === 'connecting';
+	return (
+		<>
+			<FormSection title="Connection">
+				{canDisconnect ? (
+					<ActionButton
+						label="Disconnect"
+						icon={Plug}
+						variant="destructive"
+						loading={state === 'closing'}
+						loadingLabel="Closing..."
+						onClick={onDisconnect}
+					/>
+				) : (
+					<ActionButton
+						label="Connect"
+						icon={PlugZap}
+						loading={connecting}
+						loadingLabel="Connecting..."
+						disabled={!canConnect}
+						onClick={onConnect}
+					/>
+				)}
+			</FormSection>
+
+			<FormSection title="Subprotocols">
+				<FormInput
+					label="Subprotocols"
+					value={subprotocols}
+					placeholder="graphql-ws, graphql-transport-ws"
+					hint="Comma-separated. Sent in Sec-WebSocket-Protocol on connect."
+					onValueChange={onSubprotocolsChange}
+					size="compact"
+				/>
+			</FormSection>
+
+			<FormSection title="Display">
+				<FormCheckbox
+					label="Auto-decode JSON"
+					hint="Pretty-print received text frames when they parse as JSON."
+					checked={autoDecodeJson}
+					onCheckedChange={onAutoDecodeJsonChange}
+					size="compact"
+				/>
+			</FormSection>
+
+			<FormSection title="Samples">
+				<Button variant="outline" size="sm" className="w-full" onClick={onLoadSample}>
+					<FlaskConical className="h-3.5 w-3.5" />
+					Load echo sample
+				</Button>
+			</FormSection>
+
+			<FormSection title="Actions">
+				<Button variant="outline" size="sm" className="w-full" onClick={onClearLog}>
+					<Trash2 className="h-3.5 w-3.5" />
+					Clear log
+				</Button>
+			</FormSection>
+
+			<FormSection title="About">
+				<FormInfo>
+					Local WebSocket client. Connections go directly from your machine. Custom request headers
+					are deferred to a follow-up change.
+				</FormInfo>
+			</FormSection>
+		</>
+	);
+}
+
+interface ConnectionBarProps {
+	readonly url: string;
+	readonly state: WsConnectionState;
+	readonly stateLabel: string;
+	readonly stateTone: ToneBadgeTone | null;
+	readonly canConnect: boolean;
+	readonly canDisconnect: boolean;
+	readonly onUrlChange: (value: string) => void;
+	readonly onConnect: () => void;
+	readonly onDisconnect: () => void;
+}
+
+function ConnectionBar({
+	url,
+	state,
+	stateLabel,
+	stateTone,
+	canConnect,
+	canDisconnect,
+	onUrlChange,
+	onConnect,
+	onDisconnect,
+}: ConnectionBarProps) {
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === 'Enter' && canConnect) {
+			e.preventDefault();
+			onConnect();
+		}
+	};
+
+	return (
+		<div className="shrink-0 border-b bg-surface-2 px-4 py-3">
+			<div className="mx-auto flex max-w-3xl items-end gap-2">
+				<div className="flex-1">
+					<label htmlFor="ws-url" className="mb-1 block text-xs font-medium text-muted-foreground">
+						WebSocket URL
+					</label>
+					<input
+						id="ws-url"
+						type="text"
+						value={url}
+						placeholder="wss://example.com/socket"
+						onChange={(e) => onUrlChange(e.target.value)}
+						onKeyDown={handleKeyDown}
+						className="flex h-9 w-full rounded-md border bg-background px-3 py-1 font-mono text-sm shadow-xs transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+					/>
+				</div>
+				{canDisconnect ? (
+					<Button
+						type="button"
+						variant="destructive"
+						className="h-9"
+						onClick={onDisconnect}
+						aria-label="Disconnect WebSocket"
+					>
+						<Plug className="h-4 w-4" />
+						Disconnect
+					</Button>
+				) : (
+					<Button
+						type="button"
+						className="h-9"
+						disabled={!canConnect}
+						onClick={onConnect}
+						aria-label="Connect WebSocket"
+					>
+						<PlugZap className="h-4 w-4" />
+						Connect
+					</Button>
+				)}
+			</div>
+			<div className="mx-auto mt-2 flex max-w-3xl items-center gap-2">
+				<span className="text-xs font-medium text-muted-foreground">State:</span>
+				{stateTone ? (
+					<ToneBadge tone={stateTone}>{stateLabel}</ToneBadge>
+				) : (
+					<Badge variant="outline">{stateLabel}</Badge>
+				)}
+				<span className="text-xs text-muted-foreground" aria-hidden="true">
+					{state === 'connecting' || state === 'closing' ? '...' : ''}
+				</span>
+			</div>
+		</div>
+	);
+}
+
+interface FrameBubbleProps {
+	readonly frame: LogEntry;
+	readonly autoDecodeJson: boolean;
+}
+
+function FrameBubble({ frame, autoDecodeJson }: FrameBubbleProps) {
+	const isSent = frame.direction === 'sent';
+	const DirectionIcon = isSent ? ArrowRight : ArrowLeft;
+	const directionLabel: WsDirection = frame.direction;
+
+	const isBinary = frame.kind === 'binary' || frame.kind === 'ping' || frame.kind === 'pong';
+	const displayText =
+		!isBinary && autoDecodeJson && frame.kind === 'text'
+			? tryPrettifyJson(frame.data).text
+			: frame.data;
+
+	const formattedBody = isBinary ? formatHexDump(frame.data) : displayText;
+
+	return (
+		<div className={cn('flex w-full', isSent ? 'justify-end' : 'justify-start')}>
+			<Card
+				density="compact"
+				className={cn(
+					'max-w-[85%] min-w-0',
+					isSent
+						? 'border-primary/30 bg-primary/5'
+						: frame.kind === 'close'
+							? 'border-destructive/30 bg-destructive/5'
+							: 'bg-muted/40'
+				)}
+			>
+				<CardContent className="space-y-1.5">
+					<div className="flex items-center gap-2 text-2xs text-muted-foreground">
+						<DirectionIcon className="h-3 w-3" aria-hidden="true" />
+						<span className="sr-only">{directionLabel}</span>
+						<span className="font-mono tabular-nums">{formatTimestamp(frame.timestampMs)}</span>
+						<Badge variant="secondary" className="h-4 px-1.5 text-2xs uppercase">
+							{KIND_LABEL[frame.kind]}
+						</Badge>
+						<span className="font-mono tabular-nums">{formatBytes(frame.sizeBytes)}</span>
+					</div>
+					<pre
+						className={cn(
+							'whitespace-pre-wrap break-words font-mono text-xs leading-snug',
+							isBinary && 'break-all'
+						)}
+					>
+						{formattedBody || (isBinary ? '(empty)' : '')}
+					</pre>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}
+
+interface ComposerBarProps {
+	readonly composeKind: ComposeKind;
+	readonly composeText: string;
+	readonly composeHex: string;
+	readonly canSend: boolean;
+	readonly onKindChange: (value: ComposeKind) => void;
+	readonly onTextChange: (value: string) => void;
+	readonly onHexChange: (value: string) => void;
+	readonly onSend: () => void;
+}
+
+function ComposerBar({
+	composeKind,
+	composeText,
+	composeHex,
+	canSend,
+	onKindChange,
+	onTextChange,
+	onHexChange,
+	onSend,
+}: ComposerBarProps) {
+	return (
+		<div className="shrink-0 border-t bg-surface-2 px-4 py-3">
+			<div className="mx-auto flex max-w-3xl flex-col gap-2">
+				<FormMode<ComposeKind>
+					label="Compose"
+					value={composeKind}
+					layout="stacked"
+					descriptionDisplay="selected"
+					options={[
+						{
+							value: 'text',
+							label: 'Text',
+							description: 'Send a UTF-8 string. Press Ctrl/Cmd+Enter to send.',
+						},
+						{
+							value: 'binary',
+							label: 'Binary (hex)',
+							description: 'Send raw bytes. Accepts spaces and colons (e.g. 48 65 6c 6c 6f).',
+						},
+					]}
+					onValueChange={onKindChange}
+				/>
+				<div className="flex items-end gap-2">
+					<div className="flex-1">
+						{composeKind === 'text' ? (
+							<FormTextarea
+								label="Message"
+								value={composeText}
+								rows={3}
+								placeholder='{"type":"ping"}'
+								onValueChange={onTextChange}
+								size="compact"
+							/>
+						) : (
+							<FormInput
+								label="Hex bytes"
+								value={composeHex}
+								placeholder="48 65 6c 6c 6f"
+								onValueChange={onHexChange}
+								size="compact"
+							/>
+						)}
+					</div>
+					<Button
+						type="button"
+						className="h-9"
+						disabled={!canSend}
+						onClick={onSend}
+						aria-label="Send WebSocket frame"
+					>
+						<Send className="h-4 w-4" />
+						Send
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
Add an MVP WebSocket Tester under **Network**. Connects to `ws://` or `wss://` endpoints and provides a chat-style log of sent and received frames, backed by `tokio-tungstenite` and bridged to the frontend via Tauri events. Closes #236.

## MVP scope
- **Lifecycle**: connect / disconnect with state badge (connecting / open / closing / closed)
- **Chat-bubble log**: received left / sent right, with timestamp, frame size, frame kind chip
- **Text and binary** send modes (binary is hex-encoded in the composer)
- **Auto-pretty-print** incoming JSON frames (when enabled)
- **Subprotocols** support on connect
- **Samples**: `wss://echo.websocket.events`
- **Backend**: `ws_connect` / `ws_send` / `ws_close` Tauri commands + `ws_state` / `ws_message` event stream

## Deferred to follow-up PRs
- Custom request headers and auth tokens on connect
- MessagePack / CBOR auto-decoding
- Reconnect with exponential backoff
- Saved-session presets
- Replay-script export

## Changes
### Added
- `src/routes/websocket-tester.tsx`
- `src/lib/services/websocket.ts`
- `src-tauri/src/websocket.rs`
- Page registration in `src/lib/services/pages.ts`

### Modified
- `src-tauri/src/lib.rs` — `mod websocket` + `manage(WebSocketState)` + `invoke_handler!`
- `src-tauri/Cargo.toml` — `tokio-tungstenite` with `rustls-tls-native-roots`

## Test plan
- [x] `bun run check` green
- [x] `bun run lint` no new errors
- [x] `cargo check` + `cargo clippy --all-targets` clean
- [x] `cargo test --lib websocket` passes (6 hex codec tests)
- [ ] Manual: connect to `wss://echo.websocket.events` → state becomes Open
- [ ] Manual: send text → echoed back, both bubbles appear
- [ ] Manual: send binary hex `48 65 6c 6c 6f` → echoed back as text "Hello"
- [ ] Manual: disconnect → state Closed with reason

Closes #236
