### PR TITLE
feat(layout): add RelatedTools component and cross-link 8 network/converter tools

### DIFF
--- a/src/lib/components/layout/index.ts
+++ b/src/lib/components/layout/index.ts
@@ -5,6 +5,7 @@ export {
 	type KeyboardShortcutsDialogProps,
 } from './keyboard-shortcuts-dialog';
 export { NavButtons, type NavButtonsProps } from './nav-buttons';
+export { RelatedTools, type RelatedToolItem, type RelatedToolsProps } from './related-tools';
 export { SectionHeader, type SectionHeaderProps } from './section-header';
 export { SectionLabel, type SectionLabelProps } from './section-label';
 export { SplitPane, type SplitPaneProps } from './split-pane';

--- a/src/lib/components/layout/related-tools.tsx
+++ b/src/lib/components/layout/related-tools.tsx
@@ -1,0 +1,47 @@
+import { Link } from '@tanstack/react-router';
+
+import { getPageById } from '@/lib/services/pages';
+import { cn } from '@/lib/utils';
+
+interface RelatedToolItem {
+	readonly id: string;
+	readonly reason?: string;
+}
+
+interface RelatedToolsProps {
+	readonly items: readonly RelatedToolItem[];
+}
+
+export function RelatedTools({ items }: RelatedToolsProps) {
+	return (
+		<div className="flex flex-col gap-1.5">
+			{items.map((item) => {
+				const page = getPageById(item.id);
+				if (!page) return null;
+				const Icon = page.icon;
+				return (
+					<Link
+						key={item.id}
+						to={page.url}
+						className={cn(
+							'group flex items-start gap-2 rounded-md border border-border bg-background p-2 text-xs transition-colors',
+							'hover:bg-muted/40 hover:border-border'
+						)}
+					>
+						<Icon
+							className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', page.color ?? 'text-muted-foreground')}
+						/>
+						<div className="min-w-0 flex-1">
+							<div className="truncate font-medium text-foreground">{page.title}</div>
+							{item.reason ? (
+								<div className="truncate text-2xs text-muted-foreground">{item.reason}</div>
+							) : null}
+						</div>
+					</Link>
+				);
+			})}
+		</div>
+	);
+}
+
+export type { RelatedToolItem, RelatedToolsProps };

--- a/src/routes/cidr-calculator.tsx
+++ b/src/routes/cidr-calculator.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 
 import { ActionButton, CopyButton } from '@/lib/components/action';
 import { FormInfo, FormInput, FormMode, FormSection } from '@/lib/components/form';
+import { RelatedTools } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import {
@@ -201,6 +202,15 @@ function CidrCalculatorPage() {
 							value={exportFormat}
 							options={EXPORT_OPTIONS}
 							onValueChange={(v) => patch({ exportFormat: v })}
+						/>
+					</FormSection>
+
+					<FormSection title="Related">
+						<RelatedTools
+							items={[
+								{ id: 'ip-converter', reason: 'Convert IPv4 ↔ IPv6' },
+								{ id: 'dns-lookup', reason: 'Resolve a name to an IP' },
+							]}
 						/>
 					</FormSection>
 

--- a/src/routes/date-timestamp-converter.tsx
+++ b/src/routes/date-timestamp-converter.tsx
@@ -17,7 +17,7 @@ import { toast } from 'sonner';
 
 import { ActionButton, CopyButton } from '@/lib/components/action';
 import { FormError, FormInfo, FormInput, FormSection, FormSelect } from '@/lib/components/form';
-import { SectionLabel } from '@/lib/components/layout';
+import { RelatedTools, SectionLabel } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
@@ -303,6 +303,12 @@ function DateTimestampConverterPage() {
 					<ExternalLink className="h-3 w-3" />
 					Open in Cron Builder
 				</Button>
+			</FormSection>
+
+			<FormSection title="Related">
+				<RelatedTools
+					items={[{ id: 'cron-expression-builder', reason: 'Edit the cron expression' }]}
+				/>
 			</FormSection>
 
 			<FormSection title="About">

--- a/src/routes/dns-lookup.tsx
+++ b/src/routes/dns-lookup.tsx
@@ -13,6 +13,7 @@ import {
 	FormSelect,
 	FormSlider,
 } from '@/lib/components/form';
+import { RelatedTools } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
@@ -328,6 +329,16 @@ function DnsLookupRail({
 					<Terminal className="mr-1.5 h-3.5 w-3.5" />
 					Copy as dig
 				</Button>
+			</FormSection>
+
+			<FormSection title="Related">
+				<RelatedTools
+					items={[
+						{ id: 'tls-inspector', reason: 'Inspect TLS of a resolved host' },
+						{ id: 'rest-client', reason: 'Send HTTP request to a resolved host' },
+						{ id: 'cidr-calculator', reason: 'Analyse a resolved IP address' },
+					]}
+				/>
 			</FormSection>
 
 			<FormSection title="About">

--- a/src/routes/ip-converter.tsx
+++ b/src/routes/ip-converter.tsx
@@ -4,6 +4,7 @@ import { type CSSProperties, type ReactNode, useMemo, useState } from 'react';
 
 import { ActionButton, CopyButton } from '@/lib/components/action';
 import { FormCheckbox, FormError, FormInfo, FormInput, FormSection } from '@/lib/components/form';
+import { RelatedTools } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
@@ -208,6 +209,15 @@ function IpConverterRail({
 					label="Use mixed form for IPv4-mapped (::ffff:a.b.c.d)"
 					checked={favorMixedForMapped}
 					onCheckedChange={(checked) => onPatch({ favorMixedForMapped: checked })}
+				/>
+			</FormSection>
+
+			<FormSection title="Related">
+				<RelatedTools
+					items={[
+						{ id: 'cidr-calculator', reason: 'Compute subnets and ranges' },
+						{ id: 'dns-lookup', reason: 'Resolve a name to an IP' },
+					]}
 				/>
 			</FormSection>
 

--- a/src/routes/rest-client.tsx
+++ b/src/routes/rest-client.tsx
@@ -23,6 +23,7 @@ import {
 	FormSelect,
 	FormSlider,
 } from '@/lib/components/form';
+import { RelatedTools } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
@@ -328,6 +329,16 @@ function RestClientRail({
 					<Code2 className="h-3.5 w-3.5" />
 					Copy as cURL
 				</Button>
+			</FormSection>
+
+			<FormSection title="Related">
+				<RelatedTools
+					items={[
+						{ id: 'http-status-codes', reason: 'Look up a response status code' },
+						{ id: 'mime-types', reason: 'Find a Content-Type or extension' },
+						{ id: 'curl-builder', reason: 'Build or parse a cURL command' },
+					]}
+				/>
 			</FormSection>
 
 			<FormSection title="About">

--- a/src/routes/tls-inspector.tsx
+++ b/src/routes/tls-inspector.tsx
@@ -13,7 +13,7 @@ import { toast } from 'sonner';
 
 import { CopyButton } from '@/lib/components/action';
 import { FormError, FormInfo, FormInput, FormSection, FormSlider } from '@/lib/components/form';
-import { SectionLabel } from '@/lib/components/layout';
+import { RelatedTools, SectionLabel } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
@@ -257,6 +257,15 @@ function TlsInspectorPage() {
 						>
 							Copy full chain as PEM
 						</Button>
+					</FormSection>
+
+					<FormSection title="Related">
+						<RelatedTools
+							items={[
+								{ id: 'x509-decoder', reason: 'Drill into a chain certificate' },
+								{ id: 'dns-lookup', reason: 'Resolve a host before handshake' },
+							]}
+						/>
 					</FormSection>
 
 					<FormSection title="About">

--- a/src/routes/webhook-receiver.tsx
+++ b/src/routes/webhook-receiver.tsx
@@ -15,6 +15,7 @@ import { toast } from 'sonner';
 
 import { CopyButton } from '@/lib/components/action';
 import { FormInfo, FormInput, FormSection, FormTextarea } from '@/lib/components/form';
+import { RelatedTools } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
@@ -345,6 +346,10 @@ function WebhookRail({
 					<Eraser className="h-3.5 w-3.5" />
 					Clear log
 				</Button>
+			</FormSection>
+
+			<FormSection title="Related">
+				<RelatedTools items={[{ id: 'rest-client', reason: 'Replay a captured request' }]} />
 			</FormSection>
 
 			<FormSection title="About">

--- a/src/routes/x509-decoder.tsx
+++ b/src/routes/x509-decoder.tsx
@@ -20,7 +20,7 @@ import {
 	FormSlider,
 	FormTextarea,
 } from '@/lib/components/form';
-import { SectionLabel } from '@/lib/components/layout';
+import { RelatedTools, SectionLabel } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import {
@@ -299,6 +299,15 @@ function X509DecoderPage() {
 								size="compact"
 							/>
 						</FormCheckboxGroup>
+					</FormSection>
+
+					<FormSection title="Related">
+						<RelatedTools
+							items={[
+								{ id: 'tls-inspector', reason: 'Fetch a live cert chain from a host' },
+								{ id: 'rsa-tools', reason: 'Verify a signature with the public key' },
+							]}
+						/>
 					</FormSection>
 
 					<FormSection title="About">


### PR DESCRIPTION
## Summary

Adds a small **RelatedTools** component that renders a vertical stack of clickable cards in the rail's "Related" section. Each card surfaces a sibling tool with a short justification, encouraging users to chain related tasks (e.g. resolve a host in DNS Lookup, then inspect its TLS handshake, then drill into the leaf certificate).

After landing the 20-issue feature batch (#218-#237), discoverability suffered: 38 tools across 6 categories, with no in-tool cue that "this output is the input to that other tool". This PR closes the loop for the highest-value pairs without rebuilding the sidebar.

## Component

`src/lib/components/layout/related-tools.tsx`:

```tsx
<RelatedTools
  items={[
    { id: 'tls-inspector', reason: 'Inspect TLS of a resolved host' },
    { id: 'rest-client', reason: 'Send HTTP request to a resolved host' },
  ]}
/>
```

- Each row links via TanStack Router `Link`, pulls icon / title / color from the central registry via `getPageById`
- Rendered inside an existing `FormSection title="Related"` so it lives alongside the other rail sections
- No category coupling — works with any registered page ID

## Cross-link integrations (8 routes)

| From | → To | Reason |
|------|-----|--------|
| DNS Lookup | TLS Inspector | Inspect TLS of a resolved host |
|  | HTTP REST Client | Send HTTP request to a resolved host |
|  | CIDR Calculator | Analyse a resolved IP address |
| TLS Inspector | X.509 Decoder | Drill into a chain certificate |
|  | DNS Lookup | Resolve a host before handshake |
| HTTP REST Client | HTTP Status Codes | Look up a response status code |
|  | MIME Type Explorer | Find a Content-Type or extension |
|  | cURL Builder | Build or parse a cURL command |
| Webhook Receiver | HTTP REST Client | Replay a captured request |
| CIDR Calculator | IP Address Converter | Convert IPv4 ↔ IPv6 |
|  | DNS Lookup | Resolve a name to an IP |
| IP Address Converter | CIDR Calculator | Compute subnets and ranges |
|  | DNS Lookup | Resolve a name to an IP |
| X.509 Decoder | TLS Inspector | Fetch a live cert chain from a host |
|  | RSA Toolkit | Verify a signature with the public key |
| Date / Timestamp Converter | Cron Expression Builder | Edit the cron expression |

## Changes

### Added
- `src/lib/components/layout/related-tools.tsx`
- Export entry in `src/lib/components/layout/index.ts`

### Modified
- 8 route files (rail section + import line)

## Test plan
- [x] `bun run check` (TS + validate-pages + audit-design) green
- [x] Manual: DNS Lookup rail shows 3 Related cards
- [ ] Manual: click each Related card; navigates to the target tool
- [ ] Manual: Related cards inherit the target tool's icon color
