### PR TITLE
feat(archive-inspector): add Archive Inspector / Extractor under Files

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1976,6 +1976,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3334,8 +3344,10 @@ dependencies = [
  "base64 0.22.1",
  "bcrypt",
  "bytes",
+ "bzip2",
  "csnmp",
  "dns-lookup",
+ "flate2",
  "font-kit",
  "futures",
  "hickory-resolver",
@@ -3356,6 +3368,7 @@ dependencies = [
  "serde_yaml",
  "sqlparser",
  "ssh-key",
+ "tar",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
@@ -3375,7 +3388,9 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "uuid",
  "x509-parser",
+ "xz2",
  "yaml-rust2",
+ "zip",
 ]
 
 [[package]]
@@ -3528,6 +3543,17 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "mac-addr"
@@ -6473,6 +6499,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7376,6 +7413,12 @@ checksum = "a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013"
 dependencies = [
  "cipher 0.4.4",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -8713,6 +8756,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yaml-rust2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8913,6 +8975,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "bzip2",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8923,6 +9000,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -94,6 +94,13 @@ hyper = { version = "1", features = ["server", "http1"] }
 http-body-util = "0.1"
 bytes = "1"
 
+# Archive Inspector
+zip = { version = "8", default-features = false, features = ["deflate", "bzip2"] }
+tar = "0.4"
+flate2 = "1"
+bzip2 = "0.6"
+xz2 = "0.1"
+
 # Note: no direct `rand_core` dependency.
 #
 # The codebase only needs `OsRng` for `ssh-key` and `pgp` key generation,

--- a/src-tauri/src/archive_inspect.rs
+++ b/src-tauri/src/archive_inspect.rs
@@ -1,0 +1,697 @@
+//! Archive Inspector / Extractor commands.
+//!
+//! Provides four Tauri commands the frontend archive tool consumes:
+//!
+//! - `archive_open` - parse an archive on disk and return its full
+//!   entry listing without extracting any file content.
+//! - `archive_read_entry` - read a single entry's bytes (capped) for
+//!   inline previews (text, image, hex).
+//! - `archive_extract` - extract a selection (or the whole archive) to
+//!   a destination folder, respecting a conflict policy.
+//! - `archive_extract_entry` - extract a single entry to a chosen
+//!   file path (used by the per-row "Extract this file" action).
+//!
+//! Supported formats are autodetected by magic bytes:
+//!
+//! - `.zip`   (PK\x03\x04)
+//! - `.tar`   (ustar magic at offset 257, or by `.tar` extension)
+//! - `.tar.gz`/`.tgz` (1F 8B gzip header)
+//! - `.tar.bz2`/`.tbz2` (42 5A 68 bzip2 header)
+//! - `.tar.xz`/`.txz` (FD 37 7A 58 5A 00 xz header)
+//! - `.7z` (37 7A BC AF 27 1C) - format identification only; listing /
+//!   extraction are deferred to a follow-up to keep the dependency
+//!   footprint bounded.
+//!
+//! Path safety: every entry path is validated against the destination
+//! root to prevent "zip slip" style escapes via `..` components or
+//! absolute paths.
+
+use std::fs::{self, File};
+use std::io::{self, Read, Seek, SeekFrom};
+use std::path::{Component, Path, PathBuf};
+
+use bzip2::read::BzDecoder;
+use flate2::read::GzDecoder;
+use serde::{Deserialize, Serialize};
+use xz2::read::XzDecoder;
+
+/// Cap on bytes returned by `archive_read_entry`. The frontend uses
+/// this for inline previews only, so a few hundred kilobytes is plenty.
+const MAX_PREVIEW_BYTES: u64 = 256 * 1024;
+
+/// Single archive entry as serialised to the frontend.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchiveEntry {
+    /// Path relative to the archive root, normalised to forward slashes.
+    pub path: String,
+    /// `true` for directory records (entries that end in `/`).
+    pub is_dir: bool,
+    /// Uncompressed size in bytes. `0` for directory entries.
+    pub size_bytes: u64,
+    /// Compressed size in bytes. For tar variants this equals
+    /// `size_bytes` since tar itself does not compress per-entry.
+    pub compressed_size: u64,
+    /// Last-modified time as Unix milliseconds (when available).
+    pub modified_ms: Option<i64>,
+    /// CRC-32 checksum (zip only).
+    pub crc32: Option<u32>,
+}
+
+/// Archive summary returned by `archive_open`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchiveInfo {
+    /// Absolute path the archive was read from.
+    pub path: String,
+    /// One of `"zip" | "tar" | "tar.gz" | "tar.bz2" | "tar.xz" | "7z"`.
+    pub format: String,
+    /// Full list of entries.
+    pub entries: Vec<ArchiveEntry>,
+    /// `entries.len()` mirrored as a scalar so the JS side does not
+    /// need to recompute it for the status bar.
+    pub total_entries: u64,
+    /// Sum of every entry's uncompressed size.
+    pub total_uncompressed: u64,
+    /// Sum of every entry's compressed size.
+    pub total_compressed: u64,
+}
+
+/// Request payload for the batch extract command.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExtractRequest {
+    /// Source archive path.
+    pub archive_path: String,
+    /// Entries to extract. When empty every entry is extracted.
+    pub entries: Vec<String>,
+    /// Destination directory (created on demand).
+    pub destination_dir: String,
+    /// `"skip"`, `"overwrite"`, or `"rename"`.
+    pub conflict: String,
+}
+
+/// Convert a `zip::DateTime` (which exposes year/month/day/hour/min/sec
+/// accessors but not a direct `SystemTime` conversion) into Unix
+/// milliseconds. Returns `None` when the components do not form a valid
+/// calendar date.
+fn zip_datetime_to_unix_ms(dt: zip::DateTime) -> Option<i64> {
+    // Days from the Unix epoch to the start of the given year using
+    // Howard Hinnant's "days_from_civil" algorithm.
+    let y = i64::from(dt.year());
+    let m = i64::from(dt.month());
+    let d = i64::from(dt.day());
+    if !(1970..=9999).contains(&y) || !(1..=12).contains(&m) || !(1..=31).contains(&d) {
+        return None;
+    }
+    let (yy, mm) = if m <= 2 { (y - 1, m + 12) } else { (y, m) };
+    let era = yy.div_euclid(400);
+    let yoe = yy - era * 400;
+    let doy = (153 * (mm - 3) + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let days = era * 146_097 + doe - 719_468;
+    let hour = i64::from(dt.hour());
+    let minute = i64::from(dt.minute());
+    let second = i64::from(dt.second());
+    let secs = days * 86_400 + hour * 3600 + minute * 60 + second;
+    secs.checked_mul(1000)
+}
+
+/// Detect the archive format from the first few magic bytes. Falls back
+/// to filename extension when the header does not match a known format
+/// (covers raw `.tar` files which have no global magic at offset 0).
+fn detect_format(path: &Path) -> Result<&'static str, String> {
+    let mut file = File::open(path).map_err(|e| format!("Failed to open archive: {e}"))?;
+    let mut head = [0u8; 6];
+    let read = file
+        .read(&mut head)
+        .map_err(|e| format!("Failed to read archive head: {e}"))?;
+
+    if read >= 4 && head[0..4] == [0x50, 0x4B, 0x03, 0x04] {
+        return Ok("zip");
+    }
+    if read >= 2 && head[0..2] == [0x1F, 0x8B] {
+        return Ok("tar.gz");
+    }
+    if read >= 3 && head[0..3] == [0x42, 0x5A, 0x68] {
+        return Ok("tar.bz2");
+    }
+    if read >= 6 && head[0..6] == [0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00] {
+        return Ok("tar.xz");
+    }
+    if read >= 6 && head[0..6] == [0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C] {
+        return Ok("7z");
+    }
+
+    // Plain tar archives carry their magic at offset 257.
+    let mut ustar = [0u8; 8];
+    file.seek(SeekFrom::Start(257))
+        .map_err(|e| format!("Failed to seek to tar magic: {e}"))?;
+    let tar_read = file
+        .read(&mut ustar)
+        .map_err(|e| format!("Failed to read tar magic: {e}"))?;
+    if tar_read >= 5 && &ustar[0..5] == b"ustar" {
+        return Ok("tar");
+    }
+
+    // Last resort: filename extension.
+    let has_tar_extension = path
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("tar"));
+    if has_tar_extension {
+        return Ok("tar");
+    }
+    Err(format!("Unrecognised archive format: {}", path.display()))
+}
+
+fn list_zip(path: &Path) -> Result<Vec<ArchiveEntry>, String> {
+    let file = File::open(path).map_err(|e| format!("Failed to open zip: {e}"))?;
+    let mut archive =
+        zip::ZipArchive::new(file).map_err(|e| format!("Failed to parse zip: {e}"))?;
+
+    let entries: Result<Vec<ArchiveEntry>, String> = (0..archive.len())
+        .map(|i| {
+            let entry = archive
+                .by_index(i)
+                .map_err(|e| format!("Failed to read zip entry: {e}"))?;
+            let path = entry.name().replace('\\', "/");
+            let is_dir = entry.is_dir();
+            let modified_ms = entry.last_modified().and_then(zip_datetime_to_unix_ms);
+            Ok(ArchiveEntry {
+                path,
+                is_dir,
+                size_bytes: entry.size(),
+                compressed_size: entry.compressed_size(),
+                modified_ms,
+                crc32: Some(entry.crc32()),
+            })
+        })
+        .collect();
+    entries
+}
+
+fn list_tar_stream<R: Read>(reader: R) -> Result<Vec<ArchiveEntry>, String> {
+    let mut archive = tar::Archive::new(reader);
+    archive
+        .entries()
+        .map_err(|e| format!("Failed to read tar entries: {e}"))?
+        .map(|entry_result| {
+            let entry = entry_result.map_err(|e| format!("Failed to iterate tar entry: {e}"))?;
+            let header = entry.header();
+            let raw_path = entry
+                .path()
+                .map_err(|e| format!("Failed to read entry path: {e}"))?
+                .to_string_lossy()
+                .replace('\\', "/");
+            let is_dir = header.entry_type().is_dir();
+            let size = entry.size();
+            let mtime = header
+                .mtime()
+                .ok()
+                .and_then(|secs| i64::try_from(secs).ok().and_then(|s| s.checked_mul(1000)));
+            Ok(ArchiveEntry {
+                path: raw_path,
+                is_dir,
+                size_bytes: size,
+                compressed_size: size,
+                modified_ms: mtime,
+                crc32: None,
+            })
+        })
+        .collect()
+}
+
+fn list_tar(path: &Path) -> Result<Vec<ArchiveEntry>, String> {
+    let file = File::open(path).map_err(|e| format!("Failed to open tar: {e}"))?;
+    list_tar_stream(file)
+}
+
+fn list_tar_gz(path: &Path) -> Result<Vec<ArchiveEntry>, String> {
+    let file = File::open(path).map_err(|e| format!("Failed to open tar.gz: {e}"))?;
+    list_tar_stream(GzDecoder::new(file))
+}
+
+fn list_tar_bz2(path: &Path) -> Result<Vec<ArchiveEntry>, String> {
+    let file = File::open(path).map_err(|e| format!("Failed to open tar.bz2: {e}"))?;
+    list_tar_stream(BzDecoder::new(file))
+}
+
+fn list_tar_xz(path: &Path) -> Result<Vec<ArchiveEntry>, String> {
+    let file = File::open(path).map_err(|e| format!("Failed to open tar.xz: {e}"))?;
+    list_tar_stream(XzDecoder::new(file))
+}
+
+fn list_entries(format: &str, path: &Path) -> Result<Vec<ArchiveEntry>, String> {
+    match format {
+        "zip" => list_zip(path),
+        "tar" => list_tar(path),
+        "tar.gz" => list_tar_gz(path),
+        "tar.bz2" => list_tar_bz2(path),
+        "tar.xz" => list_tar_xz(path),
+        "7z" => Err("7z listing is not yet supported; format identification only.".to_string()),
+        other => Err(format!("Unsupported archive format: {other}")),
+    }
+}
+
+/// Parse an archive and return its full directory listing.
+#[tauri::command]
+pub fn archive_open(path: String) -> Result<ArchiveInfo, String> {
+    let path_buf = Path::new(&path).to_path_buf();
+    let format = detect_format(&path_buf)?;
+
+    // 7z: surface the format without crashing the UI; callers can still
+    // see metadata and offer "Open with..." paths.
+    let entries = if format == "7z" {
+        Vec::new()
+    } else {
+        list_entries(format, &path_buf)?
+    };
+
+    let total_uncompressed = entries.iter().map(|e| e.size_bytes).sum();
+    let total_compressed = entries.iter().map(|e| e.compressed_size).sum();
+    let total_entries = entries.len() as u64;
+
+    Ok(ArchiveInfo {
+        path: path_buf.to_string_lossy().into_owned(),
+        format: format.to_string(),
+        entries,
+        total_entries,
+        total_uncompressed,
+        total_compressed,
+    })
+}
+
+/// Read a single entry's bytes, capped at [`MAX_PREVIEW_BYTES`] or
+/// `max_bytes` (whichever is smaller).
+#[tauri::command]
+pub fn archive_read_entry(
+    archive_path: String,
+    entry_path: String,
+    max_bytes: u64,
+) -> Result<Vec<u8>, String> {
+    let path_buf = Path::new(&archive_path).to_path_buf();
+    let format = detect_format(&path_buf)?;
+    let cap = u64::min(max_bytes, MAX_PREVIEW_BYTES);
+
+    let take = usize::try_from(cap).unwrap_or(usize::MAX);
+
+    match format {
+        "zip" => read_zip_entry(&path_buf, &entry_path, take),
+        "tar" => {
+            let file = File::open(&path_buf).map_err(|e| format!("Failed to open tar: {e}"))?;
+            read_tar_entry_stream(file, &entry_path, take)
+        }
+        "tar.gz" => {
+            let file = File::open(&path_buf).map_err(|e| format!("Failed to open tar.gz: {e}"))?;
+            read_tar_entry_stream(GzDecoder::new(file), &entry_path, take)
+        }
+        "tar.bz2" => {
+            let file = File::open(&path_buf).map_err(|e| format!("Failed to open tar.bz2: {e}"))?;
+            read_tar_entry_stream(BzDecoder::new(file), &entry_path, take)
+        }
+        "tar.xz" => {
+            let file = File::open(&path_buf).map_err(|e| format!("Failed to open tar.xz: {e}"))?;
+            read_tar_entry_stream(XzDecoder::new(file), &entry_path, take)
+        }
+        "7z" => Err("7z preview is not yet supported.".to_string()),
+        other => Err(format!("Unsupported archive format: {other}")),
+    }
+}
+
+fn read_zip_entry(archive: &Path, entry_path: &str, take: usize) -> Result<Vec<u8>, String> {
+    let file = File::open(archive).map_err(|e| format!("Failed to open zip: {e}"))?;
+    let mut zip = zip::ZipArchive::new(file).map_err(|e| format!("Failed to parse zip: {e}"))?;
+    let mut entry = zip
+        .by_name(entry_path)
+        .map_err(|e| format!("Entry not found: {e}"))?;
+    let mut buf = Vec::new();
+    entry
+        .by_ref()
+        .take(take as u64)
+        .read_to_end(&mut buf)
+        .map_err(|e| format!("Failed to read entry: {e}"))?;
+    Ok(buf)
+}
+
+fn read_tar_entry_stream<R: Read>(
+    reader: R,
+    entry_path: &str,
+    take: usize,
+) -> Result<Vec<u8>, String> {
+    let mut archive = tar::Archive::new(reader);
+    let entries = archive
+        .entries()
+        .map_err(|e| format!("Failed to read tar entries: {e}"))?;
+    for entry_result in entries {
+        let mut entry = entry_result.map_err(|e| format!("Failed to iterate tar entry: {e}"))?;
+        let path_string = entry
+            .path()
+            .map_err(|e| format!("Failed to read entry path: {e}"))?
+            .to_string_lossy()
+            .replace('\\', "/");
+        if path_string == entry_path {
+            let mut buf = Vec::new();
+            entry
+                .by_ref()
+                .take(take as u64)
+                .read_to_end(&mut buf)
+                .map_err(|e| format!("Failed to read entry: {e}"))?;
+            return Ok(buf);
+        }
+    }
+    Err(format!("Entry not found: {entry_path}"))
+}
+
+/// Reject paths that escape `root` via absolute paths, drive prefixes,
+/// or `..` traversal. Returns the safe joined path on success.
+fn safe_join(root: &Path, entry_path: &str) -> Result<PathBuf, String> {
+    let candidate = Path::new(entry_path);
+    let mut buf = root.to_path_buf();
+    for component in candidate.components() {
+        match component {
+            Component::Normal(part) => buf.push(part),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(format!("Unsafe entry path rejected: {entry_path}"));
+            }
+        }
+    }
+    Ok(buf)
+}
+
+/// Compute a non-colliding "rename" path by appending ` (n)` before the
+/// extension. Used by the `"rename"` conflict policy.
+fn rename_path(target: &Path) -> PathBuf {
+    if !target.exists() {
+        return target.to_path_buf();
+    }
+    let parent = target.parent().unwrap_or_else(|| Path::new(""));
+    let stem = target
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let ext = target
+        .extension()
+        .map(|e| e.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    // Cap retries so the search terminates even when every plausible
+    // name on disk is taken; in practice the directory becomes the
+    // wider failure long before this limit.
+    (1u32..=10_000)
+        .map(|i| {
+            let name = if ext.is_empty() {
+                format!("{stem} ({i})")
+            } else {
+                format!("{stem} ({i}).{ext}")
+            };
+            parent.join(name)
+        })
+        .find(|p| !p.exists())
+        .unwrap_or_else(|| target.to_path_buf())
+}
+
+/// Resolve where to write a given destination according to `conflict`.
+/// Returns `None` when the entry should be skipped.
+fn resolve_destination(target: PathBuf, conflict: &str) -> Result<Option<PathBuf>, String> {
+    if !target.exists() {
+        return Ok(Some(target));
+    }
+    match conflict {
+        "skip" => Ok(None),
+        "overwrite" => Ok(Some(target)),
+        "rename" => Ok(Some(rename_path(&target))),
+        other => Err(format!("Unknown conflict policy: {other}")),
+    }
+}
+
+/// Extract a single named entry to a specified destination file path.
+/// Returns the number of bytes written. Directory entries are created
+/// without contents.
+#[tauri::command]
+pub fn archive_extract_entry(
+    archive_path: String,
+    entry_path: String,
+    destination_path: String,
+) -> Result<u64, String> {
+    let archive = Path::new(&archive_path).to_path_buf();
+    let dest = Path::new(&destination_path).to_path_buf();
+    let format = detect_format(&archive)?;
+
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create destination directory: {e}"))?;
+    }
+
+    match format {
+        "zip" => extract_zip_one(&archive, &entry_path, &dest),
+        "tar" => {
+            let file = File::open(&archive).map_err(|e| format!("Failed to open tar: {e}"))?;
+            extract_tar_one_stream(file, &entry_path, &dest)
+        }
+        "tar.gz" => {
+            let file = File::open(&archive).map_err(|e| format!("Failed to open tar.gz: {e}"))?;
+            extract_tar_one_stream(GzDecoder::new(file), &entry_path, &dest)
+        }
+        "tar.bz2" => {
+            let file = File::open(&archive).map_err(|e| format!("Failed to open tar.bz2: {e}"))?;
+            extract_tar_one_stream(BzDecoder::new(file), &entry_path, &dest)
+        }
+        "tar.xz" => {
+            let file = File::open(&archive).map_err(|e| format!("Failed to open tar.xz: {e}"))?;
+            extract_tar_one_stream(XzDecoder::new(file), &entry_path, &dest)
+        }
+        "7z" => Err("7z extraction is not yet supported.".to_string()),
+        other => Err(format!("Unsupported archive format: {other}")),
+    }
+}
+
+fn extract_zip_one(archive: &Path, entry_path: &str, dest: &Path) -> Result<u64, String> {
+    let file = File::open(archive).map_err(|e| format!("Failed to open zip: {e}"))?;
+    let mut zip = zip::ZipArchive::new(file).map_err(|e| format!("Failed to parse zip: {e}"))?;
+    let mut entry = zip
+        .by_name(entry_path)
+        .map_err(|e| format!("Entry not found: {e}"))?;
+    if entry.is_dir() {
+        fs::create_dir_all(dest).map_err(|e| format!("Failed to create directory: {e}"))?;
+        return Ok(0);
+    }
+    let mut out = File::create(dest).map_err(|e| format!("Failed to create file: {e}"))?;
+    let written = io::copy(&mut entry, &mut out).map_err(|e| format!("Failed to write: {e}"))?;
+    Ok(written)
+}
+
+fn extract_tar_one_stream<R: Read>(
+    reader: R,
+    entry_path: &str,
+    dest: &Path,
+) -> Result<u64, String> {
+    let mut archive = tar::Archive::new(reader);
+    let entries = archive
+        .entries()
+        .map_err(|e| format!("Failed to read tar entries: {e}"))?;
+    for entry_result in entries {
+        let mut entry = entry_result.map_err(|e| format!("Failed to iterate tar entry: {e}"))?;
+        let path_string = entry
+            .path()
+            .map_err(|e| format!("Failed to read entry path: {e}"))?
+            .to_string_lossy()
+            .replace('\\', "/");
+        if path_string == entry_path {
+            if entry.header().entry_type().is_dir() {
+                fs::create_dir_all(dest).map_err(|e| format!("Failed to create directory: {e}"))?;
+                return Ok(0);
+            }
+            let mut out = File::create(dest).map_err(|e| format!("Failed to create file: {e}"))?;
+            let written =
+                io::copy(&mut entry, &mut out).map_err(|e| format!("Failed to write: {e}"))?;
+            return Ok(written);
+        }
+    }
+    Err(format!("Entry not found: {entry_path}"))
+}
+
+/// Extract a selection of entries (or every entry when the selection
+/// is empty) to a destination directory. Returns the number of files
+/// actually written; skipped entries do not count.
+#[tauri::command]
+pub fn archive_extract(req: ExtractRequest) -> Result<u64, String> {
+    let archive = Path::new(&req.archive_path).to_path_buf();
+    let dest_root = Path::new(&req.destination_dir).to_path_buf();
+    fs::create_dir_all(&dest_root)
+        .map_err(|e| format!("Failed to create destination directory: {e}"))?;
+    let format = detect_format(&archive)?;
+
+    let filter: Option<std::collections::HashSet<String>> = if req.entries.is_empty() {
+        None
+    } else {
+        Some(req.entries.iter().cloned().collect())
+    };
+
+    let conflict = req.conflict.as_str();
+
+    match format {
+        "zip" => extract_zip_all(&archive, &dest_root, filter.as_ref(), conflict),
+        "tar" => {
+            let file = File::open(&archive).map_err(|e| format!("Failed to open tar: {e}"))?;
+            extract_tar_all_stream(file, &dest_root, filter.as_ref(), conflict)
+        }
+        "tar.gz" => {
+            let file = File::open(&archive).map_err(|e| format!("Failed to open tar.gz: {e}"))?;
+            extract_tar_all_stream(GzDecoder::new(file), &dest_root, filter.as_ref(), conflict)
+        }
+        "tar.bz2" => {
+            let file = File::open(&archive).map_err(|e| format!("Failed to open tar.bz2: {e}"))?;
+            extract_tar_all_stream(BzDecoder::new(file), &dest_root, filter.as_ref(), conflict)
+        }
+        "tar.xz" => {
+            let file = File::open(&archive).map_err(|e| format!("Failed to open tar.xz: {e}"))?;
+            extract_tar_all_stream(XzDecoder::new(file), &dest_root, filter.as_ref(), conflict)
+        }
+        "7z" => Err("7z extraction is not yet supported.".to_string()),
+        other => Err(format!("Unsupported archive format: {other}")),
+    }
+}
+
+fn extract_zip_all(
+    archive: &Path,
+    dest_root: &Path,
+    filter: Option<&std::collections::HashSet<String>>,
+    conflict: &str,
+) -> Result<u64, String> {
+    let file = File::open(archive).map_err(|e| format!("Failed to open zip: {e}"))?;
+    let mut zip = zip::ZipArchive::new(file).map_err(|e| format!("Failed to parse zip: {e}"))?;
+
+    let indices: Vec<usize> = (0..zip.len()).collect();
+    let mut written: u64 = 0;
+    for i in indices {
+        let mut entry = zip
+            .by_index(i)
+            .map_err(|e| format!("Failed to read zip entry: {e}"))?;
+        let name = entry.name().replace('\\', "/");
+        if let Some(set) = filter {
+            if !set.contains(&name) {
+                continue;
+            }
+        }
+        let target = safe_join(dest_root, &name)?;
+        if entry.is_dir() {
+            fs::create_dir_all(&target).map_err(|e| format!("Failed to create directory: {e}"))?;
+            continue;
+        }
+        let Some(resolved) = resolve_destination(target, conflict)? else {
+            continue;
+        };
+        if let Some(parent) = resolved.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create parent directory: {e}"))?;
+        }
+        let mut out = File::create(&resolved).map_err(|e| format!("Failed to create file: {e}"))?;
+        io::copy(&mut entry, &mut out).map_err(|e| format!("Failed to write: {e}"))?;
+        written += 1;
+    }
+    Ok(written)
+}
+
+fn extract_tar_all_stream<R: Read>(
+    reader: R,
+    dest_root: &Path,
+    filter: Option<&std::collections::HashSet<String>>,
+    conflict: &str,
+) -> Result<u64, String> {
+    let mut archive = tar::Archive::new(reader);
+    let entries = archive
+        .entries()
+        .map_err(|e| format!("Failed to read tar entries: {e}"))?;
+    let mut written: u64 = 0;
+    for entry_result in entries {
+        let mut entry = entry_result.map_err(|e| format!("Failed to iterate tar entry: {e}"))?;
+        let path_string = entry
+            .path()
+            .map_err(|e| format!("Failed to read entry path: {e}"))?
+            .to_string_lossy()
+            .replace('\\', "/");
+        if let Some(set) = filter {
+            if !set.contains(&path_string) {
+                continue;
+            }
+        }
+        let target = safe_join(dest_root, &path_string)?;
+        if entry.header().entry_type().is_dir() {
+            fs::create_dir_all(&target).map_err(|e| format!("Failed to create directory: {e}"))?;
+            continue;
+        }
+        let Some(resolved) = resolve_destination(target, conflict)? else {
+            continue;
+        };
+        if let Some(parent) = resolved.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create parent directory: {e}"))?;
+        }
+        let mut out = File::create(&resolved).map_err(|e| format!("Failed to create file: {e}"))?;
+        io::copy(&mut entry, &mut out).map_err(|e| format!("Failed to write: {e}"))?;
+        written += 1;
+    }
+    Ok(written)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_join_accepts_relative_paths() {
+        let root = Path::new("/tmp/out");
+        let result = safe_join(root, "foo/bar.txt").unwrap();
+        assert_eq!(result, Path::new("/tmp/out/foo/bar.txt"));
+    }
+
+    #[test]
+    fn safe_join_rejects_parent_traversal() {
+        let root = Path::new("/tmp/out");
+        let err = safe_join(root, "../escape.txt").unwrap_err();
+        assert!(err.contains("Unsafe"));
+    }
+
+    #[test]
+    fn safe_join_rejects_absolute_paths() {
+        let root = Path::new("/tmp/out");
+        let err = safe_join(root, "/etc/passwd").unwrap_err();
+        assert!(err.contains("Unsafe"));
+    }
+
+    #[test]
+    fn safe_join_normalises_current_dir_segments() {
+        let root = Path::new("/tmp/out");
+        let result = safe_join(root, "./foo/./bar").unwrap();
+        assert_eq!(result, Path::new("/tmp/out/foo/bar"));
+    }
+
+    #[test]
+    fn rename_path_returns_same_when_target_missing() {
+        let target = Path::new("/tmp/this-should-not-exist-kogu-test/file.txt");
+        let result = rename_path(target);
+        assert_eq!(result, target);
+    }
+
+    #[test]
+    fn resolve_destination_skips_when_policy_requests() {
+        let dir = std::env::temp_dir().join("kogu-archive-resolve");
+        fs::create_dir_all(&dir).unwrap();
+        let existing = dir.join("dup.txt");
+        fs::write(&existing, b"x").unwrap();
+        let resolved = resolve_destination(existing.clone(), "skip").unwrap();
+        assert!(resolved.is_none());
+        fs::remove_file(&existing).unwrap();
+    }
+
+    #[test]
+    fn resolve_destination_unknown_policy_errors() {
+        let dir = std::env::temp_dir().join("kogu-archive-resolve-2");
+        fs::create_dir_all(&dir).unwrap();
+        let existing = dir.join("dup.txt");
+        fs::write(&existing, b"x").unwrap();
+        let err = resolve_destination(existing.clone(), "explode").unwrap_err();
+        assert!(err.contains("Unknown conflict policy"));
+        fs::remove_file(&existing).unwrap();
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,6 +46,7 @@
 //! This library provides the Rust backend for the Kogu desktop application,
 //! including AST parsing functionality for JSON, YAML, XML, and SQL.
 
+mod archive_inspect;
 mod ast;
 mod dns_lookup;
 mod file_inspect;
@@ -486,6 +487,10 @@ pub fn run() {
             hex_editor::hex_open,
             hex_editor::hex_read,
             hex_editor::hex_save,
+            archive_inspect::archive_open,
+            archive_inspect::archive_read_entry,
+            archive_inspect::archive_extract,
+            archive_inspect::archive_extract_entry,
             tls_inspect::tls_inspect,
             webhook::webhook_start,
             webhook::webhook_stop,

--- a/src/lib/services/archive.test.ts
+++ b/src/lib/services/archive.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	ancestorPaths,
+	type ArchiveEntry,
+	entryDepth,
+	entryDisplayName,
+	formatHexPreview,
+	formatRatio,
+	matchGlob,
+	previewKindFor,
+	topLargestEntries,
+} from './archive';
+
+const entry = (overrides: Partial<ArchiveEntry> = {}): ArchiveEntry => ({
+	path: 'file.txt',
+	isDir: false,
+	sizeBytes: 100,
+	compressedSize: 60,
+	modifiedMs: null,
+	crc32: null,
+	...overrides,
+});
+
+describe('formatRatio', () => {
+	it('returns em dash for zero uncompressed size', () => {
+		expect(formatRatio(0, 0)).toBe('—');
+	});
+
+	it('renders a positive saving as integer percent', () => {
+		expect(formatRatio(100, 60)).toBe('40%');
+	});
+
+	it('clamps negative ratios to 0%', () => {
+		expect(formatRatio(100, 110)).toBe('0%');
+	});
+});
+
+describe('matchGlob', () => {
+	it('passes everything when the pattern is blank', () => {
+		expect(matchGlob('src/index.ts', '')).toBe(true);
+	});
+
+	it('respects a single star wildcard within a segment', () => {
+		expect(matchGlob('foo.png', '*.png')).toBe(true);
+		expect(matchGlob('foo/bar.png', '*.png')).toBe(false);
+	});
+
+	it('matches across slashes when ** is used', () => {
+		expect(matchGlob('src/lib/a.ts', 'src/**/*.ts')).toBe(true);
+		expect(matchGlob('src/a.ts', 'src/**/*.ts')).toBe(true);
+	});
+
+	it('uses ? for exactly one character', () => {
+		expect(matchGlob('a.txt', '?.txt')).toBe(true);
+		expect(matchGlob('ab.txt', '?.txt')).toBe(false);
+	});
+
+	it('escapes regex metacharacters', () => {
+		expect(matchGlob('a+b.txt', 'a+b.txt')).toBe(true);
+	});
+});
+
+describe('previewKindFor', () => {
+	it('reports directories as unsupported', () => {
+		expect(previewKindFor(entry({ isDir: true, path: 'dir/' }))).toBe('unsupported');
+	});
+
+	it('reports oversize files as too-large', () => {
+		expect(previewKindFor(entry({ sizeBytes: 60 * 1024 * 1024 }))).toBe('too-large');
+	});
+
+	it('identifies image extensions', () => {
+		expect(previewKindFor(entry({ path: 'a/b/c.PNG' }))).toBe('image');
+	});
+
+	it('identifies text extensions', () => {
+		expect(previewKindFor(entry({ path: 'src/index.ts' }))).toBe('text');
+	});
+
+	it('falls back to hex for unknown extensions', () => {
+		expect(previewKindFor(entry({ path: 'data.bin' }))).toBe('hex');
+	});
+});
+
+describe('formatHexPreview', () => {
+	it('formats bytes as uppercase hex pairs with ascii gutter', () => {
+		const bytes = new Uint8Array([0x48, 0x69, 0x21]);
+		const rows = formatHexPreview(bytes, 4);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.hex).toBe('48 69 21');
+		expect(rows[0]?.ascii).toBe('Hi!');
+		expect(rows[0]?.offset).toBe('000000');
+	});
+
+	it('caps the number of rows', () => {
+		const bytes = new Uint8Array(64);
+		const rows = formatHexPreview(bytes, 2);
+		expect(rows).toHaveLength(2);
+	});
+});
+
+describe('ancestorPaths', () => {
+	it('returns nothing for top-level files', () => {
+		expect(ancestorPaths('readme.md')).toEqual([]);
+	});
+
+	it('returns each ancestor chain element', () => {
+		expect(ancestorPaths('src/lib/a.ts')).toEqual(['src', 'src/lib']);
+	});
+
+	it('trims trailing slashes for directories', () => {
+		expect(ancestorPaths('src/lib/')).toEqual(['src']);
+	});
+});
+
+describe('entryDepth', () => {
+	it('returns 0 for top-level entries', () => {
+		expect(entryDepth('foo.txt')).toBe(0);
+	});
+
+	it('counts directory segments', () => {
+		expect(entryDepth('a/b/c.txt')).toBe(2);
+	});
+});
+
+describe('entryDisplayName', () => {
+	it('returns the trailing path component', () => {
+		expect(entryDisplayName('src/lib/a.ts')).toBe('a.ts');
+	});
+
+	it('strips a trailing slash from directory names', () => {
+		expect(entryDisplayName('src/lib/')).toBe('lib');
+	});
+});
+
+describe('topLargestEntries', () => {
+	it('skips directories and returns entries sorted by size', () => {
+		const entries: ArchiveEntry[] = [
+			entry({ path: 'a', sizeBytes: 1 }),
+			entry({ path: 'b/', isDir: true, sizeBytes: 9999 }),
+			entry({ path: 'c', sizeBytes: 100 }),
+			entry({ path: 'd', sizeBytes: 10 }),
+		];
+		const result = topLargestEntries(entries, 2);
+		expect(result.map((e) => e.path)).toEqual(['c', 'd']);
+	});
+});

--- a/src/lib/services/archive.ts
+++ b/src/lib/services/archive.ts
@@ -1,0 +1,358 @@
+/**
+ * Archive Inspector / Extractor service.
+ *
+ * Wraps the `archive_open` / `archive_read_entry` / `archive_extract` /
+ * `archive_extract_entry` Tauri commands and exposes pure helpers the
+ * archive viewer renders against (glob matching, ratio formatting, tree
+ * grouping).
+ *
+ * All helpers are pure functions so the frontend can call them inside
+ * `useMemo` without owning any extra state.
+ */
+import { invoke } from '@tauri-apps/api/core';
+
+export type ArchiveFormat = 'zip' | 'tar' | 'tar.gz' | 'tar.bz2' | 'tar.xz' | '7z';
+
+export interface ArchiveEntry {
+	readonly path: string;
+	readonly isDir: boolean;
+	readonly sizeBytes: number;
+	readonly compressedSize: number;
+	readonly modifiedMs: number | null;
+	readonly crc32: number | null;
+}
+
+export interface ArchiveInfo {
+	readonly path: string;
+	readonly format: ArchiveFormat | string;
+	readonly entries: readonly ArchiveEntry[];
+	readonly totalEntries: number;
+	readonly totalUncompressed: number;
+	readonly totalCompressed: number;
+}
+
+export type ConflictPolicy = 'skip' | 'overwrite' | 'rename';
+
+export interface ExtractParams {
+	readonly archivePath: string;
+	readonly entries: readonly string[];
+	readonly destinationDir: string;
+	readonly conflict: ConflictPolicy;
+}
+
+export const archiveOpen = (path: string): Promise<ArchiveInfo> => invoke('archive_open', { path });
+
+export const archiveReadEntry = (
+	archivePath: string,
+	entryPath: string,
+	maxBytes: number
+): Promise<Uint8Array> =>
+	invoke<number[]>('archive_read_entry', { archivePath, entryPath, maxBytes }).then(
+		(arr) => new Uint8Array(arr)
+	);
+
+export const archiveExtract = (params: ExtractParams): Promise<number> =>
+	invoke('archive_extract', { req: params });
+
+export const archiveExtractEntry = (
+	archivePath: string,
+	entryPath: string,
+	destinationPath: string
+): Promise<number> => invoke('archive_extract_entry', { archivePath, entryPath, destinationPath });
+
+/**
+ * Human-readable size, matches the formatter used in the file inspector
+ * and hex editor so the three tools render byte counts consistently.
+ */
+export const humanSize = (bytes: number): string => {
+	if (bytes === 0) return '0 B';
+	const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+	const exponent = Math.min(units.length - 1, Math.floor(Math.log10(Math.abs(bytes)) / 3));
+	const value = bytes / 10 ** (exponent * 3);
+	return `${value.toFixed(exponent === 0 ? 0 : 2)} ${units[exponent]}`;
+};
+
+/**
+ * Compression ratio rendered as "NN%" savings vs original size, or `—`
+ * when the original size is zero. Negative ratios (when compressed
+ * actually grew) are shown as `0%` to keep the table tidy.
+ */
+export const formatRatio = (uncompressed: number, compressed: number): string => {
+	if (uncompressed === 0) return '—';
+	const saved = 1 - compressed / uncompressed;
+	if (saved <= 0) return '0%';
+	return `${Math.round(saved * 100)}%`;
+};
+
+/**
+ * Compile a simple glob pattern to a regular expression. Supports:
+ *
+ * - `*`  - zero or more characters except `/`
+ * - `**` - zero or more characters including `/`
+ * - `?`  - exactly one character
+ * - `[abc]` / `[a-z]` - character classes
+ *
+ * Anything else is escaped and matched literally so paths with `.` /
+ * parens / `+` do not produce surprising matches.
+ */
+interface GlobToken {
+	readonly regex: string;
+	readonly consumed: number;
+}
+
+const REGEX_META = /[.+^${}()|\\]/;
+
+const tokenizeStar = (pattern: string, i: number): GlobToken => {
+	if (pattern[i + 1] === '*') {
+		// `**` matches across slashes; absorb the following `/` if present.
+		const next = pattern[i + 2] === '/' ? 3 : 2;
+		return { regex: '.*', consumed: next };
+	}
+	return { regex: '[^/]*', consumed: 1 };
+};
+
+const tokenizeBracket = (pattern: string, i: number): GlobToken => {
+	const close = pattern.indexOf(']', i + 1);
+	if (close === -1) return { regex: '\\[', consumed: 1 };
+	return { regex: pattern.slice(i, close + 1), consumed: close + 1 - i };
+};
+
+const tokenizeLiteral = (c: string): GlobToken => {
+	if (REGEX_META.test(c)) return { regex: `\\${c}`, consumed: 1 };
+	return { regex: c, consumed: 1 };
+};
+
+const tokenizeGlob = (pattern: string, i: number): GlobToken => {
+	const c = pattern[i];
+	if (c === undefined) return { regex: '', consumed: 1 };
+	if (c === '*') return tokenizeStar(pattern, i);
+	if (c === '?') return { regex: '[^/]', consumed: 1 };
+	if (c === '[') return tokenizeBracket(pattern, i);
+	return tokenizeLiteral(c);
+};
+
+const globToRegex = (pattern: string): RegExp => {
+	let out = '^';
+	let i = 0;
+	while (i < pattern.length) {
+		const token = tokenizeGlob(pattern, i);
+		out += token.regex;
+		i += token.consumed;
+	}
+	out += '$';
+	return new RegExp(out);
+};
+
+/**
+ * Match `path` against a glob `pattern`. Empty patterns match anything
+ * so the filter input behaves like a passthrough when blank.
+ */
+export const matchGlob = (path: string, pattern: string): boolean => {
+	const trimmed = pattern.trim();
+	if (trimmed.length === 0) return true;
+	try {
+		return globToRegex(trimmed).test(path);
+	} catch {
+		return false;
+	}
+};
+
+/**
+ * Decide whether an archive entry should yield an inline text preview
+ * given its extension. Mirrors the catalog used by File Inspector but
+ * works off the entry path alone (no magic bytes available yet).
+ */
+const TEXT_EXTENSIONS: ReadonlySet<string> = new Set([
+	'txt',
+	'md',
+	'rst',
+	'log',
+	'json',
+	'yaml',
+	'yml',
+	'toml',
+	'ini',
+	'cfg',
+	'conf',
+	'env',
+	'xml',
+	'html',
+	'htm',
+	'css',
+	'scss',
+	'less',
+	'js',
+	'mjs',
+	'cjs',
+	'jsx',
+	'ts',
+	'tsx',
+	'py',
+	'rb',
+	'rs',
+	'go',
+	'java',
+	'kt',
+	'swift',
+	'c',
+	'h',
+	'cc',
+	'cpp',
+	'hpp',
+	'cs',
+	'php',
+	'pl',
+	'sh',
+	'bash',
+	'zsh',
+	'fish',
+	'sql',
+	'csv',
+	'tsv',
+	'gitignore',
+	'gitattributes',
+	'editorconfig',
+	'lock',
+	'license',
+	'readme',
+]);
+
+const IMAGE_EXTENSIONS: ReadonlySet<string> = new Set([
+	'png',
+	'jpg',
+	'jpeg',
+	'gif',
+	'webp',
+	'bmp',
+	'svg',
+	'ico',
+	'avif',
+]);
+
+export type PreviewKind = 'text' | 'image' | 'hex' | 'too-large' | 'unsupported';
+
+/**
+ * Decide which preview renderer to use for a given entry. Files above
+ * `tooLargeThreshold` (default 50 MB) skip the preview entirely.
+ */
+export const previewKindFor = (
+	entry: ArchiveEntry,
+	tooLargeThreshold = 50 * 1024 * 1024
+): PreviewKind => {
+	if (entry.isDir) return 'unsupported';
+	if (entry.sizeBytes > tooLargeThreshold) return 'too-large';
+	const lower = entry.path.toLowerCase();
+	const dot = lower.lastIndexOf('.');
+	const ext = dot >= 0 ? lower.slice(dot + 1) : '';
+	if (IMAGE_EXTENSIONS.has(ext)) return 'image';
+	if (TEXT_EXTENSIONS.has(ext)) return 'text';
+	const base = lower.split('/').pop() ?? '';
+	if (TEXT_EXTENSIONS.has(base)) return 'text';
+	return 'hex';
+};
+
+/**
+ * Decode head bytes as UTF-8 for inline text preview. Mirrors File
+ * Inspector's helper so the two tools render the same surface.
+ */
+export const decodeTextPreview = (bytes: Uint8Array, maxChars: number): string => {
+	const decoder = new TextDecoder('utf-8', { fatal: false });
+	const text = decoder.decode(bytes);
+	if (text.length <= maxChars) return text;
+	return `${text.slice(0, maxChars)}…`;
+};
+
+/**
+ * Format a contiguous hex preview row. Each row contains up to
+ * `bytesPerRow` bytes and is rendered as `OFFSET  HEX HEX HEX  ascii`.
+ */
+export interface HexPreviewRow {
+	readonly offset: string;
+	readonly hex: string;
+	readonly ascii: string;
+}
+
+const PRINTABLE_LO = 0x20;
+const PRINTABLE_HI = 0x7e;
+
+const printableChar = (b: number): string =>
+	b >= PRINTABLE_LO && b <= PRINTABLE_HI ? String.fromCharCode(b) : '.';
+
+export const formatHexPreview = (
+	bytes: Uint8Array,
+	maxRows: number,
+	bytesPerRow = 16
+): readonly HexPreviewRow[] => {
+	const rows: HexPreviewRow[] = [];
+	for (let i = 0; i < bytes.length && rows.length < maxRows; i += bytesPerRow) {
+		const slice = bytes.subarray(i, Math.min(bytes.length, i + bytesPerRow));
+		const hex = Array.from(slice)
+			.map((b) => b.toString(16).padStart(2, '0').toUpperCase())
+			.join(' ');
+		const ascii = Array.from(slice).map(printableChar).join('');
+		rows.push({
+			offset: i.toString(16).padStart(6, '0').toUpperCase(),
+			hex,
+			ascii,
+		});
+	}
+	return rows;
+};
+
+/**
+ * Format a Unix-millisecond timestamp as a locale string. Returns
+ * `'—'` for nullish inputs so the UI never shows `Invalid Date`.
+ */
+export const formatTimestamp = (ms: number | null | undefined): string => {
+	if (ms == null || !Number.isFinite(ms)) return '—';
+	return new Date(ms).toLocaleString();
+};
+
+/**
+ * Pull the trailing path component from an entry path so the tree row
+ * can render a short label while keeping the full path elsewhere.
+ */
+export const entryDisplayName = (path: string): string => {
+	const trimmed = path.endsWith('/') ? path.slice(0, -1) : path;
+	const slash = trimmed.lastIndexOf('/');
+	return slash >= 0 ? trimmed.slice(slash + 1) : trimmed;
+};
+
+/**
+ * Split an entry path into its directory chain (e.g. `src/lib/index.ts`
+ * yields `['src', 'src/lib']`). Used to drive the folder expansion
+ * model in the entry table.
+ */
+export const ancestorPaths = (path: string): readonly string[] => {
+	const trimmed = path.endsWith('/') ? path.slice(0, -1) : path;
+	const parts = trimmed.split('/');
+	if (parts.length <= 1) return [];
+	const out: string[] = [];
+	for (let i = 1; i < parts.length; i += 1) {
+		out.push(parts.slice(0, i).join('/'));
+	}
+	return out;
+};
+
+/**
+ * Compute the depth of an entry path. Top-level files / folders have
+ * depth `0`. Used to drive the indent of tree rows.
+ */
+export const entryDepth = (path: string): number => {
+	const trimmed = path.endsWith('/') ? path.slice(0, -1) : path;
+	const segments = trimmed.split('/').filter((s) => s.length > 0);
+	return Math.max(0, segments.length - 1);
+};
+
+/**
+ * Top-N largest files in the archive, used by the stats panel. Skips
+ * directory entries and clamps to the requested count.
+ */
+export const topLargestEntries = (
+	entries: readonly ArchiveEntry[],
+	n: number
+): readonly ArchiveEntry[] =>
+	entries
+		.filter((e) => !e.isDir)
+		.toSorted((a, b) => b.sizeBytes - a.sizeBytes)
+		.slice(0, n);

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -43,6 +43,7 @@ import {
 	Lock,
 	type LucideIcon,
 	Network,
+	Package,
 	Pencil,
 	Play,
 	Plug,
@@ -560,6 +561,15 @@ export const PAGES: readonly PageDefinition[] = [
 		icon: FileDigit,
 		description: 'View and edit binary files as hex with search, jump, and per-byte selection',
 		color: 'text-amber-700',
+		category: 'files',
+	},
+	{
+		id: 'archive-inspector',
+		title: 'Archive Inspector',
+		url: '/archive-inspector',
+		icon: Package,
+		description: 'Browse and extract .zip / .tar / .gz / .bz2 / .xz / .7z archives',
+		color: 'text-amber-800',
 		category: 'files',
 	},
 	{

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -54,6 +54,7 @@ import { Route as CronExpressionBuilderRouteImport } from './routes/cron-express
 import { Route as CidrCalculatorRouteImport } from './routes/cidr-calculator';
 import { Route as BcryptGeneratorRouteImport } from './routes/bcrypt-generator';
 import { Route as Base64EncoderRouteImport } from './routes/base64-encoder';
+import { Route as ArchiveInspectorRouteImport } from './routes/archive-inspector';
 import { Route as IndexRouteImport } from './routes/index';
 
 const YamlFormatterRoute = YamlFormatterRouteImport.update({
@@ -281,6 +282,11 @@ const Base64EncoderRoute = Base64EncoderRouteImport.update({
 	path: '/base64-encoder',
 	getParentRoute: () => rootRouteImport,
 } as any);
+const ArchiveInspectorRoute = ArchiveInspectorRouteImport.update({
+	id: '/archive-inspector',
+	path: '/archive-inspector',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const IndexRoute = IndexRouteImport.update({
 	id: '/',
 	path: '/',
@@ -289,6 +295,7 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
 	'/': typeof IndexRoute;
+	'/archive-inspector': typeof ArchiveInspectorRoute;
 	'/base64-encoder': typeof Base64EncoderRoute;
 	'/bcrypt-generator': typeof BcryptGeneratorRoute;
 	'/cidr-calculator': typeof CidrCalculatorRoute;
@@ -337,6 +344,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
 	'/': typeof IndexRoute;
+	'/archive-inspector': typeof ArchiveInspectorRoute;
 	'/base64-encoder': typeof Base64EncoderRoute;
 	'/bcrypt-generator': typeof BcryptGeneratorRoute;
 	'/cidr-calculator': typeof CidrCalculatorRoute;
@@ -386,6 +394,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
 	__root__: typeof rootRouteImport;
 	'/': typeof IndexRoute;
+	'/archive-inspector': typeof ArchiveInspectorRoute;
 	'/base64-encoder': typeof Base64EncoderRoute;
 	'/bcrypt-generator': typeof BcryptGeneratorRoute;
 	'/cidr-calculator': typeof CidrCalculatorRoute;
@@ -436,6 +445,7 @@ export interface FileRouteTypes {
 	fileRoutesByFullPath: FileRoutesByFullPath;
 	fullPaths:
 		| '/'
+		| '/archive-inspector'
 		| '/base64-encoder'
 		| '/bcrypt-generator'
 		| '/cidr-calculator'
@@ -484,6 +494,7 @@ export interface FileRouteTypes {
 	fileRoutesByTo: FileRoutesByTo;
 	to:
 		| '/'
+		| '/archive-inspector'
 		| '/base64-encoder'
 		| '/bcrypt-generator'
 		| '/cidr-calculator'
@@ -532,6 +543,7 @@ export interface FileRouteTypes {
 	id:
 		| '__root__'
 		| '/'
+		| '/archive-inspector'
 		| '/base64-encoder'
 		| '/bcrypt-generator'
 		| '/cidr-calculator'
@@ -581,6 +593,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
 	IndexRoute: typeof IndexRoute;
+	ArchiveInspectorRoute: typeof ArchiveInspectorRoute;
 	Base64EncoderRoute: typeof Base64EncoderRoute;
 	BcryptGeneratorRoute: typeof BcryptGeneratorRoute;
 	CidrCalculatorRoute: typeof CidrCalculatorRoute;
@@ -945,6 +958,13 @@ declare module '@tanstack/react-router' {
 			preLoaderRoute: typeof Base64EncoderRouteImport;
 			parentRoute: typeof rootRouteImport;
 		};
+		'/archive-inspector': {
+			id: '/archive-inspector';
+			path: '/archive-inspector';
+			fullPath: '/archive-inspector';
+			preLoaderRoute: typeof ArchiveInspectorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
 		'/': {
 			id: '/';
 			path: '/';
@@ -957,6 +977,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
 	IndexRoute: IndexRoute,
+	ArchiveInspectorRoute: ArchiveInspectorRoute,
 	Base64EncoderRoute: Base64EncoderRoute,
 	BcryptGeneratorRoute: BcryptGeneratorRoute,
 	CidrCalculatorRoute: CidrCalculatorRoute,

--- a/src/routes/archive-inspector.tsx
+++ b/src/routes/archive-inspector.tsx
@@ -1,0 +1,1055 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { open as openDialog } from '@tauri-apps/plugin-dialog';
+import {
+	ArrowDownNarrowWide,
+	ArrowUpNarrowWide,
+	ChevronDown,
+	ChevronRight,
+	FileSearch,
+	FolderOpen,
+	Loader2,
+	Package,
+	PackageOpen,
+	Trash2,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState, type DragEvent } from 'react';
+import { toast } from 'sonner';
+
+import { FormInfo, FormInput, FormMode, FormSection, FormSelect } from '@/lib/components/form';
+import { RelatedTools, SectionLabel } from '@/lib/components/layout';
+import { ToolShell } from '@/lib/components/shell';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { Badge } from '@/lib/components/ui/badge';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { Checkbox } from '@/lib/components/ui/checkbox';
+import { useDocumentTitle } from '@/lib/hooks';
+import {
+	ancestorPaths,
+	archiveExtract,
+	archiveOpen,
+	archiveReadEntry,
+	type ArchiveEntry,
+	type ArchiveInfo,
+	type ConflictPolicy,
+	decodeTextPreview,
+	entryDepth,
+	entryDisplayName,
+	formatHexPreview,
+	formatRatio,
+	formatTimestamp,
+	humanSize,
+	matchGlob,
+	type PreviewKind,
+	previewKindFor,
+} from '@/lib/services/archive';
+import { createToolOptionsStore } from '@/lib/stores';
+import { cn } from '@/lib/utils';
+
+type SortColumn = 'path' | 'size' | 'compressed' | 'modified';
+type SortDirection = 'asc' | 'desc';
+
+interface ArchiveInspectorPrefs {
+	readonly globFilter: string;
+	readonly sortColumn: SortColumn;
+	readonly sortDir: SortDirection;
+	readonly conflictPolicy: ConflictPolicy;
+}
+
+const DEFAULT_PREFS: ArchiveInspectorPrefs = {
+	globFilter: '',
+	sortColumn: 'path',
+	sortDir: 'asc',
+	conflictPolicy: 'rename',
+};
+
+const useArchiveInspectorPrefs = createToolOptionsStore<ArchiveInspectorPrefs>(
+	'archive-inspector',
+	DEFAULT_PREFS
+);
+
+const PREVIEW_CAP_BYTES = 256 * 1024;
+
+const SORT_OPTIONS: readonly { readonly value: SortColumn; readonly label: string }[] = [
+	{ value: 'path', label: 'Path' },
+	{ value: 'size', label: 'Size' },
+	{ value: 'compressed', label: 'Compressed' },
+	{ value: 'modified', label: 'Modified' },
+];
+
+const CONFLICT_OPTIONS: readonly { readonly value: ConflictPolicy; readonly label: string }[] = [
+	{ value: 'skip', label: 'Skip if exists' },
+	{ value: 'overwrite', label: 'Overwrite' },
+	{ value: 'rename', label: 'Rename' },
+];
+
+export const Route = createFileRoute('/archive-inspector')({
+	component: ArchiveInspectorPage,
+});
+
+function ArchiveInspectorPage() {
+	useDocumentTitle('Archive Inspector');
+
+	const { value: prefs, patch } = useArchiveInspectorPrefs();
+
+	const [archive, setArchive] = useState<ArchiveInfo | null>(null);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [isDragOver, setIsDragOver] = useState(false);
+	const [showRail, setShowRail] = useState(true);
+	const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
+	const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
+	const [previewEntry, setPreviewEntry] = useState<ArchiveEntry | null>(null);
+	const [previewBytes, setPreviewBytes] = useState<Uint8Array | null>(null);
+	const [previewLoading, setPreviewLoading] = useState(false);
+	const [extracting, setExtracting] = useState(false);
+
+	const handleClear = useCallback(() => {
+		setArchive(null);
+		setError(null);
+		setSelected(new Set());
+		setExpanded(new Set());
+		setPreviewEntry(null);
+		setPreviewBytes(null);
+	}, []);
+
+	const loadFromPath = useCallback(async (path: string) => {
+		setLoading(true);
+		setError(null);
+		try {
+			const info = await archiveOpen(path);
+			setArchive(info);
+			setSelected(new Set());
+			setExpanded(new Set());
+			setPreviewEntry(null);
+			setPreviewBytes(null);
+			if (info.format === '7z' && info.entries.length === 0) {
+				toast.info('7z format detected', {
+					description: 'Listing and extraction are deferred to a follow-up.',
+				});
+			}
+		} catch (e) {
+			const message = e instanceof Error ? e.message : String(e);
+			setError(message);
+			toast.error('Failed to open archive', { description: message });
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	const handlePickFile = async () => {
+		try {
+			const picked = await openDialog({ multiple: false, directory: false });
+			if (typeof picked === 'string' && picked.length > 0) {
+				await loadFromPath(picked);
+			}
+		} catch (e) {
+			const message = e instanceof Error ? e.message : String(e);
+			toast.error('Failed to open file dialog', { description: message });
+		}
+	};
+
+	const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		setIsDragOver(false);
+		const dropped = e.dataTransfer.files[0] as (File & { readonly path?: string }) | undefined;
+		if (!dropped) return;
+		if (dropped.path) {
+			loadFromPath(dropped.path).catch(() => undefined);
+			return;
+		}
+		toast.error('Could not determine file path', {
+			description: 'Use the Open archive button to pick the file.',
+		});
+	};
+	const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		setIsDragOver(true);
+	};
+	const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		setIsDragOver(false);
+	};
+
+	const filteredEntries = useMemo(() => {
+		if (!archive) return [];
+		const pattern = prefs.globFilter.trim();
+		if (pattern.length === 0) return archive.entries;
+		return archive.entries.filter((entry) => matchGlob(entry.path, pattern));
+	}, [archive, prefs.globFilter]);
+
+	const sortedEntries = useMemo(() => {
+		const compareBy = (a: ArchiveEntry, b: ArchiveEntry): number => {
+			switch (prefs.sortColumn) {
+				case 'size':
+					return a.sizeBytes - b.sizeBytes;
+				case 'compressed':
+					return a.compressedSize - b.compressedSize;
+				case 'modified':
+					return (a.modifiedMs ?? 0) - (b.modifiedMs ?? 0);
+				default:
+					return a.path.localeCompare(b.path);
+			}
+		};
+		const dir = prefs.sortDir === 'asc' ? 1 : -1;
+		return [...filteredEntries].sort((a, b) => dir * compareBy(a, b));
+	}, [filteredEntries, prefs.sortColumn, prefs.sortDir]);
+
+	// Build the visible row list: hide entries inside collapsed folders.
+	const visibleEntries = useMemo(() => {
+		if (expanded.size === 0 && prefs.globFilter.trim().length === 0) {
+			// Default view: show only depth-0 entries until folders are expanded.
+			return sortedEntries.filter((entry) => entryDepth(entry.path) === 0);
+		}
+		return sortedEntries.filter((entry) => {
+			const ancestors = ancestorPaths(entry.path);
+			if (ancestors.length === 0) return true;
+			return ancestors.every((p) => expanded.has(p));
+		});
+	}, [sortedEntries, expanded, prefs.globFilter]);
+
+	const folderSet = useMemo(() => {
+		const folders = new Set<string>();
+		for (const entry of sortedEntries) {
+			if (entry.isDir) folders.add(entry.path.replace(/\/$/, ''));
+			for (const ancestor of ancestorPaths(entry.path)) folders.add(ancestor);
+		}
+		return folders;
+	}, [sortedEntries]);
+
+	const toggleExpanded = (path: string) => {
+		setExpanded((prev) => {
+			const next = new Set(prev);
+			if (next.has(path)) next.delete(path);
+			else next.add(path);
+			return next;
+		});
+	};
+
+	const expandAll = () => {
+		setExpanded(new Set(folderSet));
+	};
+	const collapseAll = () => {
+		setExpanded(new Set());
+	};
+
+	const toggleSelected = (path: string) => {
+		setSelected((prev) => {
+			const next = new Set(prev);
+			if (next.has(path)) next.delete(path);
+			else next.add(path);
+			return next;
+		});
+	};
+
+	const selectAll = () => {
+		setSelected(new Set(sortedEntries.filter((e) => !e.isDir).map((e) => e.path)));
+	};
+	const selectNone = () => {
+		setSelected(new Set());
+	};
+	const invertSelection = () => {
+		setSelected((prev) => {
+			const next = new Set<string>();
+			for (const entry of sortedEntries) {
+				if (entry.isDir) continue;
+				if (!prev.has(entry.path)) next.add(entry.path);
+			}
+			return next;
+		});
+	};
+
+	const handlePreview = useCallback(
+		async (entry: ArchiveEntry) => {
+			if (!archive) return;
+			if (entry.isDir) return;
+			setPreviewEntry(entry);
+			setPreviewBytes(null);
+			const kind = previewKindFor(entry);
+			if (kind === 'too-large' || kind === 'unsupported') return;
+			setPreviewLoading(true);
+			try {
+				const bytes = await archiveReadEntry(archive.path, entry.path, PREVIEW_CAP_BYTES);
+				setPreviewBytes(bytes);
+			} catch (e) {
+				const message = e instanceof Error ? e.message : String(e);
+				toast.error('Failed to read entry', { description: message });
+			} finally {
+				setPreviewLoading(false);
+			}
+		},
+		[archive]
+	);
+
+	const pickDestination = async (): Promise<string | null> => {
+		try {
+			const picked = await openDialog({ multiple: false, directory: true });
+			return typeof picked === 'string' && picked.length > 0 ? picked : null;
+		} catch (e) {
+			const message = e instanceof Error ? e.message : String(e);
+			toast.error('Failed to open folder dialog', { description: message });
+			return null;
+		}
+	};
+
+	const runExtract = useCallback(
+		async (entries: readonly string[]) => {
+			if (!archive) return;
+			const destination = await pickDestination();
+			if (!destination) return;
+			setExtracting(true);
+			try {
+				const count = await archiveExtract({
+					archivePath: archive.path,
+					entries,
+					destinationDir: destination,
+					conflict: prefs.conflictPolicy,
+				});
+				toast.success('Extraction complete', {
+					description: `${count} file${count === 1 ? '' : 's'} written to ${destination}`,
+				});
+			} catch (e) {
+				const message = e instanceof Error ? e.message : String(e);
+				toast.error('Extraction failed', { description: message });
+			} finally {
+				setExtracting(false);
+			}
+		},
+		[archive, prefs.conflictPolicy]
+	);
+
+	const handleExtractSelected = () => {
+		if (selected.size === 0) {
+			toast.error('Select at least one entry to extract.');
+			return;
+		}
+		runExtract(Array.from(selected)).catch(() => undefined);
+	};
+
+	const handleExtractAll = () => {
+		runExtract([]).catch(() => undefined);
+	};
+
+	const hasArchive = archive !== null;
+	const filename = archive?.path.split('/').pop() ?? '';
+	const selectedCount = selected.size;
+	const totalEntries = archive?.entries.length ?? 0;
+	const filteredCount = filteredEntries.length;
+
+	return (
+		<ToolShell
+			showRail={showRail}
+			onShowRailChange={setShowRail}
+			valid={hasArchive ? true : null}
+			error={error ?? undefined}
+			statusContent={
+				hasArchive && archive ? (
+					<>
+						<StatItem
+							label="Entries"
+							value={
+								filteredCount === totalEntries
+									? totalEntries.toLocaleString()
+									: `${filteredCount.toLocaleString()} / ${totalEntries.toLocaleString()}`
+							}
+						/>
+						<StatItem label="Selected" value={selectedCount.toLocaleString()} />
+						<StatItem label="Total size" value={humanSize(archive.totalUncompressed)} />
+						<StatItem
+							label="Ratio"
+							value={formatRatio(archive.totalUncompressed, archive.totalCompressed)}
+						/>
+					</>
+				) : null
+			}
+			rail={
+				<>
+					<FormSection title="Open">
+						<div className="flex flex-col gap-2">
+							<Button variant="default" size="sm" onClick={handlePickFile} disabled={loading}>
+								<FolderOpen className="h-3.5 w-3.5" />
+								{hasArchive ? 'Choose another' : 'Open archive…'}
+							</Button>
+							{hasArchive ? (
+								<Button variant="outline" size="sm" onClick={handleClear}>
+									<Trash2 className="h-3.5 w-3.5" />
+									Clear
+								</Button>
+							) : null}
+						</div>
+					</FormSection>
+
+					<FormSection title="Filter">
+						<FormInput
+							label="Glob pattern"
+							value={prefs.globFilter}
+							onValueChange={(v) => patch({ globFilter: v })}
+							placeholder="*.png or src/**/*.ts"
+							size="compact"
+						/>
+					</FormSection>
+
+					<FormSection title="Sort">
+						<FormSelect
+							label="Column"
+							value={prefs.sortColumn}
+							options={SORT_OPTIONS}
+							size="compact"
+							onValueChange={(v) => patch({ sortColumn: v as SortColumn })}
+						/>
+						<FormMode<SortDirection>
+							label="Direction"
+							value={prefs.sortDir}
+							options={[
+								{ value: 'asc', label: 'Ascending' },
+								{ value: 'desc', label: 'Descending' },
+							]}
+							onValueChange={(v) => patch({ sortDir: v })}
+						/>
+					</FormSection>
+
+					<FormSection title="Selection">
+						<div className="flex flex-wrap gap-1.5">
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={selectAll}
+								disabled={!hasArchive || totalEntries === 0}
+							>
+								All
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={selectNone}
+								disabled={selectedCount === 0}
+							>
+								None
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={invertSelection}
+								disabled={!hasArchive || totalEntries === 0}
+							>
+								Invert
+							</Button>
+						</div>
+					</FormSection>
+
+					<FormSection title="Extract">
+						<FormSelect
+							label="On conflict"
+							value={prefs.conflictPolicy}
+							options={CONFLICT_OPTIONS}
+							size="compact"
+							onValueChange={(v) => patch({ conflictPolicy: v as ConflictPolicy })}
+						/>
+						<div className="flex flex-col gap-2">
+							<Button
+								variant="default"
+								size="sm"
+								onClick={handleExtractSelected}
+								disabled={!hasArchive || extracting || selectedCount === 0}
+							>
+								{extracting ? (
+									<Loader2 className="h-3.5 w-3.5 animate-spin" />
+								) : (
+									<PackageOpen className="h-3.5 w-3.5" />
+								)}
+								Extract selected…
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={handleExtractAll}
+								disabled={!hasArchive || extracting || totalEntries === 0}
+							>
+								<PackageOpen className="h-3.5 w-3.5" />
+								Extract all…
+							</Button>
+						</div>
+					</FormSection>
+
+					<FormSection title="Tree">
+						<div className="flex flex-wrap gap-1.5">
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={expandAll}
+								disabled={folderSet.size === 0}
+							>
+								Expand all
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={collapseAll}
+								disabled={expanded.size === 0}
+							>
+								Collapse all
+							</Button>
+						</div>
+					</FormSection>
+
+					<FormSection title="Related">
+						<RelatedTools
+							items={[
+								{ id: 'file-inspector', reason: 'Inspect a single file' },
+								{ id: 'hex-editor', reason: 'View binary content' },
+							]}
+						/>
+					</FormSection>
+
+					<FormSection title="About">
+						<FormInfo>
+							Read-only browsing plus selective extract. Supports .zip / .tar / .tar.gz / .tar.bz2 /
+							.tar.xz, and identifies .7z (full 7z browsing is deferred).
+						</FormInfo>
+					</FormSection>
+				</>
+			}
+		>
+			{hasArchive && archive ? (
+				<ArchiveView
+					archive={archive}
+					filename={filename}
+					filteredCount={filteredCount}
+					visibleEntries={visibleEntries}
+					selected={selected}
+					expanded={expanded}
+					folderSet={folderSet}
+					sortColumn={prefs.sortColumn}
+					sortDir={prefs.sortDir}
+					previewEntry={previewEntry}
+					previewBytes={previewBytes}
+					previewLoading={previewLoading}
+					onToggleSelected={toggleSelected}
+					onToggleExpanded={toggleExpanded}
+					onSortChange={(column) => {
+						if (column === prefs.sortColumn) {
+							patch({ sortDir: prefs.sortDir === 'asc' ? 'desc' : 'asc' });
+						} else {
+							patch({ sortColumn: column, sortDir: 'asc' });
+						}
+					}}
+					onPreview={handlePreview}
+					onClosePreview={() => {
+						setPreviewEntry(null);
+						setPreviewBytes(null);
+					}}
+				/>
+			) : (
+				<DropZone
+					loading={loading}
+					isDragOver={isDragOver}
+					onDrop={handleDrop}
+					onDragOver={handleDragOver}
+					onDragLeave={handleDragLeave}
+					onPick={handlePickFile}
+				/>
+			)}
+		</ToolShell>
+	);
+}
+
+interface DropZoneProps {
+	readonly loading: boolean;
+	readonly isDragOver: boolean;
+	readonly onDrop: (e: DragEvent<HTMLDivElement>) => void;
+	readonly onDragOver: (e: DragEvent<HTMLDivElement>) => void;
+	readonly onDragLeave: (e: DragEvent<HTMLDivElement>) => void;
+	readonly onPick: () => void;
+}
+
+function DropZone({ loading, isDragOver, onDrop, onDragOver, onDragLeave, onPick }: DropZoneProps) {
+	return (
+		<section
+			aria-label="Archive drop zone"
+			onDrop={onDrop}
+			onDragOver={onDragOver}
+			onDragLeave={onDragLeave}
+			className={cn(
+				'flex h-full items-center justify-center p-6 transition-colors',
+				isDragOver && 'bg-primary/5'
+			)}
+		>
+			<div
+				className={cn(
+					'flex w-full max-w-xl flex-col items-center gap-4 rounded-xl border-2 border-dashed p-10 text-center transition-colors',
+					isDragOver ? 'border-primary bg-primary/10' : 'border-border'
+				)}
+			>
+				<EmbeddedEmptyState
+					icon={Package}
+					title="Open an archive"
+					description="Drag a .zip / .tar / .gz / .bz2 / .xz / .7z file here, or use the button below."
+				/>
+				<Button variant="default" size="sm" onClick={onPick} disabled={loading}>
+					{loading ? (
+						<Loader2 className="h-3.5 w-3.5 animate-spin" />
+					) : (
+						<FolderOpen className="h-3.5 w-3.5" />
+					)}
+					{loading ? 'Loading…' : 'Open archive…'}
+				</Button>
+			</div>
+		</section>
+	);
+}
+
+interface ArchiveViewProps {
+	readonly archive: ArchiveInfo;
+	readonly filename: string;
+	readonly filteredCount: number;
+	readonly visibleEntries: readonly ArchiveEntry[];
+	readonly selected: ReadonlySet<string>;
+	readonly expanded: ReadonlySet<string>;
+	readonly folderSet: ReadonlySet<string>;
+	readonly sortColumn: SortColumn;
+	readonly sortDir: SortDirection;
+	readonly previewEntry: ArchiveEntry | null;
+	readonly previewBytes: Uint8Array | null;
+	readonly previewLoading: boolean;
+	readonly onToggleSelected: (path: string) => void;
+	readonly onToggleExpanded: (path: string) => void;
+	readonly onSortChange: (column: SortColumn) => void;
+	readonly onPreview: (entry: ArchiveEntry) => void;
+	readonly onClosePreview: () => void;
+}
+
+function ArchiveView({
+	archive,
+	filename,
+	filteredCount,
+	visibleEntries,
+	selected,
+	expanded,
+	folderSet,
+	sortColumn,
+	sortDir,
+	previewEntry,
+	previewBytes,
+	previewLoading,
+	onToggleSelected,
+	onToggleExpanded,
+	onSortChange,
+	onPreview,
+	onClosePreview,
+}: ArchiveViewProps) {
+	return (
+		<div className="flex h-full flex-col overflow-hidden">
+			<div className="shrink-0 border-b p-3">
+				<ArchiveBanner archive={archive} filename={filename} filteredCount={filteredCount} />
+			</div>
+			<div className="flex flex-1 min-h-0 flex-col gap-3 overflow-hidden p-3">
+				<EntryTable
+					entries={visibleEntries}
+					selected={selected}
+					expanded={expanded}
+					folderSet={folderSet}
+					sortColumn={sortColumn}
+					sortDir={sortDir}
+					previewEntry={previewEntry}
+					onToggleSelected={onToggleSelected}
+					onToggleExpanded={onToggleExpanded}
+					onSortChange={onSortChange}
+					onPreview={onPreview}
+				/>
+				{previewEntry ? (
+					<PreviewPane
+						entry={previewEntry}
+						bytes={previewBytes}
+						loading={previewLoading}
+						onClose={onClosePreview}
+					/>
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+interface ArchiveBannerProps {
+	readonly archive: ArchiveInfo;
+	readonly filename: string;
+	readonly filteredCount: number;
+}
+
+function ArchiveBanner({ archive, filename, filteredCount }: ArchiveBannerProps) {
+	const ratio = formatRatio(archive.totalUncompressed, archive.totalCompressed);
+	return (
+		<Card density="compact">
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2 text-sm">
+					<Package className="h-4 w-4 text-amber-700" />
+					<span className="truncate font-mono">{filename}</span>
+					<Badge variant="outline" className="text-2xs uppercase">
+						{archive.format}
+					</Badge>
+					<Badge
+						variant="outline"
+						className="border-info/40 bg-info/10 text-info text-2xs"
+						title="Overall compression ratio"
+					>
+						{ratio} saved
+					</Badge>
+				</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<dl className="grid grid-cols-[140px_1fr] gap-x-3 gap-y-1 text-xs">
+					<dt className="text-muted-foreground">Entries</dt>
+					<dd className="font-mono">
+						{archive.entries.length.toLocaleString()}
+						{filteredCount !== archive.entries.length
+							? ` (${filteredCount.toLocaleString()} shown)`
+							: ''}
+					</dd>
+					<dt className="text-muted-foreground">Uncompressed</dt>
+					<dd className="font-mono">
+						{humanSize(archive.totalUncompressed)} ({archive.totalUncompressed.toLocaleString()} B)
+					</dd>
+					<dt className="text-muted-foreground">Compressed</dt>
+					<dd className="font-mono">
+						{humanSize(archive.totalCompressed)} ({archive.totalCompressed.toLocaleString()} B)
+					</dd>
+				</dl>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface EntryTableProps {
+	readonly entries: readonly ArchiveEntry[];
+	readonly selected: ReadonlySet<string>;
+	readonly expanded: ReadonlySet<string>;
+	readonly folderSet: ReadonlySet<string>;
+	readonly sortColumn: SortColumn;
+	readonly sortDir: SortDirection;
+	readonly previewEntry: ArchiveEntry | null;
+	readonly onToggleSelected: (path: string) => void;
+	readonly onToggleExpanded: (path: string) => void;
+	readonly onSortChange: (column: SortColumn) => void;
+	readonly onPreview: (entry: ArchiveEntry) => void;
+}
+
+function EntryTable({
+	entries,
+	selected,
+	expanded,
+	folderSet,
+	sortColumn,
+	sortDir,
+	previewEntry,
+	onToggleSelected,
+	onToggleExpanded,
+	onSortChange,
+	onPreview,
+}: EntryTableProps) {
+	if (entries.length === 0) {
+		return (
+			<div className="flex-1">
+				<EmbeddedEmptyState
+					icon={FileSearch}
+					title="No entries to display"
+					description="Adjust the glob filter or expand a folder to see contents."
+					fillHeight
+				/>
+			</div>
+		);
+	}
+	return (
+		<div className="flex flex-1 min-h-0 flex-col overflow-hidden rounded-md border bg-card">
+			<TableHeader sortColumn={sortColumn} sortDir={sortDir} onSortChange={onSortChange} />
+			<div className="flex-1 overflow-auto font-mono text-xs">
+				<ul className="divide-y divide-border">
+					{entries.map((entry) => (
+						<EntryRow
+							key={entry.path}
+							entry={entry}
+							isSelected={selected.has(entry.path)}
+							isExpanded={expanded.has(entry.path.replace(/\/$/, ''))}
+							isFolder={entry.isDir || folderSet.has(entry.path.replace(/\/$/, ''))}
+							isActive={previewEntry?.path === entry.path}
+							onToggleSelected={onToggleSelected}
+							onToggleExpanded={onToggleExpanded}
+							onPreview={onPreview}
+						/>
+					))}
+				</ul>
+			</div>
+		</div>
+	);
+}
+
+interface TableHeaderProps {
+	readonly sortColumn: SortColumn;
+	readonly sortDir: SortDirection;
+	readonly onSortChange: (column: SortColumn) => void;
+}
+
+function TableHeader({ sortColumn, sortDir, onSortChange }: TableHeaderProps) {
+	return (
+		<div className="sticky top-0 z-10 grid grid-cols-[24px_24px_1fr_90px_90px_60px_140px] items-center gap-2 border-b bg-muted/40 px-3 py-2 text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+			<span className="sr-only">Select</span>
+			<span className="sr-only">Expand</span>
+			<SortHeader
+				column="path"
+				label="Path"
+				sortColumn={sortColumn}
+				sortDir={sortDir}
+				onSortChange={onSortChange}
+				align="left"
+			/>
+			<SortHeader
+				column="size"
+				label="Size"
+				sortColumn={sortColumn}
+				sortDir={sortDir}
+				onSortChange={onSortChange}
+				align="right"
+			/>
+			<SortHeader
+				column="compressed"
+				label="Compressed"
+				sortColumn={sortColumn}
+				sortDir={sortDir}
+				onSortChange={onSortChange}
+				align="right"
+			/>
+			<span className="text-right">Ratio</span>
+			<SortHeader
+				column="modified"
+				label="Modified"
+				sortColumn={sortColumn}
+				sortDir={sortDir}
+				onSortChange={onSortChange}
+				align="right"
+			/>
+		</div>
+	);
+}
+
+interface SortHeaderProps {
+	readonly column: SortColumn;
+	readonly label: string;
+	readonly sortColumn: SortColumn;
+	readonly sortDir: SortDirection;
+	readonly onSortChange: (column: SortColumn) => void;
+	readonly align: 'left' | 'right';
+}
+
+function SortHeader({ column, label, sortColumn, sortDir, onSortChange, align }: SortHeaderProps) {
+	const isActive = sortColumn === column;
+	return (
+		<button
+			type="button"
+			onClick={() => onSortChange(column)}
+			className={cn(
+				'flex items-center gap-1 truncate transition-colors hover:text-foreground',
+				align === 'right' && 'justify-end',
+				isActive && 'text-foreground'
+			)}
+		>
+			<span className="truncate">{label}</span>
+			{isActive ? (
+				sortDir === 'asc' ? (
+					<ArrowUpNarrowWide className="h-3 w-3 shrink-0" />
+				) : (
+					<ArrowDownNarrowWide className="h-3 w-3 shrink-0" />
+				)
+			) : null}
+		</button>
+	);
+}
+
+interface EntryRowProps {
+	readonly entry: ArchiveEntry;
+	readonly isSelected: boolean;
+	readonly isExpanded: boolean;
+	readonly isFolder: boolean;
+	readonly isActive: boolean;
+	readonly onToggleSelected: (path: string) => void;
+	readonly onToggleExpanded: (path: string) => void;
+	readonly onPreview: (entry: ArchiveEntry) => void;
+}
+
+function EntryRow({
+	entry,
+	isSelected,
+	isExpanded,
+	isFolder,
+	isActive,
+	onToggleSelected,
+	onToggleExpanded,
+	onPreview,
+}: EntryRowProps) {
+	const depth = entryDepth(entry.path);
+	const display = entryDisplayName(entry.path);
+	const ratio = entry.isDir ? '—' : formatRatio(entry.sizeBytes, entry.compressedSize);
+	const folderKey = entry.path.replace(/\/$/, '');
+	return (
+		<li
+			className={cn(
+				'grid grid-cols-[24px_24px_1fr_90px_90px_60px_140px] items-center gap-2 px-3 py-1.5 transition-colors hover:bg-muted/40',
+				isActive && 'bg-primary/10'
+			)}
+			// CSS variable lets the indent track tree depth without inline math.
+			style={{ paddingLeft: `calc(0.75rem + ${depth * 14}px)` }}
+		>
+			<Checkbox
+				checked={isSelected}
+				disabled={entry.isDir}
+				onCheckedChange={() => onToggleSelected(entry.path)}
+				aria-label={`Select ${entry.path}`}
+				className="h-3.5 w-3.5"
+			/>
+			{isFolder && !entry.isDir ? (
+				<span aria-hidden className="h-3 w-3" />
+			) : isFolder ? (
+				<button
+					type="button"
+					onClick={() => onToggleExpanded(folderKey)}
+					className="flex h-4 w-4 items-center justify-center rounded hover:bg-muted"
+					aria-label={isExpanded ? `Collapse ${display}` : `Expand ${display}`}
+				>
+					{isExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+				</button>
+			) : (
+				<span aria-hidden className="h-3 w-3" />
+			)}
+			<button
+				type="button"
+				onClick={() => (entry.isDir ? onToggleExpanded(folderKey) : onPreview(entry))}
+				className="truncate text-left text-foreground hover:underline"
+				title={entry.path}
+			>
+				{display}
+				{entry.isDir ? '/' : ''}
+			</button>
+			<span className="truncate text-right text-muted-foreground">
+				{entry.isDir ? '—' : humanSize(entry.sizeBytes)}
+			</span>
+			<span className="truncate text-right text-muted-foreground">
+				{entry.isDir ? '—' : humanSize(entry.compressedSize)}
+			</span>
+			<span className="truncate text-right text-muted-foreground">{ratio}</span>
+			<span className="truncate text-right text-muted-foreground">
+				{formatTimestamp(entry.modifiedMs)}
+			</span>
+		</li>
+	);
+}
+
+interface PreviewPaneProps {
+	readonly entry: ArchiveEntry;
+	readonly bytes: Uint8Array | null;
+	readonly loading: boolean;
+	readonly onClose: () => void;
+}
+
+function PreviewPane({ entry, bytes, loading, onClose }: PreviewPaneProps) {
+	const kind: PreviewKind = previewKindFor(entry);
+	return (
+		<Card density="compact" className="shrink-0">
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2 text-sm">
+					<SectionLabel icon={FileSearch}>Preview</SectionLabel>
+					<span className="ml-1 truncate font-mono text-xs text-muted-foreground">
+						{entry.path}
+					</span>
+					<Button variant="ghost" size="sm" className="ml-auto" onClick={onClose}>
+						Close
+					</Button>
+				</CardTitle>
+			</CardHeader>
+			<CardContent>
+				{loading ? (
+					<div className="flex items-center gap-2 text-xs text-muted-foreground">
+						<Loader2 className="h-3.5 w-3.5 animate-spin" />
+						Loading preview…
+					</div>
+				) : (
+					<PreviewBody entry={entry} kind={kind} bytes={bytes} />
+				)}
+			</CardContent>
+		</Card>
+	);
+}
+
+interface PreviewBodyProps {
+	readonly entry: ArchiveEntry;
+	readonly kind: PreviewKind;
+	readonly bytes: Uint8Array | null;
+}
+
+function PreviewBody({ entry, kind, bytes }: PreviewBodyProps) {
+	if (kind === 'too-large') {
+		return (
+			<p className="text-xs text-muted-foreground">
+				Entry is {humanSize(entry.sizeBytes)} — too large for inline preview. Extract it to inspect
+				the contents.
+			</p>
+		);
+	}
+	if (kind === 'unsupported') {
+		return (
+			<p className="text-xs text-muted-foreground">Preview is not available for this entry.</p>
+		);
+	}
+	if (!bytes) {
+		return <p className="text-xs text-muted-foreground">No preview data.</p>;
+	}
+	if (kind === 'image') {
+		// Copy into a fresh ArrayBuffer so the Blob constructor accepts
+		// the buffer-backed view without TS complaining about
+		// SharedArrayBuffer being a possible underlying buffer type.
+		const copy = new Uint8Array(bytes.byteLength);
+		copy.set(bytes);
+		const blob = new Blob([copy.buffer]);
+		const url = URL.createObjectURL(blob);
+		return (
+			<div className="flex flex-col gap-2">
+				<ImagePreview url={url} alt={entry.path} />
+				<p className="text-2xs text-muted-foreground">
+					First {humanSize(bytes.length)} of {humanSize(entry.sizeBytes)}.
+				</p>
+			</div>
+		);
+	}
+	if (kind === 'text') {
+		const text = decodeTextPreview(bytes, 8192);
+		return (
+			<pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded bg-muted/40 p-2 text-2xs leading-relaxed">
+				{text}
+			</pre>
+		);
+	}
+	const rows = formatHexPreview(bytes, 64);
+	return (
+		<div className="max-h-72 overflow-auto rounded bg-muted/40 p-2 font-mono text-2xs leading-relaxed">
+			{rows.map((row) => (
+				<div key={row.offset} className="flex gap-3">
+					<span className="text-muted-foreground">{row.offset}</span>
+					<span className="flex-1 truncate">{row.hex}</span>
+					<span className="text-muted-foreground/80">{row.ascii}</span>
+				</div>
+			))}
+		</div>
+	);
+}
+
+interface ImagePreviewProps {
+	readonly url: string;
+	readonly alt: string;
+}
+
+function ImagePreview({ url, alt }: ImagePreviewProps) {
+	useEffect(() => () => URL.revokeObjectURL(url), [url]);
+	return (
+		<img
+			src={url}
+			alt={alt}
+			className="max-h-72 max-w-full rounded border border-border object-contain"
+		/>
+	);
+}


### PR DESCRIPTION
## Summary

- Adds Archive Inspector / Extractor as the third tool under the Files category (after File Inspector and Hex Editor).
- Supports browsing and selective extraction for `.zip` / `.tar` / `.tar.gz` / `.tar.bz2` / `.tar.xz` with magic-byte format auto-detection.
- Identifies `.7z` archives but defers listing and extraction to a follow-up; full 7z support brings a heavy dependency surface that did not justify landing in this PR.

## Changes

### Added

- `src-tauri/src/archive_inspect.rs` — four Tauri commands:
    - `archive_open` — full directory listing without extracting any file.
    - `archive_read_entry` — bounded byte read (max 256 KB) for inline preview.
    - `archive_extract` — bulk extract with selection + conflict policy.
    - `archive_extract_entry` — single-entry extraction to a chosen path.
- `src/lib/services/archive.ts` — frontend service wrapping the Tauri commands plus pure helpers (`matchGlob`, `formatRatio`, `previewKindFor`, `formatHexPreview`, `entryDepth`, `ancestorPaths`, `entryDisplayName`, `topLargestEntries`).
- `src/lib/services/archive.test.ts` — 23 unit tests covering glob matching, ratio formatting, preview-kind selection, hex preview, path helpers.
- `src/routes/archive-inspector.tsx` — page route with rail (Open / Filter / Sort / Selection / Extract / Tree / Related / About), entry table with sticky sortable header, selection checkboxes, folder tree expand/collapse, and inline preview (text / image / hex / too-large placeholder).

### Modified

- `src/lib/services/pages.ts` — registered the new tool under `files`.
- `src-tauri/src/lib.rs` — declared the new module and registered four commands in the invoke handler.
- `src-tauri/Cargo.toml` — added `zip` / `tar` / `flate2` / `bzip2` / `xz2` dependencies (no 7z crate; defer).

## Backend Details

- Path safety: every entry path is sanitised via `safe_join`, which rejects absolute paths, drive prefixes, and `..` traversal so a malicious archive cannot escape the destination root.
- Conflict policies: `skip` / `overwrite` / `rename` (rename appends ` (n)` before the extension and gives up after 10 000 attempts).
- zip 8 `DateTime` does not implement a direct `SystemTime` conversion, so a small `zip_datetime_to_unix_ms` helper computes Unix milliseconds via Hinnant's `days_from_civil` algorithm.
- 7 Rust unit tests cover `safe_join` (positive / parent-escape / absolute / current-dir) and `resolve_destination` (skip / unknown-policy).

## Frontend Details

- Filter accepts a glob (`*`, `**`, `?`, `[abc]`). Inputs are compiled to RegExp through a small hand-rolled tokenizer to avoid pulling in a glob library.
- Tree rows render at depth `entryDepth(path)` via inline padding; folder rows expand/collapse with a chevron and feed off `expanded: Set<string>`.
- Sort column is reflected in the header through arrow icons (`ArrowUpNarrowWide` / `ArrowDownNarrowWide`); clicking the same header toggles direction, clicking a different header resets to ascending.
- Selection is per-entry checkbox plus "All / None / Invert" buttons in the rail.
- Preview pane picks `text` / `image` / `hex` based on the entry path extension and renders inline, with a `too-large` placeholder for entries above 50 MB.

## Deviations From Plan

- **7z extraction deferred.** The original brief listed three candidate 7z crates and noted "if 7z support adds significant friction, defer it." `sevenz-rust2` 0.21 requires `rustc >= 1.93`, which is ahead of this project's current toolchain, and would have pulled in a large LZMA tree for a format we only need to identify. Format detection is still wired up (magic `37 7A BC AF 27 1C`) and the UI shows a toast explaining the deferment, so users see consistent behaviour for the file type.
- **`fs:allow-write-file` capability** was already present in `src-tauri/capabilities/default.json`, so no capability change was needed.

## Test Plan

- [x] `bun run check` (TypeScript + validate-pages + audit-design)
- [x] `bun run test` (164 vitest tests, including 23 new archive tests)
- [x] `bun run format` (Prettier)
- [x] `bun run lint` (no new lint issues from added files; pre-existing project-wide issues unchanged)
- [x] `cargo check` (clean)
- [x] `cargo clippy --all-targets` (clean)
- [x] `cargo test archive_inspect` (7 tests pass)
- [ ] Manual: open a `.zip` and confirm tree + sort + filter + preview
- [ ] Manual: open a `.tar.gz` and extract a selection with each conflict policy
- [ ] Manual: open a `.7z` and confirm the deferment toast
