### PR TITLE
feat(template): share About + Related across every formatter tab

### DIFF
--- a/src/lib/components/formatter-tabs/json/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/query-tab.tsx
@@ -11,6 +11,8 @@ import {
 import { getErrorMessage } from '@/lib/utils';
 import { InputOutputSplit } from '@/lib/components/layout';
 import { Rail } from '@/lib/components/ui/rail';
+
+import { FormatterAboutFooter } from '@/lib/components/template';
 import { useClipboardActions, useReportStats, useValidation } from '@/lib/hooks';
 import { executeJsonPath, validateJson } from '@/lib/services/formatters';
 import { useJsonFormatterOptions } from '@/lib/stores';
@@ -208,6 +210,7 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 						</div>
 					</div>
 				</FormSection>
+				<FormatterAboutFooter />
 			</Rail>
 
 			<InputOutputSplit

--- a/src/lib/components/formatter-tabs/json/schema-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/schema-tab.tsx
@@ -9,6 +9,8 @@ import { CodeEditor } from '@/lib/components/editor';
 import { FormCheckbox, FormCheckboxGroup, FormSection } from '@/lib/components/form';
 import { SplitPane } from '@/lib/components/layout';
 import { Rail } from '@/lib/components/ui/rail';
+
+import { FormatterAboutFooter } from '@/lib/components/template';
 import { Button } from '@/lib/components/ui/button';
 import { inferJsonSchema, parseJson, validateJson } from '@/lib/services/formatters';
 import { useJsonFormatterOptions } from '@/lib/stores';
@@ -280,6 +282,7 @@ export function SchemaTab({ input, onInputChange, onStatsChange }: SchemaTabProp
 						</p>
 					</div>
 				</FormSection>
+				<FormatterAboutFooter />
 			</Rail>
 
 			<SplitPane

--- a/src/lib/components/formatter-tabs/xml/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/query-tab.tsx
@@ -5,6 +5,8 @@ import { FormInput, FormSection } from '@/lib/components/form';
 import { getErrorMessage } from '@/lib/utils';
 import { InputOutputSplit } from '@/lib/components/layout';
 import { Rail } from '@/lib/components/ui/rail';
+
+import { FormatterAboutFooter } from '@/lib/components/template';
 import { useClipboardActions, useReportStats, useValidation } from '@/lib/hooks';
 import { executeXPath, formatXml } from '@/lib/services/formatters';
 
@@ -129,6 +131,7 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 						</div>
 					</div>
 				</FormSection>
+				<FormatterAboutFooter />
 			</Rail>
 
 			<InputOutputSplit

--- a/src/lib/components/formatter-tabs/xml/schema-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/schema-tab.tsx
@@ -7,6 +7,8 @@ import { CodeEditor } from '@/lib/components/editor';
 import { FormCheckbox, FormCheckboxGroup, FormSection } from '@/lib/components/form';
 import { SplitPane } from '@/lib/components/layout';
 import { Rail } from '@/lib/components/ui/rail';
+
+import { FormatterAboutFooter } from '@/lib/components/template';
 import { Button } from '@/lib/components/ui/button';
 import { cn } from '@/lib/utils';
 import { getErrorMessage } from '@/lib/utils';
@@ -345,6 +347,7 @@ export function SchemaTab({ input, onInputChange, onStatsChange }: SchemaTabProp
 						</p>
 					</div>
 				</FormSection>
+				<FormatterAboutFooter />
 			</Rail>
 
 			<SplitPane

--- a/src/lib/components/formatter-tabs/yaml/query-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/query-tab.tsx
@@ -12,6 +12,8 @@ import {
 import { getErrorMessage } from '@/lib/utils';
 import { InputOutputSplit } from '@/lib/components/layout';
 import { Rail } from '@/lib/components/ui/rail';
+
+import { FormatterAboutFooter } from '@/lib/components/template';
 import { useClipboardActions, useReportStats, useValidation } from '@/lib/hooks';
 import { executeJsonPath } from '@/lib/services/formatters';
 
@@ -213,6 +215,7 @@ export function QueryTab({ input, onInputChange, onStatsChange }: QueryTabProps)
 						</div>
 					</div>
 				</FormSection>
+				<FormatterAboutFooter />
 			</Rail>
 
 			<InputOutputSplit

--- a/src/lib/components/formatter-tabs/yaml/schema-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/schema-tab.tsx
@@ -10,6 +10,8 @@ import { CodeEditor } from '@/lib/components/editor';
 import { FormCheckbox, FormCheckboxGroup, FormMode, FormSection } from '@/lib/components/form';
 import { SplitPane } from '@/lib/components/layout';
 import { Rail } from '@/lib/components/ui/rail';
+
+import { FormatterAboutFooter } from '@/lib/components/template';
 import { Button } from '@/lib/components/ui/button';
 import { inferJsonSchema } from '@/lib/services/formatters';
 import { cn } from '@/lib/utils';
@@ -309,6 +311,7 @@ export function SchemaTab({ input, onInputChange, onStatsChange }: SchemaTabProp
 						</p>
 					</div>
 				</FormSection>
+				<FormatterAboutFooter />
 			</Rail>
 
 			<SplitPane

--- a/src/lib/components/template/compare-tab.tsx
+++ b/src/lib/components/template/compare-tab.tsx
@@ -11,6 +11,8 @@ import { Rail } from '@/lib/components/ui/rail';
 import { Button } from '@/lib/components/ui/button';
 import type { GenericDiffItem } from '@/lib/constants/diff';
 
+import { FormatterAboutFooter } from './formatter-about';
+
 type EditorMode = 'json' | 'xml' | 'yaml';
 
 interface TabStats {
@@ -184,6 +186,7 @@ export function CompareTab({
 				) : null}
 
 				<DiffLegend />
+				<FormatterAboutFooter />
 			</Rail>
 
 			<div className="flex min-h-0 flex-1 flex-col overflow-hidden">

--- a/src/lib/components/template/convert-tab.tsx
+++ b/src/lib/components/template/convert-tab.tsx
@@ -5,6 +5,8 @@ import type { EditorMode } from '@/lib/components/editor';
 import { InputOutputSplit } from '@/lib/components/layout';
 import { Rail } from '@/lib/components/ui/rail';
 
+import { FormatterAboutFooter } from './formatter-about';
+
 type ValidationResult = { valid: boolean | null } & Record<string, unknown>;
 type StatsResult = { input: string; valid: boolean | null; error: string } & Record<
 	string,
@@ -106,6 +108,7 @@ export function ConvertTab({
 			>
 				{renderFormatSection?.()}
 				{renderOptions?.()}
+				<FormatterAboutFooter />
 			</Rail>
 
 			<InputOutputSplit

--- a/src/lib/components/template/format-tab.tsx
+++ b/src/lib/components/template/format-tab.tsx
@@ -7,6 +7,8 @@ import { InputOutputSplit } from '@/lib/components/layout';
 import { Rail } from '@/lib/components/ui/rail';
 import { useClipboardActions, useReportStats } from '@/lib/hooks';
 
+import { FormatterAboutFooter } from './formatter-about';
+
 type FormatMode = 'format' | 'minify';
 
 interface TabStats {
@@ -105,6 +107,7 @@ export function FormatTabTemplate<TOptions>({
 					/>
 				</FormSection>
 				{renderOptions(options, setOptions)}
+				<FormatterAboutFooter />
 			</Rail>
 
 			<InputOutputSplit

--- a/src/lib/components/template/formatter-about.tsx
+++ b/src/lib/components/template/formatter-about.tsx
@@ -1,0 +1,51 @@
+import { createContext, useContext, type ReactNode } from 'react';
+
+import { FormInfo, FormSection } from '@/lib/components/form';
+import { RelatedTools, type RelatedToolItem } from '@/lib/components/layout';
+
+interface FormatterAboutValue {
+	readonly aboutText?: ReactNode;
+	readonly relatedItems?: readonly RelatedToolItem[];
+}
+
+const FormatterAboutContext = createContext<FormatterAboutValue>({});
+
+interface FormatterAboutProviderProps {
+	readonly value: FormatterAboutValue;
+	readonly children: ReactNode;
+}
+
+/**
+ * Carries the About / Related text down to every formatter tab template
+ * so each rail can render the same footer without each tab having to
+ * accept and forward a prop.
+ */
+export function FormatterAboutProvider({ value, children }: FormatterAboutProviderProps) {
+	return <FormatterAboutContext.Provider value={value}>{children}</FormatterAboutContext.Provider>;
+}
+
+/**
+ * Renders About + Related at the bottom of the rail when supplied via
+ * `<FormatterAboutProvider>`. No-op when neither is provided so tab
+ * templates can drop it in unconditionally.
+ */
+export function FormatterAboutFooter() {
+	const { aboutText, relatedItems } = useContext(FormatterAboutContext);
+	if (!aboutText && (!relatedItems || relatedItems.length === 0)) return null;
+	return (
+		<>
+			{relatedItems && relatedItems.length > 0 ? (
+				<FormSection title="Related">
+					<RelatedTools items={relatedItems} />
+				</FormSection>
+			) : null}
+			{aboutText ? (
+				<FormSection title="About">
+					<FormInfo>{aboutText}</FormInfo>
+				</FormSection>
+			) : null}
+		</>
+	);
+}
+
+export type { FormatterAboutProviderProps, FormatterAboutValue };

--- a/src/lib/components/template/generate-tab.tsx
+++ b/src/lib/components/template/generate-tab.tsx
@@ -13,6 +13,8 @@ import {
 import { InputOutputSplit } from '@/lib/components/layout';
 import { Rail } from '@/lib/components/ui/rail';
 import { useClipboardActions, useReportStats } from '@/lib/hooks';
+
+import { FormatterAboutFooter } from './formatter-about';
 import {
 	type CSharpOptions,
 	generateCode,
@@ -853,6 +855,8 @@ export function GenerateTabTemplate({
 						</FormCheckboxGroup>
 					</FormSection>
 				) : null}
+
+				<FormatterAboutFooter />
 			</Rail>
 
 			<InputOutputSplit

--- a/src/lib/components/template/index.ts
+++ b/src/lib/components/template/index.ts
@@ -17,3 +17,6 @@ export type { GenerateTabTemplateProps, TabStats as GenerateTabStats } from './g
 
 export { TabbedFormatterPage } from './tabbed-formatter-page';
 export type { TabbedFormatterPageProps, TabContentProps } from './tabbed-formatter-page';
+
+export { FormatterAboutFooter, FormatterAboutProvider } from './formatter-about';
+export type { FormatterAboutProviderProps, FormatterAboutValue } from './formatter-about';

--- a/src/lib/components/template/tabbed-formatter-page.tsx
+++ b/src/lib/components/template/tabbed-formatter-page.tsx
@@ -1,6 +1,7 @@
 import { ArrowRightLeft, Code2, FileCheck, GitCompare, Play, Search } from 'lucide-react';
 import type { ReactNode } from 'react';
 
+import type { RelatedToolItem } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
@@ -8,6 +9,8 @@ import {
 	type FormatterTabType,
 	type TabStats,
 } from '@/lib/hooks/use-formatter-page';
+
+import { FormatterAboutProvider } from './formatter-about';
 
 /**
  * Tab content props passed to renderTabContent.
@@ -49,6 +52,17 @@ interface TabbedFormatterPageProps<TStats> {
 	readonly renderStatusContent?: (liveStats: TStats | null) => ReactNode;
 	/** Render prop for tab content - receives tab props */
 	readonly renderTabContent: (props: TabContentProps) => ReactNode;
+	/**
+	 * Optional About text shown at the bottom of every tab's rail via the
+	 * shared `FormatterAboutFooter`. Skip if the formatter is too domain-
+	 * specific to summarize concisely.
+	 */
+	readonly aboutText?: ReactNode;
+	/**
+	 * Optional list of related tool routes shown above the About block.
+	 * Empty / omitted → no Related section is rendered.
+	 */
+	readonly relatedItems?: readonly RelatedToolItem[];
 }
 
 export function TabbedFormatterPage<TStats>({
@@ -57,6 +71,8 @@ export function TabbedFormatterPage<TStats>({
 	persistKey,
 	renderStatusContent,
 	renderTabContent,
+	aboutText,
+	relatedItems,
 }: TabbedFormatterPageProps<TStats>) {
 	const page = useFormatterPage<TStats>({ calculateStats, persistKey });
 
@@ -67,23 +83,25 @@ export function TabbedFormatterPage<TStats>({
 	};
 
 	return (
-		<ToolShell
-			layout="tabbed"
-			tabs={TABS}
-			activeTab={page.tabSync.activeTab}
-			onTabChange={handleTabChange}
-			valid={page.currentStats.valid}
-			error={page.currentStats.error}
-			statusContent={renderStatusContent ? renderStatusContent(page.liveStats) : null}
-			renderTabContent={(tab) =>
-				renderTabContent({
-					tab: tab as FormatterTabType,
-					input: page.sharedInput,
-					onInputChange: page.setSharedInput,
-					onStatsChange: page.handleStatsChange(tab as FormatterTabType),
-				})
-			}
-		/>
+		<FormatterAboutProvider value={{ aboutText, relatedItems }}>
+			<ToolShell
+				layout="tabbed"
+				tabs={TABS}
+				activeTab={page.tabSync.activeTab}
+				onTabChange={handleTabChange}
+				valid={page.currentStats.valid}
+				error={page.currentStats.error}
+				statusContent={renderStatusContent ? renderStatusContent(page.liveStats) : null}
+				renderTabContent={(tab) =>
+					renderTabContent({
+						tab: tab as FormatterTabType,
+						input: page.sharedInput,
+						onInputChange: page.setSharedInput,
+						onStatsChange: page.handleStatsChange(tab as FormatterTabType),
+					})
+				}
+			/>
+		</FormatterAboutProvider>
 	);
 }
 

--- a/src/routes/json-formatter.tsx
+++ b/src/routes/json-formatter.tsx
@@ -27,6 +27,13 @@ function JsonFormatterPage() {
 			title="JSON Formatter"
 			calculateStats={(input) => calculateJsonStats(input, inputFormat)}
 			persistKey="json-formatter"
+			aboutText="Format, minify, query, compare, convert, generate schemas, or emit code from JSON. All transforms run locally in the browser."
+			relatedItems={[
+				{ id: 'yaml-formatter', reason: 'Same actions in YAML' },
+				{ id: 'xml-formatter', reason: 'Same actions in XML' },
+				{ id: 'diff-viewer', reason: 'Compare arbitrary text' },
+				{ id: 'jwt-decoder', reason: 'Decode JWT payloads as JSON' },
+			]}
 			renderStatusContent={(liveStats) =>
 				liveStats ? (
 					<>

--- a/src/routes/xml-formatter.tsx
+++ b/src/routes/xml-formatter.tsx
@@ -22,6 +22,13 @@ function XmlFormatterPage() {
 			title="XML Formatter"
 			calculateStats={calculateXmlStats}
 			persistKey="xml-formatter"
+			aboutText="Format, minify, query (XPath), compare, convert, generate schemas, or emit code from XML. All transforms run locally in the browser."
+			relatedItems={[
+				{ id: 'json-formatter', reason: 'Same actions in JSON' },
+				{ id: 'yaml-formatter', reason: 'Same actions in YAML' },
+				{ id: 'diff-viewer', reason: 'Compare arbitrary text' },
+				{ id: 'x509-decoder', reason: 'Inspect certificates as XML/ASN.1' },
+			]}
 			renderStatusContent={(liveStats) =>
 				liveStats ? (
 					<>

--- a/src/routes/yaml-formatter.tsx
+++ b/src/routes/yaml-formatter.tsx
@@ -22,6 +22,12 @@ function YamlFormatterPage() {
 			title="YAML Formatter"
 			calculateStats={calculateYamlStats}
 			persistKey="yaml-formatter"
+			aboutText="Format, minify, query, compare, convert, generate schemas, or emit code from YAML. All transforms run locally in the browser."
+			relatedItems={[
+				{ id: 'json-formatter', reason: 'Same actions in JSON' },
+				{ id: 'xml-formatter', reason: 'Same actions in XML' },
+				{ id: 'diff-viewer', reason: 'Compare arbitrary text' },
+			]}
 			renderStatusContent={(liveStats) =>
 				liveStats ? (
 					<>


### PR DESCRIPTION
## Summary

Surface About + Related sections in the rail of every formatter tab (JSON / YAML / XML). The rail in `TabbedFormatterPage`-based routes lives inside each tab's render — there was no shared place to drop a footer.

## Approach

Threading `aboutText` / `relatedItems` through every tab component would have meant a prop chain in 24 files (Format / Query / Compare / Convert / Schema / Generate × 4 formats). Instead the strings travel through a React context:

- `FormatterAboutProvider` carries `{ aboutText, relatedItems }`.
- `FormatterAboutFooter` consumes the context and renders the same `Related` + `About` `FormSection` pair at the bottom of any rail. No-op when neither prop is provided so templates can drop it in unconditionally.
- `TabbedFormatterPage` accepts `aboutText` / `relatedItems` props and wraps its shell in the provider.

## Changes

- New `src/lib/components/template/formatter-about.tsx` with `FormatterAboutProvider` + `FormatterAboutFooter`.
- `TabbedFormatterPage` gains `aboutText` / `relatedItems` props.
- Format / Compare / Convert / Generate templates render `<FormatterAboutFooter />` at the bottom of their `<Rail>`.
- Per-format Query and Schema tabs (json, yaml, xml) do the same.
- Wire concrete About + Related on `json-formatter`, `yaml-formatter`, `xml-formatter`.

`sql-formatter` and `url-encoder` use `ToolShell` directly and already own their rail Related / About from the earlier rollout — no change required.

## Test plan

- [ ] `bun run check` clean.
- [ ] `/json-formatter` shows About + Related at the bottom of the rail on Format / Query / Compare / Convert / Schema / Generate.
- [ ] Same for `/yaml-formatter` and `/xml-formatter`.
- [ ] `/sql-formatter` and `/url-encoder` rails remain unchanged.
