### PR TITLE
feat(webhook-receiver): add Webhook Receiver (MVP)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -375,6 +375,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2744,6 +2790,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2765,6 +2817,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -3277,13 +3330,17 @@ dependencies = [
 name = "kogu"
 version = "0.0.6"
 dependencies = [
+ "axum",
  "base64 0.22.1",
  "bcrypt",
+ "bytes",
  "csnmp",
  "dns-lookup",
  "font-kit",
  "futures",
  "hickory-resolver",
+ "http-body-util",
+ "hyper",
  "if-addrs",
  "ipnetwork",
  "mdns-sd",
@@ -3497,6 +3554,12 @@ dependencies = [
  "tendril",
  "web_atoms",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -88,6 +88,12 @@ csnmp = "0.6.0"
 # WebSocket Client
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
 
+# Webhook Receiver — local HTTP listener
+axum = { version = "0.8", default-features = false, features = ["tokio", "http1"] }
+hyper = { version = "1", features = ["server", "http1"] }
+http-body-util = "0.1"
+bytes = "1"
+
 # Note: no direct `rand_core` dependency.
 #
 # The codebase only needs `OsRng` for `ssh-key` and `pgp` key generation,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -55,6 +55,7 @@ mod network;
 mod rest_client;
 mod settings;
 mod tls_inspect;
+mod webhook;
 mod websocket;
 
 use tauri::Manager;
@@ -404,6 +405,7 @@ pub fn run() {
         .manage(WorkerProcessState::new())
         .manage(NetworkScannerState::new())
         .manage(websocket::WebSocketState::new())
+        .manage(webhook::WebhookState::new())
         .setup(|app| {
             // Windows: enable Snap Layout support via the decorum overlay titlebar.
             // The same call on macOS injects transparent <div data-tauri-drag-region>
@@ -479,6 +481,9 @@ pub fn run() {
             websocket::ws_close,
             dns_lookup::dns_lookup,
             tls_inspect::tls_inspect,
+            webhook::webhook_start,
+            webhook::webhook_stop,
+            webhook::webhook_status,
             settings::get_settings,
             settings::update_settings,
             settings::reset_settings,

--- a/src-tauri/src/webhook.rs
+++ b/src-tauri/src/webhook.rs
@@ -1,0 +1,343 @@
+//! Local HTTP listener for inspecting incoming webhook requests.
+//!
+//! Exposes three Tauri commands (`webhook_start`, `webhook_stop`,
+//! `webhook_status`) that manage a single-instance HTTP server bound to
+//! `127.0.0.1` only. Every incoming request is emitted to the frontend via
+//! the `webhook_request` event with full request metadata (method, path,
+//! query, headers, body, remote address, timestamp).
+//!
+//! # Security
+//!
+//! The listener binds to `127.0.0.1` exclusively. It is never reachable
+//! from another machine, container, or VM. This is enforced in
+//! [`bind_loopback`] below — there is no code path that constructs a
+//! `0.0.0.0` or routable `SocketAddr`.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::body::to_bytes;
+use axum::extract::{ConnectInfo, Request, State};
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::any;
+use axum::Router;
+use serde::Serialize;
+use tauri::Emitter;
+use tokio::sync::{oneshot, Mutex};
+use uuid::Uuid;
+
+/// Tauri event name carrying each captured request.
+const WEBHOOK_REQUEST_EVENT: &str = "webhook_request";
+
+/// Upper bound on captured body bytes. 16 MiB matches what the REST client
+/// can already handle and prevents a misconfigured caller from exhausting
+/// memory by streaming gigabytes of body.
+const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+
+/// Result returned to the frontend after a successful start.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebhookStartResult {
+    /// Full origin (e.g. `http://127.0.0.1:54321`).
+    pub address: String,
+    /// Bound port number. Useful when `port = None` was passed in.
+    pub port: u16,
+}
+
+/// Reported state for the status command.
+#[derive(Debug, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct WebhookStatus {
+    /// `true` when a server task is currently running.
+    pub running: bool,
+    /// Bound origin when running.
+    pub address: Option<String>,
+    /// Bound port when running.
+    pub port: Option<u16>,
+}
+
+/// Single captured request emitted to the frontend.
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WebhookRequest {
+    /// Stable id (UUID v4) per request.
+    pub id: String,
+    /// Unix epoch milliseconds when the request was received.
+    pub timestamp_ms: u128,
+    /// HTTP method (e.g. `GET`, `POST`).
+    pub method: String,
+    /// Path component of the request URI (always starts with `/`).
+    pub path: String,
+    /// Raw query string (does not include leading `?`; empty if absent).
+    pub query: String,
+    /// Header pairs in arrival order, values lossily UTF-8 decoded.
+    pub headers: Vec<(String, String)>,
+    /// Request body as UTF-8 lossy text. Truncated at `MAX_BODY_BYTES`.
+    pub body: String,
+    /// Total body size in bytes (pre-truncation).
+    pub body_bytes: u64,
+    /// Remote socket address.
+    pub remote_addr: String,
+}
+
+/// Configurable response applied to every incoming request.
+#[derive(Debug, Clone)]
+struct ResponseConfig {
+    status: u16,
+    content_type: String,
+    body: String,
+}
+
+/// State shared with the request handler.
+#[derive(Clone)]
+struct HandlerState {
+    app: tauri::AppHandle,
+    response: ResponseConfig,
+}
+
+/// Per-server task handle: shutdown signal + bound metadata.
+struct RunningServer {
+    shutdown: oneshot::Sender<()>,
+    address: String,
+    port: u16,
+}
+
+/// Tauri-managed state. `None` when no server is running.
+#[derive(Default)]
+pub struct WebhookState {
+    inner: Arc<Mutex<Option<RunningServer>>>,
+}
+
+impl WebhookState {
+    /// Construct an empty state ready to host a single server.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Build a loopback `SocketAddr`. This is the *only* place the server's
+/// bind address is constructed, so the `127.0.0.1` invariant is co-located
+/// with the security comment at the top of this file.
+fn bind_loopback(port: u16) -> SocketAddr {
+    SocketAddr::from(([127, 0, 0, 1], port))
+}
+
+/// Convert a [`HeaderMap`] into an ordered `Vec<(String, String)>`. Values
+/// that are not valid UTF-8 are reported as an empty string rather than
+/// dropped, preserving header ordering for diagnostic display.
+fn header_pairs(headers: &HeaderMap<HeaderValue>) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            (
+                name.as_str().to_string(),
+                value.to_str().unwrap_or("").to_string(),
+            )
+        })
+        .collect()
+}
+
+/// Return current wall-clock time in epoch milliseconds. Falls back to `0`
+/// when the system clock is before 1970, which is fine for diagnostic UI.
+fn now_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_millis())
+}
+
+/// Request handler: capture the request, emit the event, return the
+/// user-configured response. Reads the entire body up to `MAX_BODY_BYTES`.
+async fn handle(
+    State(state): State<HandlerState>,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    request: Request,
+) -> Response {
+    let method = request.method().as_str().to_string();
+    let path = request.uri().path().to_string();
+    let query = request.uri().query().unwrap_or("").to_string();
+    let headers = header_pairs(request.headers());
+
+    let (_, body) = request.into_parts();
+    let body_bytes = to_bytes(body, MAX_BODY_BYTES).await.unwrap_or_default();
+    let body_len = body_bytes.len();
+    let body_text = String::from_utf8_lossy(&body_bytes).into_owned();
+
+    let captured = WebhookRequest {
+        id: Uuid::new_v4().to_string(),
+        timestamp_ms: now_ms(),
+        method,
+        path,
+        query,
+        headers,
+        body: body_text,
+        body_bytes: body_len as u64,
+        remote_addr: remote.to_string(),
+    };
+
+    // Fire-and-forget emit: even if the frontend listener is gone we still
+    // want to send the response so the caller does not block.
+    let _ = state.app.emit(WEBHOOK_REQUEST_EVENT, captured);
+
+    build_response(&state.response)
+}
+
+/// Render the user-configured response. Falls back to `200 OK` if the
+/// configured status is not a valid HTTP status code.
+fn build_response(cfg: &ResponseConfig) -> Response {
+    let status = StatusCode::from_u16(cfg.status).unwrap_or(StatusCode::OK);
+    let content_type =
+        HeaderValue::from_str(&cfg.content_type).unwrap_or(HeaderValue::from_static("text/plain"));
+    let mut response = (status, cfg.body.clone()).into_response();
+    response
+        .headers_mut()
+        .insert(axum::http::header::CONTENT_TYPE, content_type);
+    response
+}
+
+/// Start the listener. Stops any previously running server first so the
+/// command is idempotent from the UI's perspective.
+///
+/// # Errors
+///
+/// Returns an error string when binding to the requested port fails.
+#[tauri::command]
+pub async fn webhook_start(
+    state: tauri::State<'_, WebhookState>,
+    app: tauri::AppHandle,
+    port: Option<u16>,
+    status: u16,
+    response_body: String,
+    response_content_type: String,
+) -> Result<WebhookStartResult, String> {
+    // Replace any existing server before starting the new one so the user
+    // cannot accidentally orphan a listener by clicking Start twice.
+    {
+        let mut guard = state.inner.lock().await;
+        if let Some(existing) = guard.take() {
+            let _ = existing.shutdown.send(());
+        }
+    }
+
+    let response = ResponseConfig {
+        status,
+        content_type: response_content_type,
+        body: response_body,
+    };
+    let handler_state = HandlerState {
+        app: app.clone(),
+        response,
+    };
+
+    let router = Router::new()
+        .fallback(any(handle))
+        .with_state(handler_state);
+
+    let bind_addr = bind_loopback(port.unwrap_or(0));
+    let listener = tokio::net::TcpListener::bind(bind_addr)
+        .await
+        .map_err(|e| format!("Failed to bind {bind_addr}: {e}"))?;
+    let bound = listener
+        .local_addr()
+        .map_err(|e| format!("Failed to read bound address: {e}"))?;
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let make_service = router.into_make_service_with_connect_info::<SocketAddr>();
+
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, make_service)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await;
+    });
+
+    let address = format!("http://{bound}");
+    let port = bound.port();
+
+    {
+        let mut guard = state.inner.lock().await;
+        *guard = Some(RunningServer {
+            shutdown: shutdown_tx,
+            address: address.clone(),
+            port,
+        });
+    }
+
+    Ok(WebhookStartResult { address, port })
+}
+
+/// Stop the listener if one is running. No-op when already stopped.
+///
+/// # Errors
+///
+/// Currently never returns an error; the signature reserves `Result` so a
+/// future implementation can surface shutdown failures without breaking
+/// the IPC contract.
+#[tauri::command]
+pub async fn webhook_stop(state: tauri::State<'_, WebhookState>) -> Result<(), String> {
+    let taken = {
+        let mut guard = state.inner.lock().await;
+        guard.take()
+    };
+    if let Some(existing) = taken {
+        let _ = existing.shutdown.send(());
+    }
+    Ok(())
+}
+
+/// Report the current running state of the listener.
+///
+/// # Errors
+///
+/// Currently never returns an error; the signature reserves `Result` so a
+/// future implementation can surface lock contention or other failures.
+#[tauri::command]
+pub async fn webhook_status(
+    state: tauri::State<'_, WebhookState>,
+) -> Result<WebhookStatus, String> {
+    let guard = state.inner.lock().await;
+    Ok(guard
+        .as_ref()
+        .map_or_else(WebhookStatus::default, |running| WebhookStatus {
+            running: true,
+            address: Some(running.address.clone()),
+            port: Some(running.port),
+        }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bind_loopback_uses_127_0_0_1() {
+        let addr = bind_loopback(0);
+        assert_eq!(addr.ip().to_string(), "127.0.0.1");
+        assert_eq!(addr.port(), 0);
+    }
+
+    #[test]
+    fn header_pairs_preserves_order_and_lossy_values() {
+        let mut headers = HeaderMap::new();
+        headers.append("x-first", HeaderValue::from_static("1"));
+        headers.append("x-second", HeaderValue::from_static("two"));
+        let pairs = header_pairs(&headers);
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0], ("x-first".to_string(), "1".to_string()));
+        assert_eq!(pairs[1], ("x-second".to_string(), "two".to_string()));
+    }
+
+    #[test]
+    fn build_response_falls_back_to_ok_for_invalid_status() {
+        let cfg = ResponseConfig {
+            status: 9999,
+            content_type: "text/plain".to_string(),
+            body: "ok".to_string(),
+        };
+        let response = build_response(&cfg);
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -31,6 +31,7 @@ import {
 	Globe2,
 	Hash,
 	House,
+	Inbox,
 	Key,
 	KeyRound,
 	KeySquare,
@@ -522,6 +523,15 @@ export const PAGES: readonly PageDefinition[] = [
 		icon: Plug,
 		description: 'Connect to ws:// or wss:// endpoints with a chat-style frame log',
 		color: 'text-fuchsia-700',
+		category: 'network',
+	},
+	{
+		id: 'webhook-receiver',
+		title: 'Webhook Receiver',
+		url: '/webhook-receiver',
+		icon: Inbox,
+		description: 'Local HTTP listener for inspecting incoming webhook requests',
+		color: 'text-orange-700',
 		category: 'network',
 	},
 	{

--- a/src/lib/services/webhook.ts
+++ b/src/lib/services/webhook.ts
@@ -1,0 +1,176 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+
+/** Successful start payload returned by the Rust backend. */
+export interface WebhookStartResult {
+	readonly address: string;
+	readonly port: number;
+}
+
+/** Current server state reported by the backend. */
+export interface WebhookStatus {
+	readonly running: boolean;
+	readonly address: string | null;
+	readonly port: number | null;
+}
+
+/** A captured incoming HTTP request as emitted on the `webhook_request` event. */
+export interface WebhookRequest {
+	readonly id: string;
+	readonly timestampMs: number;
+	readonly method: string;
+	readonly path: string;
+	readonly query: string;
+	readonly headers: readonly (readonly [string, string])[];
+	readonly body: string;
+	readonly bodyBytes: number;
+	readonly remoteAddr: string;
+}
+
+/** Parameters for starting the listener. `port` omitted = ephemeral port. */
+export interface WebhookStartParams {
+	readonly port?: number;
+	readonly status: number;
+	readonly responseBody: string;
+	readonly responseContentType: string;
+}
+
+/** Start the local listener. Returns the actual bound address. */
+export const webhookStart = (params: WebhookStartParams): Promise<WebhookStartResult> =>
+	invoke<WebhookStartResult>('webhook_start', {
+		port: params.port,
+		status: params.status,
+		responseBody: params.responseBody,
+		responseContentType: params.responseContentType,
+	});
+
+/** Stop the local listener. Safe to call when already stopped. */
+export const webhookStop = (): Promise<void> => invoke<void>('webhook_stop');
+
+/** Query the current server state. */
+export const webhookStatus = (): Promise<WebhookStatus> => invoke<WebhookStatus>('webhook_status');
+
+/**
+ * Subscribe to incoming requests. The returned promise resolves to an
+ * unlisten function — call it inside the `useEffect` cleanup.
+ */
+export const onWebhookRequest = (handler: (req: WebhookRequest) => void): Promise<UnlistenFn> =>
+	listen<WebhookRequest>('webhook_request', (event) => handler(event.payload));
+
+/** Per-method tone mapping for the request log badge. */
+export const METHOD_TONES: Readonly<
+	Record<string, 'success' | 'info' | 'warning' | 'destructive'>
+> = {
+	GET: 'success',
+	POST: 'info',
+	PUT: 'warning',
+	PATCH: 'warning',
+	DELETE: 'destructive',
+	OPTIONS: 'info',
+	HEAD: 'info',
+};
+
+/** Default fallback tone for unknown methods. */
+export const DEFAULT_METHOD_TONE = 'info' as const;
+
+/** Resolve a tone for a method label, falling back to `DEFAULT_METHOD_TONE`. */
+export const methodTone = (method: string): 'success' | 'info' | 'warning' | 'destructive' =>
+	METHOD_TONES[method.toUpperCase()] ?? DEFAULT_METHOD_TONE;
+
+/** Find a header value case-insensitively. */
+export const headerValue = (
+	headers: readonly (readonly [string, string])[],
+	name: string
+): string | undefined => {
+	const lower = name.toLowerCase();
+	return headers.find(([k]) => k.toLowerCase() === lower)?.[1];
+};
+
+/** Format a byte count for compact display. */
+export const formatBytes = (bytes: number): string => {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+};
+
+/** Format an epoch ms timestamp as `HH:MM:SS.mmm`. */
+export const formatTimestamp = (ms: number): string => {
+	const date = new Date(ms);
+	const pad = (n: number, width = 2): string => n.toString().padStart(width, '0');
+	return `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}.${pad(
+		date.getMilliseconds(),
+		3
+	)}`;
+};
+
+/**
+ * Pretty-print a body when the Content-Type indicates JSON. Returns the
+ * original text and `isJson=false` when parsing fails or the content type
+ * is not JSON.
+ */
+export const tryPrettifyJson = (
+	body: string,
+	contentType: string | undefined
+): { readonly text: string; readonly isJson: boolean } => {
+	if (!contentType) return { text: body, isJson: false };
+	const lower = contentType.toLowerCase();
+	if (!lower.includes('application/json') && !lower.includes('+json')) {
+		return { text: body, isJson: false };
+	}
+	try {
+		const parsed = JSON.parse(body) as unknown;
+		return { text: JSON.stringify(parsed, null, 2), isJson: true };
+	} catch {
+		return { text: body, isJson: false };
+	}
+};
+
+/** Parse a URL query string into an ordered list of pairs. */
+export const parseQueryPairs = (query: string): readonly (readonly [string, string])[] => {
+	if (!query) return [];
+	const trimmed = query.startsWith('?') ? query.slice(1) : query;
+	return trimmed
+		.split('&')
+		.filter((part) => part.length > 0)
+		.map((part) => {
+			const eq = part.indexOf('=');
+			if (eq < 0) return [decodeURIComponentSafe(part), ''] as const;
+			return [
+				decodeURIComponentSafe(part.slice(0, eq)),
+				decodeURIComponentSafe(part.slice(eq + 1)),
+			] as const;
+		});
+};
+
+const decodeURIComponentSafe = (input: string): string => {
+	try {
+		return decodeURIComponent(input.replace(/\+/g, ' '));
+	} catch {
+		return input;
+	}
+};
+
+const shellEscape = (input: string): string => `'${input.replace(/'/g, `'\\''`)}'`;
+
+/**
+ * Render a cURL command that reproduces the captured request against the
+ * supplied replay URL (the running server's origin + path + query).
+ */
+export const exportAsCurl = (req: WebhookRequest, replayUrl: string): string => {
+	const parts: string[] = ['curl'];
+	const method = req.method.toUpperCase();
+	if (method !== 'GET') {
+		parts.push('-X', method);
+	}
+	req.headers.forEach(([key, value]) => {
+		const lower = key.toLowerCase();
+		// Skip transport-level headers cURL will set itself based on body.
+		if (lower === 'content-length' || lower === 'host') return;
+		parts.push('-H', shellEscape(`${key}: ${value}`));
+	});
+	if (req.body.length > 0) {
+		parts.push('--data', shellEscape(req.body));
+	}
+	parts.push(shellEscape(replayUrl));
+	return parts.join(' ');
+};

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -13,6 +13,7 @@ import { Route as YamlFormatterRouteImport } from './routes/yaml-formatter'
 import { Route as XmlFormatterRouteImport } from './routes/xml-formatter'
 import { Route as X509DecoderRouteImport } from './routes/x509-decoder'
 import { Route as WebsocketTesterRouteImport } from './routes/websocket-tester'
+import { Route as WebhookReceiverRouteImport } from './routes/webhook-receiver'
 import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator'
 import { Route as UrlEncoderRouteImport } from './routes/url-encoder'
 import { Route as TlsInspectorRouteImport } from './routes/tls-inspector'
@@ -71,6 +72,11 @@ const X509DecoderRoute = X509DecoderRouteImport.update({
 const WebsocketTesterRoute = WebsocketTesterRouteImport.update({
   id: '/websocket-tester',
   path: '/websocket-tester',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const WebhookReceiverRoute = WebhookReceiverRouteImport.update({
+  id: '/webhook-receiver',
+  path: '/webhook-receiver',
   getParentRoute: () => rootRouteImport,
 } as any)
 const UuidGeneratorRoute = UuidGeneratorRouteImport.update({
@@ -309,6 +315,7 @@ export interface FileRoutesByFullPath {
   '/tls-inspector': typeof TlsInspectorRoute
   '/url-encoder': typeof UrlEncoderRoute
   '/uuid-generator': typeof UuidGeneratorRoute
+  '/webhook-receiver': typeof WebhookReceiverRoute
   '/websocket-tester': typeof WebsocketTesterRoute
   '/x509-decoder': typeof X509DecoderRoute
   '/xml-formatter': typeof XmlFormatterRoute
@@ -354,6 +361,7 @@ export interface FileRoutesByTo {
   '/tls-inspector': typeof TlsInspectorRoute
   '/url-encoder': typeof UrlEncoderRoute
   '/uuid-generator': typeof UuidGeneratorRoute
+  '/webhook-receiver': typeof WebhookReceiverRoute
   '/websocket-tester': typeof WebsocketTesterRoute
   '/x509-decoder': typeof X509DecoderRoute
   '/xml-formatter': typeof XmlFormatterRoute
@@ -400,6 +408,7 @@ export interface FileRoutesById {
   '/tls-inspector': typeof TlsInspectorRoute
   '/url-encoder': typeof UrlEncoderRoute
   '/uuid-generator': typeof UuidGeneratorRoute
+  '/webhook-receiver': typeof WebhookReceiverRoute
   '/websocket-tester': typeof WebsocketTesterRoute
   '/x509-decoder': typeof X509DecoderRoute
   '/xml-formatter': typeof XmlFormatterRoute
@@ -447,6 +456,7 @@ export interface FileRouteTypes {
     | '/tls-inspector'
     | '/url-encoder'
     | '/uuid-generator'
+    | '/webhook-receiver'
     | '/websocket-tester'
     | '/x509-decoder'
     | '/xml-formatter'
@@ -492,6 +502,7 @@ export interface FileRouteTypes {
     | '/tls-inspector'
     | '/url-encoder'
     | '/uuid-generator'
+    | '/webhook-receiver'
     | '/websocket-tester'
     | '/x509-decoder'
     | '/xml-formatter'
@@ -537,6 +548,7 @@ export interface FileRouteTypes {
     | '/tls-inspector'
     | '/url-encoder'
     | '/uuid-generator'
+    | '/webhook-receiver'
     | '/websocket-tester'
     | '/x509-decoder'
     | '/xml-formatter'
@@ -583,6 +595,7 @@ export interface RootRouteChildren {
   TlsInspectorRoute: typeof TlsInspectorRoute
   UrlEncoderRoute: typeof UrlEncoderRoute
   UuidGeneratorRoute: typeof UuidGeneratorRoute
+  WebhookReceiverRoute: typeof WebhookReceiverRoute
   WebsocketTesterRoute: typeof WebsocketTesterRoute
   X509DecoderRoute: typeof X509DecoderRoute
   XmlFormatterRoute: typeof XmlFormatterRoute
@@ -617,6 +630,13 @@ declare module '@tanstack/react-router' {
       path: '/websocket-tester'
       fullPath: '/websocket-tester'
       preLoaderRoute: typeof WebsocketTesterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/webhook-receiver': {
+      id: '/webhook-receiver'
+      path: '/webhook-receiver'
+      fullPath: '/webhook-receiver'
+      preLoaderRoute: typeof WebhookReceiverRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/uuid-generator': {
@@ -935,6 +955,7 @@ const rootRouteChildren: RootRouteChildren = {
   TlsInspectorRoute: TlsInspectorRoute,
   UrlEncoderRoute: UrlEncoderRoute,
   UuidGeneratorRoute: UuidGeneratorRoute,
+  WebhookReceiverRoute: WebhookReceiverRoute,
   WebsocketTesterRoute: WebsocketTesterRoute,
   X509DecoderRoute: X509DecoderRoute,
   XmlFormatterRoute: XmlFormatterRoute,

--- a/src/routes/webhook-receiver.tsx
+++ b/src/routes/webhook-receiver.tsx
@@ -1,0 +1,644 @@
+import { createFileRoute } from '@tanstack/react-router';
+import {
+	Activity,
+	Clock,
+	Code2,
+	Eraser,
+	Inbox,
+	Play,
+	RotateCcw,
+	Server,
+	Square,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
+import { CopyButton } from '@/lib/components/action';
+import { FormInfo, FormInput, FormSection, FormTextarea } from '@/lib/components/form';
+import { ToolShell } from '@/lib/components/shell';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { ToneBadge } from '@/lib/components/ui/tone-badge';
+import { useDocumentTitle } from '@/lib/hooks';
+import {
+	exportAsCurl,
+	formatBytes,
+	formatTimestamp,
+	headerValue,
+	methodTone,
+	onWebhookRequest,
+	parseQueryPairs,
+	tryPrettifyJson,
+	webhookStart,
+	webhookStatus,
+	webhookStop,
+	type WebhookRequest,
+	type WebhookStatus,
+} from '@/lib/services/webhook';
+import { createToolOptionsStore } from '@/lib/stores';
+import { cn, getErrorMessage } from '@/lib/utils';
+
+interface WebhookReceiverOptions {
+	readonly port: string;
+	readonly responseStatus: string;
+	readonly responseContentType: string;
+	readonly responseBody: string;
+}
+
+const DEFAULT_RESPONSE_BODY = `{
+  "received": true
+}`;
+
+const DEFAULTS: WebhookReceiverOptions = {
+	port: '',
+	responseStatus: '200',
+	responseContentType: 'application/json',
+	responseBody: DEFAULT_RESPONSE_BODY,
+};
+
+const SAMPLE_ECHO_JSON = `{
+  "received": true,
+  "method": "$method",
+  "path": "$path"
+}`;
+
+const SAMPLE_PLAIN_OK = 'OK';
+
+const MAX_LOG_ENTRIES = 500;
+
+const useWebhookOptions = createToolOptionsStore<WebhookReceiverOptions>(
+	'webhook-receiver',
+	DEFAULTS
+);
+
+export const Route = createFileRoute('/webhook-receiver')({
+	component: WebhookReceiverPage,
+});
+
+function WebhookReceiverPage() {
+	const { value: options, patch, reset } = useWebhookOptions();
+	const { port, responseStatus, responseContentType, responseBody } = options;
+
+	const [serverStatus, setServerStatus] = useState<WebhookStatus | null>(null);
+	const [requests, setRequests] = useState<readonly WebhookRequest[]>([]);
+	const [selectedRequestId, setSelectedRequestId] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [busy, setBusy] = useState(false);
+
+	useDocumentTitle('Webhook Receiver');
+
+	useEffect(() => {
+		let unlisten: (() => void) | undefined;
+		let cancelled = false;
+		(async () => {
+			const off = await onWebhookRequest((req) => {
+				setRequests((prev) => {
+					const next = [req, ...prev];
+					return next.length > MAX_LOG_ENTRIES ? next.slice(0, MAX_LOG_ENTRIES) : next;
+				});
+			});
+			if (cancelled) {
+				off();
+				return;
+			}
+			unlisten = off;
+		})().catch(() => {
+			// Listener registration failures are non-fatal; the user simply
+			// will not see live updates until the next page mount.
+		});
+		webhookStatus()
+			.then((s) => setServerStatus(s))
+			.catch(() => setServerStatus(null));
+		return () => {
+			cancelled = true;
+			unlisten?.();
+		};
+	}, []);
+
+	const isRunning = serverStatus?.running ?? false;
+	const boundAddress = serverStatus?.address ?? null;
+
+	const handleStart = useCallback(async () => {
+		setError(null);
+		setBusy(true);
+		try {
+			const portNumber = port.trim().length > 0 ? Number.parseInt(port.trim(), 10) : undefined;
+			if (port.trim().length > 0 && (!Number.isFinite(portNumber) || (portNumber ?? 0) < 0)) {
+				throw new Error(`Invalid port: ${port}`);
+			}
+			const statusNumber = Number.parseInt(responseStatus.trim(), 10);
+			if (!Number.isFinite(statusNumber) || statusNumber < 100 || statusNumber > 599) {
+				throw new Error(`Status code must be between 100 and 599 (got ${responseStatus})`);
+			}
+			const result = await webhookStart({
+				port: portNumber,
+				status: statusNumber,
+				responseBody,
+				responseContentType,
+			});
+			setServerStatus({ running: true, address: result.address, port: result.port });
+			toast.success(`Listening on ${result.address}`);
+		} catch (e) {
+			const message = getErrorMessage(e);
+			setError(message);
+			toast.error('Failed to start listener', { description: message });
+		} finally {
+			setBusy(false);
+		}
+	}, [port, responseBody, responseContentType, responseStatus]);
+
+	const handleStop = useCallback(async () => {
+		setBusy(true);
+		try {
+			await webhookStop();
+			setServerStatus({ running: false, address: null, port: null });
+			toast.success('Listener stopped');
+		} catch (e) {
+			toast.error('Failed to stop listener', { description: getErrorMessage(e) });
+		} finally {
+			setBusy(false);
+		}
+	}, []);
+
+	const handleClearLog = useCallback(() => {
+		setRequests([]);
+		setSelectedRequestId(null);
+	}, []);
+
+	const selectedRequest = useMemo(
+		() => (selectedRequestId ? (requests.find((r) => r.id === selectedRequestId) ?? null) : null),
+		[requests, selectedRequestId]
+	);
+
+	const lastRequestLabel = useMemo(() => {
+		const latest = requests[0];
+		if (!latest) return '—';
+		return formatTimestamp(latest.timestampMs);
+	}, [requests]);
+
+	const rail = (
+		<WebhookRail
+			isRunning={isRunning}
+			busy={busy}
+			port={port}
+			responseStatus={responseStatus}
+			responseContentType={responseContentType}
+			responseBody={responseBody}
+			onPatch={patch}
+			onReset={reset}
+			onStart={handleStart}
+			onStop={handleStop}
+			onLoadEcho={() =>
+				patch({ responseContentType: 'application/json', responseBody: SAMPLE_ECHO_JSON })
+			}
+			onLoadPlain={() =>
+				patch({ responseContentType: 'text/plain', responseBody: SAMPLE_PLAIN_OK })
+			}
+			onClearLog={handleClearLog}
+		/>
+	);
+
+	const statusContent = (
+		<StatusBarContent
+			isRunning={isRunning}
+			port={serverStatus?.port ?? null}
+			requestCount={requests.length}
+			lastRequestLabel={lastRequestLabel}
+		/>
+	);
+
+	return (
+		<ToolShell
+			valid={error ? false : isRunning ? true : null}
+			error={error ?? undefined}
+			rail={rail}
+			statusContent={statusContent}
+		>
+			<div className="flex h-full flex-col overflow-hidden">
+				<div className="flex-1 overflow-auto p-4">
+					<div className="mx-auto flex max-w-5xl flex-col gap-4">
+						<ServerStatusCard
+							isRunning={isRunning}
+							busy={busy}
+							address={boundAddress}
+							onStart={handleStart}
+							onStop={handleStop}
+						/>
+
+						<RequestLogCard
+							requests={requests}
+							selectedId={selectedRequestId}
+							onSelect={setSelectedRequestId}
+						/>
+
+						{selectedRequest ? (
+							<RequestDetailCard request={selectedRequest} address={boundAddress} />
+						) : null}
+					</div>
+				</div>
+			</div>
+		</ToolShell>
+	);
+}
+
+interface WebhookRailProps {
+	readonly isRunning: boolean;
+	readonly busy: boolean;
+	readonly port: string;
+	readonly responseStatus: string;
+	readonly responseContentType: string;
+	readonly responseBody: string;
+	readonly onPatch: (delta: Partial<WebhookReceiverOptions>) => void;
+	readonly onReset: () => void;
+	readonly onStart: () => void;
+	readonly onStop: () => void;
+	readonly onLoadEcho: () => void;
+	readonly onLoadPlain: () => void;
+	readonly onClearLog: () => void;
+}
+
+function WebhookRail({
+	isRunning,
+	busy,
+	port,
+	responseStatus,
+	responseContentType,
+	responseBody,
+	onPatch,
+	onReset,
+	onStart,
+	onStop,
+	onLoadEcho,
+	onLoadPlain,
+	onClearLog,
+}: WebhookRailProps) {
+	return (
+		<>
+			<FormSection title="Server">
+				<FormInput
+					label="Port"
+					value={port}
+					placeholder="Leave empty for ephemeral"
+					hint="When empty, the OS picks an unused port."
+					size="compact"
+					onValueChange={(v) => onPatch({ port: v })}
+				/>
+				{isRunning ? (
+					<Button
+						type="button"
+						className="w-full"
+						variant="destructive"
+						onClick={onStop}
+						disabled={busy}
+					>
+						<Square className="h-3.5 w-3.5" />
+						Stop listener
+					</Button>
+				) : (
+					<Button type="button" className="w-full" onClick={onStart} disabled={busy}>
+						<Play className="h-3.5 w-3.5" />
+						Start listener
+					</Button>
+				)}
+			</FormSection>
+
+			<FormSection title="Response">
+				<FormInput
+					label="Status code"
+					value={responseStatus}
+					placeholder="200"
+					size="compact"
+					onValueChange={(v) => onPatch({ responseStatus: v })}
+				/>
+				<FormInput
+					label="Content-Type"
+					value={responseContentType}
+					placeholder="application/json"
+					size="compact"
+					onValueChange={(v) => onPatch({ responseContentType: v })}
+				/>
+				<FormTextarea
+					label="Body"
+					value={responseBody}
+					rows={6}
+					size="compact"
+					onValueChange={(v) => onPatch({ responseBody: v })}
+				/>
+				<Button variant="outline" size="sm" className="w-full" onClick={onReset}>
+					<RotateCcw className="h-3.5 w-3.5" />
+					Reset to defaults
+				</Button>
+			</FormSection>
+
+			<FormSection title="Samples">
+				<Button variant="outline" size="sm" className="w-full" onClick={onLoadEcho}>
+					Echo JSON
+				</Button>
+				<Button variant="outline" size="sm" className="w-full" onClick={onLoadPlain}>
+					Plain text OK
+				</Button>
+			</FormSection>
+
+			<FormSection title="Actions">
+				<Button variant="outline" size="sm" className="w-full" onClick={onClearLog}>
+					<Eraser className="h-3.5 w-3.5" />
+					Clear log
+				</Button>
+			</FormSection>
+
+			<FormSection title="About">
+				<FormInfo>
+					Binds to 127.0.0.1 only — never reachable from another machine. Restart the app to reset
+					listener state if a command fails.
+				</FormInfo>
+			</FormSection>
+		</>
+	);
+}
+
+interface ServerStatusCardProps {
+	readonly isRunning: boolean;
+	readonly busy: boolean;
+	readonly address: string | null;
+	readonly onStart: () => void;
+	readonly onStop: () => void;
+}
+
+function ServerStatusCard({ isRunning, busy, address, onStart, onStop }: ServerStatusCardProps) {
+	return (
+		<Card density="compact">
+			<CardHeader className="pb-3">
+				<div className="flex items-center gap-2">
+					<Server className="h-4 w-4 text-muted-foreground" />
+					<CardTitle className="text-sm font-medium">Listener</CardTitle>
+				</div>
+			</CardHeader>
+			<CardContent>
+				<div className="flex flex-wrap items-center gap-3">
+					<ToneBadge tone={isRunning ? 'success' : 'warning'}>
+						{isRunning ? 'Running' : 'Stopped'}
+					</ToneBadge>
+					{isRunning && address ? (
+						<>
+							<code className="flex-1 truncate rounded-md border bg-muted/40 px-3 py-2 font-mono text-sm">
+								{address}
+							</code>
+							<CopyButton text={address} label="Copy URL" />
+						</>
+					) : (
+						<span className="flex-1 text-sm text-muted-foreground">
+							Start the listener to receive requests.
+						</span>
+					)}
+					{isRunning ? (
+						<Button type="button" variant="destructive" size="sm" onClick={onStop} disabled={busy}>
+							<Square className="h-3.5 w-3.5" />
+							Stop
+						</Button>
+					) : (
+						<Button type="button" size="sm" onClick={onStart} disabled={busy}>
+							<Play className="h-3.5 w-3.5" />
+							Start
+						</Button>
+					)}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface RequestLogCardProps {
+	readonly requests: readonly WebhookRequest[];
+	readonly selectedId: string | null;
+	readonly onSelect: (id: string) => void;
+}
+
+function RequestLogCard({ requests, selectedId, onSelect }: RequestLogCardProps) {
+	return (
+		<Card density="compact">
+			<CardHeader className="pb-3">
+				<div className="flex items-center gap-2">
+					<Inbox className="h-4 w-4 text-muted-foreground" />
+					<CardTitle className="text-sm font-medium">
+						Requests
+						{requests.length > 0 ? (
+							<span className="ml-1.5 text-xs font-normal text-muted-foreground">
+								({requests.length})
+							</span>
+						) : null}
+					</CardTitle>
+				</div>
+			</CardHeader>
+			<CardContent>
+				{requests.length === 0 ? (
+					<EmbeddedEmptyState
+						icon={Inbox}
+						title="Waiting for requests"
+						description="Start the listener, then send an HTTP request to the bound address. Each request appears here as it arrives."
+					/>
+				) : (
+					<RequestTable requests={requests} selectedId={selectedId} onSelect={onSelect} />
+				)}
+			</CardContent>
+		</Card>
+	);
+}
+
+interface RequestTableProps {
+	readonly requests: readonly WebhookRequest[];
+	readonly selectedId: string | null;
+	readonly onSelect: (id: string) => void;
+}
+
+function RequestTable({ requests, selectedId, onSelect }: RequestTableProps) {
+	return (
+		<div className="overflow-x-auto">
+			<table className="w-full text-xs">
+				<thead>
+					<tr className="border-b text-left text-muted-foreground">
+						<th className="py-1.5 pr-3 font-medium">Time</th>
+						<th className="py-1.5 pr-3 font-medium">Method</th>
+						<th className="py-1.5 pr-3 font-medium">Path</th>
+						<th className="py-1.5 pr-3 font-medium">Content-Type</th>
+						<th className="py-1.5 pr-3 font-medium">Size</th>
+					</tr>
+				</thead>
+				<tbody>
+					{requests.map((req) => {
+						const isSelected = req.id === selectedId;
+						const contentType = headerValue(req.headers, 'content-type') ?? '—';
+						return (
+							<tr
+								key={req.id}
+								onClick={() => onSelect(req.id)}
+								className={cn(
+									'cursor-pointer border-b border-border/40 transition-colors hover:bg-interactive-hover',
+									isSelected && 'bg-interactive-hover'
+								)}
+							>
+								<td className="py-1.5 pr-3 font-mono text-muted-foreground">
+									{formatTimestamp(req.timestampMs)}
+								</td>
+								<td className="py-1.5 pr-3">
+									<ToneBadge tone={methodTone(req.method)}>{req.method}</ToneBadge>
+								</td>
+								<td className="py-1.5 pr-3 font-mono">
+									{req.path}
+									{req.query ? <span className="text-muted-foreground">?{req.query}</span> : null}
+								</td>
+								<td className="py-1.5 pr-3 font-mono text-muted-foreground">{contentType}</td>
+								<td className="py-1.5 pr-3 text-right tabular-nums text-muted-foreground">
+									{formatBytes(req.bodyBytes)}
+								</td>
+							</tr>
+						);
+					})}
+				</tbody>
+			</table>
+		</div>
+	);
+}
+
+interface RequestDetailCardProps {
+	readonly request: WebhookRequest;
+	readonly address: string | null;
+}
+
+function RequestDetailCard({ request, address }: RequestDetailCardProps) {
+	const contentType = headerValue(request.headers, 'content-type');
+	const { text: prettyBody, isJson } = useMemo(
+		() => tryPrettifyJson(request.body, contentType),
+		[request.body, contentType]
+	);
+
+	const queryPairs = useMemo(() => parseQueryPairs(request.query), [request.query]);
+	const replayUrl = useMemo(() => {
+		const origin = address ?? 'http://127.0.0.1';
+		const trimmed = origin.endsWith('/') ? origin.slice(0, -1) : origin;
+		return `${trimmed}${request.path}${request.query ? `?${request.query}` : ''}`;
+	}, [address, request.path, request.query]);
+
+	const handleCopyCurl = useCallback(async () => {
+		const command = exportAsCurl(request, replayUrl);
+		try {
+			await navigator.clipboard.writeText(command);
+			toast.success('cURL command copied to clipboard');
+		} catch {
+			toast.error('Failed to copy to clipboard');
+		}
+	}, [request, replayUrl]);
+
+	return (
+		<Card density="compact">
+			<CardHeader className="pb-3">
+				<div className="flex flex-wrap items-center gap-2">
+					<ToneBadge tone={methodTone(request.method)}>{request.method}</ToneBadge>
+					<code className="flex-1 truncate font-mono text-sm">
+						{request.path}
+						{request.query ? <span className="text-muted-foreground">?{request.query}</span> : null}
+					</code>
+					<span className="text-xs text-muted-foreground">from {request.remoteAddr}</span>
+					<Button variant="outline" size="sm" onClick={handleCopyCurl}>
+						<Code2 className="h-3.5 w-3.5" />
+						Copy as cURL
+					</Button>
+				</div>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				<DetailSection title={`Headers (${request.headers.length})`}>
+					<KeyValueTable rows={request.headers.map(([k, v]) => [k, v] as const)} />
+				</DetailSection>
+
+				<DetailSection title={`Query (${queryPairs.length})`}>
+					{queryPairs.length === 0 ? (
+						<p className="text-xs text-muted-foreground">No query parameters.</p>
+					) : (
+						<KeyValueTable rows={queryPairs.map(([k, v]) => [k, v] as const)} />
+					)}
+				</DetailSection>
+
+				<DetailSection title={`Body (${formatBytes(request.bodyBytes)}${isJson ? ' · JSON' : ''})`}>
+					{request.body.length === 0 ? (
+						<p className="text-xs text-muted-foreground">Empty body.</p>
+					) : (
+						<pre className="max-h-96 overflow-auto rounded-md border bg-muted/40 p-3 font-mono text-xs">
+							{prettyBody}
+						</pre>
+					)}
+				</DetailSection>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface DetailSectionProps {
+	readonly title: string;
+	readonly children: React.ReactNode;
+}
+
+function DetailSection({ title, children }: DetailSectionProps) {
+	return (
+		<section className="space-y-2">
+			<h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+				{title}
+			</h3>
+			{children}
+		</section>
+	);
+}
+
+interface KeyValueTableProps {
+	readonly rows: readonly (readonly [string, string])[];
+}
+
+function KeyValueTable({ rows }: KeyValueTableProps) {
+	if (rows.length === 0) {
+		return <p className="text-xs text-muted-foreground">No entries.</p>;
+	}
+	// Headers and query strings can legitimately repeat the same key (e.g.
+	// multiple `Set-Cookie`), so the key + value pair is the most stable
+	// React key available without rebuilding the source data.
+	return (
+		<div className="overflow-x-auto">
+			<table className="w-full text-xs">
+				<tbody>
+					{rows.map(([key, value]) => (
+						<tr key={`${key}=${value}`} className="border-b border-border/40 last:border-b-0">
+							<td className="w-1/3 py-1 pr-3 font-mono text-muted-foreground">{key}</td>
+							<td className="py-1 break-all font-mono">{value}</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+}
+
+interface StatusBarContentProps {
+	readonly isRunning: boolean;
+	readonly port: number | null;
+	readonly requestCount: number;
+	readonly lastRequestLabel: string;
+}
+
+function StatusBarContent({
+	isRunning,
+	port,
+	requestCount,
+	lastRequestLabel,
+}: StatusBarContentProps) {
+	return (
+		<>
+			<StatItem
+				label="Status"
+				value={isRunning ? 'Running' : 'Stopped'}
+				icon={Activity}
+				variant={isRunning ? 'success' : 'default'}
+			/>
+			<StatItem label="Port" value={port ?? '—'} />
+			<StatItem label="Requests" value={requestCount} />
+			<StatItem label="Last" value={lastRequestLabel} icon={Clock} />
+		</>
+	);
+}


### PR DESCRIPTION
## Summary
Add an MVP Webhook Receiver under **Network**. Starts a local HTTP listener bound to `127.0.0.1` only, logs every incoming request with method / path / headers / body, and shows them in real time. Closes #237.

## MVP scope
- **Backend**: Tauri commands `webhook_start` / `webhook_stop` / `webhook_status`, bound to `127.0.0.1` only
- **Ephemeral or user-specified port**
- **Configurable response** (status / Content-Type / body) applied to all paths
- **Live request log** via `webhook_request` Tauri event
- **Detail panel** per request: headers table, parsed query params, pretty-printed body
- **Copy as cURL** reproducer

## Deferred to follow-up PRs
- Multi-route support (different paths -> different responses)
- "Replay" deep-link to HTTP REST Client
- Per-route response presets

## Changes
### Added
- `src/routes/webhook-receiver.tsx`
- `src/lib/services/webhook.ts`
- `src-tauri/src/webhook.rs`
- Page registration in `src/lib/services/pages.ts`

### Modified
- `src-tauri/src/lib.rs` — `mod webhook` + `manage(WebhookState)` + `invoke_handler!`
- `src-tauri/Cargo.toml` — `axum` + `hyper` + `http-body-util` + `bytes`

## Security
- The listener binds to **127.0.0.1 only**. There is no path that binds to `0.0.0.0` or a routable interface. The bind address is constructed in a single helper co-located with the security comment.

## Test plan
- [x] `bun run check` green
- [x] `bun run lint` no new errors (existing pre-existing errors unchanged)
- [x] `cargo check` + `cargo clippy --all-targets` clean
- [x] `cargo test --lib webhook` — 3 unit tests pass (loopback bind, header preservation, status fallback)
- [ ] Manual: click Start -> URL appears (`http://127.0.0.1:XXXXX/`)
- [ ] Manual: `curl http://127.0.0.1:XXXXX/foo?a=1 -X POST -d '{"x":1}'` -> request appears
- [ ] Manual: click row -> headers / query / pretty body shown
- [ ] Manual: change response status to 503 -> curl receives 503
- [ ] Manual: Click Stop -> next curl fails to connect

Closes #237
