### PR TITLE
refactor(pages): add Converters category and rename TLS Inspector

### DIFF
--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -64,7 +64,13 @@ import {
 /**
  * Page categories for sidebar grouping.
  */
-export type PageCategory = 'formatters' | 'encoders' | 'generators' | 'text' | 'network';
+export type PageCategory =
+	| 'formatters'
+	| 'encoders'
+	| 'converters'
+	| 'generators'
+	| 'text'
+	| 'network';
 
 export interface PageTab {
 	readonly id: string;
@@ -319,7 +325,7 @@ export const PAGES: readonly PageDefinition[] = [
 		icon: CalendarClock,
 		description: 'Convert between Unix, ISO, RFC formats with multi-timezone support',
 		color: 'text-amber-600',
-		category: 'generators',
+		category: 'converters',
 	},
 	{
 		id: 'number-base-converter',
@@ -329,7 +335,7 @@ export const PAGES: readonly PageDefinition[] = [
 		description:
 			'Convert between binary, octal, decimal, and hex with bitwise operations and IEEE 754 view',
 		color: 'text-orange-600',
-		category: 'generators',
+		category: 'converters',
 	},
 	{
 		id: 'image-converter',
@@ -338,7 +344,7 @@ export const PAGES: readonly PageDefinition[] = [
 		icon: Aperture,
 		description: 'Convert and compress images (PNG / JPEG / WebP) with resize and rotation',
 		color: 'text-pink-600',
-		category: 'generators',
+		category: 'converters',
 	},
 	{
 		id: 'lorem-ipsum',
@@ -441,7 +447,7 @@ export const PAGES: readonly PageDefinition[] = [
 		description:
 			'Convert between IPv4 and IPv6 with IPv4-mapped / 6to4 / Teredo embeddings and notation normalizer',
 		color: 'text-sky-600',
-		category: 'network',
+		category: 'converters',
 	},
 	{
 		id: 'mac-lookup',
@@ -509,7 +515,7 @@ export const PAGES: readonly PageDefinition[] = [
 	},
 	{
 		id: 'tls-inspector',
-		title: 'SSL / TLS Inspector',
+		title: 'TLS Inspector',
 		url: '/tls-inspector',
 		icon: Lock,
 		description: 'Inspect TLS handshake details and certificate chain for any host:port',
@@ -598,6 +604,14 @@ export const CATEGORIES: readonly CategoryInfo[] = [
 		defaultOpen: true,
 		borderClass: 'border-success/40',
 		iconClass: 'text-success',
+	},
+	{
+		id: 'converters',
+		label: 'Converters',
+		icon: ArrowRightLeft,
+		defaultOpen: true,
+		borderClass: 'border-violet-500/40',
+		iconClass: 'text-violet-500',
 	},
 	{
 		id: 'generators',

--- a/src/routes/tls-inspector.tsx
+++ b/src/routes/tls-inspector.tsx
@@ -121,7 +121,7 @@ export const Route = createFileRoute('/tls-inspector')({
 });
 
 function TlsInspectorPage() {
-	useDocumentTitle('SSL / TLS Inspector');
+	useDocumentTitle('TLS Inspector');
 
 	const { value: options, patch } = useTlsInspectorOptions();
 	const { host, port, sni, timeoutMs } = options;


### PR DESCRIPTION
## Summary

After landing the 20-issue feature batch (#218-#237), the **Generators** category swelled to 14 tools and **Network** to 12, mixing distinct concerns. This PR introduces a dedicated **Converters** category, moves the four explicit "convert A to B" tools into it, and renames TLS Inspector.

## Changes

### `src/lib/services/pages.ts`

- Add `'converters'` to the `PageCategory` union
- Sidebar order becomes: Formatters / Encoders / **Converters** / Generators / Text / Network
- Move 4 pages into `converters`:
  - `date-timestamp-converter` (from generators)
  - `number-base-converter` (from generators)
  - `image-converter` (from generators)
  - `ip-converter` (from network — converts between IPv4 / IPv6 representations, not a network probe)
- Rename `'SSL / TLS Inspector'` → `'TLS Inspector'` (SSL is legacy; the implementation only uses TLS)

### `src/routes/tls-inspector.tsx`

- Update `useDocumentTitle('SSL / TLS Inspector')` → `useDocumentTitle('TLS Inspector')`

## Why

The "Converters" category captures a clear semantic boundary: tools that produce equivalent representations of the same value, distinct from generators (synthesise new values) and inspectors (analyse existing values).

| Before | After |
|--------|-------|
| Generators (14) | Generators (11) |
| Network (12) | Network (11) |
| — | **Converters (4)** |

## URL stability

URLs are unchanged. Existing pins, deep links, and search/history entries keep working.

## Test plan

- [x] `bun run check` (TS + validate-pages + audit-design) green
- [x] Manual: sidebar shows Converters group between Encoders and Generators with 4 tools
- [x] Manual: dashboard category sections show Converters
- [ ] Manual: existing pins to `date-timestamp-converter`/`number-base-converter`/`image-converter`/`ip-converter` still work
- [ ] Manual: `/tls-inspector` title bar shows "TLS Inspector"
