### PR TITLE
feat(path-tool): add Path Manipulation Tool under Files

### DIFF
--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -58,6 +58,7 @@ import {
 	Shield,
 	ShieldCheck,
 	Sparkles,
+	SplitSquareHorizontal,
 	Table,
 	Target,
 	Terminal,
@@ -570,6 +571,15 @@ export const PAGES: readonly PageDefinition[] = [
 		icon: Package,
 		description: 'Browse and extract .zip / .tar / .gz / .bz2 / .xz / .7z archives',
 		color: 'text-amber-800',
+		category: 'files',
+	},
+	{
+		id: 'path-tool',
+		title: 'Path Tool',
+		url: '/path-tool',
+		icon: SplitSquareHorizontal,
+		description: 'Parse paths and convert between Windows / POSIX / URL / shell-escaped formats',
+		color: 'text-amber-300',
 		category: 'files',
 	},
 	{

--- a/src/lib/services/path-tool.ts
+++ b/src/lib/services/path-tool.ts
@@ -1,0 +1,329 @@
+/**
+ * Pure helpers for the Path Tool route.
+ *
+ * Parses filesystem paths and converts between POSIX, Windows, and URL
+ * representations. All functions are framework-agnostic so they can be
+ * unit tested without DOM or Tauri dependencies.
+ *
+ * Style detection precedence:
+ *   1. `file://` prefix              -> 'url'
+ *   2. Backslash present              -> 'windows'
+ *   3. Drive prefix (`C:`) present    -> 'windows'
+ *   4. UNC prefix (`\\\\server`)      -> 'windows'
+ *   5. Otherwise                      -> 'posix'
+ */
+
+export type PathStyle = 'posix' | 'windows' | 'url';
+
+export interface ParsedPath {
+	readonly root: string;
+	readonly dir: string;
+	readonly base: string;
+	readonly name: string;
+	readonly ext: string;
+	readonly segments: readonly string[];
+	readonly isAbsolute: boolean;
+	readonly style: PathStyle;
+}
+
+const FILE_URL_PREFIX = 'file://';
+const WINDOWS_DRIVE_RE = /^[A-Za-z]:/;
+const WINDOWS_UNC_RE = /^\\\\[^\\]+/;
+
+/**
+ * Detect the style of the given path string by inspecting prefix and
+ * separator hints. Falls back to POSIX for plain paths.
+ */
+export const detectStyle = (input: string): PathStyle => {
+	if (input.startsWith(FILE_URL_PREFIX)) return 'url';
+	if (WINDOWS_UNC_RE.test(input)) return 'windows';
+	if (input.includes('\\')) return 'windows';
+	if (WINDOWS_DRIVE_RE.test(input)) return 'windows';
+	return 'posix';
+};
+
+/**
+ * Return the POSIX representation of `input`. Converts backslashes to
+ * forward slashes; for a `file://` URL, percent-decodes the path
+ * portion. Drive letters (`C:`) are preserved as the leading segment.
+ */
+export const toPosix = (input: string): string => {
+	if (input.startsWith(FILE_URL_PREFIX)) return fromFileUrl(input);
+	return input.replaceAll('\\', '/');
+};
+
+/**
+ * Return the Windows representation of `input`. Converts forward
+ * slashes to backslashes; for a `file://` URL, percent-decodes first
+ * and then converts.
+ */
+export const toWindows = (input: string): string => {
+	const source = input.startsWith(FILE_URL_PREFIX) ? fromFileUrl(input) : input;
+	return source.replaceAll('/', '\\');
+};
+
+/**
+ * Build a `file://` URL from a path. Drive letters become the
+ * authority-less form `file:///C:/...`. UNC paths become
+ * `file://server/share/...`. Path segments are percent-encoded except
+ * for forward slashes.
+ */
+export const toFileUrl = (input: string): string => {
+	if (input.startsWith(FILE_URL_PREFIX)) return input;
+	const posix = toPosix(input).trimEnd();
+	if (WINDOWS_UNC_RE.test(input)) {
+		// UNC `\\server\share\path` becomes `file://server/share/path`.
+		const stripped = posix.replace(/^\/\//, '');
+		return `file://${encodePathPreservingSlashes(stripped)}`;
+	}
+	if (WINDOWS_DRIVE_RE.test(posix)) {
+		return `file:///${encodePathPreservingSlashes(posix)}`;
+	}
+	const withSlash = posix.startsWith('/') ? posix : `/${posix}`;
+	return `file://${encodePathPreservingSlashes(withSlash)}`;
+};
+
+/**
+ * Decode a `file://` URL back to a plain filesystem path. The result
+ * uses forward slashes regardless of platform.
+ */
+export const fromFileUrl = (input: string): string => {
+	if (!input.startsWith(FILE_URL_PREFIX)) return input;
+	const rest = input.slice(FILE_URL_PREFIX.length);
+	// `file:///C:/path` -> strip the leading slash so the drive prefix
+	// becomes the head; `file://server/share` keeps `server/share`.
+	if (rest.startsWith('/') && WINDOWS_DRIVE_RE.test(rest.slice(1))) {
+		return safeDecode(rest.slice(1));
+	}
+	return safeDecode(rest);
+};
+
+/**
+ * Percent-encode the path, preserving forward slashes so segment
+ * boundaries remain visible.
+ */
+export const urlEncodePath = (input: string): string => {
+	const posix = toPosix(input);
+	return encodePathPreservingSlashes(posix);
+};
+
+/**
+ * Quote `input` for use as a single argument in a POSIX shell (bash,
+ * zsh). Uses single-quote wrapping; an embedded single quote becomes
+ * the safe sequence `'\''`. Empty input becomes `''`.
+ */
+export const shellEscapeBash = (input: string): string => {
+	if (input.length === 0) return "''";
+	if (/^[A-Za-z0-9_./-]+$/.test(input)) return input;
+	return `'${input.replaceAll("'", "'\\''")}'`;
+};
+
+/**
+ * Quote `input` for use as a single argument in PowerShell. Wraps in
+ * single quotes; embedded single quotes are doubled (PowerShell's
+ * single-quoted strings do not interpret backslashes).
+ */
+export const shellEscapePowershell = (input: string): string => {
+	if (input.length === 0) return "''";
+	return `'${input.replaceAll("'", "''")}'`;
+};
+
+/**
+ * Parse a path into its components. Detects the style automatically
+ * unless an explicit one would be useful; that overload is omitted to
+ * keep the public surface minimal.
+ */
+export const parsePath = (input: string): ParsedPath => {
+	const style = detectStyle(input);
+	const source = style === 'url' ? fromFileUrl(input) : input;
+	const sep = style === 'windows' ? '\\' : '/';
+	const normalized = style === 'windows' ? source.replaceAll('/', '\\') : source;
+
+	const root = extractRoot(normalized, style);
+	const withoutRoot = normalized.slice(root.length);
+	const segments = withoutRoot.split(sep).filter((s) => s.length > 0);
+	const base = segments.length > 0 ? (segments[segments.length - 1] ?? '') : '';
+	const dirSegments = segments.slice(0, -1);
+	const dir = root + dirSegments.join(sep);
+	const dotIdx = base.lastIndexOf('.');
+	// A leading dot (`.gitignore`) is treated as part of the name, not
+	// an extension. Multiple dots use the last one as the extension
+	// boundary, matching Node.js `path.parse` behaviour.
+	const hasExt = dotIdx > 0 && dotIdx < base.length - 1;
+	const name = hasExt ? base.slice(0, dotIdx) : base;
+	const ext = hasExt ? base.slice(dotIdx) : '';
+	const isAbsolute = root.length > 0;
+
+	return {
+		root,
+		dir: dir || (isAbsolute ? root : ''),
+		base,
+		name,
+		ext,
+		segments,
+		isAbsolute,
+		style,
+	};
+};
+
+/**
+ * Reduce raw segments by collapsing `.` and resolving `..` against the
+ * accumulated stack. `..` only pops a real segment; against an absolute
+ * root it is discarded, otherwise it accumulates so relative paths can
+ * walk above their starting point.
+ */
+const collapseSegments = (segments: readonly string[], hasRoot: boolean): readonly string[] =>
+	segments.reduce<string[]>((stack, seg) => {
+		if (seg === '.') return stack;
+		if (seg !== '..') {
+			stack.push(seg);
+			return stack;
+		}
+		const top = stack[stack.length - 1];
+		if (top !== undefined && top !== '..') {
+			stack.pop();
+			return stack;
+		}
+		if (hasRoot) return stack;
+		stack.push('..');
+		return stack;
+	}, []);
+
+/**
+ * Collapse `.` and `..` segments, deduplicate separators, and return
+ * the canonical form in the requested style.
+ */
+export const normalize = (input: string, style: PathStyle): string => {
+	const source = style === 'url' ? fromFileUrl(input) : input;
+	const sep = style === 'windows' ? '\\' : '/';
+	const unified = style === 'windows' ? source.replaceAll('/', '\\') : source.replaceAll('\\', '/');
+	const root = extractRoot(unified, style === 'url' ? 'posix' : style);
+	const body = unified.slice(root.length);
+	const rawSegments = body.split(sep).filter((s) => s.length > 0);
+	const stack = collapseSegments(rawSegments, root.length > 0);
+	const joined = stack.join(sep);
+	const result = root + joined;
+	if (style === 'url') return toFileUrl(result || '/');
+	if (result.length === 0) return root.length > 0 ? root : '.';
+	return result;
+};
+
+/**
+ * Resolve `input` against `base`. If `input` is already absolute it is
+ * returned (normalized) unchanged. Otherwise the two are joined and
+ * normalized.
+ */
+export const absolutize = (input: string, base: string, style: PathStyle): string => {
+	if (input.length === 0) return normalize(base, style);
+	const sep = style === 'windows' ? '\\' : '/';
+	const inputStyle = detectStyle(input);
+	const isInputAbsolute = parsePath(input).isAbsolute;
+	if (isInputAbsolute) {
+		const converted =
+			style === 'posix' && inputStyle === 'windows'
+				? toPosix(input)
+				: style === 'windows' && inputStyle === 'posix'
+					? toWindows(input)
+					: input;
+		return normalize(converted, style);
+	}
+	const baseNorm = normalize(base, style);
+	const joiner = baseNorm.endsWith(sep) ? '' : sep;
+	const inputUnified =
+		style === 'windows' ? input.replaceAll('/', '\\') : input.replaceAll('\\', '/');
+	return normalize(`${baseNorm}${joiner}${inputUnified}`, style);
+};
+
+/**
+ * Express `target` as a path relative to `base`. Both arguments are
+ * absolutised first so callers can pass either form.
+ *
+ * The result uses the requested `style`. When the two paths share no
+ * common root (different drive letters, UNC vs local), the absolute
+ * `target` is returned unchanged.
+ */
+export const relativize = (target: string, base: string, style: PathStyle): string => {
+	const sep = style === 'windows' ? '\\' : '/';
+	const absTarget = absolutize(target, base, style);
+	const absBase = absolutize(base, base, style);
+	const targetParsed = parsePath(absTarget);
+	const baseParsed = parsePath(absBase);
+	if (targetParsed.root.toLowerCase() !== baseParsed.root.toLowerCase()) {
+		return absTarget;
+	}
+	const targetSegs = targetParsed.segments;
+	const baseSegs = baseParsed.segments;
+	let common = 0;
+	const maxCommon = Math.min(targetSegs.length, baseSegs.length);
+	while (common < maxCommon && segmentEquals(targetSegs[common], baseSegs[common], style)) {
+		common += 1;
+	}
+	const up = baseSegs.length - common;
+	const down = targetSegs.slice(common);
+	const parts = [...Array.from({ length: up }, () => '..'), ...down];
+	if (parts.length === 0) return '.';
+	return parts.join(sep);
+};
+
+// --- internal helpers ---------------------------------------------------
+
+const safeDecode = (input: string): string => {
+	try {
+		return decodeURIComponent(input);
+	} catch {
+		return input;
+	}
+};
+
+const encodePathPreservingSlashes = (input: string): string =>
+	input
+		.split('/')
+		.map((seg) =>
+			encodeURIComponent(seg)
+				// Restore characters that are safe inside a path segment
+				// but get over-encoded by `encodeURIComponent`.
+				.replaceAll('%3A', ':')
+				.replaceAll('%40', '@')
+				.replaceAll('%2C', ',')
+				.replaceAll('%3B', ';')
+				.replaceAll('%26', '&')
+				.replaceAll('%3D', '=')
+				.replaceAll('%2B', '+')
+				.replaceAll('%24', '$')
+				.replaceAll("'", '%27')
+		)
+		.join('/');
+
+const extractRoot = (input: string, style: PathStyle): string => {
+	if (style === 'windows') {
+		const uncMatch = input.match(/^\\\\[^\\]+\\[^\\]+\\?/);
+		if (uncMatch) return uncMatch[0];
+		const driveMatch = input.match(/^([A-Za-z]):[\\]?/);
+		if (driveMatch) return driveMatch[0];
+		if (input.startsWith('\\')) return '\\';
+		return '';
+	}
+	if (style === 'url') {
+		return input.startsWith('/') ? '/' : '';
+	}
+	return input.startsWith('/') ? '/' : '';
+};
+
+const segmentEquals = (a: string | undefined, b: string | undefined, style: PathStyle): boolean => {
+	if (a === undefined || b === undefined) return false;
+	// Windows file systems are case-insensitive in practice; relativize
+	// against differing-case segments should still find the common
+	// prefix.
+	return style === 'windows' ? a.toLowerCase() === b.toLowerCase() : a === b;
+};
+
+/**
+ * Sample paths for the rail's "load sample" buttons. Each entry covers
+ * a distinct style so the user can quickly experiment with conversion.
+ */
+export const SAMPLE_PATHS: Readonly<Record<'windows' | 'unix' | 'url' | 'unc', string>> = {
+	windows: 'C:\\Users\\Alice\\Documents\\report final.txt',
+	unix: '/home/alice/Documents/report final.txt',
+	url: 'file:///home/alice/Documents/report%20final.txt',
+	unc: '\\\\server\\share\\folder\\file.txt',
+};

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -27,6 +27,7 @@ import { Route as RsaToolsRouteImport } from './routes/rsa-tools';
 import { Route as RestClientRouteImport } from './routes/rest-client';
 import { Route as RegexTesterRouteImport } from './routes/regex-tester';
 import { Route as QrCodeGeneratorRouteImport } from './routes/qr-code-generator';
+import { Route as PathToolRouteImport } from './routes/path-tool';
 import { Route as PasswordGeneratorRouteImport } from './routes/password-generator';
 import { Route as NumberBaseConverterRouteImport } from './routes/number-base-converter';
 import { Route as NetworkScannerRouteImport } from './routes/network-scanner';
@@ -145,6 +146,11 @@ const RegexTesterRoute = RegexTesterRouteImport.update({
 const QrCodeGeneratorRoute = QrCodeGeneratorRouteImport.update({
 	id: '/qr-code-generator',
 	path: '/qr-code-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
+const PathToolRoute = PathToolRouteImport.update({
+	id: '/path-tool',
+	path: '/path-tool',
 	getParentRoute: () => rootRouteImport,
 } as any);
 const PasswordGeneratorRoute = PasswordGeneratorRouteImport.update({
@@ -323,6 +329,7 @@ export interface FileRoutesByFullPath {
 	'/network-scanner': typeof NetworkScannerRoute;
 	'/number-base-converter': typeof NumberBaseConverterRoute;
 	'/password-generator': typeof PasswordGeneratorRoute;
+	'/path-tool': typeof PathToolRoute;
 	'/qr-code-generator': typeof QrCodeGeneratorRoute;
 	'/regex-tester': typeof RegexTesterRoute;
 	'/rest-client': typeof RestClientRoute;
@@ -372,6 +379,7 @@ export interface FileRoutesByTo {
 	'/network-scanner': typeof NetworkScannerRoute;
 	'/number-base-converter': typeof NumberBaseConverterRoute;
 	'/password-generator': typeof PasswordGeneratorRoute;
+	'/path-tool': typeof PathToolRoute;
 	'/qr-code-generator': typeof QrCodeGeneratorRoute;
 	'/regex-tester': typeof RegexTesterRoute;
 	'/rest-client': typeof RestClientRoute;
@@ -422,6 +430,7 @@ export interface FileRoutesById {
 	'/network-scanner': typeof NetworkScannerRoute;
 	'/number-base-converter': typeof NumberBaseConverterRoute;
 	'/password-generator': typeof PasswordGeneratorRoute;
+	'/path-tool': typeof PathToolRoute;
 	'/qr-code-generator': typeof QrCodeGeneratorRoute;
 	'/regex-tester': typeof RegexTesterRoute;
 	'/rest-client': typeof RestClientRoute;
@@ -473,6 +482,7 @@ export interface FileRouteTypes {
 		| '/network-scanner'
 		| '/number-base-converter'
 		| '/password-generator'
+		| '/path-tool'
 		| '/qr-code-generator'
 		| '/regex-tester'
 		| '/rest-client'
@@ -522,6 +532,7 @@ export interface FileRouteTypes {
 		| '/network-scanner'
 		| '/number-base-converter'
 		| '/password-generator'
+		| '/path-tool'
 		| '/qr-code-generator'
 		| '/regex-tester'
 		| '/rest-client'
@@ -571,6 +582,7 @@ export interface FileRouteTypes {
 		| '/network-scanner'
 		| '/number-base-converter'
 		| '/password-generator'
+		| '/path-tool'
 		| '/qr-code-generator'
 		| '/regex-tester'
 		| '/rest-client'
@@ -621,6 +633,7 @@ export interface RootRouteChildren {
 	NetworkScannerRoute: typeof NetworkScannerRoute;
 	NumberBaseConverterRoute: typeof NumberBaseConverterRoute;
 	PasswordGeneratorRoute: typeof PasswordGeneratorRoute;
+	PathToolRoute: typeof PathToolRoute;
 	QrCodeGeneratorRoute: typeof QrCodeGeneratorRoute;
 	RegexTesterRoute: typeof RegexTesterRoute;
 	RestClientRoute: typeof RestClientRoute;
@@ -767,6 +780,13 @@ declare module '@tanstack/react-router' {
 			path: '/qr-code-generator';
 			fullPath: '/qr-code-generator';
 			preLoaderRoute: typeof QrCodeGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/path-tool': {
+			id: '/path-tool';
+			path: '/path-tool';
+			fullPath: '/path-tool';
+			preLoaderRoute: typeof PathToolRouteImport;
 			parentRoute: typeof rootRouteImport;
 		};
 		'/password-generator': {
@@ -1005,6 +1025,7 @@ const rootRouteChildren: RootRouteChildren = {
 	NetworkScannerRoute: NetworkScannerRoute,
 	NumberBaseConverterRoute: NumberBaseConverterRoute,
 	PasswordGeneratorRoute: PasswordGeneratorRoute,
+	PathToolRoute: PathToolRoute,
 	QrCodeGeneratorRoute: QrCodeGeneratorRoute,
 	RegexTesterRoute: RegexTesterRoute,
 	RestClientRoute: RestClientRoute,

--- a/src/routes/path-tool.tsx
+++ b/src/routes/path-tool.tsx
@@ -1,0 +1,551 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { open as openDialog } from '@tauri-apps/plugin-dialog';
+import {
+	ClipboardPaste,
+	FilePlus2,
+	FolderOpen,
+	Sparkles,
+	SplitSquareHorizontal,
+	Terminal,
+	Trash2,
+} from 'lucide-react';
+import { useCallback, useMemo, useState, type DragEvent } from 'react';
+import { toast } from 'sonner';
+
+import { CopyButton } from '@/lib/components/action';
+import {
+	FormCheckbox,
+	FormCheckboxGroup,
+	FormInfo,
+	FormInput,
+	FormSection,
+} from '@/lib/components/form';
+import { RelatedTools, SectionLabel } from '@/lib/components/layout';
+import { ToolShell } from '@/lib/components/shell';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { Badge } from '@/lib/components/ui/badge';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { useDocumentTitle } from '@/lib/hooks';
+import {
+	absolutize,
+	fromFileUrl,
+	normalize,
+	parsePath,
+	relativize,
+	SAMPLE_PATHS,
+	shellEscapeBash,
+	shellEscapePowershell,
+	toFileUrl,
+	toPosix,
+	toWindows,
+	urlEncodePath,
+	type ParsedPath,
+	type PathStyle,
+} from '@/lib/services/path-tool';
+import { createToolOptionsStore } from '@/lib/stores';
+import { cn } from '@/lib/utils';
+
+interface PathToolPrefs {
+	readonly basePath: string;
+	readonly applyNormalize: boolean;
+	readonly applyLowercase: boolean;
+}
+
+const DEFAULT_PREFS: PathToolPrefs = {
+	basePath: '',
+	applyNormalize: false,
+	applyLowercase: false,
+};
+
+const usePathToolPrefs = createToolOptionsStore<PathToolPrefs>('path-tool', DEFAULT_PREFS);
+
+export const Route = createFileRoute('/path-tool')({
+	component: PathToolPage,
+});
+
+function PathToolPage() {
+	useDocumentTitle('Path Tool');
+
+	const { value: prefs, patch } = usePathToolPrefs();
+
+	const [input, setInput] = useState('');
+	const [isDragOver, setIsDragOver] = useState(false);
+	const [showRail, setShowRail] = useState(true);
+
+	const transformedInput = useMemo(() => {
+		let working = input;
+		if (prefs.applyLowercase) working = working.toLowerCase();
+		return working;
+	}, [input, prefs.applyLowercase]);
+
+	const parsed: ParsedPath | null = useMemo(() => {
+		if (transformedInput.length === 0) return null;
+		return parsePath(transformedInput);
+	}, [transformedInput]);
+
+	// Apply normalization at display time so the equivalents card always
+	// reflects what the user sees in the Parsed card. When no input has
+	// been entered yet, downstream cards render their empty state.
+	const styleForOps: PathStyle = parsed?.style ?? 'posix';
+	const normalizedSource = useMemo(() => {
+		if (!parsed) return '';
+		return prefs.applyNormalize ? normalize(transformedInput, styleForOps) : transformedInput;
+	}, [parsed, prefs.applyNormalize, styleForOps, transformedInput]);
+
+	const equivalents = useMemo(() => {
+		if (!parsed) return null;
+		const posix = toPosix(normalizedSource);
+		const windows = toWindows(normalizedSource);
+		const fileUrl = toFileUrl(normalizedSource);
+		return {
+			posix,
+			windows,
+			fileUrl,
+			urlEncoded: urlEncodePath(normalizedSource),
+			bash: shellEscapeBash(posix),
+			powershell: shellEscapePowershell(windows),
+		};
+	}, [normalizedSource, parsed]);
+
+	const operations = useMemo(() => {
+		if (!parsed) return null;
+		const base = prefs.basePath.trim();
+		const baseStyle: PathStyle = base.length > 0 ? parsePath(base).style : styleForOps;
+		// When the user has supplied a base path, absolutize / relativize
+		// follow that path's style so the result reads natively (POSIX or
+		// Windows). The normalize result stays in the input's own style.
+		const targetStyle: PathStyle = base.length > 0 ? baseStyle : styleForOps;
+		return {
+			normalized: normalize(normalizedSource, styleForOps),
+			absolutized: base.length > 0 ? absolutize(normalizedSource, base, targetStyle) : null,
+			relativized: base.length > 0 ? relativize(normalizedSource, base, targetStyle) : null,
+		};
+	}, [parsed, prefs.basePath, normalizedSource, styleForOps]);
+
+	const handleLoadSample = useCallback(
+		(key: keyof typeof SAMPLE_PATHS) => {
+			setInput(SAMPLE_PATHS[key]);
+		},
+		[setInput]
+	);
+
+	const handlePaste = useCallback(async () => {
+		try {
+			const text = await navigator.clipboard.readText();
+			if (text.length > 0) setInput(text);
+		} catch (e) {
+			const message = e instanceof Error ? e.message : String(e);
+			toast.error('Failed to read clipboard', { description: message });
+		}
+	}, []);
+
+	const handlePickFile = useCallback(async () => {
+		try {
+			const selected = await openDialog({ multiple: false, directory: false });
+			if (typeof selected === 'string' && selected.length > 0) setInput(selected);
+		} catch (e) {
+			const message = e instanceof Error ? e.message : String(e);
+			toast.error('Failed to open file dialog', { description: message });
+		}
+	}, []);
+
+	const handlePickFolder = useCallback(async () => {
+		try {
+			const selected = await openDialog({ multiple: false, directory: true });
+			if (typeof selected === 'string' && selected.length > 0) setInput(selected);
+		} catch (e) {
+			const message = e instanceof Error ? e.message : String(e);
+			toast.error('Failed to open folder dialog', { description: message });
+		}
+	}, []);
+
+	const handleClear = useCallback(() => {
+		setInput('');
+	}, []);
+
+	const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		setIsDragOver(false);
+		const file = e.dataTransfer.files[0] as (File & { readonly path?: string }) | undefined;
+		if (!file) return;
+		if (file.path) {
+			setInput(file.path);
+			return;
+		}
+		// Browser-only fallback: relative `name` is the best we can do
+		// when the webview does not expose the absolute path.
+		setInput(file.name);
+	};
+	const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		setIsDragOver(true);
+	};
+	const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		setIsDragOver(false);
+	};
+
+	const hasInput = input.length > 0;
+	const valid = hasInput ? parsed !== null : null;
+
+	return (
+		<ToolShell
+			showRail={showRail}
+			onShowRailChange={setShowRail}
+			valid={valid}
+			statusContent={
+				parsed ? (
+					<>
+						<StatItem label="Style" value={parsed.style.toUpperCase()} />
+						<StatItem label="Kind" value={parsed.isAbsolute ? 'Absolute' : 'Relative'} />
+						<StatItem label="Segments" value={parsed.segments.length} />
+					</>
+				) : null
+			}
+			rail={
+				<>
+					<FormSection title="Input">
+						<div className="flex flex-col gap-2">
+							<Button variant="default" size="sm" onClick={handlePaste}>
+								<ClipboardPaste className="h-3.5 w-3.5" />
+								Paste from clipboard
+							</Button>
+							<Button variant="outline" size="sm" onClick={handlePickFile}>
+								<FilePlus2 className="h-3.5 w-3.5" />
+								Open file…
+							</Button>
+							<Button variant="outline" size="sm" onClick={handlePickFolder}>
+								<FolderOpen className="h-3.5 w-3.5" />
+								Open folder…
+							</Button>
+							<div className="grid grid-cols-2 gap-2 pt-1">
+								<Button variant="ghost" size="sm" onClick={() => handleLoadSample('windows')}>
+									<Sparkles className="h-3 w-3" />
+									Windows
+								</Button>
+								<Button variant="ghost" size="sm" onClick={() => handleLoadSample('unix')}>
+									<Sparkles className="h-3 w-3" />
+									Unix
+								</Button>
+								<Button variant="ghost" size="sm" onClick={() => handleLoadSample('url')}>
+									<Sparkles className="h-3 w-3" />
+									URL
+								</Button>
+								<Button variant="ghost" size="sm" onClick={() => handleLoadSample('unc')}>
+									<Sparkles className="h-3 w-3" />
+									UNC
+								</Button>
+							</div>
+							{hasInput ? (
+								<Button variant="outline" size="sm" onClick={handleClear}>
+									<Trash2 className="h-3.5 w-3.5" />
+									Clear
+								</Button>
+							) : null}
+						</div>
+					</FormSection>
+
+					<FormSection title="Base path">
+						<FormInput
+							label="Base for absolutize / relativize"
+							value={prefs.basePath}
+							placeholder="/home/alice or C:\\Users\\Alice"
+							size="compact"
+							onValueChange={(v) => patch({ basePath: v })}
+						/>
+					</FormSection>
+
+					<FormSection title="Operations">
+						<FormCheckboxGroup>
+							<FormCheckbox
+								label="Normalize (collapse . / ..)"
+								checked={prefs.applyNormalize}
+								onCheckedChange={(checked) => patch({ applyNormalize: checked === true })}
+								size="compact"
+							/>
+							<FormCheckbox
+								label="Lowercase input"
+								checked={prefs.applyLowercase}
+								onCheckedChange={(checked) => patch({ applyLowercase: checked === true })}
+								size="compact"
+							/>
+						</FormCheckboxGroup>
+					</FormSection>
+
+					<FormSection title="Related">
+						<RelatedTools
+							items={[
+								{ id: 'file-inspector', reason: 'Inspect file metadata for this path' },
+								{ id: 'url-encoder', reason: 'Encode / decode generic URLs' },
+								{ id: 'escape-tool', reason: 'Escape strings for shells and code' },
+							]}
+						/>
+					</FormSection>
+
+					<FormSection title="About">
+						<FormInfo>
+							Pure local parsing. Detection inspects the prefix and separator hints. URL form uses
+							RFC 8089 (`file://`) with percent-encoded segments. Shell escapes target bash /
+							zsh-compatible POSIX shells and PowerShell single-quoted strings.
+						</FormInfo>
+					</FormSection>
+				</>
+			}
+		>
+			<MainArea
+				input={input}
+				onInputChange={setInput}
+				isDragOver={isDragOver}
+				onDrop={handleDrop}
+				onDragOver={handleDragOver}
+				onDragLeave={handleDragLeave}
+				parsed={parsed}
+				normalizedSource={normalizedSource}
+				equivalents={equivalents}
+				operations={operations}
+				basePath={prefs.basePath}
+			/>
+		</ToolShell>
+	);
+}
+
+interface Equivalents {
+	readonly posix: string;
+	readonly windows: string;
+	readonly fileUrl: string;
+	readonly urlEncoded: string;
+	readonly bash: string;
+	readonly powershell: string;
+}
+
+interface Operations {
+	readonly normalized: string;
+	readonly absolutized: string | null;
+	readonly relativized: string | null;
+}
+
+interface MainAreaProps {
+	readonly input: string;
+	readonly onInputChange: (value: string) => void;
+	readonly isDragOver: boolean;
+	readonly onDrop: (e: DragEvent<HTMLDivElement>) => void;
+	readonly onDragOver: (e: DragEvent<HTMLDivElement>) => void;
+	readonly onDragLeave: (e: DragEvent<HTMLDivElement>) => void;
+	readonly parsed: ParsedPath | null;
+	readonly normalizedSource: string;
+	readonly equivalents: Equivalents | null;
+	readonly operations: Operations | null;
+	readonly basePath: string;
+}
+
+function MainArea({
+	input,
+	onInputChange,
+	isDragOver,
+	onDrop,
+	onDragOver,
+	onDragLeave,
+	parsed,
+	normalizedSource,
+	equivalents,
+	operations,
+	basePath,
+}: MainAreaProps) {
+	return (
+		<div className="flex h-full flex-col overflow-hidden">
+			<div className="flex shrink-0 items-center gap-2 border-b bg-surface-2 px-4 py-3">
+				<label htmlFor="path-input" className="sr-only">
+					Path input
+				</label>
+				<input
+					id="path-input"
+					type="text"
+					value={input}
+					onChange={(e) => onInputChange(e.target.value)}
+					placeholder="Paste, drop, or open a path…"
+					className={cn(
+						'h-9 min-w-0 flex-1 rounded-md border bg-background px-3 font-mono text-sm transition-colors',
+						'placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+					)}
+				/>
+				{input.length > 0 ? <CopyButton text={input} toastLabel="Input path" size="sm" /> : null}
+			</div>
+
+			<section
+				aria-label="Path drop zone"
+				onDrop={onDrop}
+				onDragOver={onDragOver}
+				onDragLeave={onDragLeave}
+				className={cn('flex-1 overflow-auto transition-colors', isDragOver && 'bg-primary/5')}
+			>
+				{parsed && equivalents && operations ? (
+					<div className="grid grid-cols-1 gap-3 p-4 xl:grid-cols-2">
+						<ParsedCard parsed={parsed} />
+						<OperationsCard operations={operations} basePath={basePath} />
+						<EquivalentsCard equivalents={equivalents} normalizedSource={normalizedSource} />
+					</div>
+				) : (
+					<DropZone isDragOver={isDragOver} />
+				)}
+			</section>
+		</div>
+	);
+}
+
+function DropZone({ isDragOver }: { readonly isDragOver: boolean }) {
+	return (
+		<div className="flex h-full items-center justify-center p-6">
+			<div
+				className={cn(
+					'flex w-full max-w-xl flex-col items-center gap-4 rounded-xl border-2 border-dashed p-10 text-center transition-colors',
+					isDragOver ? 'border-primary bg-primary/10' : 'border-border'
+				)}
+			>
+				<EmbeddedEmptyState
+					icon={SplitSquareHorizontal}
+					title="Drop, paste, or open a path"
+					description="The path appears parsed into components, converted between styles, and shell-escaped."
+				/>
+			</div>
+		</div>
+	);
+}
+
+// Carry a running offset into each segment so React keys reflect both
+// position and content, avoiding the array-index anti-pattern.
+const keySegments = (
+	segments: readonly string[]
+): readonly { readonly key: string; readonly value: string }[] => {
+	let offset = 0;
+	return segments.map((value) => {
+		const key = `${offset}:${value}`;
+		offset += value.length + 1;
+		return { key, value };
+	});
+};
+
+function ParsedCard({ parsed }: { readonly parsed: ParsedPath }) {
+	return (
+		<Card density="compact">
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2 text-sm">
+					<SplitSquareHorizontal className="h-4 w-4 text-muted-foreground" />
+					Parsed components
+				</CardTitle>
+			</CardHeader>
+			<CardContent className="space-y-1.5">
+				<FieldRow label="Style" value={parsed.style.toUpperCase()} />
+				<FieldRow label="Kind" value={parsed.isAbsolute ? 'Absolute' : 'Relative'} />
+				<FieldRow label="Root" value={parsed.root || '(none)'} mono />
+				<FieldRow label="Directory" value={parsed.dir || '(none)'} mono copyable />
+				<FieldRow label="Base" value={parsed.base || '(none)'} mono copyable />
+				<FieldRow label="Name" value={parsed.name || '(none)'} mono />
+				<FieldRow label="Extension" value={parsed.ext || '(none)'} mono />
+				{parsed.segments.length > 0 ? (
+					<div className="pt-1">
+						<SectionLabel>Segments ({parsed.segments.length})</SectionLabel>
+						<div className="flex flex-wrap gap-1">
+							{keySegments(parsed.segments).map(({ key, value }) => (
+								<Badge key={key} variant="outline" className="font-mono text-2xs">
+									{value}
+								</Badge>
+							))}
+						</div>
+					</div>
+				) : null}
+			</CardContent>
+		</Card>
+	);
+}
+
+interface EquivalentsCardProps {
+	readonly equivalents: Equivalents;
+	readonly normalizedSource: string;
+}
+
+function EquivalentsCard({ equivalents, normalizedSource }: EquivalentsCardProps) {
+	const rows: readonly { readonly label: string; readonly value: string }[] = [
+		{ label: 'Source', value: normalizedSource },
+		{ label: 'POSIX', value: equivalents.posix },
+		{ label: 'Windows', value: equivalents.windows },
+		{ label: 'file:// URL', value: equivalents.fileUrl },
+		{ label: 'URL-encoded', value: equivalents.urlEncoded },
+		{ label: 'Bash escape', value: equivalents.bash },
+		{ label: 'PowerShell escape', value: equivalents.powershell },
+	];
+	return (
+		<Card density="compact">
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2 text-sm">
+					<Terminal className="h-4 w-4 text-muted-foreground" />
+					Equivalents
+				</CardTitle>
+			</CardHeader>
+			<CardContent className="space-y-1.5">
+				{rows.map((row) => (
+					<FieldRow key={row.label} label={row.label} value={row.value} mono copyable />
+				))}
+			</CardContent>
+		</Card>
+	);
+}
+
+interface OperationsCardProps {
+	readonly operations: Operations;
+	readonly basePath: string;
+}
+
+function OperationsCard({ operations, basePath }: OperationsCardProps) {
+	const baseShown = basePath.trim().length > 0;
+	return (
+		<Card density="compact">
+			<CardHeader>
+				<CardTitle className="text-sm">Operations</CardTitle>
+			</CardHeader>
+			<CardContent className="space-y-1.5">
+				<FieldRow label="Normalize" value={operations.normalized} mono copyable />
+				<FieldRow
+					label="Absolutize"
+					value={baseShown ? (operations.absolutized ?? '—') : 'Set a base path in the rail'}
+					mono
+					copyable={baseShown && operations.absolutized !== null}
+				/>
+				<FieldRow
+					label="Relativize"
+					value={baseShown ? (operations.relativized ?? '—') : 'Set a base path in the rail'}
+					mono
+					copyable={baseShown && operations.relativized !== null}
+				/>
+				{baseShown ? (
+					<div className="pt-1">
+						<SectionLabel>Base path</SectionLabel>
+						<FieldRow label="Base" value={basePath} mono />
+						<FieldRow
+							label="Decoded"
+							value={basePath.startsWith('file://') ? fromFileUrl(basePath) : basePath}
+							mono
+						/>
+					</div>
+				) : null}
+			</CardContent>
+		</Card>
+	);
+}
+
+interface FieldRowProps {
+	readonly label: string;
+	readonly value: string;
+	readonly mono?: boolean;
+	readonly copyable?: boolean;
+}
+
+function FieldRow({ label, value, mono = false, copyable = false }: FieldRowProps) {
+	return (
+		<div className="flex items-start gap-2 text-xs">
+			<span className="w-28 shrink-0 text-muted-foreground">{label}</span>
+			<span className={cn('min-w-0 flex-1 break-all', mono && 'font-mono')}>{value}</span>
+			{copyable ? <CopyButton text={value} toastLabel={label} size="sm" /> : null}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

- Add Path Tool under the Files category for parsing filesystem paths and converting between Windows, POSIX, `file://` URL, URL-encoded, Bash, and PowerShell shell-escaped representations.
- Provide pure functional services (style detection, parse, normalize, absolutize, relativize, shell escape) with no Tauri command dependency.
- Wire the route into the central page registry and the auto-generated route tree.

## Changes

### Added

- `src/lib/services/path-tool.ts` — pure path parsing and conversion helpers.
- `src/routes/path-tool.tsx` — `ToolShell`-based UI with `FormSection` rail, drop zone, parsed components, equivalents, and operations cards.

### Modified

- `src/lib/services/pages.ts` — register the new Path Tool page under the Files category.
- `src/route-tree.gen.ts` — regenerated route tree.

## Test plan

- [x] `bun run check` green (TypeScript, validate-pages, audit-design).
- [ ] Manual verification: paste, drop, and open file / folder; load each sample; toggle normalize and lowercase; verify operations card against a base path; confirm shell escapes.
