### PR TITLE
fix(utils): normalize filename extraction across Windows and POSIX

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,3 +1,4 @@
 export { cn } from './cn';
 export { getErrorMessage } from './errors';
 export { formatBytes } from './format';
+export { basename } from './path';

--- a/src/lib/utils/path.ts
+++ b/src/lib/utils/path.ts
@@ -1,0 +1,33 @@
+/**
+ * Lightweight cross-platform path helpers.
+ *
+ * Tauri dialogs return native paths — backslash-separated on Windows,
+ * forward-slash on macOS / Linux. UI code that wants just the file
+ * name (`split('/').pop()`) breaks silently on Windows because the
+ * separator never appears.
+ *
+ * For richer parsing / style conversion see
+ * `@/lib/services/path-tool`; prefer the helpers here for the common
+ * "show the filename" case so consumers don't drag in the heavier
+ * `path-tool` module.
+ */
+
+const SEP_PATTERN = /[\\/]/;
+
+/**
+ * Returns the last non-empty segment of `path` after splitting on
+ * either Unix (`/`) or Windows (`\`) separators. Falls back to the
+ * original path when no segment exists (empty input or trailing
+ * separator only).
+ *
+ * Examples:
+ *   basename('C:\\Users\\Alice\\file.zip') -> 'file.zip'
+ *   basename('/Users/alice/file.zip')      -> 'file.zip'
+ *   basename('/Users/alice/')              -> 'alice'
+ *   basename('')                           -> ''
+ */
+export const basename = (path: string): string => {
+	if (!path) return path;
+	const segments = path.split(SEP_PATTERN).filter((segment) => segment.length > 0);
+	return segments[segments.length - 1] ?? path;
+};

--- a/src/routes/archive-inspector.tsx
+++ b/src/routes/archive-inspector.tsx
@@ -51,7 +51,7 @@ import {
 	previewKindFor,
 } from '@/lib/services/archive';
 import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
-import { cn } from '@/lib/utils';
+import { basename, cn } from '@/lib/utils';
 
 type SortColumn = 'path' | 'size' | 'compressed' | 'modified';
 type SortDirection = 'asc' | 'desc';
@@ -338,7 +338,7 @@ function ArchiveInspectorPage() {
 	};
 
 	const hasArchive = archive !== null;
-	const filename = archive?.path.split('/').pop() ?? '';
+	const filename = archive ? basename(archive.path) : '';
 	const selectedCount = selected.size;
 	const totalEntries = archive?.entries.length ?? 0;
 	const filteredCount = filteredEntries.length;

--- a/src/routes/folder-tree-visualizer.tsx
+++ b/src/routes/folder-tree-visualizer.tsx
@@ -53,7 +53,7 @@ import {
 	type TreeNode,
 } from '@/lib/services/folder-tree';
 import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
-import { cn } from '@/lib/utils';
+import { basename, cn } from '@/lib/utils';
 
 const TOP_N = 20;
 
@@ -793,7 +793,7 @@ interface LargestFileRowProps {
 function LargestFileRow({ file, rank, biggest, onReveal }: LargestFileRowProps) {
 	const ratio = biggest > 0 ? file.sizeBytes / biggest : 0;
 	const pct = Math.max(2, Math.round(ratio * 100));
-	const name = file.path.split('/').pop() ?? file.path;
+	const name = basename(file.path);
 	return (
 		<li className="group flex flex-col gap-1 rounded-md border border-border bg-background p-2 text-xs transition-colors hover:bg-muted/40">
 			<div className="flex items-center gap-2">

--- a/src/routes/hex-editor.tsx
+++ b/src/routes/hex-editor.tsx
@@ -51,7 +51,7 @@ import {
 	type HexFileInfo,
 } from '@/lib/services/hex-editor';
 import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
-import { cn } from '@/lib/utils';
+import { basename, cn } from '@/lib/utils';
 
 const ROW_HEIGHT = 20;
 const OVERSCAN_ROWS = 12;
@@ -200,7 +200,7 @@ function HexEditorPage() {
 	const mimeInfo = useMemo(() => {
 		if (!buffer || !file) return null;
 		const head = buffer.subarray(0, Math.min(buffer.length, 4096));
-		return detectMimeFromMagic(head, file.path.split('/').pop() ?? file.path);
+		return detectMimeFromMagic(head, basename(file.path));
 	}, [buffer, file]);
 	const detectedMime = mimeInfo?.mime ?? mimeInfo?.expectedFromExtension ?? null;
 
@@ -914,7 +914,7 @@ interface FileBannerProps {
 }
 
 function FileBanner({ file, detectedMime, magicHex, dirty, pendingCount }: FileBannerProps) {
-	const filename = file.path.split('/').pop() ?? file.path;
+	const filename = basename(file.path);
 	return (
 		<Card density="compact">
 			<CardHeader>


### PR DESCRIPTION
## Summary

- Add `basename()` in `src/lib/utils/path.ts` that splits on either `/` or `\` separator and returns the last non-empty segment.
- Route four call sites that previously did `path.split('/').pop()` through the new helper.
- Restores correct filename display on Windows, where Tauri dialogs return backslash-delimited native paths.

## Changes

### Added

- `src/lib/utils/path.ts` — new cross-platform `basename()` helper with a regex separator (`/[\\/]/`).
- Re-export from `src/lib/utils/index.ts`.

### Fixed

- `src/routes/archive-inspector.tsx` (line 341) — archive title.
- `src/routes/folder-tree-visualizer.tsx` (line 796) — tree node label.
- `src/routes/hex-editor.tsx` (lines 203, 917) — MIME magic detection input and FileBanner label.

## Why

`split('/').pop()` silently returns the full Windows path (`C:\Users\Alice\file.zip`) instead of the filename. The four affected routes consume `path` strings returned by Tauri's native file pickers, which are backslash-delimited on Windows. Heavier path normalization lives in `src/lib/services/path-tool.ts`, but consumers that only need the filename should not pull in that module — hence a local utility.

Archive entry paths inside ZIP/TAR are deliberately left using `split('/')`: PKZIP APPNOTE 6.3.7 and POSIX 1003.1-2017 both specify forward-slash as the canonical entry separator, so `src/lib/services/archive.ts` is correct as-is.

## Test Plan

- [x] `bun run check` — types + page validation + design audit pass.
- [x] `bun run format` — no diff.
- [x] `bun run lint` — no new warnings introduced (existing 27 warnings unrelated).
- [ ] Smoke on Windows: open Archive Inspector against a `.zip` selected from `C:\Users\...\` — header shows `file.zip` rather than full path.
- [ ] Smoke on macOS: same flow with `/Users/.../file.zip` — unchanged behavior.

## Scope

Part 1/8 of the cross-platform audit rollout. See plan `ancient-cooking-castle.md`. PR B (Windows hardlink fallback) follows.
