### PR TITLE
refactor(pages): rebalance categories and strengthen file-utility cross-links

### DIFF
--- a/src/lib/services/pages.ts
+++ b/src/lib/services/pages.ts
@@ -370,7 +370,7 @@ export const PAGES: readonly PageDefinition[] = [
 		icon: TextQuote,
 		description: 'Generate placeholder text in multiple flavors with structure and format controls',
 		color: 'text-amber-700',
-		category: 'generators',
+		category: 'text',
 	},
 	{
 		id: 'curl-builder',
@@ -379,7 +379,7 @@ export const PAGES: readonly PageDefinition[] = [
 		icon: Terminal,
 		description: 'Build and parse cURL commands; emit fetch / Python / Go snippets',
 		color: 'text-zinc-500',
-		category: 'generators',
+		category: 'network',
 		tabs: [
 			{ id: 'build', label: 'Build', icon: Pencil },
 			{ id: 'parse', label: 'Parse', icon: Search },

--- a/src/routes/drive-info.tsx
+++ b/src/routes/drive-info.tsx
@@ -163,8 +163,9 @@ function DriveInfoPage() {
 					<FormSection title="Related">
 						<RelatedTools
 							items={[
+								{ id: 'duplicate-finder', reason: 'Reclaim space by removing duplicates' },
+								{ id: 'folder-tree-visualizer', reason: 'Find the largest folders on a drive' },
 								{ id: 'file-inspector', reason: 'Inspect a file on a drive' },
-								{ id: 'hex-editor', reason: 'Open a binary file from disk' },
 							]}
 						/>
 					</FormSection>

--- a/src/routes/duplicate-finder.tsx
+++ b/src/routes/duplicate-finder.tsx
@@ -500,9 +500,10 @@ function DuplicateFinderPage() {
 					<FormSection title="Related">
 						<RelatedTools
 							items={[
+								{ id: 'drive-info', reason: 'See how much space the duplicates occupy' },
+								{ id: 'folder-tree-visualizer', reason: 'Inspect the folder structure first' },
 								{ id: 'file-inspector', reason: 'Inspect a single file in depth' },
 								{ id: 'hash-generator', reason: 'Hash arbitrary text or bytes' },
-								{ id: 'hex-editor', reason: 'View raw bytes of a file' },
 							]}
 						/>
 					</FormSection>

--- a/src/routes/file-watch.tsx
+++ b/src/routes/file-watch.tsx
@@ -11,6 +11,7 @@ import {
 	FormInput,
 	FormSection,
 } from '@/lib/components/form';
+import { RelatedTools } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
@@ -184,6 +185,16 @@ function FileWatchPage() {
 								/>
 							))}
 						</FormCheckboxGroup>
+					</FormSection>
+
+					<FormSection title="Related">
+						<RelatedTools
+							items={[
+								{ id: 'file-inspector', reason: 'Inspect a changed file in detail' },
+								{ id: 'hex-editor', reason: 'View raw bytes of an updated file' },
+								{ id: 'folder-tree-visualizer', reason: 'See size impact of the watched tree' },
+							]}
+						/>
 					</FormSection>
 
 					<FormSection title="About">

--- a/src/routes/folder-tree-visualizer.tsx
+++ b/src/routes/folder-tree-visualizer.tsx
@@ -387,8 +387,9 @@ function FolderTreeVisualizerPage() {
 					<FormSection title="Related">
 						<RelatedTools
 							items={[
+								{ id: 'duplicate-finder', reason: 'Eliminate duplicates inside the tree' },
+								{ id: 'drive-info', reason: 'See total drive capacity and usage' },
 								{ id: 'file-inspector', reason: 'Drill into a single file' },
-								{ id: 'hex-editor', reason: 'Open bytes for any file in the tree' },
 							]}
 						/>
 					</FormSection>


### PR DESCRIPTION
## Summary

- Move `lorem-ipsum` from Generators to Text (it generates _text_, not a key/UUID/QR artifact).
- Move `curl-builder` from Generators to Network (it is an HTTP tool, not a generator).
- Add the missing `RelatedTools` rail to File Watch.
- Strengthen cross-links between Drive Info, Duplicate Finder, and Folder Tree to surface the "reclaim disk space" workflow.

## Why

After the 12-tool file-utility batch (#338-#349), the Files category jumped from 0 to 11 entries while Generators stayed at 11. Two long-standing Generators entries did not actually generate persistent artifacts and pulled the category off-purpose. The disk-management trio also lacked the in-rail cues that point to each other for a coherent "find big folders → drop duplicates → re-measure drive" loop.

## Changes

### Modified

- `src/lib/services/pages.ts` — category reassignment for `lorem-ipsum` and `curl-builder`.
- `src/routes/file-watch.tsx` — add a `Related` section in the rail.
- `src/routes/drive-info.tsx` — promote `duplicate-finder` and `folder-tree-visualizer` to the top of Related.
- `src/routes/duplicate-finder.tsx` — link back to `drive-info` and `folder-tree-visualizer`.
- `src/routes/folder-tree-visualizer.tsx` — link to `duplicate-finder` and `drive-info`.

## Out of scope

- Hash Generator → Encoders move (debated, leaves user mental model intact for now).
- Splitting Network into "lookup" vs "client" sub-groups (no clean dividing line).
- Tab consolidation across JSON/YAML/XML formatters (parsers differ).

## Test plan

- [x] `bun run check` green (TS + validate-pages + audit-design).
- [x] `bun run format` + lefthook pre-commit clean.
- [ ] Manual verification of the four updated rails.
