### PR TITLE
fix(duplicate-finder): add Windows hard-link fallback for duplicate replacement

### DIFF
--- a/src-tauri/src/duplicate_finder.rs
+++ b/src-tauri/src/duplicate_finder.rs
@@ -545,17 +545,26 @@ pub fn duplicate_delete(paths: Vec<String>) -> Result<u64, String> {
     }
 }
 
-/// Replace `source` with a symlink to `target`. Both paths must already
-/// exist; `source` is removed and a new symlink with the same name is
-/// created pointing at `target`. Windows callers receive an error - the
-/// frontend already disables the action there.
+/// Replace `source` with a link to `target`. Both paths must already
+/// exist; `source` is removed and a new link with the same name is
+/// created pointing at `target`. The link kind depends on the OS:
+///
+/// - Unix: symbolic link via [`std::os::unix::fs::symlink`].
+/// - Windows: hard link via [`std::fs::hard_link`]. Hard links cannot
+///   span volumes; cross-volume attempts return an error from the OS.
+///
+/// Symbolic and hard links both reclaim duplicate disk space, but their
+/// semantics differ: a symlink mirrors a path (broken if the target
+/// moves); a hardlink shares the inode (broken only if every reference
+/// is removed). The frontend surfaces this distinction in the action
+/// label and About copy.
 ///
 /// # Errors
 ///
 /// Returns a stringified error when the source cannot be removed or the
-/// symlink cannot be created.
+/// link cannot be created (including the Windows cross-volume case).
 #[tauri::command]
-pub fn duplicate_replace_with_symlink(source: String, target: String) -> Result<(), String> {
+pub fn duplicate_replace_with_link(source: String, target: String) -> Result<(), String> {
     let source_path = PathBuf::from(&source);
     let target_path = PathBuf::from(&target);
 
@@ -571,9 +580,19 @@ pub fn duplicate_replace_with_symlink(source: String, target: String) -> Result<
             .map_err(|e| format!("Symlink failed: {e}"))?;
         Ok(())
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
     {
-        Err("Symlink replacement is only supported on Unix-like systems".to_string())
+        std::fs::hard_link(&target_path, &source_path).map_err(|e| {
+            format!(
+                "Hard link failed: {e} (hard links cannot span volumes; source and target must \
+                 reside on the same drive)"
+            )
+        })?;
+        Ok(())
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        Err("Link replacement is not supported on this platform".to_string())
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -493,7 +493,7 @@ pub fn run() {
             dns_lookup::dns_lookup,
             duplicate_finder::duplicate_scan,
             duplicate_finder::duplicate_delete,
-            duplicate_finder::duplicate_replace_with_symlink,
+            duplicate_finder::duplicate_replace_with_link,
             drive_info::drives_list,
             drive_info::folder_size_scan,
             file_inspect::file_inspect,

--- a/src/lib/services/duplicate-finder.ts
+++ b/src/lib/services/duplicate-finder.ts
@@ -2,7 +2,7 @@
  * Duplicate File Finder service.
  *
  * Wraps the `duplicate_scan` / `duplicate_delete` /
- * `duplicate_replace_with_symlink` Tauri commands and exposes helpers
+ * `duplicate_replace_with_link` Tauri commands and exposes helpers
  * for the duplicate-finder tool. The Rust backend handles a 3-stage
  * pipeline (size bucket -> partial hash of the first 8 KiB -> full
  * hash). Progress events stream into the UI via the
@@ -64,11 +64,12 @@ export const deleteFiles = (paths: readonly string[]): Promise<number> =>
 	invoke<number>('duplicate_delete', { paths });
 
 /**
- * Replace `source` with a symlink to `target`. Unix-only - the frontend
- * disables the action on Windows.
+ * Replace `source` with a link to `target`. The link kind is
+ * platform-dependent: symbolic link on Unix, hard link on Windows.
+ * Hard links require source and target to live on the same volume.
  */
-export const replaceWithSymlink = (source: string, target: string): Promise<void> =>
-	invoke<void>('duplicate_replace_with_symlink', { source, target });
+export const replaceWithLink = (source: string, target: string): Promise<void> =>
+	invoke<void>('duplicate_replace_with_link', { source, target });
 
 /**
  * Subscribe to scan progress events. Returns an unlisten function the

--- a/src/routes/duplicate-finder.tsx
+++ b/src/routes/duplicate-finder.tsx
@@ -27,7 +27,7 @@ import {
 	humanSize,
 	onScanProgress,
 	pickKeeper,
-	replaceWithSymlink,
+	replaceWithLink,
 	scanForDuplicates,
 	selectDeletablePaths,
 	type DuplicateEntry,
@@ -37,7 +37,7 @@ import {
 	type ScanProgress,
 	type ScanResult,
 } from '@/lib/services/duplicate-finder';
-import { getPlatform } from '@/lib/services/platform';
+import { getPlatform, type Platform } from '@/lib/services/platform';
 import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 
 // Size threshold sliders use a log-style mapping so the user can pick a
@@ -129,13 +129,15 @@ function dropDeletedFromResult(prev: ScanResult, deletedPaths: readonly string[]
 }
 
 /**
- * Replace every `selected` path with a symlink pointing at the keeper
- * for its duplicate group. The keeper is the first entry whose path is
- * not in `selected`, which mirrors the backend's shortest-path-first
- * ordering. Returns the number of successful replacements and a list of
- * per-path error messages so the caller can surface both.
+ * Replace every `selected` path with a link pointing at the keeper for
+ * its duplicate group. The link kind is platform-dependent (symlink on
+ * Unix, hard link on Windows) and resolved entirely on the Rust side.
+ * The keeper is the first entry whose path is not in `selected`, which
+ * mirrors the backend's shortest-path-first ordering. Returns the
+ * number of successful replacements and a list of per-path error
+ * messages so the caller can surface both.
  */
-async function runSymlinkReplacement(
+async function runLinkReplacement(
 	groups: readonly DuplicateGroup[],
 	selected: ReadonlySet<string>
 ): Promise<{ readonly replaced: number; readonly errors: readonly string[] }> {
@@ -157,7 +159,7 @@ async function runSymlinkReplacement(
 			continue;
 		}
 		try {
-			await replaceWithSymlink(source, keeper.path);
+			await replaceWithLink(source, keeper.path);
 			replaced += 1;
 		} catch (e) {
 			const message = e instanceof Error ? e.message : String(e);
@@ -179,18 +181,20 @@ function DuplicateFinderPage() {
 	const [progress, setProgress] = useState<ScanProgress | null>(null);
 	const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
 	const [showRail, setShowRail] = usePersistedRail('duplicate-finder');
-	const [supportsSymlink, setSupportsSymlink] = useState(true);
+	const [platform, setPlatform] = useState<Platform>('unknown');
 
 	const minSize = MIN_SIZE_STEPS[prefs.minSizeIdx] ?? MIN_SIZE_STEPS[3] ?? 1024;
 	const maxSize = MAX_SIZE_STEPS[prefs.maxSizeIdx] ?? MAX_SIZE_STEPS[4] ?? 1024 * 1024 * 1024;
 
-	// Decide symlink support once at mount; Windows shows the action as
-	// disabled with a tooltip explaining why.
+	// Resolve platform once at mount so the link action uses an
+	// OS-appropriate verb (symlink on Unix, hard link on Windows).
 	useEffect(() => {
 		getPlatform()
-			.then((p) => setSupportsSymlink(p !== 'windows'))
-			.catch(() => setSupportsSymlink(true));
+			.then(setPlatform)
+			.catch(() => undefined);
 	}, []);
+
+	const linkKind: 'symlink' | 'hardlink' = platform === 'windows' ? 'hardlink' : 'symlink';
 
 	// Subscribe to progress events for the duration of the page. The
 	// unlisten function is captured in a ref so it remains stable across
@@ -310,14 +314,15 @@ function DuplicateFinderPage() {
 		}
 	}, [selected]);
 
-	const handleReplaceWithSymlink = useCallback(async () => {
+	const handleReplaceWithLink = useCallback(async () => {
 		if (!result || selected.size === 0) {
 			toast.error('No files selected');
 			return;
 		}
-		const { replaced, errors } = await runSymlinkReplacement(result.groups, selected);
+		const { replaced, errors } = await runLinkReplacement(result.groups, selected);
+		const linkNoun = linkKind === 'hardlink' ? 'hard links' : 'symlinks';
 		if (replaced > 0) {
-			toast.success(`Replaced ${replaced} file${replaced === 1 ? '' : 's'} with symlinks`);
+			toast.success(`Replaced ${replaced} file${replaced === 1 ? '' : 's'} with ${linkNoun}`);
 		}
 		if (errors.length > 0) {
 			toast.error(`${errors.length} failure${errors.length === 1 ? '' : 's'}`, {
@@ -325,7 +330,7 @@ function DuplicateFinderPage() {
 			});
 		}
 		setSelected(new Set());
-	}, [result, selected]);
+	}, [result, selected, linkKind]);
 
 	const handleClear = useCallback(() => {
 		setResult(null);
@@ -475,16 +480,16 @@ function DuplicateFinderPage() {
 							<Button
 								variant="outline"
 								size="sm"
-								onClick={handleReplaceWithSymlink}
-								disabled={!supportsSymlink || selected.size === 0}
+								onClick={handleReplaceWithLink}
+								disabled={selected.size === 0}
 								title={
-									supportsSymlink
-										? 'Replace selected duplicates with symlinks to the kept file'
-										: 'Symlinks are not supported on Windows'
+									linkKind === 'hardlink'
+										? 'Replace selected duplicates with hard links to the kept file (same volume only)'
+										: 'Replace selected duplicates with symlinks to the kept file'
 								}
 							>
 								<Link2 className="h-3.5 w-3.5" />
-								Replace with symlink
+								{linkKind === 'hardlink' ? 'Replace with hard link' : 'Replace with symlink'}
 							</Button>
 						</div>
 					</FormSection>
@@ -504,7 +509,9 @@ function DuplicateFinderPage() {
 						<FormInfo>
 							Files are bucketed by size, then by the SHA-256 / BLAKE3 hash of the first 8 KiB, then
 							by their full-content hash. Scanning, partial hashing, and full hashing all run
-							locally; nothing leaves your machine. Symlink replacement is Unix-only.
+							locally; nothing leaves your machine. Replace-with-link uses a symbolic link on macOS
+							and Linux and a hard link on Windows. Hard links cannot span volumes, so the source
+							and kept file must share the same drive.
 						</FormInfo>
 					</FormSection>
 				</>


### PR DESCRIPTION
## Summary

- Add a Windows hard-link fallback for the duplicate-finder's "replace selected duplicates with link" action; the action was previously disabled on Windows.
- Rename the Tauri command from `duplicate_replace_with_symlink` to `duplicate_replace_with_link` so the name reflects the platform-resolved semantics.
- Surface the link kind end-to-end: action label, tooltip, success toast, and About copy.

## Changes

### Added

- `#[cfg(windows)]` branch in `duplicate_finder::duplicate_replace_with_link` that calls `std::fs::hard_link`.

### Changed

- Tauri command rename across `src-tauri/src/duplicate_finder.rs` and `src-tauri/src/lib.rs`.
- `src/lib/services/duplicate-finder.ts` — `replaceWithSymlink` → `replaceWithLink`.
- `src/routes/duplicate-finder.tsx` — read platform via `getPlatform()`, derive `linkKind`, route label and toast through it; About note explains the symlink-vs-hardlink distinction and the Windows same-volume constraint.

### Removed

- `supportsSymlink` boolean that gated the action on Unix-only. The action is now available on every OS Kogu ships to.

## Why

The previous implementation returned `"Symlink replacement is only supported on Unix-like systems"` on Windows, leaving Windows users without any space-reclaiming alternative to outright deletion. Symbolic links on Windows need administrator or developer-mode privileges, so they are not a viable default. Hard links produce the same disk-space savings as symlinks within a single volume, require no elevation, and are transparent to user-mode tools (`fsutil hardlink list` shows the multiple paths sharing a single inode).

Hard links cannot span volumes — the Rust error message and the About copy both flag this. The shared filename `replaceWithLink` keeps the command surface platform-agnostic so frontend logic does not need an OS branch on the call site.

## Test Plan

- [x] `bun run check` — types, page validation, design audit pass.
- [x] `bun run format` — no diff after format.
- [x] `bun run lint` — no new warnings (27 pre-existing unchanged).
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — clean.
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -- -W clippy::all` — clean.
- [ ] Manual on Windows: pick a folder with known duplicates, click "Replace with hard link", confirm `fsutil hardlink list <file>` lists both paths sharing one inode and the file content is preserved.
- [ ] Manual on macOS / Linux: existing symlink path unchanged — `ls -la` shows `source -> target` and `readlink source` returns the keeper.

## Scope

Part 2/8 of the cross-platform audit rollout. See plan `ancient-cooking-castle.md`. PR C (locale-agnostic ARP / NDP parsing) follows.
