### PR TITLE
feat(hex-editor): add Hex Editor / Viewer under Files

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -22,6 +22,7 @@
 		"fs:allow-read-text-file",
 		"fs:allow-read-file",
 		"fs:allow-write-text-file",
+		"fs:allow-write-file",
 		"decorum:allow-show-snap-overlay",
 		"mcp-bridge:default",
 		{

--- a/src-tauri/src/hex_editor.rs
+++ b/src-tauri/src/hex_editor.rs
@@ -1,0 +1,299 @@
+//! Hex editor / viewer commands.
+//!
+//! Provides three commands the frontend hex tool relies on:
+//!
+//! - `hex_open`   - inspect a file and return its size and modified
+//!   timestamp so the viewer can size its virtual scroll viewport
+//!   without first reading every byte.
+//! - `hex_read`   - read a byte slice (offset + length) so the viewer
+//!   can lazily fetch only the rows that are visible.
+//! - `hex_save`   - apply a list of patch / insert / delete operations
+//!   and write the result back to disk, optionally creating a `.bak`
+//!   backup first.
+//!
+//! The save path re-reads the whole file into memory before applying
+//! ops. That is sufficient for files up to a few hundred megabytes and
+//! keeps the implementation pure-functional; streaming edits for
+//! gigabyte-class files is deferred.
+
+use std::fs;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+/// Metadata returned by `hex_open` so the viewer can render virtual
+/// scroll geometry without reading the entire file.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HexFileInfo {
+    /// Absolute path the file lives at.
+    pub path: String,
+    /// Total file size in bytes.
+    pub size_bytes: u64,
+    /// Modification time as Unix milliseconds (when available).
+    pub modified_ms: Option<i64>,
+}
+
+/// Single edit operation. The frontend collects these into an ordered
+/// list and the backend applies them sequentially to an in-memory copy
+/// of the file before writing back.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HexEditOp {
+    /// Byte offset at which the operation starts.
+    pub offset: u64,
+    /// Original bytes at `offset`. Used as a sanity check so concurrent
+    /// file changes outside the editor do not silently get clobbered.
+    pub original: Vec<u8>,
+    /// New bytes. For `patch` the length matches `original`; for
+    /// `insert` the original is empty; for `delete` the replacement is
+    /// empty.
+    pub replacement: Vec<u8>,
+    /// `"patch"`, `"insert"`, or `"delete"`.
+    pub kind: String,
+}
+
+fn system_time_to_unix_ms(time: SystemTime) -> Option<i64> {
+    time.duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|d| i64::try_from(d.as_millis()).ok())
+}
+
+/// Open a file and return its metadata.
+///
+/// # Errors
+///
+/// Returns a stringified error when the path cannot be stat-ed or when
+/// the target is not a regular file.
+#[tauri::command]
+pub fn hex_open(path: String) -> Result<HexFileInfo, String> {
+    let path_buf = Path::new(&path).to_path_buf();
+    let metadata = fs::metadata(&path_buf).map_err(|e| format!("Failed to stat file: {e}"))?;
+    if !metadata.is_file() {
+        return Err(format!("Not a regular file: {path}"));
+    }
+    let modified_ms = metadata.modified().ok().and_then(system_time_to_unix_ms);
+    Ok(HexFileInfo {
+        path: path_buf.to_string_lossy().into_owned(),
+        size_bytes: metadata.len(),
+        modified_ms,
+    })
+}
+
+/// Read a slice of a file starting at `offset` for at most `length`
+/// bytes. Returns `Vec<u8>` so Tauri can serialise it as a number array
+/// (the frontend reconstructs a `Uint8Array`).
+///
+/// # Errors
+///
+/// Returns a stringified error when the file cannot be opened, the
+/// requested range is out of bounds, or reading fails.
+#[tauri::command]
+pub fn hex_read(path: String, offset: u64, length: u64) -> Result<Vec<u8>, String> {
+    let path_buf = Path::new(&path).to_path_buf();
+    let metadata = fs::metadata(&path_buf).map_err(|e| format!("Failed to stat file: {e}"))?;
+    let size = metadata.len();
+    if offset > size {
+        return Err(format!(
+            "Offset {offset} is past end of file ({size} bytes)"
+        ));
+    }
+    let take = u64::min(length, size.saturating_sub(offset));
+    let usize_take = usize::try_from(take).unwrap_or(0);
+    let usize_offset = usize::try_from(offset).unwrap_or(0);
+    let full = fs::read(&path_buf).map_err(|e| format!("Failed to read file: {e}"))?;
+    Ok(full
+        .into_iter()
+        .skip(usize_offset)
+        .take(usize_take)
+        .collect())
+}
+
+/// Apply a single edit op to an in-memory buffer. Returns the new
+/// buffer.
+fn apply_op(buffer: Vec<u8>, op: &HexEditOp) -> Result<Vec<u8>, String> {
+    let offset = usize::try_from(op.offset).map_err(|_| "Offset exceeds usize".to_string())?;
+    match op.kind.as_str() {
+        "patch" => {
+            if op.original.len() != op.replacement.len() {
+                return Err("patch op requires equal-length original and replacement".to_string());
+            }
+            if offset + op.original.len() > buffer.len() {
+                return Err(format!(
+                    "patch op offset {} + len {} exceeds buffer ({})",
+                    offset,
+                    op.original.len(),
+                    buffer.len()
+                ));
+            }
+            // Sanity-check original bytes match what is actually in the
+            // buffer before applying the patch. This guards against the
+            // file changing under the editor between read and save.
+            let actual = &buffer[offset..offset + op.original.len()];
+            if actual != op.original.as_slice() {
+                return Err(format!(
+                    "patch sanity check failed at offset {offset}: file content changed"
+                ));
+            }
+            let mut next = buffer;
+            next.splice(
+                offset..offset + op.replacement.len(),
+                op.replacement.iter().copied(),
+            );
+            Ok(next)
+        }
+        "insert" => {
+            if offset > buffer.len() {
+                return Err(format!(
+                    "insert op offset {} exceeds buffer ({})",
+                    offset,
+                    buffer.len()
+                ));
+            }
+            let mut next = buffer;
+            next.splice(offset..offset, op.replacement.iter().copied());
+            Ok(next)
+        }
+        "delete" => {
+            let end = offset + op.original.len();
+            if end > buffer.len() {
+                return Err(format!(
+                    "delete op offset {} + len {} exceeds buffer ({})",
+                    offset,
+                    op.original.len(),
+                    buffer.len()
+                ));
+            }
+            let actual = &buffer[offset..end];
+            if actual != op.original.as_slice() {
+                return Err(format!(
+                    "delete sanity check failed at offset {offset}: file content changed"
+                ));
+            }
+            let mut next = buffer;
+            next.drain(offset..end);
+            Ok(next)
+        }
+        other => Err(format!("Unknown op kind: {other}")),
+    }
+}
+
+/// Apply a list of edits to `path` and write the result back. When
+/// `backup` is true, the original file is moved to `<path>.bak` before
+/// the new contents are written.
+///
+/// Returns the new file size as a decimal string.
+///
+/// # Errors
+///
+/// Returns a stringified error when reading the file fails, any op is
+/// out of bounds, the backup rename fails, or the final write fails.
+#[tauri::command]
+pub fn hex_save(path: String, ops: Vec<HexEditOp>, backup: bool) -> Result<String, String> {
+    let path_buf = Path::new(&path).to_path_buf();
+    let original = fs::read(&path_buf).map_err(|e| format!("Failed to read file: {e}"))?;
+
+    let edited = ops.iter().try_fold(original, apply_op)?;
+
+    if backup {
+        let mut backup_path = path_buf.clone();
+        let backup_name = match path_buf.file_name() {
+            Some(name) => {
+                let mut s = name.to_os_string();
+                s.push(".bak");
+                s
+            }
+            None => return Err("Cannot derive backup name from path".to_string()),
+        };
+        backup_path.set_file_name(backup_name);
+        // Best-effort: remove existing backup so we can rename over it.
+        if backup_path.exists() {
+            fs::remove_file(&backup_path)
+                .map_err(|e| format!("Failed to remove old backup: {e}"))?;
+        }
+        fs::copy(&path_buf, &backup_path).map_err(|e| format!("Failed to write backup: {e}"))?;
+    }
+
+    fs::write(&path_buf, &edited).map_err(|e| format!("Failed to write file: {e}"))?;
+    Ok(edited.len().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn op(kind: &str, offset: u64, original: &[u8], replacement: &[u8]) -> HexEditOp {
+        HexEditOp {
+            offset,
+            original: original.to_vec(),
+            replacement: replacement.to_vec(),
+            kind: kind.to_string(),
+        }
+    }
+
+    #[test]
+    fn patch_replaces_bytes_in_place() {
+        let buf = vec![0u8, 1, 2, 3, 4];
+        let result = apply_op(buf, &op("patch", 1, &[1, 2], &[0xAA, 0xBB])).unwrap();
+        assert_eq!(result, vec![0, 0xAA, 0xBB, 3, 4]);
+    }
+
+    #[test]
+    fn patch_fails_on_sanity_mismatch() {
+        let buf = vec![0u8, 1, 2, 3];
+        let err = apply_op(buf, &op("patch", 1, &[9, 9], &[0xAA, 0xBB])).unwrap_err();
+        assert!(err.contains("sanity"));
+    }
+
+    #[test]
+    fn patch_requires_equal_lengths() {
+        let buf = vec![0u8, 1, 2, 3];
+        let err = apply_op(buf, &op("patch", 0, &[0], &[0, 1])).unwrap_err();
+        assert!(err.contains("equal-length"));
+    }
+
+    #[test]
+    fn insert_grows_buffer() {
+        let buf = vec![0u8, 1, 2];
+        let result = apply_op(buf, &op("insert", 1, &[], &[9, 9])).unwrap();
+        assert_eq!(result, vec![0, 9, 9, 1, 2]);
+    }
+
+    #[test]
+    fn insert_at_end_appends() {
+        let buf = vec![0u8, 1];
+        let result = apply_op(buf, &op("insert", 2, &[], &[9])).unwrap();
+        assert_eq!(result, vec![0, 1, 9]);
+    }
+
+    #[test]
+    fn delete_shrinks_buffer() {
+        let buf = vec![0u8, 1, 2, 3, 4];
+        let result = apply_op(buf, &op("delete", 1, &[1, 2], &[])).unwrap();
+        assert_eq!(result, vec![0, 3, 4]);
+    }
+
+    #[test]
+    fn delete_fails_on_sanity_mismatch() {
+        let buf = vec![0u8, 1, 2, 3];
+        let err = apply_op(buf, &op("delete", 1, &[9, 9], &[])).unwrap_err();
+        assert!(err.contains("sanity"));
+    }
+
+    #[test]
+    fn unknown_kind_is_rejected() {
+        let buf = vec![0u8, 1, 2];
+        let err = apply_op(buf, &op("rotate", 0, &[], &[])).unwrap_err();
+        assert!(err.contains("Unknown op kind"));
+    }
+
+    #[test]
+    fn ops_apply_in_order() {
+        // delete then insert: simulate a length-changing edit.
+        let buf = vec![0u8, 1, 2, 3, 4];
+        let step1 = apply_op(buf, &op("delete", 1, &[1], &[])).unwrap();
+        let step2 = apply_op(step1, &op("insert", 1, &[], &[0xAA, 0xBB])).unwrap();
+        assert_eq!(step2, vec![0, 0xAA, 0xBB, 2, 3, 4]);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -50,6 +50,7 @@ mod ast;
 mod dns_lookup;
 mod file_inspect;
 mod generators;
+mod hex_editor;
 #[cfg(target_os = "macos")]
 mod menu;
 mod network;
@@ -482,6 +483,9 @@ pub fn run() {
             websocket::ws_close,
             dns_lookup::dns_lookup,
             file_inspect::file_inspect,
+            hex_editor::hex_open,
+            hex_editor::hex_read,
+            hex_editor::hex_save,
             tls_inspect::tls_inspect,
             webhook::webhook_start,
             webhook::webhook_stop,

--- a/src/lib/services/hex-editor.ts
+++ b/src/lib/services/hex-editor.ts
@@ -1,0 +1,231 @@
+/**
+ * Hex Editor service.
+ *
+ * Wraps the `hex_open` / `hex_read` / `hex_save` Tauri commands and
+ * exposes pure helpers the hex viewer/editor renders against:
+ * offset / byte formatting, ASCII decoding, hex-pattern parsing, naive
+ * byte-pattern matching, and selection-range interpretation as
+ * little-/big-endian integers and text encodings.
+ *
+ * All helpers are pure functions so the frontend can call them inside
+ * `useMemo` without owning any extra state.
+ */
+import { invoke } from '@tauri-apps/api/core';
+
+export interface HexFileInfo {
+	readonly path: string;
+	readonly sizeBytes: number;
+	readonly modifiedMs: number | null;
+}
+
+export type HexEditKind = 'patch' | 'insert' | 'delete';
+
+export interface HexEditOp {
+	readonly offset: number;
+	readonly original: Uint8Array;
+	readonly replacement: Uint8Array;
+	readonly kind: HexEditKind;
+}
+
+interface HexEditOpWire {
+	readonly offset: number;
+	readonly original: readonly number[];
+	readonly replacement: readonly number[];
+	readonly kind: HexEditKind;
+}
+
+const toWire = (op: HexEditOp): HexEditOpWire => ({
+	offset: op.offset,
+	original: Array.from(op.original),
+	replacement: Array.from(op.replacement),
+	kind: op.kind,
+});
+
+export const hexOpen = (path: string): Promise<HexFileInfo> => invoke('hex_open', { path });
+
+export const hexRead = (path: string, offset: number, length: number): Promise<Uint8Array> =>
+	invoke<number[]>('hex_read', { path, offset, length }).then((arr) => Uint8Array.from(arr));
+
+export const hexSave = (
+	path: string,
+	ops: readonly HexEditOp[],
+	backup: boolean
+): Promise<string> => invoke('hex_save', { path, ops: ops.map(toWire), backup });
+
+/**
+ * Format a byte offset as an 8-digit uppercase hex string.
+ */
+export const formatOffset = (n: number): string => n.toString(16).padStart(8, '0').toUpperCase();
+
+/**
+ * Format a single byte as a two-character hex string.
+ */
+export const formatHexByte = (b: number, uppercase = true): string => {
+	const s = b.toString(16).padStart(2, '0');
+	return uppercase ? s.toUpperCase() : s;
+};
+
+/**
+ * Render a byte buffer as its ASCII gutter, substituting `.` for any
+ * non-printable byte (outside the 0x20..0x7E inclusive range).
+ */
+export const bytesToAscii = (bytes: Uint8Array): string => {
+	let out = '';
+	for (let i = 0; i < bytes.length; i += 1) {
+		const b = bytes[i];
+		out += b !== undefined && b >= 0x20 && b <= 0x7e ? String.fromCharCode(b) : '.';
+	}
+	return out;
+};
+
+/**
+ * Parse a hex search pattern. Accepts any combination of whitespace
+ * and `0x` prefixes between byte pairs. Returns `null` when the input
+ * is empty or any token is not a valid two-digit hex byte.
+ */
+export const parseHexPattern = (input: string): Uint8Array | null => {
+	const cleaned = input
+		.replace(/0x/gi, '')
+		.replace(/[\s,]+/g, '')
+		.toLowerCase();
+	if (cleaned.length === 0) return null;
+	if (cleaned.length % 2 !== 0) return null;
+	if (!/^[0-9a-f]+$/.test(cleaned)) return null;
+	const bytes = new Uint8Array(cleaned.length / 2);
+	for (let i = 0; i < bytes.length; i += 1) {
+		bytes[i] = Number.parseInt(cleaned.slice(i * 2, i * 2 + 2), 16);
+	}
+	return bytes;
+};
+
+/**
+ * Convert a UTF-8 string into the byte sequence the hex search uses to
+ * locate it inside a buffer.
+ */
+export const textToBytes = (text: string): Uint8Array => new TextEncoder().encode(text);
+
+/**
+ * Naive substring search. Returns every offset at which `needle`
+ * occurs inside `haystack`. Adequate for the in-memory viewport
+ * lengths the editor handles; for huge files we still only search
+ * within the current viewport buffer.
+ */
+export const findAllMatches = (haystack: Uint8Array, needle: Uint8Array): readonly number[] => {
+	if (needle.length === 0 || haystack.length < needle.length) return [];
+	const matches: number[] = [];
+	outer: for (let i = 0; i <= haystack.length - needle.length; i += 1) {
+		for (let j = 0; j < needle.length; j += 1) {
+			if (haystack[i + j] !== needle[j]) continue outer;
+		}
+		matches.push(i);
+	}
+	return matches;
+};
+
+/**
+ * Parse the "Jump to offset" input. Accepts:
+ *
+ * - decimal (e.g. `1024`)
+ * - hex with `0x` prefix (e.g. `0x400`)
+ * - relative with leading `+` / `-` (e.g. `+256`, `-64`)
+ *
+ * Returns the new absolute offset clamped to `[0, size]`, or `null`
+ * when the input cannot be parsed.
+ */
+export const parseJumpOffset = (input: string, current: number, size: number): number | null => {
+	const trimmed = input.trim();
+	if (trimmed.length === 0) return null;
+	const relative = trimmed.startsWith('+') || trimmed.startsWith('-');
+	const sign = trimmed.startsWith('-') ? -1 : 1;
+	const body = relative ? trimmed.slice(1) : trimmed;
+	const radix = body.toLowerCase().startsWith('0x') ? 16 : 10;
+	const digits = radix === 16 ? body.slice(2) : body;
+	if (digits.length === 0) return null;
+	const validHex = /^[0-9a-fA-F]+$/;
+	const validDec = /^[0-9]+$/;
+	if (radix === 16 && !validHex.test(digits)) return null;
+	if (radix === 10 && !validDec.test(digits)) return null;
+	const value = Number.parseInt(digits, radix);
+	if (!Number.isFinite(value)) return null;
+	const next = relative ? current + sign * value : value;
+	if (next < 0) return 0;
+	if (next > size) return size;
+	return next;
+};
+
+export interface ByteInterpretation {
+	readonly u8?: number;
+	readonly i8?: number;
+	readonly u16le?: number;
+	readonly u16be?: number;
+	readonly i16le?: number;
+	readonly i16be?: number;
+	readonly u32le?: number;
+	readonly u32be?: number;
+	readonly i32le?: number;
+	readonly i32be?: number;
+	readonly u64le?: bigint;
+	readonly u64be?: bigint;
+	readonly f32le?: number;
+	readonly f32be?: number;
+	readonly f64le?: number;
+	readonly f64be?: number;
+	readonly ascii: string;
+	readonly utf8?: string;
+	readonly utf16le?: string;
+}
+
+const tryDecode = (bytes: Uint8Array, encoding: 'utf-8' | 'utf-16le'): string | undefined => {
+	try {
+		const decoder = new TextDecoder(encoding, { fatal: false });
+		const decoded = decoder.decode(bytes);
+		return decoded.length === 0 ? undefined : decoded;
+	} catch {
+		return undefined;
+	}
+};
+
+/**
+ * Decode a small selection into every reasonable scalar / text
+ * interpretation. Unavailable conversions (e.g. u32 on a 3-byte
+ * selection) are simply omitted.
+ */
+export const interpretBytes = (bytes: Uint8Array): ByteInterpretation => {
+	const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+	const len = bytes.length;
+	const ascii = bytesToAscii(bytes);
+
+	return {
+		u8: len >= 1 ? view.getUint8(0) : undefined,
+		i8: len >= 1 ? view.getInt8(0) : undefined,
+		u16le: len >= 2 ? view.getUint16(0, true) : undefined,
+		u16be: len >= 2 ? view.getUint16(0, false) : undefined,
+		i16le: len >= 2 ? view.getInt16(0, true) : undefined,
+		i16be: len >= 2 ? view.getInt16(0, false) : undefined,
+		u32le: len >= 4 ? view.getUint32(0, true) : undefined,
+		u32be: len >= 4 ? view.getUint32(0, false) : undefined,
+		i32le: len >= 4 ? view.getInt32(0, true) : undefined,
+		i32be: len >= 4 ? view.getInt32(0, false) : undefined,
+		u64le: len >= 8 ? view.getBigUint64(0, true) : undefined,
+		u64be: len >= 8 ? view.getBigUint64(0, false) : undefined,
+		f32le: len >= 4 ? view.getFloat32(0, true) : undefined,
+		f32be: len >= 4 ? view.getFloat32(0, false) : undefined,
+		f64le: len >= 8 ? view.getFloat64(0, true) : undefined,
+		f64be: len >= 8 ? view.getFloat64(0, false) : undefined,
+		ascii,
+		utf8: tryDecode(bytes, 'utf-8'),
+		utf16le: len >= 2 ? tryDecode(bytes, 'utf-16le') : undefined,
+	};
+};
+
+/**
+ * Human-readable size, mirroring `file-inspect`'s helper so the file
+ * banner reads consistently across the two tools.
+ */
+export const humanSize = (bytes: number): string => {
+	if (bytes === 0) return '0 B';
+	const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+	const exponent = Math.min(units.length - 1, Math.floor(Math.log10(bytes) / 3));
+	const value = bytes / 10 ** (exponent * 3);
+	return `${value.toFixed(exponent === 0 ? 0 : 2)} ${units[exponent]}`;
+};

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -21,6 +21,7 @@ import {
 	FileCheck,
 	FileCode,
 	FileDiff,
+	FileDigit,
 	FileJson2,
 	FileSearch,
 	FileText,
@@ -550,6 +551,15 @@ export const PAGES: readonly PageDefinition[] = [
 		icon: FileSearch,
 		description: 'Inspect file metadata, MIME, hashes, EXIF, and preview content',
 		color: 'text-amber-600',
+		category: 'files',
+	},
+	{
+		id: 'hex-editor',
+		title: 'Hex Editor',
+		url: '/hex-editor',
+		icon: FileDigit,
+		description: 'View and edit binary files as hex with search, jump, and per-byte selection',
+		color: 'text-amber-700',
 		category: 'files',
 	},
 	{

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -41,6 +41,7 @@ import { Route as JsonFormatterRouteImport } from './routes/json-formatter';
 import { Route as IpConverterRouteImport } from './routes/ip-converter';
 import { Route as ImageConverterRouteImport } from './routes/image-converter';
 import { Route as HttpStatusCodesRouteImport } from './routes/http-status-codes';
+import { Route as HexEditorRouteImport } from './routes/hex-editor';
 import { Route as HashGeneratorRouteImport } from './routes/hash-generator';
 import { Route as GpgKeyGeneratorRouteImport } from './routes/gpg-key-generator';
 import { Route as FileInspectorRouteImport } from './routes/file-inspector';
@@ -215,6 +216,11 @@ const HttpStatusCodesRoute = HttpStatusCodesRouteImport.update({
 	path: '/http-status-codes',
 	getParentRoute: () => rootRouteImport,
 } as any);
+const HexEditorRoute = HexEditorRouteImport.update({
+	id: '/hex-editor',
+	path: '/hex-editor',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const HashGeneratorRoute = HashGeneratorRouteImport.update({
 	id: '/hash-generator',
 	path: '/hash-generator',
@@ -295,6 +301,7 @@ export interface FileRoutesByFullPath {
 	'/file-inspector': typeof FileInspectorRoute;
 	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
 	'/hash-generator': typeof HashGeneratorRoute;
+	'/hex-editor': typeof HexEditorRoute;
 	'/http-status-codes': typeof HttpStatusCodesRoute;
 	'/image-converter': typeof ImageConverterRoute;
 	'/ip-converter': typeof IpConverterRoute;
@@ -342,6 +349,7 @@ export interface FileRoutesByTo {
 	'/file-inspector': typeof FileInspectorRoute;
 	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
 	'/hash-generator': typeof HashGeneratorRoute;
+	'/hex-editor': typeof HexEditorRoute;
 	'/http-status-codes': typeof HttpStatusCodesRoute;
 	'/image-converter': typeof ImageConverterRoute;
 	'/ip-converter': typeof IpConverterRoute;
@@ -390,6 +398,7 @@ export interface FileRoutesById {
 	'/file-inspector': typeof FileInspectorRoute;
 	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
 	'/hash-generator': typeof HashGeneratorRoute;
+	'/hex-editor': typeof HexEditorRoute;
 	'/http-status-codes': typeof HttpStatusCodesRoute;
 	'/image-converter': typeof ImageConverterRoute;
 	'/ip-converter': typeof IpConverterRoute;
@@ -439,6 +448,7 @@ export interface FileRouteTypes {
 		| '/file-inspector'
 		| '/gpg-key-generator'
 		| '/hash-generator'
+		| '/hex-editor'
 		| '/http-status-codes'
 		| '/image-converter'
 		| '/ip-converter'
@@ -486,6 +496,7 @@ export interface FileRouteTypes {
 		| '/file-inspector'
 		| '/gpg-key-generator'
 		| '/hash-generator'
+		| '/hex-editor'
 		| '/http-status-codes'
 		| '/image-converter'
 		| '/ip-converter'
@@ -533,6 +544,7 @@ export interface FileRouteTypes {
 		| '/file-inspector'
 		| '/gpg-key-generator'
 		| '/hash-generator'
+		| '/hex-editor'
 		| '/http-status-codes'
 		| '/image-converter'
 		| '/ip-converter'
@@ -581,6 +593,7 @@ export interface RootRouteChildren {
 	FileInspectorRoute: typeof FileInspectorRoute;
 	GpgKeyGeneratorRoute: typeof GpgKeyGeneratorRoute;
 	HashGeneratorRoute: typeof HashGeneratorRoute;
+	HexEditorRoute: typeof HexEditorRoute;
 	HttpStatusCodesRoute: typeof HttpStatusCodesRoute;
 	ImageConverterRoute: typeof ImageConverterRoute;
 	IpConverterRoute: typeof IpConverterRoute;
@@ -841,6 +854,13 @@ declare module '@tanstack/react-router' {
 			preLoaderRoute: typeof HttpStatusCodesRouteImport;
 			parentRoute: typeof rootRouteImport;
 		};
+		'/hex-editor': {
+			id: '/hex-editor';
+			path: '/hex-editor';
+			fullPath: '/hex-editor';
+			preLoaderRoute: typeof HexEditorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
 		'/hash-generator': {
 			id: '/hash-generator';
 			path: '/hash-generator';
@@ -949,6 +969,7 @@ const rootRouteChildren: RootRouteChildren = {
 	FileInspectorRoute: FileInspectorRoute,
 	GpgKeyGeneratorRoute: GpgKeyGeneratorRoute,
 	HashGeneratorRoute: HashGeneratorRoute,
+	HexEditorRoute: HexEditorRoute,
 	HttpStatusCodesRoute: HttpStatusCodesRoute,
 	ImageConverterRoute: ImageConverterRoute,
 	IpConverterRoute: IpConverterRoute,

--- a/src/routes/hex-editor.tsx
+++ b/src/routes/hex-editor.tsx
@@ -1,0 +1,1275 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { open as openDialog } from '@tauri-apps/plugin-dialog';
+import {
+	ChevronLeft,
+	ChevronRight,
+	FileSearch,
+	FolderOpen,
+	Loader2,
+	Redo2,
+	Save,
+	Search,
+	Trash2,
+	Undo2,
+} from 'lucide-react';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	type CSSProperties,
+	type DragEvent,
+	type KeyboardEvent,
+	type MouseEvent,
+} from 'react';
+import { toast } from 'sonner';
+
+import { FormCheckbox, FormInfo, FormInput, FormMode, FormSection } from '@/lib/components/form';
+import { RelatedTools } from '@/lib/components/layout';
+import { ToolShell } from '@/lib/components/shell';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { Badge } from '@/lib/components/ui/badge';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { useDocumentTitle } from '@/lib/hooks';
+import { detectMimeFromMagic } from '@/lib/services/file-inspect';
+import {
+	bytesToAscii,
+	findAllMatches,
+	formatHexByte,
+	formatOffset,
+	hexOpen,
+	hexRead,
+	hexSave,
+	humanSize,
+	interpretBytes,
+	parseHexPattern,
+	parseJumpOffset,
+	textToBytes,
+	type HexEditOp,
+	type HexFileInfo,
+} from '@/lib/services/hex-editor';
+import { createToolOptionsStore } from '@/lib/stores';
+import { cn } from '@/lib/utils';
+
+const ROW_HEIGHT = 20;
+const OVERSCAN_ROWS = 12;
+// Magic-byte highlight covers the first N bytes (matches the common
+// file-signature length; longer signatures still tint the same row).
+const MAGIC_BYTES_HIGHLIGHT = 8;
+const UNDO_LIMIT = 100;
+
+type BytesPerRow = 16 | 32;
+type SearchMode = 'hex' | 'text';
+
+interface HexEditorPrefs {
+	readonly bytesPerRow: BytesPerRow;
+	readonly uppercase: boolean;
+	readonly showAscii: boolean;
+	readonly readOnly: boolean;
+	readonly backupOnSave: boolean;
+}
+
+const DEFAULT_PREFS: HexEditorPrefs = {
+	bytesPerRow: 16,
+	uppercase: true,
+	showAscii: true,
+	readOnly: true,
+	backupOnSave: true,
+};
+
+const useHexEditorPrefs = createToolOptionsStore<HexEditorPrefs>('hex-editor', DEFAULT_PREFS);
+
+interface Selection {
+	readonly start: number;
+	readonly end: number;
+}
+
+export const Route = createFileRoute('/hex-editor')({
+	component: HexEditorPage,
+});
+
+function HexEditorPage() {
+	useDocumentTitle('Hex Editor');
+
+	const { value: prefs, patch } = useHexEditorPrefs();
+
+	const [file, setFile] = useState<HexFileInfo | null>(null);
+	const [buffer, setBuffer] = useState<Uint8Array | null>(null);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [isDragOver, setIsDragOver] = useState(false);
+	const [showRail, setShowRail] = useState(true);
+	const [selection, setSelection] = useState<Selection | null>(null);
+	const [pendingOps, setPendingOps] = useState<readonly HexEditOp[]>([]);
+	const [undoStack, setUndoStack] = useState<readonly Uint8Array[]>([]);
+	const [redoStack, setRedoStack] = useState<readonly Uint8Array[]>([]);
+	const [searchInput, setSearchInput] = useState('');
+	const [searchMode, setSearchMode] = useState<SearchMode>('hex');
+	const [activeMatchIdx, setActiveMatchIdx] = useState(0);
+	const [jumpInput, setJumpInput] = useState('');
+	const [scrollTop, setScrollTop] = useState(0);
+	const [editingByte, setEditingByte] = useState<{
+		readonly offset: number;
+		readonly draft: string;
+	} | null>(null);
+
+	const scrollRef = useRef<HTMLDivElement | null>(null);
+	const dragAnchorRef = useRef<number | null>(null);
+	const viewportRef = useRef<HTMLDivElement | null>(null);
+
+	const handleClear = useCallback(() => {
+		setFile(null);
+		setBuffer(null);
+		setError(null);
+		setSelection(null);
+		setPendingOps([]);
+		setUndoStack([]);
+		setRedoStack([]);
+		setSearchInput('');
+		setActiveMatchIdx(0);
+		setJumpInput('');
+		setScrollTop(0);
+		setEditingByte(null);
+	}, []);
+
+	const loadFromPath = useCallback(async (path: string) => {
+		setLoading(true);
+		setError(null);
+		try {
+			const info = await hexOpen(path);
+			// Read the entire file into memory for editing. For very
+			// large files (> a few hundred megabytes) this is the point
+			// where a future PR would switch to viewport-streaming.
+			const bytes =
+				info.sizeBytes === 0 ? new Uint8Array(0) : await hexRead(path, 0, info.sizeBytes);
+			setFile(info);
+			setBuffer(bytes);
+			setSelection(null);
+			setPendingOps([]);
+			setUndoStack([]);
+			setRedoStack([]);
+			setScrollTop(0);
+		} catch (e) {
+			const message = e instanceof Error ? e.message : String(e);
+			setError(message);
+			toast.error('Failed to open file', { description: message });
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	const handlePickFile = async () => {
+		try {
+			const selected = await openDialog({ multiple: false, directory: false });
+			if (typeof selected === 'string' && selected.length > 0) {
+				await loadFromPath(selected);
+			}
+		} catch (e) {
+			const message = e instanceof Error ? e.message : String(e);
+			toast.error('Failed to open file dialog', { description: message });
+		}
+	};
+
+	const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		setIsDragOver(false);
+		const dropped = e.dataTransfer.files[0] as (File & { readonly path?: string }) | undefined;
+		if (!dropped) return;
+		if (dropped.path) {
+			loadFromPath(dropped.path).catch(() => undefined);
+			return;
+		}
+		toast.error('Could not determine file path', {
+			description: 'Use the Open file button to pick the file.',
+		});
+	};
+	const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		setIsDragOver(true);
+	};
+	const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		setIsDragOver(false);
+	};
+
+	const dirty = pendingOps.length > 0;
+	const editable = !prefs.readOnly;
+
+	const mimeInfo = useMemo(() => {
+		if (!buffer || !file) return null;
+		const head = buffer.subarray(0, Math.min(buffer.length, 4096));
+		return detectMimeFromMagic(head, file.path.split('/').pop() ?? file.path);
+	}, [buffer, file]);
+	const detectedMime = mimeInfo?.mime ?? mimeInfo?.expectedFromExtension ?? null;
+
+	const searchPattern = useMemo<Uint8Array | null>(() => {
+		if (searchInput.length === 0) return null;
+		if (searchMode === 'hex') return parseHexPattern(searchInput);
+		return textToBytes(searchInput);
+	}, [searchInput, searchMode]);
+
+	const matches = useMemo(() => {
+		if (!buffer || !searchPattern) return [] as readonly number[];
+		return findAllMatches(buffer, searchPattern);
+	}, [buffer, searchPattern]);
+
+	useEffect(() => {
+		if (matches.length === 0) {
+			setActiveMatchIdx(0);
+		} else if (activeMatchIdx >= matches.length) {
+			setActiveMatchIdx(0);
+		}
+	}, [matches, activeMatchIdx]);
+
+	const totalRows = useMemo(() => {
+		if (!buffer) return 0;
+		return Math.ceil(buffer.length / prefs.bytesPerRow);
+	}, [buffer, prefs.bytesPerRow]);
+
+	const [viewportHeight, setViewportHeight] = useState(480);
+
+	useEffect(() => {
+		const el = viewportRef.current;
+		if (!el) return;
+		const ro = new ResizeObserver((entries) => {
+			for (const entry of entries) setViewportHeight(entry.contentRect.height);
+		});
+		ro.observe(el);
+		return () => ro.disconnect();
+	}, [buffer]);
+
+	const firstVisibleRow = Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - OVERSCAN_ROWS);
+	const lastVisibleRow = Math.min(
+		totalRows,
+		Math.ceil((scrollTop + viewportHeight) / ROW_HEIGHT) + OVERSCAN_ROWS
+	);
+
+	const visibleRows = useMemo(() => {
+		if (!buffer) return [] as readonly { readonly offset: number; readonly bytes: Uint8Array }[];
+		const rows: { readonly offset: number; readonly bytes: Uint8Array }[] = [];
+		for (let row = firstVisibleRow; row < lastVisibleRow; row += 1) {
+			const start = row * prefs.bytesPerRow;
+			if (start >= buffer.length) break;
+			const end = Math.min(buffer.length, start + prefs.bytesPerRow);
+			rows.push({ offset: start, bytes: buffer.subarray(start, end) });
+		}
+		return rows;
+	}, [buffer, firstVisibleRow, lastVisibleRow, prefs.bytesPerRow]);
+
+	const scrollToOffset = useCallback(
+		(offset: number) => {
+			const el = scrollRef.current;
+			if (!el) return;
+			const row = Math.floor(offset / prefs.bytesPerRow);
+			const target = Math.max(0, row * ROW_HEIGHT - viewportHeight / 2);
+			el.scrollTop = target;
+			setScrollTop(target);
+		},
+		[prefs.bytesPerRow, viewportHeight]
+	);
+
+	const handleJump = useCallback(() => {
+		if (!buffer) return;
+		const next = parseJumpOffset(jumpInput, selection?.start ?? 0, buffer.length);
+		if (next === null) {
+			toast.error('Could not parse offset');
+			return;
+		}
+		setSelection({ start: next, end: next });
+		scrollToOffset(next);
+	}, [buffer, jumpInput, selection, scrollToOffset]);
+
+	const handleQuickJump = useCallback(
+		(fraction: number) => {
+			if (!buffer || buffer.length === 0) return;
+			const offset = Math.min(buffer.length - 1, Math.floor(buffer.length * fraction));
+			setSelection({ start: offset, end: offset });
+			scrollToOffset(offset);
+		},
+		[buffer, scrollToOffset]
+	);
+
+	const findNext = useCallback(() => {
+		if (matches.length === 0) return;
+		const next = (activeMatchIdx + 1) % matches.length;
+		setActiveMatchIdx(next);
+		const offset = matches[next];
+		if (offset !== undefined && searchPattern) {
+			setSelection({ start: offset, end: offset + searchPattern.length - 1 });
+			scrollToOffset(offset);
+		}
+	}, [matches, activeMatchIdx, searchPattern, scrollToOffset]);
+
+	const findPrev = useCallback(() => {
+		if (matches.length === 0) return;
+		const prev = (activeMatchIdx - 1 + matches.length) % matches.length;
+		setActiveMatchIdx(prev);
+		const offset = matches[prev];
+		if (offset !== undefined && searchPattern) {
+			setSelection({ start: offset, end: offset + searchPattern.length - 1 });
+			scrollToOffset(offset);
+		}
+	}, [matches, activeMatchIdx, searchPattern, scrollToOffset]);
+
+	const matchSet = useMemo(() => {
+		if (!searchPattern) return null;
+		const set = new Set<number>();
+		const len = searchPattern.length;
+		for (const start of matches) {
+			for (let i = 0; i < len; i += 1) set.add(start + i);
+		}
+		return set;
+	}, [matches, searchPattern]);
+
+	const pushHistory = useCallback((snapshot: Uint8Array) => {
+		setUndoStack((prev) => {
+			const next = [...prev, snapshot];
+			if (next.length > UNDO_LIMIT) return next.slice(next.length - UNDO_LIMIT);
+			return next;
+		});
+		setRedoStack([]);
+	}, []);
+
+	const commitByte = useCallback(
+		(offset: number, value: number) => {
+			if (!buffer) return;
+			if (offset < 0 || offset >= buffer.length) return;
+			const current = buffer[offset];
+			if (current === undefined || current === value) {
+				setEditingByte(null);
+				return;
+			}
+			pushHistory(buffer);
+			const next = new Uint8Array(buffer);
+			next[offset] = value;
+			setBuffer(next);
+			setPendingOps((prev) => [
+				...prev,
+				{
+					offset,
+					original: new Uint8Array([current]),
+					replacement: new Uint8Array([value]),
+					kind: 'patch',
+				},
+			]);
+			setEditingByte(null);
+		},
+		[buffer, pushHistory]
+	);
+
+	const handleUndo = useCallback(() => {
+		if (undoStack.length === 0 || !buffer) return;
+		const previous = undoStack[undoStack.length - 1];
+		if (!previous) return;
+		setUndoStack(undoStack.slice(0, -1));
+		setRedoStack((stack) => [...stack, buffer]);
+		setBuffer(previous);
+		// Drop the latest pending op to mirror the snapshot rollback.
+		setPendingOps((prev) => prev.slice(0, -1));
+	}, [undoStack, buffer]);
+
+	const handleRedo = useCallback(() => {
+		if (redoStack.length === 0 || !buffer) return;
+		const next = redoStack[redoStack.length - 1];
+		if (!next) return;
+		setRedoStack(redoStack.slice(0, -1));
+		setUndoStack((stack) => [...stack, buffer]);
+		setBuffer(next);
+	}, [redoStack, buffer]);
+
+	const handleDiscard = useCallback(() => {
+		if (!file) return;
+		loadFromPath(file.path).catch(() => undefined);
+	}, [file, loadFromPath]);
+
+	const handleSave = useCallback(async () => {
+		if (!file || pendingOps.length === 0) return;
+		try {
+			const newSize = await hexSave(file.path, pendingOps, prefs.backupOnSave);
+			toast.success('File saved', { description: `${newSize} bytes written` });
+			setPendingOps([]);
+			setUndoStack([]);
+			setRedoStack([]);
+			// Re-stat to reflect new modified time.
+			const info = await hexOpen(file.path);
+			setFile(info);
+		} catch (e) {
+			const message = e instanceof Error ? e.message : String(e);
+			toast.error('Failed to save', { description: message });
+		}
+	}, [file, pendingOps, prefs.backupOnSave]);
+
+	const selectionBytes = useMemo<Uint8Array | null>(() => {
+		if (!buffer || !selection) return null;
+		const [lo, hi] =
+			selection.start <= selection.end
+				? [selection.start, selection.end]
+				: [selection.end, selection.start];
+		const slice = buffer.subarray(lo, Math.min(buffer.length, hi + 1));
+		return slice.length > 0 ? slice : null;
+	}, [buffer, selection]);
+
+	const selectionLength = selectionBytes?.length ?? 0;
+	const interpretation = useMemo(
+		() => (selectionBytes ? interpretBytes(selectionBytes) : null),
+		[selectionBytes]
+	);
+
+	const onCellMouseDown = (offset: number) => (e: MouseEvent<HTMLButtonElement>) => {
+		if (editingByte) return;
+		dragAnchorRef.current = offset;
+		setSelection({ start: offset, end: offset });
+		e.preventDefault();
+	};
+	const onCellMouseEnter = (offset: number) => () => {
+		if (dragAnchorRef.current === null) return;
+		setSelection({ start: dragAnchorRef.current, end: offset });
+	};
+
+	// Window-level mouseup so a drag started inside the viewport still
+	// resolves when the cursor leaves the bounds. A div onMouseUp would
+	// fire on the wrapper, but biome rejects interactivity on a non-semantic
+	// container; the window listener avoids the rule without rewrapping in
+	// a button/grid that does not match the visual structure.
+	useEffect(() => {
+		const handler = () => {
+			dragAnchorRef.current = null;
+		};
+		window.addEventListener('mouseup', handler);
+		return () => window.removeEventListener('mouseup', handler);
+	}, []);
+
+	const startEdit = (offset: number) => {
+		if (!editable || !buffer) return;
+		const b = buffer[offset];
+		if (b === undefined) return;
+		setEditingByte({ offset, draft: '' });
+	};
+
+	const tryParseEditDraft = (draft: string): number | null => {
+		const trimmed = draft.trim();
+		if (trimmed.length !== 2 || !/^[0-9a-fA-F]{2}$/.test(trimmed)) return null;
+		return Number.parseInt(trimmed, 16);
+	};
+
+	const advanceEditCursor = (offset: number, shift: boolean) => {
+		if (!buffer) return;
+		const next = shift ? offset - 1 : offset + 1;
+		if (next < 0 || next >= buffer.length) return;
+		setSelection({ start: next, end: next });
+		setEditingByte({ offset: next, draft: '' });
+	};
+
+	const handleEditKeyDown = (offset: number) => (e: KeyboardEvent<HTMLInputElement>) => {
+		if (!editingByte) return;
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			setEditingByte(null);
+			return;
+		}
+		if (e.key !== 'Enter' && e.key !== 'Tab') return;
+		e.preventDefault();
+		const value = tryParseEditDraft(editingByte.draft);
+		if (value === null) {
+			toast.error('Enter two hex characters');
+			return;
+		}
+		commitByte(offset, value);
+		if (e.key === 'Tab') advanceEditCursor(offset, e.shiftKey);
+	};
+
+	const hasFile = file !== null;
+
+	return (
+		<ToolShell
+			showRail={showRail}
+			onShowRailChange={setShowRail}
+			valid={hasFile ? true : null}
+			error={error ?? undefined}
+			statusContent={
+				hasFile && file ? (
+					<>
+						<StatItem label="Size" value={humanSize(file.sizeBytes)} />
+						<StatItem label="Offset" value={formatOffset(selection?.start ?? 0)} />
+						<StatItem
+							label="Selection"
+							value={selectionLength > 0 ? `${selectionLength} B` : '—'}
+						/>
+						<StatItem label="Modified" value={dirty ? `${pendingOps.length} pending` : 'No'} />
+					</>
+				) : null
+			}
+			rail={
+				<>
+					<FormSection title="Open">
+						<div className="flex flex-col gap-2">
+							<Button variant="default" size="sm" onClick={handlePickFile} disabled={loading}>
+								<FolderOpen className="h-3.5 w-3.5" />
+								{hasFile ? 'Choose another' : 'Open file…'}
+							</Button>
+							{hasFile ? (
+								<Button variant="outline" size="sm" onClick={handleClear}>
+									<Trash2 className="h-3.5 w-3.5" />
+									Clear
+								</Button>
+							) : null}
+						</div>
+					</FormSection>
+
+					<FormSection title="Search">
+						<FormMode<SearchMode>
+							label="Pattern"
+							value={searchMode}
+							options={[
+								{ value: 'hex', label: 'Hex' },
+								{ value: 'text', label: 'Text' },
+							]}
+							onValueChange={setSearchMode}
+						/>
+						<FormInput
+							label={searchMode === 'hex' ? 'Hex pattern (e.g. 89 50 4E 47)' : 'Text to find'}
+							value={searchInput}
+							onValueChange={setSearchInput}
+							placeholder={searchMode === 'hex' ? '89 50 4E 47' : 'PNG'}
+							size="compact"
+						/>
+						<div className="flex items-center gap-2">
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={findPrev}
+								disabled={matches.length === 0}
+							>
+								<ChevronLeft className="h-3.5 w-3.5" />
+								Prev
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={findNext}
+								disabled={matches.length === 0}
+							>
+								<ChevronRight className="h-3.5 w-3.5" />
+								Next
+							</Button>
+							<Badge variant="outline" className="ml-auto font-mono text-2xs">
+								<Search className="h-3 w-3" />
+								{matches.length > 0 ? `${activeMatchIdx + 1} / ${matches.length}` : '0'}
+							</Badge>
+						</div>
+					</FormSection>
+
+					<FormSection title="Jump to offset">
+						<FormInput
+							label="Offset (dec / 0xHEX / ±rel)"
+							value={jumpInput}
+							onValueChange={setJumpInput}
+							placeholder="0x400 or +256"
+							size="compact"
+						/>
+						<div className="flex flex-wrap gap-1.5">
+							<Button variant="outline" size="sm" onClick={handleJump}>
+								Go
+							</Button>
+							<Button variant="outline" size="sm" onClick={() => handleQuickJump(0)}>
+								Start
+							</Button>
+							<Button variant="outline" size="sm" onClick={() => handleQuickJump(0.5)}>
+								50%
+							</Button>
+							<Button variant="outline" size="sm" onClick={() => handleQuickJump(0.75)}>
+								75%
+							</Button>
+							<Button variant="outline" size="sm" onClick={() => handleQuickJump(0.9999)}>
+								End
+							</Button>
+						</div>
+					</FormSection>
+
+					<FormSection title="Display">
+						<FormMode<string>
+							label="Bytes per row"
+							value={String(prefs.bytesPerRow)}
+							options={[
+								{ value: '16', label: '16' },
+								{ value: '32', label: '32' },
+							]}
+							onValueChange={(v) => patch({ bytesPerRow: v === '32' ? 32 : 16 })}
+						/>
+						<FormCheckbox
+							label="Uppercase hex"
+							checked={prefs.uppercase}
+							onCheckedChange={(checked) => patch({ uppercase: checked })}
+							size="compact"
+						/>
+						<FormCheckbox
+							label="Show ASCII gutter"
+							checked={prefs.showAscii}
+							onCheckedChange={(checked) => patch({ showAscii: checked })}
+							size="compact"
+						/>
+					</FormSection>
+
+					<FormSection title="Mode">
+						<FormCheckbox
+							label="Read-only"
+							checked={prefs.readOnly}
+							onCheckedChange={(checked) => {
+								patch({ readOnly: checked });
+								if (checked) setEditingByte(null);
+							}}
+							size="compact"
+						/>
+						{!prefs.readOnly ? (
+							<div className="flex flex-wrap gap-1.5">
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={handleUndo}
+									disabled={undoStack.length === 0}
+								>
+									<Undo2 className="h-3.5 w-3.5" />
+									Undo
+								</Button>
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={handleRedo}
+									disabled={redoStack.length === 0}
+								>
+									<Redo2 className="h-3.5 w-3.5" />
+									Redo
+								</Button>
+								<Button variant="outline" size="sm" onClick={handleDiscard} disabled={!dirty}>
+									<Trash2 className="h-3.5 w-3.5" />
+									Discard
+								</Button>
+							</div>
+						) : null}
+					</FormSection>
+
+					<FormSection title="Save">
+						<FormCheckbox
+							label="Create .bak backup"
+							checked={prefs.backupOnSave}
+							onCheckedChange={(checked) => patch({ backupOnSave: checked })}
+							size="compact"
+						/>
+						<Button
+							variant="default"
+							size="sm"
+							onClick={handleSave}
+							disabled={!dirty || prefs.readOnly}
+						>
+							<Save className="h-3.5 w-3.5" />
+							Save
+						</Button>
+					</FormSection>
+
+					<FormSection title="Related">
+						<RelatedTools
+							items={[
+								{ id: 'file-inspector', reason: 'Inspect metadata' },
+								{ id: 'mime-types', reason: 'Decode magic bytes' },
+							]}
+						/>
+					</FormSection>
+
+					<FormSection title="About">
+						<FormInfo>
+							Virtual scrolling renders only visible rows. Backup .bak is written on save when
+							enabled. Insert / delete operations that change file length are deferred to a future
+							iteration.
+						</FormInfo>
+					</FormSection>
+				</>
+			}
+		>
+			{hasFile && file && buffer ? (
+				<HexView
+					file={file}
+					detectedMime={detectedMime}
+					magicHex={mimeInfo?.matchedBytes ?? null}
+					prefs={prefs}
+					selection={selection}
+					matchSet={matchSet}
+					activeMatchOffset={matches[activeMatchIdx] ?? null}
+					patternLength={searchPattern?.length ?? 0}
+					editable={editable}
+					editingByte={editingByte}
+					interpretation={interpretation}
+					selectionBytes={selectionBytes}
+					selectionLength={selectionLength}
+					totalRows={totalRows}
+					firstVisibleRow={firstVisibleRow}
+					visibleRows={visibleRows}
+					dirty={dirty}
+					pendingCount={pendingOps.length}
+					onScrollChange={setScrollTop}
+					scrollRef={scrollRef}
+					viewportRef={viewportRef}
+					onCellMouseDown={onCellMouseDown}
+					onCellMouseEnter={onCellMouseEnter}
+					onStartEdit={startEdit}
+					onDraftChange={(draft) =>
+						setEditingByte((prev) => (prev ? { offset: prev.offset, draft } : prev))
+					}
+					onEditKeyDown={handleEditKeyDown}
+				/>
+			) : (
+				<DropZone
+					loading={loading}
+					isDragOver={isDragOver}
+					onDrop={handleDrop}
+					onDragOver={handleDragOver}
+					onDragLeave={handleDragLeave}
+					onPick={handlePickFile}
+				/>
+			)}
+		</ToolShell>
+	);
+}
+
+interface DropZoneProps {
+	readonly loading: boolean;
+	readonly isDragOver: boolean;
+	readonly onDrop: (e: DragEvent<HTMLDivElement>) => void;
+	readonly onDragOver: (e: DragEvent<HTMLDivElement>) => void;
+	readonly onDragLeave: (e: DragEvent<HTMLDivElement>) => void;
+	readonly onPick: () => void;
+}
+
+function DropZone({ loading, isDragOver, onDrop, onDragOver, onDragLeave, onPick }: DropZoneProps) {
+	return (
+		<section
+			aria-label="File drop zone"
+			onDrop={onDrop}
+			onDragOver={onDragOver}
+			onDragLeave={onDragLeave}
+			className={cn(
+				'flex h-full items-center justify-center p-6 transition-colors',
+				isDragOver && 'bg-primary/5'
+			)}
+		>
+			<div
+				className={cn(
+					'flex w-full max-w-xl flex-col items-center gap-4 rounded-xl border-2 border-dashed p-10 text-center transition-colors',
+					isDragOver ? 'border-primary bg-primary/10' : 'border-border'
+				)}
+			>
+				<EmbeddedEmptyState
+					icon={FileSearch}
+					title="Open a binary file"
+					description="Drag a file here, or use the button below."
+				/>
+				<Button variant="default" size="sm" onClick={onPick} disabled={loading}>
+					{loading ? (
+						<Loader2 className="h-3.5 w-3.5 animate-spin" />
+					) : (
+						<FolderOpen className="h-3.5 w-3.5" />
+					)}
+					{loading ? 'Loading…' : 'Open file…'}
+				</Button>
+			</div>
+		</section>
+	);
+}
+
+interface HexViewProps {
+	readonly file: HexFileInfo;
+	readonly detectedMime: string | null;
+	readonly magicHex: string | null;
+	readonly prefs: HexEditorPrefs;
+	readonly selection: Selection | null;
+	readonly matchSet: ReadonlySet<number> | null;
+	readonly activeMatchOffset: number | null;
+	readonly patternLength: number;
+	readonly editable: boolean;
+	readonly editingByte: { readonly offset: number; readonly draft: string } | null;
+	readonly interpretation: ReturnType<typeof interpretBytes> | null;
+	readonly selectionBytes: Uint8Array | null;
+	readonly selectionLength: number;
+	readonly totalRows: number;
+	readonly firstVisibleRow: number;
+	readonly visibleRows: readonly { readonly offset: number; readonly bytes: Uint8Array }[];
+	readonly dirty: boolean;
+	readonly pendingCount: number;
+	readonly onScrollChange: (top: number) => void;
+	readonly scrollRef: React.RefObject<HTMLDivElement | null>;
+	readonly viewportRef: React.RefObject<HTMLDivElement | null>;
+	readonly onCellMouseDown: (offset: number) => (e: MouseEvent<HTMLButtonElement>) => void;
+	readonly onCellMouseEnter: (offset: number) => () => void;
+	readonly onStartEdit: (offset: number) => void;
+	readonly onDraftChange: (draft: string) => void;
+	readonly onEditKeyDown: (offset: number) => (e: KeyboardEvent<HTMLInputElement>) => void;
+}
+
+function HexView({
+	file,
+	detectedMime,
+	magicHex,
+	prefs,
+	selection,
+	matchSet,
+	activeMatchOffset,
+	patternLength,
+	editable,
+	editingByte,
+	interpretation,
+	selectionBytes,
+	selectionLength,
+	totalRows,
+	firstVisibleRow,
+	visibleRows,
+	dirty,
+	pendingCount,
+	onScrollChange,
+	scrollRef,
+	viewportRef,
+	onCellMouseDown,
+	onCellMouseEnter,
+	onStartEdit,
+	onDraftChange,
+	onEditKeyDown,
+}: HexViewProps) {
+	const selectionRange = useMemo(() => {
+		if (!selection) return null;
+		return selection.start <= selection.end
+			? { lo: selection.start, hi: selection.end }
+			: { lo: selection.end, hi: selection.start };
+	}, [selection]);
+
+	return (
+		<div className="flex h-full flex-col overflow-hidden">
+			<div className="shrink-0 border-b p-3">
+				<FileBanner
+					file={file}
+					detectedMime={detectedMime}
+					magicHex={magicHex}
+					dirty={dirty}
+					pendingCount={pendingCount}
+				/>
+			</div>
+
+			<div
+				ref={viewportRef}
+				className="relative flex-1 overflow-hidden bg-muted/30 font-mono text-xs"
+			>
+				<div
+					ref={scrollRef}
+					className="h-full overflow-auto"
+					onScroll={(e) => onScrollChange(e.currentTarget.scrollTop)}
+				>
+					<div style={{ height: totalRows * ROW_HEIGHT }} className="relative">
+						<div
+							style={{ transform: `translateY(${firstVisibleRow * ROW_HEIGHT}px)` }}
+							className="absolute left-0 right-0 top-0"
+						>
+							{visibleRows.map((row) => (
+								<HexRow
+									key={row.offset}
+									offset={row.offset}
+									bytes={row.bytes}
+									bytesPerRow={prefs.bytesPerRow}
+									uppercase={prefs.uppercase}
+									showAscii={prefs.showAscii}
+									selectionRange={selectionRange}
+									matchSet={matchSet}
+									activeMatchOffset={activeMatchOffset}
+									patternLength={patternLength}
+									isMagicRow={row.offset < MAGIC_BYTES_HIGHLIGHT && magicHex !== null}
+									editable={editable}
+									editingByte={editingByte}
+									onCellMouseDown={onCellMouseDown}
+									onCellMouseEnter={onCellMouseEnter}
+									onStartEdit={onStartEdit}
+									onDraftChange={onDraftChange}
+									onEditKeyDown={onEditKeyDown}
+								/>
+							))}
+						</div>
+					</div>
+				</div>
+			</div>
+
+			{selectionBytes && interpretation && selectionRange ? (
+				<SelectionPanel
+					range={selectionRange}
+					length={selectionLength}
+					interpretation={interpretation}
+				/>
+			) : null}
+		</div>
+	);
+}
+
+interface FileBannerProps {
+	readonly file: HexFileInfo;
+	readonly detectedMime: string | null;
+	readonly magicHex: string | null;
+	readonly dirty: boolean;
+	readonly pendingCount: number;
+}
+
+function FileBanner({ file, detectedMime, magicHex, dirty, pendingCount }: FileBannerProps) {
+	const filename = file.path.split('/').pop() ?? file.path;
+	return (
+		<Card density="compact">
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2 text-sm">
+					<span className="truncate font-mono">{filename}</span>
+					{dirty ? (
+						<Badge variant="outline" className="border-warning/50 bg-warning/10 text-warning">
+							{pendingCount} pending edit{pendingCount > 1 ? 's' : ''}
+						</Badge>
+					) : null}
+				</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<dl className="grid grid-cols-[110px_1fr] gap-x-3 gap-y-1 text-xs">
+					<dt className="text-muted-foreground">Size</dt>
+					<dd className="font-mono">
+						{humanSize(file.sizeBytes)} ({file.sizeBytes.toLocaleString()} B)
+					</dd>
+					<dt className="text-muted-foreground">Modified</dt>
+					<dd className="font-mono">
+						{file.modifiedMs ? new Date(file.modifiedMs).toLocaleString() : '—'}
+					</dd>
+					<dt className="text-muted-foreground">Detected MIME</dt>
+					<dd className="font-mono">{detectedMime ?? '(unknown)'}</dd>
+					{magicHex ? (
+						<>
+							<dt className="text-muted-foreground">Magic bytes</dt>
+							<dd className="font-mono">{magicHex}</dd>
+						</>
+					) : null}
+				</dl>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface HexRowProps {
+	readonly offset: number;
+	readonly bytes: Uint8Array;
+	readonly bytesPerRow: BytesPerRow;
+	readonly uppercase: boolean;
+	readonly showAscii: boolean;
+	readonly selectionRange: { readonly lo: number; readonly hi: number } | null;
+	readonly matchSet: ReadonlySet<number> | null;
+	readonly activeMatchOffset: number | null;
+	readonly patternLength: number;
+	readonly isMagicRow: boolean;
+	readonly editable: boolean;
+	readonly editingByte: { readonly offset: number; readonly draft: string } | null;
+	readonly onCellMouseDown: (offset: number) => (e: MouseEvent<HTMLButtonElement>) => void;
+	readonly onCellMouseEnter: (offset: number) => () => void;
+	readonly onStartEdit: (offset: number) => void;
+	readonly onDraftChange: (draft: string) => void;
+	readonly onEditKeyDown: (offset: number) => (e: KeyboardEvent<HTMLInputElement>) => void;
+}
+
+function HexRow({
+	offset,
+	bytes,
+	bytesPerRow,
+	uppercase,
+	showAscii,
+	selectionRange,
+	matchSet,
+	activeMatchOffset,
+	patternLength,
+	isMagicRow,
+	editable,
+	editingByte,
+	onCellMouseDown,
+	onCellMouseEnter,
+	onStartEdit,
+	onDraftChange,
+	onEditKeyDown,
+}: HexRowProps) {
+	const offsetStr = uppercase ? formatOffset(offset) : formatOffset(offset).toLowerCase();
+
+	const ascii = bytesToAscii(bytes);
+	const groupSize = bytesPerRow / 2;
+
+	return (
+		<div
+			style={{ height: ROW_HEIGHT } as CSSProperties}
+			className="flex items-center gap-3 px-3 leading-none"
+		>
+			<span className="shrink-0 text-muted-foreground">{offsetStr}</span>
+			<div className="flex flex-1 items-center gap-2">
+				<HexGroup
+					bytes={bytes.subarray(0, groupSize)}
+					rowOffset={offset}
+					groupOffset={0}
+					uppercase={uppercase}
+					selectionRange={selectionRange}
+					matchSet={matchSet}
+					activeMatchOffset={activeMatchOffset}
+					patternLength={patternLength}
+					isMagicRow={isMagicRow}
+					magicHighlightCount={MAGIC_BYTES_HIGHLIGHT}
+					editable={editable}
+					editingByte={editingByte}
+					onCellMouseDown={onCellMouseDown}
+					onCellMouseEnter={onCellMouseEnter}
+					onStartEdit={onStartEdit}
+					onDraftChange={onDraftChange}
+					onEditKeyDown={onEditKeyDown}
+				/>
+				{bytes.length > groupSize ? (
+					<HexGroup
+						bytes={bytes.subarray(groupSize)}
+						rowOffset={offset}
+						groupOffset={groupSize}
+						uppercase={uppercase}
+						selectionRange={selectionRange}
+						matchSet={matchSet}
+						activeMatchOffset={activeMatchOffset}
+						patternLength={patternLength}
+						isMagicRow={isMagicRow}
+						magicHighlightCount={MAGIC_BYTES_HIGHLIGHT}
+						editable={editable}
+						editingByte={editingByte}
+						onCellMouseDown={onCellMouseDown}
+						onCellMouseEnter={onCellMouseEnter}
+						onStartEdit={onStartEdit}
+						onDraftChange={onDraftChange}
+						onEditKeyDown={onEditKeyDown}
+					/>
+				) : null}
+			</div>
+			{showAscii ? (
+				<span className="shrink-0 whitespace-pre text-muted-foreground/80">{ascii}</span>
+			) : null}
+		</div>
+	);
+}
+
+interface HexGroupProps {
+	readonly bytes: Uint8Array;
+	readonly rowOffset: number;
+	readonly groupOffset: number;
+	readonly uppercase: boolean;
+	readonly selectionRange: { readonly lo: number; readonly hi: number } | null;
+	readonly matchSet: ReadonlySet<number> | null;
+	readonly activeMatchOffset: number | null;
+	readonly patternLength: number;
+	readonly isMagicRow: boolean;
+	readonly magicHighlightCount: number;
+	readonly editable: boolean;
+	readonly editingByte: { readonly offset: number; readonly draft: string } | null;
+	readonly onCellMouseDown: (offset: number) => (e: MouseEvent<HTMLButtonElement>) => void;
+	readonly onCellMouseEnter: (offset: number) => () => void;
+	readonly onStartEdit: (offset: number) => void;
+	readonly onDraftChange: (draft: string) => void;
+	readonly onEditKeyDown: (offset: number) => (e: KeyboardEvent<HTMLInputElement>) => void;
+}
+
+function HexGroup({
+	bytes,
+	rowOffset,
+	groupOffset,
+	uppercase,
+	selectionRange,
+	matchSet,
+	activeMatchOffset,
+	patternLength,
+	isMagicRow,
+	magicHighlightCount,
+	editable,
+	editingByte,
+	onCellMouseDown,
+	onCellMouseEnter,
+	onStartEdit,
+	onDraftChange,
+	onEditKeyDown,
+}: HexGroupProps) {
+	const cells: React.ReactNode[] = [];
+	for (let i = 0; i < bytes.length; i += 1) {
+		const absoluteOffset = rowOffset + groupOffset + i;
+		const byte = bytes[i];
+		if (byte === undefined) continue;
+		const selected =
+			selectionRange && absoluteOffset >= selectionRange.lo && absoluteOffset <= selectionRange.hi;
+		const isMatch = matchSet?.has(absoluteOffset) ?? false;
+		const isActiveMatch =
+			activeMatchOffset !== null &&
+			absoluteOffset >= activeMatchOffset &&
+			absoluteOffset < activeMatchOffset + patternLength;
+		const isMagic = isMagicRow && absoluteOffset - rowOffset + groupOffset < magicHighlightCount;
+		const editing = editingByte?.offset === absoluteOffset;
+		cells.push(
+			<HexCell
+				key={absoluteOffset}
+				offset={absoluteOffset}
+				byte={byte}
+				uppercase={uppercase}
+				selected={selected ?? false}
+				match={isMatch}
+				activeMatch={isActiveMatch}
+				magic={isMagic}
+				editable={editable}
+				editing={editing}
+				draft={editing ? (editingByte?.draft ?? '') : ''}
+				onMouseDown={onCellMouseDown(absoluteOffset)}
+				onMouseEnter={onCellMouseEnter(absoluteOffset)}
+				onStartEdit={() => onStartEdit(absoluteOffset)}
+				onDraftChange={onDraftChange}
+				onKeyDown={onEditKeyDown(absoluteOffset)}
+			/>
+		);
+	}
+	return <div className="flex gap-1">{cells}</div>;
+}
+
+interface HexCellProps {
+	readonly offset: number;
+	readonly byte: number;
+	readonly uppercase: boolean;
+	readonly selected: boolean;
+	readonly match: boolean;
+	readonly activeMatch: boolean;
+	readonly magic: boolean;
+	readonly editable: boolean;
+	readonly editing: boolean;
+	readonly draft: string;
+	readonly onMouseDown: (e: MouseEvent<HTMLButtonElement>) => void;
+	readonly onMouseEnter: () => void;
+	readonly onStartEdit: () => void;
+	readonly onDraftChange: (draft: string) => void;
+	readonly onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
+}
+
+function HexCell({
+	byte,
+	uppercase,
+	selected,
+	match,
+	activeMatch,
+	magic,
+	editable,
+	editing,
+	draft,
+	onMouseDown,
+	onMouseEnter,
+	onStartEdit,
+	onDraftChange,
+	onKeyDown,
+}: HexCellProps) {
+	const inputRef = useRef<HTMLInputElement | null>(null);
+	useEffect(() => {
+		if (editing) inputRef.current?.focus();
+	}, [editing]);
+
+	if (editing) {
+		return (
+			<input
+				ref={inputRef}
+				className={cn(
+					'w-7 rounded-sm border border-primary bg-background px-1 text-center font-mono uppercase outline-none'
+				)}
+				value={draft}
+				maxLength={2}
+				onChange={(e) => onDraftChange(e.target.value)}
+				onKeyDown={onKeyDown}
+			/>
+		);
+	}
+	return (
+		<button
+			type="button"
+			tabIndex={editable ? 0 : -1}
+			onMouseDown={onMouseDown}
+			onMouseEnter={onMouseEnter}
+			onDoubleClick={editable ? onStartEdit : undefined}
+			className={cn(
+				'inline-block w-6 cursor-pointer select-none rounded-sm bg-transparent text-center transition-colors',
+				selected && 'bg-primary/20',
+				match && 'bg-warning/30',
+				activeMatch && 'ring-1 ring-warning',
+				magic && 'border border-info text-info'
+			)}
+		>
+			{formatHexByte(byte, uppercase)}
+		</button>
+	);
+}
+
+interface SelectionPanelProps {
+	readonly range: { readonly lo: number; readonly hi: number };
+	readonly length: number;
+	readonly interpretation: ReturnType<typeof interpretBytes>;
+}
+
+function SelectionPanel({ range, length, interpretation }: SelectionPanelProps) {
+	const rows: { readonly label: string; readonly value: string }[] = [];
+	const push = (label: string, value: number | bigint | string | undefined) => {
+		if (value === undefined || value === null) return;
+		rows.push({ label, value: typeof value === 'bigint' ? value.toString() : String(value) });
+	};
+	push('u8', interpretation.u8);
+	push('i8', interpretation.i8);
+	push('u16 LE', interpretation.u16le);
+	push('u16 BE', interpretation.u16be);
+	push('i16 LE', interpretation.i16le);
+	push('i16 BE', interpretation.i16be);
+	push('u32 LE', interpretation.u32le);
+	push('u32 BE', interpretation.u32be);
+	push('i32 LE', interpretation.i32le);
+	push('i32 BE', interpretation.i32be);
+	push('u64 LE', interpretation.u64le);
+	push('u64 BE', interpretation.u64be);
+	push('f32 LE', interpretation.f32le);
+	push('f32 BE', interpretation.f32be);
+	push('f64 LE', interpretation.f64le);
+	push('f64 BE', interpretation.f64be);
+
+	return (
+		<div className="shrink-0 border-t bg-surface-2 p-3">
+			<div className="mb-2 flex items-center gap-4 text-2xs text-muted-foreground">
+				<span>
+					Start <span className="font-mono text-foreground">{formatOffset(range.lo)}</span>
+				</span>
+				<span>
+					End <span className="font-mono text-foreground">{formatOffset(range.hi)}</span>
+				</span>
+				<span>
+					Length <span className="font-mono text-foreground">{length} B</span>
+				</span>
+			</div>
+			<div className="grid grid-cols-2 gap-x-4 gap-y-1 text-2xs sm:grid-cols-3 xl:grid-cols-4">
+				{rows.map((row) => (
+					<div key={row.label} className="flex items-baseline gap-2">
+						<span className="w-16 shrink-0 text-muted-foreground">{row.label}</span>
+						<span className="min-w-0 flex-1 truncate font-mono">{row.value}</span>
+					</div>
+				))}
+				{interpretation.ascii ? (
+					<div className="col-span-full flex items-baseline gap-2">
+						<span className="w-16 shrink-0 text-muted-foreground">ASCII</span>
+						<span className="min-w-0 flex-1 truncate whitespace-pre font-mono">
+							{interpretation.ascii}
+						</span>
+					</div>
+				) : null}
+				{interpretation.utf8 ? (
+					<div className="col-span-full flex items-baseline gap-2">
+						<span className="w-16 shrink-0 text-muted-foreground">UTF-8</span>
+						<span className="min-w-0 flex-1 truncate font-mono">{interpretation.utf8}</span>
+					</div>
+				) : null}
+				{interpretation.utf16le ? (
+					<div className="col-span-full flex items-baseline gap-2">
+						<span className="w-16 shrink-0 text-muted-foreground">UTF-16 LE</span>
+						<span className="min-w-0 flex-1 truncate font-mono">{interpretation.utf16le}</span>
+					</div>
+				) : null}
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

- Adds a virtual-scrolling **Hex Editor / Viewer** under the Files category.
- Backed by three Tauri commands: `hex_open`, `hex_read`, `hex_save`.
- Read-only by default; an opt-in edit mode supports per-byte patches, undo/redo, and `.bak` backup on save.

## Changes

### Added

- `src-tauri/src/hex_editor.rs` — `hex_open` (metadata), `hex_read` (range slice), `hex_save` (ordered op list with sanity-checked patch / insert / delete + optional `.bak`). 9 unit tests cover op semantics and error paths.
- `src/lib/services/hex-editor.ts` — pure helpers: offset / byte formatting, ASCII gutter, hex-pattern parsing, naive `findAllMatches`, `parseJumpOffset` (decimal / `0x` / `±relative`), `interpretBytes` (u8/i8/u16/i16/u32/i32/u64 LE+BE, f32/f64 LE+BE, ASCII, UTF-8, UTF-16LE).
- `src/routes/hex-editor.tsx` — `ToolShell` page with:
  - File banner (size, modified, detected MIME via existing MIME catalog, magic hex, dirty badge).
  - Virtual-scrolled hex grid (16 or 32 bytes/row, 8+8 grouping, optional ASCII gutter, magic-byte tint, search-match tint, selection tint).
  - Rail: Open, Search (hex or text + Find Next/Prev + match count), Jump to offset (with quick Start / 50% / 75% / End), Display (bytes-per-row, uppercase, ASCII gutter), Mode (Read-only toggle, Undo / Redo / Discard), Save (.bak backup + Save), Related (file-inspector, mime-types), About.
  - Sticky selection panel showing start / end / length and every scalar / text interpretation of the selected bytes.
- Persisted prefs via `createToolOptionsStore<'hex-editor'>`.

### Changed

- `src-tauri/src/lib.rs` — registers `hex_open` / `hex_read` / `hex_save`.
- `src-tauri/capabilities/default.json` — adds `fs:allow-write-file` for binary save.
- `src/lib/services/pages.ts` — registers the `hex-editor` page (icon `FileDigit`, category `files`).
- `src/route-tree.gen.ts` — regenerated to include `/hex-editor`.

## Notes / deferred

- Insert / delete commands exist in the backend (and are unit-tested) but the editor UI only wires up per-byte patches. Length-changing edits ship in a follow-up.
- Files are loaded fully into memory on open. `hex_read` supports range fetches so a future PR can switch the viewer to viewport-streaming for >500 MB files.

## Test Plan

- [ ] `bun run check` — passes (existing pre-existing complexity warnings remain; no new errors introduced).
- [ ] `cargo test --lib hex_editor` — 9/9 passing.
- [ ] `cargo clippy --all-targets` — clean.
- [ ] Open a small binary (PNG / mp3) via Open file… and verify the magic-byte tint and detected MIME.
- [ ] Search for `89 50 4E 47` in a PNG and step through with Find Next / Prev.
- [ ] Jump to `0x100`, `+128`, `-32`, `End`.
- [ ] Toggle off Read-only, double-click a byte, type two hex chars, press Enter; verify dirty badge and Undo / Redo / Discard.
- [ ] Save with `.bak` backup enabled and verify the backup file is written next to the original.
