### PR TITLE
feat(stores): persist per-route rail collapsed state

### DIFF
--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -4,3 +4,9 @@ export { useSidebarStore } from './sidebar';
 export { useTabStore, useActiveTab } from './tabs';
 export { createToolOptionsStore } from './tool-options';
 export { useToolPinsStore } from './tool-pins';
+export {
+	createToolRailStore,
+	usePersistedRail,
+	type ToolRailHook,
+	type ToolRailState,
+} from './tool-rail';

--- a/src/lib/stores/tool-rail.ts
+++ b/src/lib/stores/tool-rail.ts
@@ -1,0 +1,62 @@
+import { create, type StoreApi, type UseBoundStore } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+interface ToolRailState {
+	readonly showRail: boolean;
+	readonly setShowRail: (next: boolean) => void;
+}
+
+type ToolRailHook = UseBoundStore<StoreApi<ToolRailState>>;
+
+/**
+ * Factory: persist a tool route's rail collapsed/expanded state under
+ * `kogu:tool:<routeId>:rail`. Pair the returned hook with
+ * `<ToolShell showRail={…} onShowRailChange={…} />` so the rail
+ * remembers its position across navigations and reloads.
+ *
+ * Example:
+ *   const useUuidRail = createToolRailStore('uuid-generator');
+ *   const showRail = useUuidRail((s) => s.showRail);
+ *   const setShowRail = useUuidRail((s) => s.setShowRail);
+ */
+export function createToolRailStore(routeId: string, defaultShow = true): ToolRailHook {
+	return create<ToolRailState>()(
+		persist(
+			(set) => ({
+				showRail: defaultShow,
+				setShowRail: (next) => set({ showRail: next }),
+			}),
+			{ name: `kogu:tool:${routeId}:rail`, storage: createJSONStorage(() => localStorage) }
+		)
+	);
+}
+
+// Module-level cache so repeated `usePersistedRail('uuid-generator')`
+// calls share a single Zustand store per route. Without this, every
+// render would spawn a new store and lose persistence wiring.
+const RAIL_STORES = new Map<string, ToolRailHook>();
+
+/**
+ * Drop-in replacement for `useState(true)` that persists the rail's
+ * collapsed/expanded state under `kogu:tool:<routeId>:rail`. Returns a
+ * `[showRail, setShowRail]` tuple so the call site reads identically
+ * to the previous `useState` declaration.
+ *
+ * Example:
+ *   const [showRail, setShowRail] = usePersistedRail('uuid-generator');
+ */
+export function usePersistedRail(
+	routeId: string,
+	defaultShow = true
+): readonly [boolean, (next: boolean) => void] {
+	let store = RAIL_STORES.get(routeId);
+	if (!store) {
+		store = createToolRailStore(routeId, defaultShow);
+		RAIL_STORES.set(routeId, store);
+	}
+	const showRail = store((s) => s.showRail);
+	const setShowRail = store((s) => s.setShowRail);
+	return [showRail, setShowRail] as const;
+}
+
+export type { ToolRailHook, ToolRailState };

--- a/src/routes/archive-inspector.tsx
+++ b/src/routes/archive-inspector.tsx
@@ -50,7 +50,7 @@ import {
 	type PreviewKind,
 	previewKindFor,
 } from '@/lib/services/archive';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 
 type SortColumn = 'path' | 'size' | 'compressed' | 'modified';
@@ -103,7 +103,7 @@ function ArchiveInspectorPage() {
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [isDragOver, setIsDragOver] = useState(false);
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('archive-inspector');
 	const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
 	const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
 	const [previewEntry, setPreviewEntry] = useState<ArchiveEntry | null>(null);

--- a/src/routes/base64-encoder.tsx
+++ b/src/routes/base64-encoder.tsx
@@ -17,6 +17,7 @@ import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { useDocumentTitle } from '@/lib/hooks';
+import { usePersistedRail } from '@/lib/stores';
 import {
 	BASE64_MIME_TYPES,
 	type Base64DecodeOptions,
@@ -43,7 +44,7 @@ export const Route = createFileRoute('/base64-encoder')({
 function Base64EncoderPage() {
 	const [mode, setMode] = useState<Mode>('encode');
 	const [input, setInput] = useState('');
-	const [showOptions, setShowOptions] = useState(true);
+	const [showOptions, setShowOptions] = usePersistedRail('base64-encoder');
 
 	const [variant, setVariant] = useState<Base64Variant>(defaultBase64EncodeOptions.variant);
 	const [padding, setPadding] = useState(defaultBase64EncodeOptions.padding);

--- a/src/routes/bcrypt-generator.tsx
+++ b/src/routes/bcrypt-generator.tsx
@@ -18,6 +18,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { CodeBlock } from '@/lib/components/ui/code-block';
 import { useDocumentTitle } from '@/lib/hooks';
+import { usePersistedRail } from '@/lib/stores';
 import {
 	type BcryptCostInfo,
 	type BcryptHashResult,
@@ -55,7 +56,7 @@ function BcryptGeneratorPage() {
 	const [verifyError, setVerifyError] = useState<string | null>(null);
 	const verifyCancelledRef = useRef(false);
 
-	const [showOptions, setShowOptions] = useState(true);
+	const [showOptions, setShowOptions] = usePersistedRail('bcrypt-generator');
 	const [costInfo, setCostInfo] = useState<BcryptCostInfo | null>(null);
 	const [activeTab, setActiveTab] = useState<ActiveTab>('generate');
 	const [flashCounter, setFlashCounter] = useState(0);

--- a/src/routes/cidr-calculator.tsx
+++ b/src/routes/cidr-calculator.tsx
@@ -33,7 +33,7 @@ import {
 	splitIntoSubnets,
 	tryAggregate,
 } from '@/lib/services/cidr';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 
 type FamilyOption = 'auto' | IpFamily;
@@ -103,7 +103,7 @@ function CidrCalculatorPage() {
 	const [input, setInput] = useState<string>(SAMPLE_V4);
 	const [childPrefixText, setChildPrefixText] = useState<string>('27');
 	const [aggregateInput, setAggregateInput] = useState<string>('');
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('cidr-calculator');
 
 	const result = useMemo(
 		() => parseCidr(input, familyOverride === 'auto' ? undefined : familyOverride),

--- a/src/routes/csv-tool.tsx
+++ b/src/routes/csv-tool.tsx
@@ -65,7 +65,7 @@ import {
 	type SortDirection,
 	updateCell,
 } from '@/lib/services/csv-tool';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 
 interface CsvToolPrefs {
@@ -133,7 +133,7 @@ function CsvToolPage() {
 	const [filterQuery, setFilterQuery] = useState('');
 	const [sort, setSort] = useState<SortState | null>(null);
 	const [isDragOver, setIsDragOver] = useState(false);
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('csv-tool');
 	const [editingHeader, setEditingHeader] = useState<number | null>(null);
 	const [editingCell, setEditingCell] = useState<{
 		readonly rowIndex: number;

--- a/src/routes/date-timestamp-converter.tsx
+++ b/src/routes/date-timestamp-converter.tsx
@@ -45,7 +45,7 @@ import {
 	representationsOf,
 	zonedClock,
 } from '@/lib/services/date-timestamp';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 
 interface DateTimestampOptions {
@@ -94,7 +94,7 @@ function DateTimestampConverterPage() {
 	const [nowMs, setNowMs] = useState<number>(() => Date.now());
 	const [inputText, setInputText] = useState<string>(() => String(Date.now()));
 	const [pickedMs, setPickedMs] = useState<number>(() => Date.now());
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('date-timestamp-converter');
 
 	// Tick once per second while sticky mode is on. `useEffect` is the correct
 	// home for this side effect — every tick is a real wall-clock change, not a

--- a/src/routes/diff-viewer.tsx
+++ b/src/routes/diff-viewer.tsx
@@ -15,6 +15,7 @@ import {
 import { ToolShell } from '@/lib/components/shell';
 import { EmptyState } from '@/lib/components/status';
 import { useDocumentTitle } from '@/lib/hooks';
+import { usePersistedRail } from '@/lib/stores';
 import {
 	areTextsIdentical,
 	computeEnhancedDiff,
@@ -52,7 +53,7 @@ function DiffViewerPage() {
 	const [leftInput, setLeftInput] = useState('');
 	const [rightInput, setRightInput] = useState('');
 	const [viewMode, setViewMode] = useState<ViewMode>('split');
-	const [showOptions, setShowOptions] = useState(true);
+	const [showOptions, setShowOptions] = usePersistedRail('diff-viewer');
 
 	const [ignoreWhitespace, setIgnoreWhitespace] = useState<boolean>(
 		defaultDiffOptions.ignoreWhitespace

--- a/src/routes/dns-lookup.tsx
+++ b/src/routes/dns-lookup.tsx
@@ -36,7 +36,7 @@ import {
 	SAMPLE_REVERSE_IP,
 	toReverseDnsName,
 } from '@/lib/services/dns';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 
 interface DnsLookupOptions {
 	readonly recordTypes: readonly RecordType[];
@@ -77,7 +77,7 @@ function DnsLookupPage() {
 	const [result, setResult] = useState<DnsLookupResult | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [loading, setLoading] = useState<boolean>(false);
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('dns-lookup');
 
 	const trimmedName = name.trim();
 	const reverseLookup = trimmedName.length > 0 && isIpLiteral(trimmedName);

--- a/src/routes/drive-info.tsx
+++ b/src/routes/drive-info.tsx
@@ -30,7 +30,7 @@ import {
 	usagePercent,
 	usageTier,
 } from '@/lib/services/drive-info';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 
 interface DriveInfoPrefs {
@@ -76,7 +76,7 @@ function DriveInfoPage() {
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [loaded, setLoaded] = useState(false);
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('drive-info');
 
 	const refresh = useCallback(async () => {
 		setLoading(true);

--- a/src/routes/duplicate-finder.tsx
+++ b/src/routes/duplicate-finder.tsx
@@ -38,7 +38,7 @@ import {
 	type ScanResult,
 } from '@/lib/services/duplicate-finder';
 import { getPlatform } from '@/lib/services/platform';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 
 // Size threshold sliders use a log-style mapping so the user can pick a
 // few bytes or a few gigabytes from the same control. We store the raw
@@ -178,7 +178,7 @@ function DuplicateFinderPage() {
 	const [error, setError] = useState<string | null>(null);
 	const [progress, setProgress] = useState<ScanProgress | null>(null);
 	const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('duplicate-finder');
 	const [supportsSymlink, setSupportsSymlink] = useState(true);
 
 	const minSize = MIN_SIZE_STEPS[prefs.minSizeIdx] ?? MIN_SIZE_STEPS[3] ?? 1024;

--- a/src/routes/encoding-converter.tsx
+++ b/src/routes/encoding-converter.tsx
@@ -39,7 +39,7 @@ import {
 	type Encoding,
 	type LineEnding,
 } from '@/lib/services/encoding-converter';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 
 interface EncodingConverterPrefs {
@@ -97,7 +97,7 @@ function EncodingConverterPage() {
 	const [overrideEncoding, setOverrideEncoding] = useState<Encoding | null>(null);
 	const [loading, setLoading] = useState(false);
 	const [isDragOver, setIsDragOver] = useState(false);
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('encoding-converter');
 
 	const detected = useMemo<DetectedEncoding | null>(() => {
 		if (!sourceBytes) return null;

--- a/src/routes/file-inspector.tsx
+++ b/src/routes/file-inspector.tsx
@@ -31,7 +31,7 @@ import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { useDocumentTitle } from '@/lib/hooks';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import {
 	base64ToBytes,
 	decodeTextPreview,
@@ -99,7 +99,7 @@ function FileInspectorPage() {
 		readonly channels: number;
 	} | null>(null);
 	const [isDragOver, setIsDragOver] = useState(false);
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('file-inspector');
 
 	const headBytes = useMemo<Uint8Array | null>(() => {
 		if (!result) return null;

--- a/src/routes/file-watch.tsx
+++ b/src/routes/file-watch.tsx
@@ -24,7 +24,7 @@ import {
 	type FileWatchEventKind,
 	useFileWatch,
 } from '@/lib/services/file-watch';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 
 const ALL_KINDS: readonly FileWatchEventKind[] = ['create', 'modify', 'delete', 'rename'];
@@ -66,7 +66,7 @@ function FileWatchPage() {
 	const { value: prefs, patch } = useFileWatchPrefs();
 
 	const [path, setPath] = useState(prefs.lastPath);
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('file-watch');
 	const [error, setError] = useState<string | null>(null);
 
 	const { events, watching, start, stop, clear } = useFileWatch();

--- a/src/routes/folder-tree-visualizer.tsx
+++ b/src/routes/folder-tree-visualizer.tsx
@@ -52,7 +52,7 @@ import {
 	type SortKey,
 	type TreeNode,
 } from '@/lib/services/folder-tree';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 
 const TOP_N = 20;
@@ -99,7 +99,7 @@ function FolderTreeVisualizerPage() {
 	const [largest, setLargest] = useState<readonly LargestFile[]>([]);
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('folder-tree-visualizer');
 	const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
 	const [scanTimeMs, setScanTimeMs] = useState<number | null>(null);
 	const [rootPath, setRootPath] = useState<string | null>(null);

--- a/src/routes/gpg-key-generator.tsx
+++ b/src/routes/gpg-key-generator.tsx
@@ -26,6 +26,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { CodeBlock } from '@/lib/components/ui/code-block';
 import { useDocumentTitle } from '@/lib/hooks';
+import { usePersistedRail } from '@/lib/stores';
 import {
 	buildGpgUserId,
 	cancelWorkerOperation,
@@ -62,7 +63,7 @@ function GpgKeyGeneratorPage() {
 
 	const [cliAvailability, setCliAvailability] = useState<CliAvailability | null>(null);
 
-	const [showOptions, setShowOptions] = useState(true);
+	const [showOptions, setShowOptions] = usePersistedRail('gpg-key-generator');
 	const [showKeyInfo, setShowKeyInfo] = useState(true);
 	const [showGpgCommands, setShowGpgCommands] = useState(true);
 

--- a/src/routes/hash-generator.tsx
+++ b/src/routes/hash-generator.tsx
@@ -56,7 +56,7 @@ import {
 	type VerifyOutcome,
 	verifyShasum,
 } from '@/lib/services/encoders';
-import { createToolOptionsStore, useActiveTab, useTabStore } from '@/lib/stores';
+import { createToolOptionsStore, useActiveTab, useTabStore, usePersistedRail } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 
 type HashTab = 'text' | 'batch';
@@ -108,7 +108,7 @@ function HashGeneratorPage() {
 		if (tab === 'text' || tab === 'batch') setActive(PERSIST_KEY, tab);
 	};
 
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('hash-generator');
 
 	return (
 		<ToolShell
@@ -550,7 +550,7 @@ interface FileTabLayoutProps {
 }
 
 function FileTabLayout({ rail, statusContent, valid, children }: FileTabLayoutProps) {
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('hash-generator');
 	return (
 		<div className="grid h-full min-h-0 grid-rows-[1fr_var(--status-h)] overflow-hidden">
 			<div className="flex min-h-0 overflow-hidden">

--- a/src/routes/hex-editor.tsx
+++ b/src/routes/hex-editor.tsx
@@ -50,7 +50,7 @@ import {
 	type HexEditOp,
 	type HexFileInfo,
 } from '@/lib/services/hex-editor';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 
 const ROW_HEIGHT = 20;
@@ -100,7 +100,7 @@ function HexEditorPage() {
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [isDragOver, setIsDragOver] = useState(false);
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('hex-editor');
 	const [selection, setSelection] = useState<Selection | null>(null);
 	const [pendingOps, setPendingOps] = useState<readonly HexEditOp[]>([]);
 	const [undoStack, setUndoStack] = useState<readonly Uint8Array[]>([]);

--- a/src/routes/http-status-codes.tsx
+++ b/src/routes/http-status-codes.tsx
@@ -31,7 +31,7 @@ import {
 	STATUS_CODES,
 	TOTAL_CODES,
 } from '@/lib/services/http-status';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 
 interface HttpStatusOptions {
@@ -65,7 +65,7 @@ function HttpStatusCodesPage() {
 	const { value: options, patch } = useHttpStatusOptions();
 	const { query, categories, includeNonStandard, misuseOnly, selectedCode } = options;
 
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('http-status-codes');
 	const [debouncedQuery, setDebouncedQuery] = useState(query);
 
 	// Debounce text input by 100ms so typing does not thrash the grid.

--- a/src/routes/image-converter.tsx
+++ b/src/routes/image-converter.tsx
@@ -19,7 +19,7 @@ import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/lib/components/ui/tabs';
 import { useDocumentTitle } from '@/lib/hooks';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import {
 	ALL_FORMATS,
 	buildOutputFilename,
@@ -88,7 +88,7 @@ function ImageConverterPage() {
 	const [activeFormat, setActiveFormat] = useState<ImageFormat | null>(null);
 	const [converting, setConverting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('image-converter');
 
 	const fileInputRef = useRef<HTMLInputElement | null>(null);
 

--- a/src/routes/ip-converter.tsx
+++ b/src/routes/ip-converter.tsx
@@ -30,7 +30,7 @@ import {
 	SAMPLE_V4,
 	SAMPLE_V6,
 } from '@/lib/services/ip-convert';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 
 interface IpConverterOptions {
@@ -74,7 +74,7 @@ function IpConverterPage() {
 	const { showBitmap, favorMixedForMapped } = options;
 
 	const [input, setInput] = useState<string>(SAMPLE_V4);
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('ip-converter');
 
 	const result = useMemo(() => parseIp(input), [input]);
 	const fromIpv4 = useMemo(

--- a/src/routes/jwt-decoder.tsx
+++ b/src/routes/jwt-decoder.tsx
@@ -12,6 +12,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/ca
 import { IconTooltip } from '@/lib/components/ui/icon-tooltip';
 import { CodeBlock } from '@/lib/components/ui/code-block';
 import { useDocumentTitle } from '@/lib/hooks';
+import { usePersistedRail } from '@/lib/stores';
 import {
 	decodeJwt,
 	JWT_STANDARD_CLAIMS,
@@ -64,7 +65,7 @@ export const Route = createFileRoute('/jwt-decoder')({
 
 function JwtDecoderPage() {
 	const [input, setInput] = useState('');
-	const [showOptions, setShowOptions] = useState(true);
+	const [showOptions, setShowOptions] = usePersistedRail('jwt-decoder');
 
 	useDocumentTitle('JWT Decoder');
 

--- a/src/routes/lorem-ipsum.tsx
+++ b/src/routes/lorem-ipsum.tsx
@@ -17,7 +17,7 @@ import { ToolShell } from '@/lib/components/shell';
 import { LiveStatusRegion, StatItem } from '@/lib/components/status';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { useDocumentTitle } from '@/lib/hooks';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import {
 	COUNT_RANGES,
 	countStats,
@@ -49,7 +49,7 @@ function LoremIpsumPage() {
 	const { flavor, unit, count, sentenceLength, startWithClassic, format } = options;
 
 	const [regenerateCounter, setRegenerateCounter] = useState(0);
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('lorem-ipsum');
 
 	useDocumentTitle('Lorem Ipsum');
 

--- a/src/routes/mac-lookup.tsx
+++ b/src/routes/mac-lookup.tsx
@@ -36,7 +36,7 @@ import {
 	toIpv6LinkLocal,
 	type VendorResult,
 } from '@/lib/services/mac';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 
 interface MacLookupOptions {
 	readonly displayFormat: MacFormat;
@@ -75,7 +75,7 @@ function MacLookupPage() {
 	const [vendor, setVendor] = useState<VendorResult | null>(null);
 	const [vendorLoading, setVendorLoading] = useState<boolean>(false);
 	const [dbInfo, setDbInfo] = useState<OuiDatabaseInfo | null>(null);
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('mac-lookup');
 
 	const parseResult = useMemo(() => parseMac(input), [input]);
 	const trimmed = input.trim();

--- a/src/routes/markdown-editor.tsx
+++ b/src/routes/markdown-editor.tsx
@@ -55,6 +55,7 @@ import {
 import { ListItemButton } from '@/lib/components/ui/list-item-button';
 import { IconTooltip } from '@/lib/components/ui/icon-tooltip';
 import { useDocumentTitle } from '@/lib/hooks';
+import { usePersistedRail } from '@/lib/stores';
 import {
 	applyFormat,
 	exportAsHtml,
@@ -247,7 +248,7 @@ function TocNav({ items, onSelect }: TocNavProps) {
 function MarkdownEditorPage() {
 	const [input, setInput] = useState('');
 	const [rightPanelMode, setRightPanelMode] = useState<RightPanelMode>('editor');
-	const [showOptions, setShowOptions] = useState(true);
+	const [showOptions, setShowOptions] = usePersistedRail('markdown-editor');
 	const [activeEditor, setActiveEditor] = useState<ActiveEditor>(null);
 	const [htmlOutput, setHtmlOutput] = useState('');
 

--- a/src/routes/mime-types.tsx
+++ b/src/routes/mime-types.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { ExternalLink, FileSearch } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import { CopyButton } from '@/lib/components/action';
 import {
@@ -29,7 +29,7 @@ import {
 	type MimeEntry,
 	MIME_ENTRIES,
 } from '@/lib/services/mime';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 
 const ALL_CATEGORIES: readonly MimeCategory[] = [
@@ -87,7 +87,7 @@ function MimeTypesPage() {
 	const { value: options, patch } = useMimeOptions();
 	const { query, categories, requireMagic, selectedType } = options;
 
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('mime-types');
 
 	const categoriesSet = useMemo(() => new Set<MimeCategory>(categories), [categories]);
 

--- a/src/routes/network-interfaces.tsx
+++ b/src/routes/network-interfaces.tsx
@@ -51,6 +51,7 @@ import {
 import { cn } from '@/lib/utils';
 import { getErrorMessage } from '@/lib/utils';
 import { useDocumentTitle } from '@/lib/hooks';
+import { usePersistedRail } from '@/lib/stores';
 
 const getInterfaceTypeIcon = (type: string) => {
 	if (type === 'WiFi') return Wifi;
@@ -125,7 +126,7 @@ function NetworkInterfacesPage() {
 	const [interfaces, setInterfaces] = useState<DetailedNetworkInterface[]>([]);
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
-	const [showOptions, setShowOptions] = useState(true);
+	const [showOptions, setShowOptions] = usePersistedRail('network-interfaces');
 	const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
 	const [showActive, setShowActive] = useState(true);
 	const [showInactive, setShowInactive] = useState(true);

--- a/src/routes/network-scanner.tsx
+++ b/src/routes/network-scanner.tsx
@@ -92,7 +92,7 @@ import {
 	WEB_PORTS,
 	WELL_KNOWN_SERVICES,
 } from '@/lib/services/network-scanner';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn, getErrorMessage } from '@/lib/utils';
 import { useDocumentTitle } from '@/lib/hooks';
 
@@ -1174,7 +1174,7 @@ function NetworkScannerPage() {
 	const [error, setError] = useState<string | null>(null);
 
 	// UI state
-	const [showOptions, setShowOptions] = useState(true);
+	const [showOptions, setShowOptions] = usePersistedRail('network-scanner');
 	const [selectedHostId, setSelectedHostId] = useState<string | null>(null);
 	const [recentlyDiscoveredIds, setRecentlyDiscoveredIds] = useState<Set<string>>(new Set());
 	const [portRangeTouched, setPortRangeTouched] = useState(false);

--- a/src/routes/number-base-converter.tsx
+++ b/src/routes/number-base-converter.tsx
@@ -26,7 +26,7 @@ import { Input } from '@/lib/components/ui/input';
 import { Label } from '@/lib/components/ui/label';
 import { ToneBadge } from '@/lib/components/ui/tone-badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/lib/components/ui/tooltip';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 import {
 	asciiInfo,
@@ -120,7 +120,7 @@ function NumberBaseConverterPage() {
 
 	useDocumentTitle('Number Base Converter');
 
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('number-base-converter');
 
 	// Canonical state: unsigned bit pattern within the current bit width.
 	const [valueA, setValueA] = useState<bigint>(0n);

--- a/src/routes/password-generator.tsx
+++ b/src/routes/password-generator.tsx
@@ -15,7 +15,7 @@ import {
 import { GeneratedListPanel } from '@/lib/components/panel';
 import { ToolShell } from '@/lib/components/shell';
 import { StatItem } from '@/lib/components/status';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
 	buildCharacterPool,
@@ -51,7 +51,7 @@ function PasswordGeneratorPage() {
 
 	const [results, setResults] = useState<readonly string[]>([]);
 	const [error, setError] = useState<string | null>(null);
-	const [showOptions, setShowOptions] = useState(true);
+	const [showOptions, setShowOptions] = usePersistedRail('password-generator');
 	const [flashCounter, setFlashCounter] = useState(0);
 
 	useDocumentTitle('Password Generator');

--- a/src/routes/path-tool.tsx
+++ b/src/routes/path-tool.tsx
@@ -43,7 +43,7 @@ import {
 	type ParsedPath,
 	type PathStyle,
 } from '@/lib/services/path-tool';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 
 interface PathToolPrefs {
@@ -71,7 +71,7 @@ function PathToolPage() {
 
 	const [input, setInput] = useState('');
 	const [isDragOver, setIsDragOver] = useState(false);
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('path-tool');
 
 	const transformedInput = useMemo(() => {
 		let working = input;

--- a/src/routes/qr-code-generator.tsx
+++ b/src/routes/qr-code-generator.tsx
@@ -35,6 +35,7 @@ import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { IconTooltip } from '@/lib/components/ui/icon-tooltip';
 import { useDocumentTitle } from '@/lib/hooks';
+import { usePersistedRail } from '@/lib/stores';
 import {
 	CONTENT_KINDS,
 	CORNER_DOT_TYPES,
@@ -111,7 +112,7 @@ function QrCodeGeneratorPage() {
 		bitcoin: { ...DEFAULT_CONTENT_BY_KIND.bitcoin } as BitcoinContent,
 	});
 	const [style, setStyle] = useState<StyleOptions>({ ...DEFAULT_STYLE_OPTIONS });
-	const [showOptions, setShowOptions] = useState(true);
+	const [showOptions, setShowOptions] = usePersistedRail('qr-code-generator');
 
 	const previewRef = useRef<HTMLDivElement | null>(null);
 	const qrInstanceRef = useRef<ReturnType<typeof createQr> | null>(null);

--- a/src/routes/regex-tester.tsx
+++ b/src/routes/regex-tester.tsx
@@ -19,7 +19,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/ca
 import { ToggleGroup, ToggleGroupItem } from '@/lib/components/ui/toggle-group';
 import { IconTooltip } from '@/lib/components/ui/icon-tooltip';
 import { useState } from 'react';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 import { groupColor, matchBackdropColor } from '@/lib/services/regex-design';
 import {
@@ -527,7 +527,7 @@ function RegexTesterPage() {
 	const [testText, setTestText] = useState('');
 	const [replaceEnabled, setReplaceEnabled] = useState(false);
 	const [replacement, setReplacement] = useState('');
-	const [showOptions, setShowOptions] = useState(true);
+	const [showOptions, setShowOptions] = usePersistedRail('regex-tester');
 
 	useDocumentTitle('Regex Tester');
 

--- a/src/routes/sql-formatter.tsx
+++ b/src/routes/sql-formatter.tsx
@@ -17,6 +17,7 @@ import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { useDocumentTitle } from '@/lib/hooks';
+import { usePersistedRail } from '@/lib/stores';
 import {
 	calculateSqlStats,
 	defaultSqlFormatOptions,
@@ -42,7 +43,7 @@ export const Route = createFileRoute('/sql-formatter')({
 function SqlFormatterPage() {
 	const [mode, setMode] = useState<Mode>('format');
 	const [input, setInput] = useState('');
-	const [showOptions, setShowOptions] = useState(true);
+	const [showOptions, setShowOptions] = usePersistedRail('sql-formatter');
 
 	const [language, setLanguage] = useState<SqlLanguage>(defaultSqlFormatOptions.language);
 	const [tabWidthStr, setTabWidthStr] = useState(String(defaultSqlFormatOptions.tabWidth));

--- a/src/routes/ssh-key-generator.tsx
+++ b/src/routes/ssh-key-generator.tsx
@@ -25,6 +25,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { CodeBlock } from '@/lib/components/ui/code-block';
 import { useDocumentTitle } from '@/lib/hooks';
+import { usePersistedRail } from '@/lib/stores';
 import {
 	cancelWorkerOperation,
 	checkCliAvailability,
@@ -68,7 +69,7 @@ function SshKeyGeneratorPage() {
 	const timerIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const isCancelledRef = useRef(false);
 
-	const [showOptions, setShowOptions] = useState(true);
+	const [showOptions, setShowOptions] = usePersistedRail('ssh-key-generator');
 	const [showFingerprint, setShowFingerprint] = useState(true);
 	const [showEquivalentCommand, setShowEquivalentCommand] = useState(true);
 

--- a/src/routes/string-case-converter.tsx
+++ b/src/routes/string-case-converter.tsx
@@ -17,6 +17,7 @@ import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Card, CardContent } from '@/lib/components/ui/card';
 import { useDocumentTitle } from '@/lib/hooks';
+import { usePersistedRail } from '@/lib/stores';
 import {
 	CASE_DEFINITIONS,
 	convertToAllCases,
@@ -32,7 +33,7 @@ export const Route = createFileRoute('/string-case-converter')({
 
 function StringCaseConverterPage() {
 	const [input, setInput] = useState('');
-	const [showOptions, setShowOptions] = useState(true);
+	const [showOptions, setShowOptions] = usePersistedRail('string-case-converter');
 	const [sortLines, setSortLines] = useState<SortOrder>('none');
 	const [removeDuplicates, setRemoveDuplicates] = useState(false);
 	const [trimLines, setTrimLines] = useState(false);

--- a/src/routes/string-compressor.tsx
+++ b/src/routes/string-compressor.tsx
@@ -40,7 +40,7 @@ import {
 	extractCurlDataRaw,
 	hexToBytes,
 } from '@/lib/services/compression';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn, formatBytes } from '@/lib/utils';
 
 type Direction = 'compress' | 'decompress';
@@ -184,7 +184,7 @@ function StringCompressorPage() {
 	const [lastResult, setLastResult] = useState<CompressResult | null>(null);
 	const [detectedAlgorithm, setDetectedAlgorithm] = useState<CompressionAlgorithm | null>(null);
 	const [busy, setBusy] = useState(false);
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('string-compressor');
 
 	const handleAlgorithmChange = (next: CompressionAlgorithm) => {
 		// Re-clamp level into the new algorithm's range so the slider stays valid.

--- a/src/routes/test-data-generator.tsx
+++ b/src/routes/test-data-generator.tsx
@@ -14,7 +14,7 @@ import {
 	TestTube,
 	Trash2,
 } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
 
 import { ActionButton } from '@/lib/components/action';
@@ -35,7 +35,7 @@ import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { useDocumentTitle } from '@/lib/hooks';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import {
 	approxUtf8Bytes,
 	COLUMN_TYPE_LABELS,
@@ -98,7 +98,7 @@ function TestDataGeneratorPage() {
 	const spec = useMemo(() => ensureColumnIds(prefs.spec), [prefs.spec]);
 	const { format, sqlTableName } = prefs;
 
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('test-data-generator');
 
 	const updateSpec = useCallback(
 		(next: Partial<DatasetSpec>) => {

--- a/src/routes/tls-inspector.tsx
+++ b/src/routes/tls-inspector.tsx
@@ -47,7 +47,7 @@ import {
 	type SanEntry,
 	type SanType,
 } from '@/lib/services/x509';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { cn, getErrorMessage } from '@/lib/utils';
 
 interface TlsInspectorOptions {
@@ -130,7 +130,7 @@ function TlsInspectorPage() {
 	const [parsedChain, setParsedChain] = useState<readonly ParsedCertificate[]>([]);
 	const [error, setError] = useState<string | null>(null);
 	const [running, setRunning] = useState(false);
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('tls-inspector');
 
 	const canRun = host.trim().length > 0 && !running;
 

--- a/src/routes/url-encoder.tsx
+++ b/src/routes/url-encoder.tsx
@@ -24,7 +24,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/ca
 import { Input } from '@/lib/components/ui/input';
 import { IconTooltip } from '@/lib/components/ui/icon-tooltip';
 import { CodeBlock } from '@/lib/components/ui/code-block';
-import { useActiveTab, useTabStore } from '@/lib/stores';
+import { useActiveTab, useTabStore, usePersistedRail } from '@/lib/stores';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
 	buildUrl,
@@ -71,7 +71,7 @@ function UrlEncoderPage() {
 
 	const [mode, setMode] = useState<Mode>('encode');
 	const [input, setInput] = useState('');
-	const [showOptions, setShowOptions] = useState(true);
+	const [showOptions, setShowOptions] = usePersistedRail('url-encoder');
 
 	const [encodeMode, setEncodeMode] = useState<UrlEncodeMode>(defaultUrlEncodeOptions.mode);
 	const [spaceEncoding, setSpaceEncoding] = useState<UrlSpaceEncoding>(

--- a/src/routes/uuid-generator.tsx
+++ b/src/routes/uuid-generator.tsx
@@ -17,7 +17,7 @@ import {
 import { GeneratedListPanel } from '@/lib/components/panel';
 import { ToolShell } from '@/lib/components/shell';
 import { StatItem } from '@/lib/components/status';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
 	DEFAULT_COUNT,
@@ -58,7 +58,7 @@ function UuidGeneratorPage() {
 	const [nameInput, setNameInput] = useState('');
 	const [results, setResults] = useState<readonly string[]>([]);
 	const [error, setError] = useState<string | null>(null);
-	const [showOptions, setShowOptions] = useState(true);
+	const [showOptions, setShowOptions] = usePersistedRail('uuid-generator');
 	const [flashCounter, setFlashCounter] = useState(0);
 
 	useDocumentTitle('UUID Generator');

--- a/src/routes/x509-decoder.tsx
+++ b/src/routes/x509-decoder.tsx
@@ -38,7 +38,7 @@ import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { useDocumentTitle } from '@/lib/hooks';
-import { createToolOptionsStore } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import {
 	buildChain,
 	daysSinceStart,
@@ -141,7 +141,7 @@ function X509DecoderPage() {
 	const [parseResult, setParseResult] = useState<ParseResult | null>(null);
 	const [parsing, setParsing] = useState(false);
 	const [now, setNow] = useState<Date>(() => new Date());
-	const [showRail, setShowRail] = useState(true);
+	const [showRail, setShowRail] = usePersistedRail('x509-decoder');
 	const [isDragOver, setIsDragOver] = useState(false);
 
 	// Re-parse whenever the textual input changes. Debounce so a long paste


### PR DESCRIPTION
## Summary

Persist each tool route's rail collapsed/expanded state across navigation and reloads. Previously every route held the flag in component-local `useState`, so the rail snapped back open the next time the page mounted.

## Changes

- New factory `createToolRailStore(routeId, defaultShow?)` (in `src/lib/stores/tool-rail.ts`) writes the flag to `kogu:tool:<routeId>:rail` via Zustand `persist`, mirroring the existing `createToolOptionsStore` pattern.
- Drop-in helper `usePersistedRail(routeId)` returns a `[showRail, setShowRail]` tuple so each route's `useState(true)` declaration becomes a one-line swap.
- Migrated 41 routes off `useState(true)` for showRail / showOptions.
- Removed two unused `useState` imports surfaced by the migration (`mime-types`, `test-data-generator`).

## Test plan

- [ ] `bun run check` clean.
- [ ] Collapse the rail on `/uuid-generator`, navigate to `/regex-tester` and back — rail should still be collapsed.
- [ ] Reload the app while a rail is collapsed — state survives reload.
- [ ] `localStorage` shows entries keyed `kogu:tool:<route>:rail`.
