### PR TITLE
feat(test-data-generator): add Test Data File Generator under Files

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "kogu",
       "dependencies": {
+        "@faker-js/faker": "^10.4.0",
         "@fontsource-variable/geist": "^5.2.8",
         "@hpcc-js/wasm-graphviz": "^1.21.5",
         "@peculiar/x509": "^2.0.0",
@@ -284,6 +285,8 @@
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
 
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
+
+    "@faker-js/faker": ["@faker-js/faker@10.4.0", "", {}, "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 	},
 	"license": "MIT",
 	"dependencies": {
+		"@faker-js/faker": "^10.4.0",
 		"@fontsource-variable/geist": "^5.2.8",
 		"@hpcc-js/wasm-graphviz": "^1.21.5",
 		"@peculiar/x509": "^2.0.0",

--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -63,6 +63,7 @@ import {
 	Table,
 	Target,
 	Terminal,
+	TestTube,
 	TextQuote,
 	TrendingUp,
 } from 'lucide-react';
@@ -599,6 +600,15 @@ export const PAGES: readonly PageDefinition[] = [
 		icon: Languages,
 		description: 'Detect and convert text encoding (UTF-8/16, Shift-JIS, EUC-JP, GBK, ...)',
 		color: 'text-amber-700',
+		category: 'files',
+	},
+	{
+		id: 'test-data-generator',
+		title: 'Test Data Generator',
+		url: '/test-data-generator',
+		icon: TestTube,
+		description: 'Generate synthetic N×M datasets (CSV / TSV / JSON / SQL) with typed columns',
+		color: 'text-amber-500',
 		category: 'files',
 	},
 	{

--- a/src/lib/services/test-data.ts
+++ b/src/lib/services/test-data.ts
@@ -1,0 +1,743 @@
+/**
+ * Test data file generator.
+ *
+ * Produces synthetic tabular datasets from a column specification
+ * (type, options, nullable rate, uniqueness) at a chosen row count,
+ * then serializes them to CSV / TSV / JSON / NDJSON / SQL.
+ *
+ * Generation runs through a Mulberry32 PRNG seeded by the user so
+ * any (spec, seed) pair is reproducible. The locale-specific
+ * provider is reseeded on each call so name / address style follows
+ * the chosen locale deterministically.
+ */
+
+import { fakerDE, fakerEN, fakerES, fakerFR, fakerJA, type Faker } from '@faker-js/faker';
+
+export type ColumnType =
+	| 'integer'
+	| 'float'
+	| 'string'
+	| 'uuid'
+	| 'email'
+	| 'phone'
+	| 'url'
+	| 'date'
+	| 'datetime'
+	| 'boolean'
+	| 'lorem-words'
+	| 'lorem-sentences'
+	| 'pick-from-list'
+	| 'sequence'
+	| 'regex'
+	| 'first-name'
+	| 'last-name'
+	| 'full-name'
+	| 'company'
+	| 'city'
+	| 'country'
+	| 'street-address';
+
+export type Locale = 'en' | 'ja' | 'fr' | 'de' | 'es';
+export type OutputFormat = 'csv' | 'tsv' | 'json' | 'ndjson' | 'sql';
+
+export interface ColumnSpec {
+	/**
+	 * Stable identifier used by the builder UI as a React key so
+	 * reorder / rename operations do not remount form rows. The
+	 * value is opaque to the generator itself.
+	 */
+	readonly id: string;
+	readonly name: string;
+	readonly type: ColumnType;
+	readonly nullablePercent?: number;
+	readonly unique?: boolean;
+	readonly options?: Record<string, unknown>;
+}
+
+export interface DatasetSpec {
+	readonly columns: readonly ColumnSpec[];
+	readonly rowCount: number;
+	readonly locale: Locale;
+	readonly seed: number;
+}
+
+export const COLUMN_TYPES: readonly ColumnType[] = [
+	'integer',
+	'float',
+	'string',
+	'uuid',
+	'email',
+	'phone',
+	'url',
+	'date',
+	'datetime',
+	'boolean',
+	'lorem-words',
+	'lorem-sentences',
+	'pick-from-list',
+	'sequence',
+	'regex',
+	'first-name',
+	'last-name',
+	'full-name',
+	'company',
+	'city',
+	'country',
+	'street-address',
+];
+
+export const COLUMN_TYPE_LABELS: Readonly<Record<ColumnType, string>> = {
+	integer: 'Integer',
+	float: 'Float',
+	string: 'String',
+	uuid: 'UUID',
+	email: 'Email',
+	phone: 'Phone',
+	url: 'URL',
+	date: 'Date',
+	datetime: 'Date / Time',
+	boolean: 'Boolean',
+	'lorem-words': 'Lorem words',
+	'lorem-sentences': 'Lorem sentences',
+	'pick-from-list': 'Pick from list',
+	sequence: 'Sequence',
+	regex: 'Regex pattern',
+	'first-name': 'First name',
+	'last-name': 'Last name',
+	'full-name': 'Full name',
+	company: 'Company',
+	city: 'City',
+	country: 'Country',
+	'street-address': 'Street address',
+};
+
+export const LOCALES: readonly Locale[] = ['en', 'ja', 'fr', 'de', 'es'];
+
+export const LOCALE_LABELS: Readonly<Record<Locale, string>> = {
+	en: 'English',
+	ja: '日本語',
+	fr: 'Français',
+	de: 'Deutsch',
+	es: 'Español',
+};
+
+export const OUTPUT_FORMATS: readonly OutputFormat[] = ['csv', 'tsv', 'json', 'ndjson', 'sql'];
+
+export const OUTPUT_FORMAT_LABELS: Readonly<Record<OutputFormat, string>> = {
+	csv: 'CSV (comma separated)',
+	tsv: 'TSV (tab separated)',
+	json: 'JSON (array of objects)',
+	ndjson: 'NDJSON (line-delimited)',
+	sql: 'SQL INSERT statements',
+};
+
+export const OUTPUT_FORMAT_EXTENSIONS: Readonly<Record<OutputFormat, string>> = {
+	csv: 'csv',
+	tsv: 'tsv',
+	json: 'json',
+	ndjson: 'ndjson',
+	sql: 'sql',
+};
+
+export const isColumnType = (value: string): value is ColumnType =>
+	COLUMN_TYPES.includes(value as ColumnType);
+export const isLocale = (value: string): value is Locale => LOCALES.includes(value as Locale);
+export const isOutputFormat = (value: string): value is OutputFormat =>
+	OUTPUT_FORMATS.includes(value as OutputFormat);
+
+export const ROW_COUNT_MIN = 1;
+export const ROW_COUNT_MAX = 100_000;
+
+/**
+ * Default options for newly added columns, keyed by type so the UI
+ * can hydrate sensible defaults without each call site duplicating
+ * the same literals.
+ */
+export const DEFAULT_COLUMN_OPTIONS: Readonly<Record<ColumnType, Record<string, unknown>>> = {
+	integer: { min: 1, max: 1000 },
+	float: { min: 0, max: 1, decimals: 2 },
+	string: { length: 12 },
+	uuid: {},
+	email: {},
+	phone: {},
+	url: {},
+	date: { format: 'YYYY-MM-DD', yearsBack: 5 },
+	datetime: { format: 'ISO', yearsBack: 5 },
+	boolean: {},
+	'lorem-words': { count: 4 },
+	'lorem-sentences': { count: 1 },
+	'pick-from-list': { values: 'red, green, blue' },
+	sequence: { start: 1, step: 1 },
+	regex: { pattern: '[A-Z]{2}-[0-9]{4}' },
+	'first-name': {},
+	'last-name': {},
+	'full-name': {},
+	company: {},
+	city: {},
+	country: {},
+	'street-address': {},
+};
+
+/**
+ * Generate a stable column identifier. Uses `crypto.randomUUID` when
+ * available (all supported browsers + Tauri WebView) and falls back
+ * to a counter for the rare environment without it (test setups,
+ * old Safari) so the persisted store does not crash at boot.
+ */
+let columnIdCounter = 0;
+export const createColumnId = (): string => {
+	if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+		return crypto.randomUUID();
+	}
+	columnIdCounter += 1;
+	return `col-${Date.now().toString(36)}-${columnIdCounter}`;
+};
+
+export const SAMPLE_SPEC: DatasetSpec = {
+	columns: [
+		{
+			id: 'sample-id',
+			name: 'id',
+			type: 'sequence',
+			options: { start: 1, step: 1 },
+			unique: true,
+		},
+		{ id: 'sample-name', name: 'name', type: 'full-name' },
+		{ id: 'sample-email', name: 'email', type: 'email' },
+		{ id: 'sample-age', name: 'age', type: 'integer', options: { min: 18, max: 80 } },
+		{
+			id: 'sample-created',
+			name: 'created',
+			type: 'datetime',
+			options: { format: 'ISO', yearsBack: 3 },
+		},
+	],
+	rowCount: 25,
+	locale: 'en',
+	seed: 42,
+};
+
+export const EMPTY_SPEC: DatasetSpec = {
+	columns: [],
+	rowCount: 25,
+	locale: 'en',
+	seed: 42,
+};
+
+/**
+ * Repair persisted specs that predate the `id` field. Required after
+ * the column-id migration; safe to call on already-migrated specs.
+ */
+export const ensureColumnIds = (spec: DatasetSpec): DatasetSpec => {
+	const needsRepair = spec.columns.some(
+		(column) => typeof column.id !== 'string' || column.id.length === 0
+	);
+	if (!needsRepair) return spec;
+	return {
+		...spec,
+		columns: spec.columns.map((column) =>
+			typeof column.id === 'string' && column.id.length > 0
+				? column
+				: { ...column, id: createColumnId() }
+		),
+	};
+};
+
+// Mulberry32 — a tiny, stable PRNG. Used so `seed` produces a
+// deterministic stream and Regenerate ticks shift the output
+// without depending on Math.random.
+const createRng = (seed: number): (() => number) => {
+	let state = seed >>> 0;
+	return () => {
+		state = (state + 0x6d2b79f5) >>> 0;
+		let t = state;
+		t = Math.imul(t ^ (t >>> 15), t | 1);
+		t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+};
+
+const pickInt = (rng: () => number, min: number, max: number): number => {
+	const lo = Math.ceil(min);
+	const hi = Math.floor(max);
+	if (hi <= lo) return lo;
+	return Math.floor(rng() * (hi - lo + 1)) + lo;
+};
+
+const pickFloat = (rng: () => number, min: number, max: number, decimals: number): string => {
+	const value = rng() * (max - min) + min;
+	const safeDecimals = Math.max(0, Math.min(20, Math.floor(decimals)));
+	return value.toFixed(safeDecimals);
+};
+
+const STRING_ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+const pickString = (rng: () => number, length: number): string => {
+	const safeLength = Math.max(0, Math.min(4096, Math.floor(length)));
+	return Array.from({ length: safeLength }, () => {
+		const idx = Math.floor(rng() * STRING_ALPHABET.length);
+		return STRING_ALPHABET.charAt(idx);
+	}).join('');
+};
+
+const pad2 = (n: number): string => n.toString().padStart(2, '0');
+
+const formatDate = (date: Date, format: string): string => {
+	const year = date.getUTCFullYear().toString();
+	const month = pad2(date.getUTCMonth() + 1);
+	const day = pad2(date.getUTCDate());
+	const hours = pad2(date.getUTCHours());
+	const minutes = pad2(date.getUTCMinutes());
+	const seconds = pad2(date.getUTCSeconds());
+	if (format === 'ISO') return date.toISOString();
+	if (format === 'UNIX') return Math.floor(date.getTime() / 1000).toString();
+	if (format === 'UNIX_MS') return date.getTime().toString();
+	return format
+		.replaceAll('YYYY', year)
+		.replaceAll('MM', month)
+		.replaceAll('DD', day)
+		.replaceAll('HH', hours)
+		.replaceAll('mm', minutes)
+		.replaceAll('ss', seconds);
+};
+
+const pickPastDate = (rng: () => number, yearsBack: number): Date => {
+	const now = Date.now();
+	const span = Math.max(1, yearsBack) * 365.25 * 24 * 60 * 60 * 1000;
+	const offset = Math.floor(rng() * span);
+	return new Date(now - offset);
+};
+
+const splitListValues = (raw: unknown): readonly string[] => {
+	if (typeof raw !== 'string') return [];
+	return raw
+		.split(/[,\n]/u)
+		.map((part) => part.trim())
+		.filter((part) => part.length > 0);
+};
+
+/**
+ * Generate a value from a regex pattern using a simple recursive
+ * generator. Supports literal chars, char classes ([abc] / [a-z]),
+ * predefined classes (\d \w \s), quantifiers ({n} {n,m} ? + *),
+ * groups and alternation. Anchors (^ $) and zero-width assertions
+ * are not supported. Returns a best-effort string on parse failure.
+ */
+export const generateFromRegex = (pattern: string, rng: () => number, maxRepeat = 8): string => {
+	let pos = 0;
+	const input = pattern.startsWith('^') ? pattern.slice(1) : pattern;
+	const stripped = input.endsWith('$') ? input.slice(0, -1) : input;
+
+	const parseClass = (): string => {
+		// At a `[` — parse char ranges and members, then return one char.
+		pos++; // consume [
+		const members: string[] = [];
+		while (pos < stripped.length && stripped.charAt(pos) !== ']') {
+			const ch = stripped.charAt(pos);
+			if (ch === '\\' && pos + 1 < stripped.length) {
+				members.push(expandEscape(stripped.charAt(pos + 1)));
+				pos += 2;
+				continue;
+			}
+			if (pos + 2 < stripped.length && stripped.charAt(pos + 1) === '-') {
+				const lo = ch.charCodeAt(0);
+				const hi = stripped.charAt(pos + 2).charCodeAt(0);
+				const [start, end] = lo <= hi ? [lo, hi] : [hi, lo];
+				for (let code = start; code <= end; code++) {
+					members.push(String.fromCharCode(code));
+				}
+				pos += 3;
+				continue;
+			}
+			members.push(ch);
+			pos++;
+		}
+		pos++; // consume ]
+		const pool = members.join('') || 'x';
+		return pool.charAt(Math.floor(rng() * pool.length));
+	};
+
+	const expandEscape = (esc: string): string => {
+		if (esc === 'd') return '0123456789';
+		if (esc === 'D') return 'abcdefghijklmnopqrstuvwxyz';
+		if (esc === 'w') return 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_';
+		if (esc === 'W') return '!@#$%^&*';
+		if (esc === 's') return ' ';
+		if (esc === 'S') return 'x';
+		if (esc === 'n') return '\n';
+		if (esc === 't') return '\t';
+		return esc;
+	};
+
+	const parseRepeat = (): readonly [number, number] | null => {
+		// At a `{` — parse {n} or {n,m}.
+		if (stripped.charAt(pos) !== '{') return null;
+		const end = stripped.indexOf('}', pos);
+		if (end < 0) return null;
+		const body = stripped.slice(pos + 1, end);
+		const parts = body.split(',').map((s) => s.trim());
+		const lo = Number.parseInt(parts[0] ?? '', 10);
+		const hi = parts.length > 1 ? Number.parseInt(parts[1] ?? '', 10) : lo;
+		if (Number.isNaN(lo) || Number.isNaN(hi)) return null;
+		pos = end + 1;
+		return [lo, hi];
+	};
+
+	const parseAtom = (): string => {
+		const ch = stripped.charAt(pos);
+		if (ch === '(') {
+			pos++; // consume (
+			const branches: string[][] = [[]];
+			while (pos < stripped.length && stripped.charAt(pos) !== ')') {
+				if (stripped.charAt(pos) === '|') {
+					branches.push([]);
+					pos++;
+					continue;
+				}
+				branches[branches.length - 1]?.push(parseAtomWithRepeat());
+			}
+			pos++; // consume )
+			const choice = branches[Math.floor(rng() * branches.length)] ?? [];
+			return choice.join('');
+		}
+		if (ch === '[') return parseClass();
+		if (ch === '\\') {
+			const esc = stripped.charAt(pos + 1) ?? '';
+			pos += 2;
+			const pool = expandEscape(esc);
+			return pool.charAt(Math.floor(rng() * pool.length));
+		}
+		if (ch === '.') {
+			pos++;
+			return STRING_ALPHABET.charAt(Math.floor(rng() * STRING_ALPHABET.length));
+		}
+		pos++;
+		return ch;
+	};
+
+	const parseAtomWithRepeat = (): string => {
+		const atom = parseAtom();
+		const next = stripped.charAt(pos);
+		if (next === '?') {
+			pos++;
+			return rng() < 0.5 ? atom : '';
+		}
+		if (next === '+') {
+			pos++;
+			const n = pickInt(rng, 1, maxRepeat);
+			return atom.repeat(n);
+		}
+		if (next === '*') {
+			pos++;
+			const n = pickInt(rng, 0, maxRepeat);
+			return atom.repeat(n);
+		}
+		if (next === '{') {
+			const range = parseRepeat();
+			if (!range) return atom;
+			const [lo, hi] = range;
+			const n = pickInt(rng, lo, hi);
+			return atom.repeat(n);
+		}
+		return atom;
+	};
+
+	try {
+		const out: string[] = [];
+		while (pos < stripped.length) {
+			out.push(parseAtomWithRepeat());
+		}
+		return out.join('');
+	} catch {
+		return pattern;
+	}
+};
+
+const FAKER_INSTANCES: Readonly<Record<Locale, Faker>> = {
+	en: fakerEN,
+	ja: fakerJA,
+	fr: fakerFR,
+	de: fakerDE,
+	es: fakerES,
+};
+
+const createFaker = (locale: Locale, seed: number): Faker => {
+	// Use the pre-built locale instance — `seed()` mutates shared
+	// state, but the row generator runs synchronously to completion
+	// before any other caller can observe it.
+	const faker = FAKER_INSTANCES[locale] ?? fakerEN;
+	faker.seed(seed);
+	return faker;
+};
+
+interface CellContext {
+	readonly rng: () => number;
+	readonly faker: Faker;
+	readonly rowIndex: number;
+	readonly uniqueSet: Set<string> | null;
+}
+
+const optNumber = (opts: Record<string, unknown>, key: string, fallback: number): number => {
+	const raw = opts[key];
+	return typeof raw === 'number' ? raw : fallback;
+};
+
+const optString = (opts: Record<string, unknown>, key: string, fallback: string): string => {
+	const raw = opts[key];
+	return typeof raw === 'string' ? raw : fallback;
+};
+
+const generateCellValue = (column: ColumnSpec, ctx: CellContext): string => {
+	const opts = column.options ?? {};
+	const { rng, faker, rowIndex } = ctx;
+	switch (column.type) {
+		case 'integer': {
+			const min = optNumber(opts, 'min', 1);
+			const max = optNumber(opts, 'max', 1000);
+			return pickInt(rng, Math.min(min, max), Math.max(min, max)).toString();
+		}
+		case 'float': {
+			const min = optNumber(opts, 'min', 0);
+			const max = optNumber(opts, 'max', 1);
+			const decimals = optNumber(opts, 'decimals', 2);
+			return pickFloat(rng, Math.min(min, max), Math.max(min, max), decimals);
+		}
+		case 'string': {
+			const length = optNumber(opts, 'length', 12);
+			return pickString(rng, length);
+		}
+		case 'uuid':
+			return faker.string.uuid();
+		case 'email':
+			return faker.internet.email().toLowerCase();
+		case 'phone':
+			return faker.phone.number();
+		case 'url':
+			return faker.internet.url();
+		case 'date': {
+			const format = optString(opts, 'format', 'YYYY-MM-DD');
+			const yearsBack = optNumber(opts, 'yearsBack', 5);
+			return formatDate(pickPastDate(rng, yearsBack), format);
+		}
+		case 'datetime': {
+			const format = optString(opts, 'format', 'ISO');
+			const yearsBack = optNumber(opts, 'yearsBack', 5);
+			return formatDate(pickPastDate(rng, yearsBack), format);
+		}
+		case 'boolean':
+			return rng() < 0.5 ? 'false' : 'true';
+		case 'lorem-words': {
+			const count = optNumber(opts, 'count', 4);
+			return faker.lorem.words(Math.max(1, Math.min(200, Math.floor(count))));
+		}
+		case 'lorem-sentences': {
+			const count = optNumber(opts, 'count', 1);
+			return faker.lorem.sentences(Math.max(1, Math.min(50, Math.floor(count))));
+		}
+		case 'pick-from-list': {
+			const values = splitListValues(opts['values']);
+			if (values.length === 0) return '';
+			return values[Math.floor(rng() * values.length)] ?? '';
+		}
+		case 'sequence': {
+			const start = optNumber(opts, 'start', 1);
+			const step = optNumber(opts, 'step', 1);
+			return (start + rowIndex * step).toString();
+		}
+		case 'regex': {
+			const pattern = optString(opts, 'pattern', '[A-Z]{2}-[0-9]{4}');
+			return generateFromRegex(pattern, rng);
+		}
+		case 'first-name':
+			return faker.person.firstName();
+		case 'last-name':
+			return faker.person.lastName();
+		case 'full-name':
+			return faker.person.fullName();
+		case 'company':
+			return faker.company.name();
+		case 'city':
+			return faker.location.city();
+		case 'country':
+			return faker.location.country();
+		case 'street-address':
+			return faker.location.streetAddress();
+		default:
+			return '';
+	}
+};
+
+/**
+ * Generate a 2D array of cell values for the supplied spec. Each
+ * row is a `readonly string[]` aligned with `spec.columns`. Cells
+ * may be the literal empty string when `nullablePercent` fires.
+ *
+ * Uniqueness is enforced via per-column `Set`s with up to 50 retries
+ * before falling back to a counter suffix so generation never
+ * deadlocks for narrow value spaces.
+ */
+export const generateDataset = (spec: DatasetSpec): readonly (readonly string[])[] => {
+	const rng = createRng(spec.seed);
+	const faker = createFaker(spec.locale, spec.seed);
+	const rowCount = Math.max(0, Math.min(ROW_COUNT_MAX, Math.floor(spec.rowCount)));
+
+	const uniqueSets = new Map<number, Set<string>>();
+	spec.columns.forEach((col, idx) => {
+		if (col.unique) uniqueSets.set(idx, new Set<string>());
+	});
+
+	return Array.from({ length: rowCount }, (_unused, rowIndex) =>
+		spec.columns.map((col, colIdx) => {
+			const nullChance = Math.max(0, Math.min(100, col.nullablePercent ?? 0));
+			if (nullChance > 0 && rng() * 100 < nullChance) return '';
+
+			const uniqueSet = uniqueSets.get(colIdx) ?? null;
+			const ctx: CellContext = { rng, faker, rowIndex, uniqueSet };
+
+			if (!uniqueSet) return generateCellValue(col, ctx);
+
+			for (let attempt = 0; attempt < 50; attempt++) {
+				const candidate = generateCellValue(col, ctx);
+				if (!uniqueSet.has(candidate)) {
+					uniqueSet.add(candidate);
+					return candidate;
+				}
+			}
+			const fallback = `${generateCellValue(col, ctx)}-${rowIndex}`;
+			uniqueSet.add(fallback);
+			return fallback;
+		})
+	);
+};
+
+const escapeDelimited = (value: string, delimiter: string): string => {
+	if (value.includes(delimiter) || value.includes('"') || value.includes('\n')) {
+		return `"${value.replaceAll('"', '""')}"`;
+	}
+	return value;
+};
+
+const formatDelimited = (
+	rows: readonly (readonly string[])[],
+	headers: readonly string[],
+	delimiter: string
+): string => {
+	const headerLine = headers.map((h) => escapeDelimited(h, delimiter)).join(delimiter);
+	const bodyLines = rows.map((row) =>
+		row.map((c) => escapeDelimited(c, delimiter)).join(delimiter)
+	);
+	return [headerLine, ...bodyLines].join('\n');
+};
+
+const tryParseNumber = (value: string): number | null => {
+	if (value.trim().length === 0) return null;
+	if (!/^-?\d+(\.\d+)?$/u.test(value)) return null;
+	const n = Number(value);
+	return Number.isFinite(n) ? n : null;
+};
+
+const toJsonValue = (value: string): string | number | boolean | null => {
+	if (value.length === 0) return null;
+	if (value === 'true') return true;
+	if (value === 'false') return false;
+	const n = tryParseNumber(value);
+	if (n !== null) return n;
+	return value;
+};
+
+const formatJson = (rows: readonly (readonly string[])[], headers: readonly string[]): string => {
+	const objects = rows.map((row) => {
+		const obj: Record<string, string | number | boolean | null> = {};
+		headers.forEach((header, idx) => {
+			obj[header] = toJsonValue(row[idx] ?? '');
+		});
+		return obj;
+	});
+	return JSON.stringify(objects, null, 2);
+};
+
+const formatNdjson = (rows: readonly (readonly string[])[], headers: readonly string[]): string =>
+	rows
+		.map((row) => {
+			const obj: Record<string, string | number | boolean | null> = {};
+			headers.forEach((header, idx) => {
+				obj[header] = toJsonValue(row[idx] ?? '');
+			});
+			return JSON.stringify(obj);
+		})
+		.join('\n');
+
+const escapeSqlIdentifier = (name: string): string => `"${name.replaceAll('"', '""')}"`;
+
+const escapeSqlValue = (value: string): string => {
+	if (value.length === 0) return 'NULL';
+	if (value === 'true' || value === 'false') return value.toUpperCase();
+	const n = tryParseNumber(value);
+	if (n !== null) return value;
+	return `'${value.replaceAll("'", "''")}'`;
+};
+
+const formatSql = (
+	rows: readonly (readonly string[])[],
+	headers: readonly string[],
+	tableName: string
+): string => {
+	const safeTable = escapeSqlIdentifier(tableName || 'generated_data');
+	const cols = headers.map(escapeSqlIdentifier).join(', ');
+	const inserts = rows.map((row) => {
+		const values = row.map(escapeSqlValue).join(', ');
+		return `INSERT INTO ${safeTable} (${cols}) VALUES (${values});`;
+	});
+	return inserts.join('\n');
+};
+
+/**
+ * Serialize the generated rows + headers to the requested format.
+ * `sqlTableName` is required only for `format === 'sql'`; other
+ * formats ignore it.
+ */
+export const formatOutput = (
+	rows: readonly (readonly string[])[],
+	headers: readonly string[],
+	format: OutputFormat,
+	sqlTableName?: string
+): string => {
+	switch (format) {
+		case 'csv':
+			return formatDelimited(rows, headers, ',');
+		case 'tsv':
+			return formatDelimited(rows, headers, '\t');
+		case 'json':
+			return formatJson(rows, headers);
+		case 'ndjson':
+			return formatNdjson(rows, headers);
+		case 'sql':
+			return formatSql(rows, headers, sqlTableName ?? 'generated_data');
+		default:
+			return '';
+	}
+};
+
+const HUMAN_UNITS: readonly string[] = ['B', 'KB', 'MB', 'GB'];
+
+/**
+ * Format a byte count as a human-readable string (e.g. `12.3 KB`).
+ * Used by the status bar to give the user a sense of how large
+ * the generated file will be before they save it.
+ */
+export const humanSize = (bytes: number): string => {
+	if (bytes < 1024) return `${bytes} B`;
+	let value = bytes;
+	let unitIndex = 0;
+	while (value >= 1024 && unitIndex < HUMAN_UNITS.length - 1) {
+		value /= 1024;
+		unitIndex += 1;
+	}
+	return `${value.toFixed(value >= 100 ? 0 : value >= 10 ? 1 : 2)} ${HUMAN_UNITS[unitIndex]}`;
+};
+
+/**
+ * Approximate UTF-8 byte length of `text` without allocating a new
+ * `Uint8Array`. Sufficient for status-bar size hints; for exact
+ * byte counts (e.g. hashing) use `TextEncoder` directly.
+ */
+export const approxUtf8Bytes = (text: string): number => new TextEncoder().encode(text).length;

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -17,6 +17,7 @@ import { Route as WebhookReceiverRouteImport } from './routes/webhook-receiver';
 import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator';
 import { Route as UrlEncoderRouteImport } from './routes/url-encoder';
 import { Route as TlsInspectorRouteImport } from './routes/tls-inspector';
+import { Route as TestDataGeneratorRouteImport } from './routes/test-data-generator';
 import { Route as StringCompressorRouteImport } from './routes/string-compressor';
 import { Route as StringCaseConverterRouteImport } from './routes/string-case-converter';
 import { Route as SshKeyGeneratorRouteImport } from './routes/ssh-key-generator';
@@ -98,6 +99,11 @@ const UrlEncoderRoute = UrlEncoderRouteImport.update({
 const TlsInspectorRoute = TlsInspectorRouteImport.update({
 	id: '/tls-inspector',
 	path: '/tls-inspector',
+	getParentRoute: () => rootRouteImport,
+} as any);
+const TestDataGeneratorRoute = TestDataGeneratorRouteImport.update({
+	id: '/test-data-generator',
+	path: '/test-data-generator',
 	getParentRoute: () => rootRouteImport,
 } as any);
 const StringCompressorRoute = StringCompressorRouteImport.update({
@@ -354,6 +360,7 @@ export interface FileRoutesByFullPath {
 	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
 	'/string-case-converter': typeof StringCaseConverterRoute;
 	'/string-compressor': typeof StringCompressorRoute;
+	'/test-data-generator': typeof TestDataGeneratorRoute;
 	'/tls-inspector': typeof TlsInspectorRoute;
 	'/url-encoder': typeof UrlEncoderRoute;
 	'/uuid-generator': typeof UuidGeneratorRoute;
@@ -406,6 +413,7 @@ export interface FileRoutesByTo {
 	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
 	'/string-case-converter': typeof StringCaseConverterRoute;
 	'/string-compressor': typeof StringCompressorRoute;
+	'/test-data-generator': typeof TestDataGeneratorRoute;
 	'/tls-inspector': typeof TlsInspectorRoute;
 	'/url-encoder': typeof UrlEncoderRoute;
 	'/uuid-generator': typeof UuidGeneratorRoute;
@@ -459,6 +467,7 @@ export interface FileRoutesById {
 	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
 	'/string-case-converter': typeof StringCaseConverterRoute;
 	'/string-compressor': typeof StringCompressorRoute;
+	'/test-data-generator': typeof TestDataGeneratorRoute;
 	'/tls-inspector': typeof TlsInspectorRoute;
 	'/url-encoder': typeof UrlEncoderRoute;
 	'/uuid-generator': typeof UuidGeneratorRoute;
@@ -513,6 +522,7 @@ export interface FileRouteTypes {
 		| '/ssh-key-generator'
 		| '/string-case-converter'
 		| '/string-compressor'
+		| '/test-data-generator'
 		| '/tls-inspector'
 		| '/url-encoder'
 		| '/uuid-generator'
@@ -565,6 +575,7 @@ export interface FileRouteTypes {
 		| '/ssh-key-generator'
 		| '/string-case-converter'
 		| '/string-compressor'
+		| '/test-data-generator'
 		| '/tls-inspector'
 		| '/url-encoder'
 		| '/uuid-generator'
@@ -617,6 +628,7 @@ export interface FileRouteTypes {
 		| '/ssh-key-generator'
 		| '/string-case-converter'
 		| '/string-compressor'
+		| '/test-data-generator'
 		| '/tls-inspector'
 		| '/url-encoder'
 		| '/uuid-generator'
@@ -670,6 +682,7 @@ export interface RootRouteChildren {
 	SshKeyGeneratorRoute: typeof SshKeyGeneratorRoute;
 	StringCaseConverterRoute: typeof StringCaseConverterRoute;
 	StringCompressorRoute: typeof StringCompressorRoute;
+	TestDataGeneratorRoute: typeof TestDataGeneratorRoute;
 	TlsInspectorRoute: typeof TlsInspectorRoute;
 	UrlEncoderRoute: typeof UrlEncoderRoute;
 	UuidGeneratorRoute: typeof UuidGeneratorRoute;
@@ -736,6 +749,13 @@ declare module '@tanstack/react-router' {
 			path: '/tls-inspector';
 			fullPath: '/tls-inspector';
 			preLoaderRoute: typeof TlsInspectorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/test-data-generator': {
+			id: '/test-data-generator';
+			path: '/test-data-generator';
+			fullPath: '/test-data-generator';
+			preLoaderRoute: typeof TestDataGeneratorRouteImport;
 			parentRoute: typeof rootRouteImport;
 		};
 		'/string-compressor': {
@@ -1078,6 +1098,7 @@ const rootRouteChildren: RootRouteChildren = {
 	SshKeyGeneratorRoute: SshKeyGeneratorRoute,
 	StringCaseConverterRoute: StringCaseConverterRoute,
 	StringCompressorRoute: StringCompressorRoute,
+	TestDataGeneratorRoute: TestDataGeneratorRoute,
 	TlsInspectorRoute: TlsInspectorRoute,
 	UrlEncoderRoute: UrlEncoderRoute,
 	UuidGeneratorRoute: UuidGeneratorRoute,

--- a/src/routes/test-data-generator.tsx
+++ b/src/routes/test-data-generator.tsx
@@ -1,0 +1,936 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { save as saveDialog } from '@tauri-apps/plugin-dialog';
+import { writeTextFile } from '@tauri-apps/plugin-fs';
+import {
+	ClipboardCopy,
+	Download,
+	Eye,
+	GripVertical,
+	Plus,
+	RefreshCw,
+	Save,
+	Shuffle,
+	Table2,
+	TestTube,
+	Trash2,
+} from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
+import { ActionButton } from '@/lib/components/action';
+import {
+	FormCheckbox,
+	FormError,
+	FormInfo,
+	FormInput,
+	FormSection,
+	FormSelect,
+	FormSlider,
+	FormTextarea,
+} from '@/lib/components/form';
+import { RelatedTools, SectionHeader } from '@/lib/components/layout';
+import { ToolShell } from '@/lib/components/shell';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { Badge } from '@/lib/components/ui/badge';
+import { Button } from '@/lib/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { useDocumentTitle } from '@/lib/hooks';
+import { createToolOptionsStore } from '@/lib/stores';
+import {
+	approxUtf8Bytes,
+	COLUMN_TYPE_LABELS,
+	COLUMN_TYPES,
+	type ColumnSpec,
+	createColumnId,
+	type DatasetSpec,
+	DEFAULT_COLUMN_OPTIONS,
+	EMPTY_SPEC,
+	ensureColumnIds,
+	formatOutput,
+	generateDataset,
+	humanSize,
+	isColumnType,
+	isLocale,
+	isOutputFormat,
+	LOCALE_LABELS,
+	LOCALES,
+	OUTPUT_FORMAT_EXTENSIONS,
+	OUTPUT_FORMAT_LABELS,
+	OUTPUT_FORMATS,
+	type OutputFormat,
+	ROW_COUNT_MAX,
+	ROW_COUNT_MIN,
+	SAMPLE_SPEC,
+} from '@/lib/services/test-data';
+import { cn } from '@/lib/utils';
+
+interface TestDataPrefs {
+	readonly spec: DatasetSpec;
+	readonly format: OutputFormat;
+	readonly sqlTableName: string;
+}
+
+const DEFAULT_PREFS: TestDataPrefs = {
+	spec: SAMPLE_SPEC,
+	format: 'csv',
+	sqlTableName: 'generated_data',
+};
+
+const useTestDataPrefs = createToolOptionsStore<TestDataPrefs>(
+	'test-data-generator',
+	DEFAULT_PREFS
+);
+
+const PREVIEW_ROWS = 10;
+const RANDOM_SEED_MAX = 9_999_999;
+
+export const Route = createFileRoute('/test-data-generator')({
+	component: TestDataGeneratorPage,
+});
+
+function TestDataGeneratorPage() {
+	useDocumentTitle('Test Data Generator');
+
+	const { value: prefs, patch } = useTestDataPrefs();
+	// Persisted specs from earlier preview builds may lack the `id`
+	// field. Repair them up-front so the rest of the component can
+	// assume every column has a stable identifier.
+	const spec = useMemo(() => ensureColumnIds(prefs.spec), [prefs.spec]);
+	const { format, sqlTableName } = prefs;
+
+	const [showRail, setShowRail] = useState(true);
+
+	const updateSpec = useCallback(
+		(next: Partial<DatasetSpec>) => {
+			patch({ spec: { ...spec, ...next } });
+		},
+		[patch, spec]
+	);
+
+	const updateColumns = useCallback(
+		(columns: readonly ColumnSpec[]) => {
+			updateSpec({ columns });
+		},
+		[updateSpec]
+	);
+
+	const handleAddColumn = useCallback(() => {
+		const nextIndex = spec.columns.length + 1;
+		const column: ColumnSpec = {
+			id: createColumnId(),
+			name: `column_${nextIndex}`,
+			type: 'string',
+			options: { ...DEFAULT_COLUMN_OPTIONS.string },
+		};
+		updateColumns([...spec.columns, column]);
+	}, [spec.columns, updateColumns]);
+
+	const handleRemoveAll = useCallback(() => {
+		updateSpec({ columns: EMPTY_SPEC.columns });
+	}, [updateSpec]);
+
+	const handleLoadSample = useCallback(() => {
+		patch({ spec: SAMPLE_SPEC });
+	}, [patch]);
+
+	const handleColumnChange = useCallback(
+		(index: number, next: ColumnSpec) => {
+			updateColumns(spec.columns.map((col, idx) => (idx === index ? next : col)));
+		},
+		[spec.columns, updateColumns]
+	);
+
+	const handleColumnRemove = useCallback(
+		(index: number) => {
+			updateColumns(spec.columns.filter((_unused, idx) => idx !== index));
+		},
+		[spec.columns, updateColumns]
+	);
+
+	const handleMoveColumn = useCallback(
+		(index: number, direction: -1 | 1) => {
+			const target = index + direction;
+			if (target < 0 || target >= spec.columns.length) return;
+			const next = [...spec.columns];
+			const [moved] = next.splice(index, 1);
+			if (!moved) return;
+			next.splice(target, 0, moved);
+			updateColumns(next);
+		},
+		[spec.columns, updateColumns]
+	);
+
+	const handleRandomSeed = useCallback(() => {
+		const seed = Math.floor(Math.random() * RANDOM_SEED_MAX);
+		updateSpec({ seed });
+	}, [updateSpec]);
+
+	const handleLocaleChange = (value: string) => {
+		if (isLocale(value)) updateSpec({ locale: value });
+	};
+
+	const handleFormatChange = (value: string) => {
+		if (isOutputFormat(value)) patch({ format: value });
+	};
+
+	const previewSpec = useMemo<DatasetSpec>(
+		() => ({ ...spec, rowCount: Math.min(spec.rowCount, PREVIEW_ROWS) }),
+		[spec]
+	);
+
+	const previewRows = useMemo(() => {
+		if (spec.columns.length === 0) return [];
+		try {
+			return generateDataset(previewSpec);
+		} catch {
+			return [];
+		}
+	}, [previewSpec, spec.columns.length]);
+
+	const headers = useMemo(() => spec.columns.map((col) => col.name), [spec.columns]);
+
+	const previewOutput = useMemo(() => {
+		if (spec.columns.length === 0) return '';
+		try {
+			return formatOutput(previewRows, headers, format, sqlTableName);
+		} catch {
+			return '';
+		}
+	}, [format, headers, previewRows, sqlTableName, spec.columns.length]);
+
+	const approximateSize = useMemo(() => {
+		if (spec.columns.length === 0 || spec.rowCount === 0) return 0;
+		if (previewRows.length === 0) return 0;
+		// Extrapolate from preview output size to the full row count so
+		// the status bar shows a realistic estimate without building the
+		// whole dataset up-front.
+		const previewBytes = approxUtf8Bytes(previewOutput);
+		const ratio = spec.rowCount / Math.max(1, previewRows.length);
+		return Math.round(previewBytes * ratio);
+	}, [previewOutput, previewRows.length, spec.columns.length, spec.rowCount]);
+
+	const duplicateNames = useMemo(() => {
+		const counts = new Map<string, number>();
+		spec.columns.forEach((col) => {
+			counts.set(col.name, (counts.get(col.name) ?? 0) + 1);
+		});
+		return Array.from(counts.entries())
+			.filter(([, n]) => n > 1)
+			.map(([name]) => name);
+	}, [spec.columns]);
+
+	const hasError = duplicateNames.length > 0;
+	const errorMessage = hasError
+		? `Duplicate column name(s): ${duplicateNames.join(', ')}`
+		: undefined;
+
+	const generateFull = useCallback((): string => {
+		const rows = generateDataset(spec);
+		return formatOutput(rows, headers, format, sqlTableName);
+	}, [format, headers, sqlTableName, spec]);
+
+	const handleCopyOutput = useCallback(async () => {
+		if (spec.columns.length === 0) {
+			toast.error('Add at least one column before generating');
+			return;
+		}
+		try {
+			const text = generateFull();
+			await navigator.clipboard.writeText(text);
+			toast.success('Generated dataset copied to clipboard', {
+				description: `${spec.rowCount.toLocaleString()} rows, ${humanSize(approxUtf8Bytes(text))}`,
+			});
+		} catch (e) {
+			const message = e instanceof Error ? e.message : String(e);
+			toast.error('Failed to generate', { description: message });
+		}
+	}, [generateFull, spec.columns.length, spec.rowCount]);
+
+	const handleSaveOutput = useCallback(async () => {
+		if (spec.columns.length === 0) {
+			toast.error('Add at least one column before generating');
+			return;
+		}
+		try {
+			const extension = OUTPUT_FORMAT_EXTENSIONS[format];
+			const defaultPath = `test-data.${extension}`;
+			const target = await saveDialog({
+				defaultPath,
+				filters: [{ name: OUTPUT_FORMAT_LABELS[format], extensions: [extension] }],
+			});
+			if (!target) return;
+			const text = generateFull();
+			await writeTextFile(target, text);
+			toast.success('Dataset saved', {
+				description: `${spec.rowCount.toLocaleString()} rows → ${target}`,
+			});
+		} catch (e) {
+			const message = e instanceof Error ? e.message : String(e);
+			toast.error('Failed to save', { description: message });
+		}
+	}, [format, generateFull, spec.columns.length, spec.rowCount]);
+
+	const handleResetDefaults = useCallback(() => {
+		patch(DEFAULT_PREFS);
+	}, [patch]);
+
+	const localeOptions = useMemo(
+		() => LOCALES.map((l) => ({ value: l, label: LOCALE_LABELS[l] })),
+		[]
+	);
+
+	const formatOptions = useMemo(
+		() => OUTPUT_FORMATS.map((f) => ({ value: f, label: OUTPUT_FORMAT_LABELS[f] })),
+		[]
+	);
+
+	const hasColumns = spec.columns.length > 0;
+
+	return (
+		<ToolShell
+			showRail={showRail}
+			onShowRailChange={setShowRail}
+			valid={hasError ? false : hasColumns ? true : null}
+			error={errorMessage}
+			statusContent={
+				<>
+					<StatItem label="Columns" value={spec.columns.length} />
+					<StatItem label="Rows" value={spec.rowCount.toLocaleString()} />
+					<StatItem label="Approx size" value={humanSize(approximateSize)} />
+				</>
+			}
+			rail={
+				<>
+					<FormSection title="Dataset">
+						<div className="flex flex-col gap-2">
+							<ActionButton label="Add column" icon={Plus} onClick={handleAddColumn} size="sm" />
+							<ActionButton
+								label="Load sample"
+								icon={TestTube}
+								variant="outline"
+								size="sm"
+								onClick={handleLoadSample}
+							/>
+							<ActionButton
+								label="Remove all"
+								icon={Trash2}
+								variant="outline"
+								size="sm"
+								onClick={handleRemoveAll}
+								disabled={!hasColumns}
+							/>
+						</div>
+					</FormSection>
+
+					<FormSection title="Row count">
+						<FormSlider
+							label="Rows"
+							value={spec.rowCount}
+							min={ROW_COUNT_MIN}
+							max={ROW_COUNT_MAX}
+							step={1}
+							valueLabel={spec.rowCount.toLocaleString()}
+							onValueChange={(v) => updateSpec({ rowCount: v })}
+							size="compact"
+						/>
+					</FormSection>
+
+					<FormSection title="Locale">
+						<FormSelect
+							label="Language / region"
+							value={spec.locale}
+							options={localeOptions}
+							onValueChange={handleLocaleChange}
+							size="compact"
+						/>
+					</FormSection>
+
+					<FormSection title="Seed">
+						<FormInput
+							label="Random seed"
+							value={String(spec.seed)}
+							onValueChange={(v) => {
+								const parsed = Number.parseInt(v, 10);
+								if (Number.isFinite(parsed)) updateSpec({ seed: parsed });
+							}}
+							hint="Same seed produces the same data"
+							size="compact"
+						/>
+						<ActionButton
+							label="Randomize seed"
+							icon={Shuffle}
+							variant="outline"
+							size="sm"
+							onClick={handleRandomSeed}
+						/>
+					</FormSection>
+
+					<FormSection title="Output">
+						<FormSelect
+							label="Format"
+							value={format}
+							options={formatOptions}
+							onValueChange={handleFormatChange}
+							size="compact"
+						/>
+						{format === 'sql' ? (
+							<FormInput
+								label="SQL table name"
+								value={sqlTableName}
+								onValueChange={(v) => patch({ sqlTableName: v })}
+								placeholder="generated_data"
+								size="compact"
+							/>
+						) : null}
+					</FormSection>
+
+					<FormSection title="Export">
+						<div className="flex flex-col gap-2">
+							<ActionButton
+								label="Copy to clipboard"
+								icon={ClipboardCopy}
+								onClick={handleCopyOutput}
+								disabled={!hasColumns || hasError}
+								size="sm"
+							/>
+							<ActionButton
+								label="Save file…"
+								icon={Save}
+								variant="outline"
+								onClick={handleSaveOutput}
+								disabled={!hasColumns || hasError}
+								size="sm"
+							/>
+							<ActionButton
+								label="Reset defaults"
+								icon={RefreshCw}
+								variant="outline"
+								size="sm"
+								onClick={handleResetDefaults}
+							/>
+						</div>
+					</FormSection>
+
+					<FormSection title="Related">
+						<RelatedTools
+							items={[
+								{ id: 'lorem-ipsum', reason: 'Generate placeholder text' },
+								{ id: 'uuid-generator', reason: 'Standalone UUIDs' },
+								{ id: 'regex-tester', reason: 'Test regex patterns first' },
+							]}
+						/>
+					</FormSection>
+
+					<FormSection title="About">
+						<FormInfo>
+							<ul className="list-inside list-disc space-y-0.5">
+								<li>20+ column types — numeric, text, date, identity, regex, sequence</li>
+								<li>Locale-aware names and addresses (en / ja / fr / de / es)</li>
+								<li>Per-column nullability and uniqueness</li>
+								<li>Export as CSV / TSV / JSON / NDJSON / SQL INSERT</li>
+								<li>Same seed → same data; randomize the seed for fresh output</li>
+							</ul>
+						</FormInfo>
+					</FormSection>
+				</>
+			}
+		>
+			<div className="flex h-full flex-col overflow-hidden">
+				<SectionHeader
+					title="Dataset"
+					trailing={
+						<div className="flex items-center gap-2">
+							<Badge variant="outline" className="font-mono text-2xs">
+								{spec.columns.length} cols × {spec.rowCount.toLocaleString()} rows
+							</Badge>
+							<Button
+								variant="outline"
+								size="sm"
+								className="h-7"
+								onClick={handleSaveOutput}
+								disabled={!hasColumns || hasError}
+							>
+								<Download className="h-3.5 w-3.5" />
+								Save
+							</Button>
+						</div>
+					}
+				/>
+				<div className="flex-1 overflow-auto p-4">
+					{hasError ? <FormError message={errorMessage} className="mb-3" /> : null}
+					{hasColumns ? (
+						<div className="grid grid-cols-1 gap-3">
+							<ColumnBuilderCard
+								columns={spec.columns}
+								onChange={handleColumnChange}
+								onRemove={handleColumnRemove}
+								onMove={handleMoveColumn}
+								onAdd={handleAddColumn}
+							/>
+							<PreviewCard
+								columns={spec.columns}
+								rows={previewRows}
+								totalRows={spec.rowCount}
+								format={format}
+								previewOutput={previewOutput}
+							/>
+						</div>
+					) : (
+						<EmptyState onLoadSample={handleLoadSample} onAdd={handleAddColumn} />
+					)}
+				</div>
+			</div>
+		</ToolShell>
+	);
+}
+
+interface EmptyStateProps {
+	readonly onLoadSample: () => void;
+	readonly onAdd: () => void;
+}
+
+function EmptyState({ onLoadSample, onAdd }: EmptyStateProps) {
+	return (
+		<div className="flex h-full items-center justify-center">
+			<div className="flex w-full max-w-md flex-col items-center gap-4 rounded-xl border-2 border-dashed border-border p-10 text-center">
+				<EmbeddedEmptyState
+					icon={TestTube}
+					title="No columns defined"
+					description="Add columns one by one, or load the sample schema to see how the builder works."
+				/>
+				<div className="flex flex-col gap-2 sm:flex-row">
+					<Button variant="default" size="sm" onClick={onLoadSample}>
+						<TestTube className="h-3.5 w-3.5" />
+						Load sample
+					</Button>
+					<Button variant="outline" size="sm" onClick={onAdd}>
+						<Plus className="h-3.5 w-3.5" />
+						Add column
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+interface ColumnBuilderCardProps {
+	readonly columns: readonly ColumnSpec[];
+	readonly onChange: (index: number, next: ColumnSpec) => void;
+	readonly onRemove: (index: number) => void;
+	readonly onMove: (index: number, direction: -1 | 1) => void;
+	readonly onAdd: () => void;
+}
+
+function ColumnBuilderCard({ columns, onChange, onRemove, onMove, onAdd }: ColumnBuilderCardProps) {
+	return (
+		<Card density="compact">
+			<CardHeader>
+				<CardTitle className="flex items-center justify-between gap-2 text-sm">
+					<span className="flex items-center gap-2">
+						<Table2 className="h-4 w-4 text-muted-foreground" />
+						Columns
+					</span>
+					<Button variant="outline" size="sm" className="h-7" onClick={onAdd}>
+						<Plus className="h-3.5 w-3.5" />
+						Add column
+					</Button>
+				</CardTitle>
+			</CardHeader>
+			<CardContent className="space-y-2">
+				{columns.map((column, index) => (
+					<ColumnRow
+						key={column.id}
+						column={column}
+						index={index}
+						total={columns.length}
+						onChange={(next) => onChange(index, next)}
+						onRemove={() => onRemove(index)}
+						onMoveUp={() => onMove(index, -1)}
+						onMoveDown={() => onMove(index, 1)}
+					/>
+				))}
+			</CardContent>
+		</Card>
+	);
+}
+
+interface ColumnRowProps {
+	readonly column: ColumnSpec;
+	readonly index: number;
+	readonly total: number;
+	readonly onChange: (next: ColumnSpec) => void;
+	readonly onRemove: () => void;
+	readonly onMoveUp: () => void;
+	readonly onMoveDown: () => void;
+}
+
+function ColumnRow({
+	column,
+	index,
+	total,
+	onChange,
+	onRemove,
+	onMoveUp,
+	onMoveDown,
+}: ColumnRowProps) {
+	const typeOptions = useMemo(
+		() => COLUMN_TYPES.map((t) => ({ value: t, label: COLUMN_TYPE_LABELS[t] })),
+		[]
+	);
+
+	const handleTypeChange = (value: string) => {
+		if (!isColumnType(value)) return;
+		// Reset type-specific options when the type changes so an
+		// incompatible carry-over (e.g. `min`/`max` on `email`) cannot
+		// confuse the cell generator.
+		onChange({
+			...column,
+			type: value,
+			options: { ...DEFAULT_COLUMN_OPTIONS[value] },
+		});
+	};
+
+	const handleNameChange = (value: string) => {
+		onChange({ ...column, name: value });
+	};
+
+	const handleNullableChange = (value: number) => {
+		onChange({ ...column, nullablePercent: value });
+	};
+
+	const handleUniqueChange = (checked: boolean) => {
+		onChange({ ...column, unique: checked });
+	};
+
+	const handleOptionChange = (key: string, value: unknown) => {
+		onChange({
+			...column,
+			options: { ...(column.options ?? {}), [key]: value },
+		});
+	};
+
+	return (
+		<div className="rounded-md border border-border bg-background p-2.5">
+			<div className="flex items-start gap-2">
+				<div className="flex flex-col items-center gap-0.5 pt-1">
+					<GripVertical className="h-3.5 w-3.5 text-muted-foreground/50" />
+					<span className="text-2xs text-muted-foreground">#{index + 1}</span>
+				</div>
+				<div className="grid min-w-0 flex-1 grid-cols-1 gap-2 md:grid-cols-2">
+					<FormInput
+						label="Name"
+						value={column.name}
+						onValueChange={handleNameChange}
+						size="compact"
+					/>
+					<FormSelect
+						label="Type"
+						value={column.type}
+						options={typeOptions}
+						onValueChange={handleTypeChange}
+						size="compact"
+					/>
+					<TypeOptionsEditor column={column} onOptionChange={handleOptionChange} />
+					<div className="space-y-1.5">
+						<FormSlider
+							label="Nullable %"
+							value={column.nullablePercent ?? 0}
+							min={0}
+							max={100}
+							step={5}
+							valueLabel={`${column.nullablePercent ?? 0}%`}
+							onValueChange={handleNullableChange}
+							size="compact"
+						/>
+						<FormCheckbox
+							label="Unique values"
+							checked={column.unique ?? false}
+							onCheckedChange={handleUniqueChange}
+							size="compact"
+						/>
+					</div>
+				</div>
+				<div className="flex flex-col gap-1">
+					<Button
+						variant="ghost"
+						size="icon-sm"
+						className="h-6 w-6"
+						onClick={onMoveUp}
+						disabled={index === 0}
+						title="Move up"
+					>
+						<span className="text-xs">▲</span>
+					</Button>
+					<Button
+						variant="ghost"
+						size="icon-sm"
+						className="h-6 w-6"
+						onClick={onMoveDown}
+						disabled={index === total - 1}
+						title="Move down"
+					>
+						<span className="text-xs">▼</span>
+					</Button>
+					<Button
+						variant="ghost"
+						size="icon-sm"
+						className="h-6 w-6 text-destructive hover:text-destructive"
+						onClick={onRemove}
+						title="Remove column"
+					>
+						<Trash2 className="h-3.5 w-3.5" />
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+interface TypeOptionsEditorProps {
+	readonly column: ColumnSpec;
+	readonly onOptionChange: (key: string, value: unknown) => void;
+}
+
+function TypeOptionsEditor({ column, onOptionChange }: TypeOptionsEditorProps) {
+	const opts = column.options ?? {};
+
+	const numberValue = (key: string, fallback: number): number => {
+		const raw = opts[key];
+		return typeof raw === 'number' ? raw : fallback;
+	};
+
+	const stringValue = (key: string, fallback: string): string => {
+		const raw = opts[key];
+		return typeof raw === 'string' ? raw : fallback;
+	};
+
+	const handleNumberInput = (key: string, fallback: number) => (value: string) => {
+		const parsed = Number(value);
+		onOptionChange(key, Number.isFinite(parsed) ? parsed : fallback);
+	};
+
+	switch (column.type) {
+		case 'integer':
+			return (
+				<div className="grid grid-cols-2 gap-2">
+					<FormInput
+						label="Min"
+						value={String(numberValue('min', 1))}
+						onValueChange={handleNumberInput('min', 1)}
+						size="compact"
+					/>
+					<FormInput
+						label="Max"
+						value={String(numberValue('max', 1000))}
+						onValueChange={handleNumberInput('max', 1000)}
+						size="compact"
+					/>
+				</div>
+			);
+		case 'float':
+			return (
+				<div className="grid grid-cols-3 gap-2">
+					<FormInput
+						label="Min"
+						value={String(numberValue('min', 0))}
+						onValueChange={handleNumberInput('min', 0)}
+						size="compact"
+					/>
+					<FormInput
+						label="Max"
+						value={String(numberValue('max', 1))}
+						onValueChange={handleNumberInput('max', 1)}
+						size="compact"
+					/>
+					<FormInput
+						label="Decimals"
+						value={String(numberValue('decimals', 2))}
+						onValueChange={handleNumberInput('decimals', 2)}
+						size="compact"
+					/>
+				</div>
+			);
+		case 'string':
+			return (
+				<FormInput
+					label="Length"
+					value={String(numberValue('length', 12))}
+					onValueChange={handleNumberInput('length', 12)}
+					size="compact"
+				/>
+			);
+		case 'date':
+		case 'datetime':
+			return (
+				<div className="grid grid-cols-2 gap-2">
+					<FormInput
+						label="Format"
+						value={stringValue('format', column.type === 'date' ? 'YYYY-MM-DD' : 'ISO')}
+						onValueChange={(value) => onOptionChange('format', value)}
+						hint="YYYY-MM-DD, ISO, UNIX, UNIX_MS"
+						size="compact"
+					/>
+					<FormInput
+						label="Years back"
+						value={String(numberValue('yearsBack', 5))}
+						onValueChange={handleNumberInput('yearsBack', 5)}
+						size="compact"
+					/>
+				</div>
+			);
+		case 'lorem-words':
+		case 'lorem-sentences':
+			return (
+				<FormInput
+					label="Count"
+					value={String(numberValue('count', column.type === 'lorem-words' ? 4 : 1))}
+					onValueChange={handleNumberInput('count', column.type === 'lorem-words' ? 4 : 1)}
+					size="compact"
+				/>
+			);
+		case 'pick-from-list':
+			return (
+				<FormTextarea
+					label="Values (comma- or newline-separated)"
+					value={stringValue('values', 'red, green, blue')}
+					onValueChange={(value) => onOptionChange('values', value)}
+					rows={2}
+					size="compact"
+				/>
+			);
+		case 'sequence':
+			return (
+				<div className="grid grid-cols-2 gap-2">
+					<FormInput
+						label="Start"
+						value={String(numberValue('start', 1))}
+						onValueChange={handleNumberInput('start', 1)}
+						size="compact"
+					/>
+					<FormInput
+						label="Step"
+						value={String(numberValue('step', 1))}
+						onValueChange={handleNumberInput('step', 1)}
+						size="compact"
+					/>
+				</div>
+			);
+		case 'regex':
+			return (
+				<FormInput
+					label="Pattern"
+					value={stringValue('pattern', '[A-Z]{2}-[0-9]{4}')}
+					onValueChange={(value) => onOptionChange('pattern', value)}
+					hint="Supports literals, classes, ?, +, *, {n}, {n,m}, |"
+					size="compact"
+				/>
+			);
+		default:
+			return (
+				<div className="flex h-full items-end text-xs text-muted-foreground">
+					<span>No additional options</span>
+				</div>
+			);
+	}
+}
+
+interface PreviewCardProps {
+	readonly columns: readonly ColumnSpec[];
+	readonly rows: readonly (readonly string[])[];
+	readonly totalRows: number;
+	readonly format: OutputFormat;
+	readonly previewOutput: string;
+}
+
+function PreviewCard({ columns, rows, totalRows, format, previewOutput }: PreviewCardProps) {
+	const displayCount = Math.min(rows.length, PREVIEW_ROWS);
+	return (
+		<Card density="compact">
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2 text-sm">
+					<Eye className="h-4 w-4 text-muted-foreground" />
+					Preview
+					<Badge variant="outline" className="font-mono text-2xs">
+						{displayCount} of {totalRows.toLocaleString()}
+					</Badge>
+				</CardTitle>
+			</CardHeader>
+			<CardContent className="space-y-3">
+				<div className="overflow-auto rounded-md border bg-muted/30">
+					<table className="w-full border-collapse text-xs">
+						<thead className="sticky top-0 bg-surface-2">
+							<tr>
+								{columns.map((col, idx) => (
+									<th
+										key={col.id}
+										className="border-b border-border px-2 py-1.5 text-left font-medium text-foreground"
+									>
+										<div className="flex items-center gap-1">
+											<span className="truncate">{col.name || `column_${idx + 1}`}</span>
+											<span className="text-2xs text-muted-foreground">
+												({COLUMN_TYPE_LABELS[col.type]})
+											</span>
+										</div>
+									</th>
+								))}
+							</tr>
+						</thead>
+						<tbody>
+							{rows.length === 0 ? (
+								<tr>
+									<td
+										colSpan={Math.max(1, columns.length)}
+										className="px-2 py-4 text-center text-xs text-muted-foreground"
+									>
+										No preview available
+									</td>
+								</tr>
+							) : (
+								rows.map((row, rowIdx) => (
+									<tr
+										// biome-ignore lint/suspicious/noArrayIndexKey: preview rows are regenerated each render and have no intrinsic id.
+										key={rowIdx}
+										className={cn(rowIdx % 2 === 0 ? 'bg-transparent' : 'bg-surface-2/40')}
+									>
+										{row.map((cell, cellIdx) => {
+											const column = columns[cellIdx];
+											const cellKey = column ? `${column.id}-${rowIdx}` : `${rowIdx}-${cellIdx}`;
+											return (
+												<td
+													key={cellKey}
+													className="border-b border-border/50 px-2 py-1 font-mono text-2xs text-foreground"
+												>
+													{cell === '' ? (
+														<span className="italic text-muted-foreground">NULL</span>
+													) : (
+														<span className="block max-w-xs truncate" title={cell}>
+															{cell}
+														</span>
+													)}
+												</td>
+											);
+										})}
+									</tr>
+								))
+							)}
+						</tbody>
+					</table>
+				</div>
+
+				<div>
+					<div className="mb-1 flex items-center justify-between gap-2">
+						<span className="text-xs font-medium text-foreground">
+							{OUTPUT_FORMAT_LABELS[format]} preview
+						</span>
+						<span className="text-2xs text-muted-foreground">
+							First {displayCount} of {totalRows.toLocaleString()} rows
+						</span>
+					</div>
+					<pre className="max-h-64 overflow-auto rounded-md border bg-muted/40 p-2 font-mono text-2xs whitespace-pre-wrap break-words text-foreground">
+						{previewOutput || '(no output)'}
+					</pre>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}


### PR DESCRIPTION
## Summary

- Add the **Test Data Generator** under the **Files** category, a new tool for producing synthetic tabular datasets with typed columns, locale-aware identity data, and reproducible seeds.
- Generate up to 100,000 rows from a column spec covering 20+ types (numeric, text, date, identity, regex, sequence, pick-from-list) with per-column nullability and uniqueness controls.
- Export the result as CSV, TSV, JSON, NDJSON, or SQL `INSERT` statements via clipboard copy or `Save file` through the Tauri dialog.

## Changes

### Added

- `src/lib/services/test-data.ts` — pure dataset / serializer service with a Mulberry32 PRNG, locale-aware identity sources, a self-contained regex value generator, and CSV / TSV / JSON / NDJSON / SQL serializers.
- `src/routes/test-data-generator.tsx` — tool route built on `ToolShell` + `Card density="compact"` + `Form*` wrappers, with a live preview table, output preview, and an empty state.
- `@faker-js/faker` dependency for locale-aware identity providers (English / Japanese / French / German / Spanish).

### Changed

- `src/lib/services/pages.ts` — register the new page under `category: 'files'` with a `TestTube` icon.
- `src/route-tree.gen.ts` — regenerated by the TanStack Router plugin to include the new `/test-data-generator` route.

## Test Plan

- [ ] `bun run check` passes (TypeScript, page validation, design audit).
- [ ] `bun run format:check` passes.
- [ ] `bun run lint` shows no new errors attributable to the new files.
- [ ] `bun run build` succeeds end-to-end.
- [ ] Loading the sample schema renders a 10-row preview and a non-empty output preview for each format (CSV / TSV / JSON / NDJSON / SQL).
- [ ] Adding, renaming, reordering, and removing columns updates the preview without remounting unrelated rows.
- [ ] Toggling `Unique values` on a narrow-domain column (`pick-from-list` with 3 values, 100 rows) does not deadlock; the fallback suffix path activates.
- [ ] Changing the locale switches name / address style; same seed reproduces identical rows.
- [ ] `Copy to clipboard` and `Save file…` produce the expected dataset, and the status bar size estimate is within the right order of magnitude.
- [ ] Duplicate column names surface as a status-bar error and disable export.
