### PR TITLE
fix(generators): probe known install locations on Windows for ssh-keygen and gpg

### DIFF
--- a/src-tauri/src/generators/cli.rs
+++ b/src-tauri/src/generators/cli.rs
@@ -1,9 +1,15 @@
 //! CLI tool detection and execution utilities
 
-use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 use std::process::Command;
 
-/// CLI tool availability status
+use serde::{Deserialize, Serialize};
+
+/// CLI tool availability status. The optional `*_path` fields surface
+/// the resolved binary location so the UI can show users which
+/// executable will be invoked - particularly useful on Windows where
+/// the binary may live in a vendor-specific install root that is not
+/// on `PATH`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CliAvailability {
     /// Whether ssh-keygen is available
@@ -14,63 +20,182 @@ pub struct CliAvailability {
     pub ssh_keygen_version: Option<String>,
     /// gpg version string if available
     pub gpg_version: Option<String>,
+    /// Resolved ssh-keygen path if available (display only).
+    pub ssh_keygen_path: Option<String>,
+    /// Resolved gpg path if available (display only).
+    pub gpg_path: Option<String>,
 }
 
-/// Check if ssh-keygen is available and get its version
-pub fn check_ssh_keygen() -> (bool, Option<String>) {
-    match Command::new("ssh-keygen").arg("-V").output() {
-        Ok(output) => {
-            // ssh-keygen -V outputs to stderr
-            let version = String::from_utf8_lossy(&output.stderr)
-                .lines()
-                .next()
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty());
+/// Locate the `ssh-keygen` binary. The probe spawns the binary with
+/// `--version` to verify reachability; a `PATH` hit yields a bare
+/// `PathBuf::from("ssh-keygen")`. On Windows the lookup additionally
+/// probes known vendor install locations (Git for Windows, OpenSSH for
+/// Windows, Git per-user install). Result is cached in a `OnceLock` so
+/// subsequent calls within the same process do not re-probe.
+fn detect_ssh_keygen() -> Option<PathBuf> {
+    static CACHE: std::sync::OnceLock<Option<PathBuf>> = std::sync::OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            #[cfg(target_os = "windows")]
+            let windows_fallbacks: &[&str] = &[
+                r"%ProgramFiles%\Git\usr\bin\ssh-keygen.exe",
+                r"%ProgramFiles%\OpenSSH\ssh-keygen.exe",
+                r"%LocalAppData%\Programs\Git\usr\bin\ssh-keygen.exe",
+            ];
+            #[cfg(not(target_os = "windows"))]
+            let windows_fallbacks: &[&str] = &[];
 
-            // If -V didn't work, try without args (some versions)
-            let version = version.or_else(|| {
-                String::from_utf8_lossy(&output.stdout)
-                    .lines()
-                    .next()
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-            });
+            detect_binary("ssh-keygen", windows_fallbacks)
+        })
+        .clone()
+}
 
-            (true, version)
-        }
-        Err(_) => (false, None),
+/// Locate the `gpg` binary. See [`detect_ssh_keygen`] for the strategy.
+fn detect_gpg() -> Option<PathBuf> {
+    static CACHE: std::sync::OnceLock<Option<PathBuf>> = std::sync::OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            #[cfg(target_os = "windows")]
+            let windows_fallbacks: &[&str] = &[
+                r"%ProgramFiles%\GnuPG\bin\gpg.exe",
+                r"%ProgramFiles(x86)%\GnuPG\bin\gpg.exe",
+            ];
+            #[cfg(not(target_os = "windows"))]
+            let windows_fallbacks: &[&str] = &[];
+
+            detect_binary("gpg", windows_fallbacks)
+        })
+        .clone()
+}
+
+/// Resolve a CLI binary across platforms. The probe first attempts a
+/// `PATH` lookup via `Command::new(name).arg("--version").output()`;
+/// `output()` succeeds when the binary is spawnable, even when the
+/// program exits with non-zero status. On Windows, when the `PATH`
+/// probe fails, each `windows_fallbacks` template is expanded and
+/// checked. The function returns `None` only when nothing is reachable
+/// on the current host, which lets the caller surface a "not installed"
+/// state in the UI.
+fn detect_binary(name: &str, windows_fallbacks: &[&str]) -> Option<PathBuf> {
+    if Command::new(name).arg("--version").output().is_ok() {
+        return Some(PathBuf::from(name));
     }
-}
 
-/// Check if gpg is available and get its version
-pub fn check_gpg() -> (bool, Option<String>) {
-    match Command::new("gpg").arg("--version").output() {
-        Ok(output) => {
-            if output.status.success() {
-                let version = String::from_utf8_lossy(&output.stdout)
-                    .lines()
-                    .next()
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty());
-                (true, version)
-            } else {
-                (false, None)
+    #[cfg(target_os = "windows")]
+    {
+        for template in windows_fallbacks {
+            let path = PathBuf::from(expand_env_vars(template));
+            if path.exists() {
+                return Some(path);
             }
         }
-        Err(_) => (false, None),
     }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = windows_fallbacks;
+    }
+
+    None
+}
+
+/// Expand `%VAR%` placeholders in a Windows-style path template. Returns
+/// the original template unchanged when a referenced variable is
+/// missing, which lets [`detect_windows_binary`] reject the candidate
+/// via the subsequent `exists()` check.
+#[cfg(target_os = "windows")]
+fn expand_env_vars(template: &str) -> String {
+    let mut result = String::new();
+    let mut chars = template.chars();
+    while let Some(c) = chars.next() {
+        if c != '%' {
+            result.push(c);
+            continue;
+        }
+        let mut name = String::new();
+        let mut closed = false;
+        for c in chars.by_ref() {
+            if c == '%' {
+                closed = true;
+                break;
+            }
+            name.push(c);
+        }
+        if !closed {
+            // Unterminated %; treat as literal so the caller's
+            // `exists()` check filters it out cleanly.
+            result.push('%');
+            result.push_str(&name);
+            continue;
+        }
+        match std::env::var(&name) {
+            Ok(value) => result.push_str(&value),
+            Err(_) => return template.to_string(),
+        }
+    }
+    result
+}
+
+/// Check if ssh-keygen is available and gather its version + resolved
+/// path.
+pub fn check_ssh_keygen() -> (bool, Option<String>, Option<String>) {
+    let Some(path) = detect_ssh_keygen() else {
+        return (false, None, None);
+    };
+    let path_display = path.to_string_lossy().into_owned();
+
+    match Command::new(&path).arg("-V").output() {
+        Ok(output) => {
+            // ssh-keygen -V outputs to stderr on OpenSSH; some builds
+            // print on stdout. Try stderr first, then stdout.
+            let version = first_non_empty_line(&output.stderr)
+                .or_else(|| first_non_empty_line(&output.stdout));
+            (true, version, Some(path_display))
+        }
+        Err(_) => (false, None, None),
+    }
+}
+
+/// Check if gpg is available and gather its version + resolved path.
+pub fn check_gpg() -> (bool, Option<String>, Option<String>) {
+    let Some(path) = detect_gpg() else {
+        return (false, None, None);
+    };
+    let path_display = path.to_string_lossy().into_owned();
+
+    match Command::new(&path).arg("--version").output() {
+        Ok(output) => {
+            if output.status.success() {
+                let version = first_non_empty_line(&output.stdout);
+                (true, version, Some(path_display))
+            } else {
+                (false, None, None)
+            }
+        }
+        Err(_) => (false, None, None),
+    }
+}
+
+/// Extract the first non-empty line from a command's output bytes.
+fn first_non_empty_line(bytes: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(bytes)
+        .lines()
+        .next()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 /// Check all CLI tool availability
 pub fn check_cli_availability() -> CliAvailability {
-    let (ssh_keygen, ssh_keygen_version) = check_ssh_keygen();
-    let (gpg, gpg_version) = check_gpg();
+    let (ssh_keygen, ssh_keygen_version, ssh_keygen_path) = check_ssh_keygen();
+    let (gpg, gpg_version, gpg_path) = check_gpg();
 
     CliAvailability {
         ssh_keygen,
         gpg,
         ssh_keygen_version,
         gpg_version,
+        ssh_keygen_path,
+        gpg_path,
     }
 }
 
@@ -85,5 +210,33 @@ mod tests {
         // ssh_keygen and gpg availability depends on system configuration
         let _ = availability.ssh_keygen;
         let _ = availability.gpg;
+    }
+
+    #[test]
+    fn test_first_non_empty_line_trims_and_skips_blanks() {
+        assert_eq!(first_non_empty_line(b""), None);
+        assert_eq!(first_non_empty_line(b"\n"), None);
+        assert_eq!(
+            first_non_empty_line(b"  hello  \nworld\n"),
+            Some("hello".to_string())
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_expand_env_vars_round_trip() {
+        std::env::set_var("KOGU_TEST_VAR", r"C:\Probe");
+        assert_eq!(
+            expand_env_vars(r"%KOGU_TEST_VAR%\bin\thing.exe"),
+            r"C:\Probe\bin\thing.exe"
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_expand_env_vars_keeps_template_when_missing() {
+        let template = r"%DEFINITELY_NOT_SET_KOGU_VAR%\bin\thing.exe";
+        std::env::remove_var("DEFINITELY_NOT_SET_KOGU_VAR");
+        assert_eq!(expand_env_vars(template), template);
     }
 }

--- a/src/lib/services/generators.ts
+++ b/src/lib/services/generators.ts
@@ -184,6 +184,10 @@ export interface CliAvailability {
 	readonly gpg: boolean;
 	readonly ssh_keygen_version?: string;
 	readonly gpg_version?: string;
+	/** Resolved path of ssh-keygen, surfaced to the user when the binary is not on PATH. */
+	readonly ssh_keygen_path?: string;
+	/** Resolved path of gpg, surfaced to the user when the binary is not on PATH. */
+	readonly gpg_path?: string;
 }
 
 // =============================================================================

--- a/src/routes/gpg-key-generator.tsx
+++ b/src/routes/gpg-key-generator.tsx
@@ -255,6 +255,11 @@ function GpgKeyGeneratorPage() {
 						{cliAvailability?.gpg_version ? (
 							<p className="mt-1 text-xs text-muted-foreground">{cliAvailability.gpg_version}</p>
 						) : null}
+						{cliAvailability?.gpg_path ? (
+							<p className="mt-0.5 break-all text-xs text-muted-foreground">
+								{cliAvailability.gpg_path}
+							</p>
+						) : null}
 					</FormSection>
 
 					<FormSection title="Actions">

--- a/src/routes/ssh-key-generator.tsx
+++ b/src/routes/ssh-key-generator.tsx
@@ -229,6 +229,11 @@ function SshKeyGeneratorPage() {
 								{cliAvailability.ssh_keygen_version}
 							</p>
 						) : null}
+						{cliAvailability?.ssh_keygen_path ? (
+							<p className="mt-0.5 break-all text-xs text-muted-foreground">
+								{cliAvailability.ssh_keygen_path}
+							</p>
+						) : null}
 					</FormSection>
 
 					<FormSection title="Actions">


### PR DESCRIPTION
## Summary

- Restructure CLI detection so the probe spawns the binary with `--version` and treats a successful spawn as availability, regardless of platform.
- On Windows, fall back to known vendor install locations (Git for Windows, OpenSSH for Windows, GnuPG) when `PATH` lookup fails.
- Cache the resolved path with `OnceLock` so subsequent invocations skip the probe.
- Surface the resolved binary path through `CliAvailability` so the SSH and GPG key-generator rails can show which executable will run.

## Changes

### Added

- `detect_binary(name, windows_fallbacks)` — shared cross-platform detection helper.
- `detect_ssh_keygen()` / `detect_gpg()` — cached probes; Windows variants include the vendor fallback templates.
- `expand_env_vars()` (Windows-only) — `%VAR%` template expansion with safe behavior when a variable is missing.
- `first_non_empty_line()` — extracted from the previous inline parsing in `check_ssh_keygen` / `check_gpg`.
- `ssh_keygen_path` / `gpg_path` fields on `CliAvailability` (both Rust and TypeScript sides).
- Rail About lines on `/ssh-key-generator` and `/gpg-key-generator` showing the discovered binary path.
- Tests: `test_first_non_empty_line_trims_and_skips_blanks`, plus Windows-only `test_expand_env_vars_round_trip` and `test_expand_env_vars_keeps_template_when_missing`.

### Changed

- `check_ssh_keygen()` and `check_gpg()` return `(bool, Option<String>, Option<String>)` so the path travels alongside the version.

## Why

Tauri ships across macOS, Linux, and Windows, but Windows installers for Git, GnuPG, and OpenSSH frequently do not update the user `PATH`. Previously this surfaced as "ssh-keygen not detected on PATH" / "gpg not detected on PATH" in the rail, even when the binary was installed and usable. The new probe path-matches known installer locations and reports the resolved binary so users can confirm which one will be invoked.

Cross-platform probe consistency was a secondary motivation: on macOS and Linux the previous code assumed `Command::new(name)` would always succeed and only failed at version capture time. The new design returns a meaningful `None` on every platform when nothing is reachable, which lets the UI render the "not installed" path uniformly.

## Test Plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — clean.
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -- -W clippy::all` — clean (no `unnecessary_wraps` warning after restructure).
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib generators::cli` — 2/2 pass on macOS (Windows-only tests skipped via `cfg`).
- [x] `bun run check` — types, page validation, design audit pass.
- [x] `bun run format` — no diff.
- [x] `bun run lint` — no new warnings (existing 27 unchanged).
- [ ] Manual on Windows: install Git for Windows without adding to PATH, open the SSH key generator, confirm the CLI method is enabled and the rail shows the resolved `ssh-keygen.exe` path under `%ProgramFiles%\Git\usr\bin\`.
- [ ] Manual on macOS / Linux: existing behavior unchanged — PATH-resolved `ssh-keygen` and `gpg` still detected.

## Scope

Part 4/8 of the cross-platform audit rollout. See plan `ancient-cooking-castle.md`. PR E (macOS Developer ID signing + notarization in CI) follows.
