### PR TITLE
refactor(csv-tool): normalize last drop-zone copy

### DIFF
--- a/src/routes/csv-tool.tsx
+++ b/src/routes/csv-tool.tsx
@@ -596,7 +596,7 @@ function MainPane({
 				<div className="flex items-center justify-between gap-2">
 					<SectionLabel icon={TableIcon}>Input</SectionLabel>
 					<span className="text-2xs text-muted-foreground">
-						Drag a file here, paste, or type below.
+						Drop a file here, paste, or type below.
 					</span>
 				</div>
 				<Textarea


### PR DESCRIPTION
## Summary

Final stretch round of the consistency rollout. Normalize the last drop-zone copy in `csv-tool`, and explicitly close out the master-detail conversion experiment for `websocket-tester`.

## Changes

- `csv-tool` input header copy: `"Drag a file here, paste, or type below."` → `"Drop a file here, paste, or type below."` so every drop affordance in the app uses the same verb.

## Why websocket-tester stays as-is

The original plan listed `websocket-tester` as a stretch candidate for `MasterDetailLayout`. On revisit, the current chat-style frame log is the canonical UX for streaming exchanges — each frame is seen in order as it arrives, mirroring the way developers reason about WebSocket sessions. Splitting frames into a master list + a detail pane would:

- Force a click per frame to read content (currently inline).
- Break the live-tail scroll behaviour as new frames arrive.
- Misrepresent the protocol shape (ordered stream, not a browsable catalog).

The same logic applies to `dns-lookup`, `tls-inspector`, and `mac-lookup` — their results are single-query auto-output flows, not browseable catalogs. The original audit flagged all four, and after implementation work confirmed the recommendation: skipping the conversion is the right call.

## Test plan

- [ ] `bun run check` clean.
- [ ] `/csv-tool` input header reads "Drop a file here, paste, or type below."
- [ ] `/websocket-tester`, `/dns-lookup`, `/tls-inspector`, `/mac-lookup` continue to render their existing layouts unchanged.
