### PR TITLE
feat(wifi-analyzer): replace placeholder table with sortable network table

### DIFF
--- a/src/lib/components/wifi-analyzer/index.ts
+++ b/src/lib/components/wifi-analyzer/index.ts
@@ -1,1 +1,2 @@
 export { WifiChannelChart } from './channel-chart';
+export { WifiNetworkTable, type SortKey, type SortDirection } from './network-table';

--- a/src/lib/components/wifi-analyzer/network-table.tsx
+++ b/src/lib/components/wifi-analyzer/network-table.tsx
@@ -1,0 +1,283 @@
+/**
+ * Wi-Fi network table — sortable, vendor-badged, RSSI-bar rows that
+ * mirror the chart selection state.
+ *
+ * The table is fully keyboard-navigable: each row is a focusable
+ * button-style cell that flips the hovered BSSID on focus, so the
+ * chart curve highlight stays in sync without requiring a mouse.
+ */
+import { ChevronDown, ChevronUp } from 'lucide-react';
+
+import { Badge } from '@/lib/components/ui/badge';
+import { cn } from '@/lib/utils';
+import {
+	type RssiBars,
+	type WifiBand,
+	type WifiNetwork,
+	bandLabel,
+	bssidColor,
+	displaySsid,
+	rssiToBars,
+	securityLabel,
+} from '@/lib/services/wifi';
+
+export type SortKey = 'rssi' | 'ssid' | 'channel' | 'band' | 'security' | 'vendor';
+export type SortDirection = 'asc' | 'desc';
+
+interface WifiNetworkTableProps {
+	readonly networks: readonly WifiNetwork[];
+	readonly sortKey: SortKey;
+	readonly sortDirection: SortDirection;
+	readonly onSortChange: (key: SortKey) => void;
+	readonly hoveredBssid: string | null;
+	readonly onHover: (bssid: string | null) => void;
+}
+
+export function WifiNetworkTable({
+	networks,
+	sortKey,
+	sortDirection,
+	onSortChange,
+	hoveredBssid,
+	onHover,
+}: WifiNetworkTableProps) {
+	const sorted = sortNetworks(networks, sortKey, sortDirection);
+
+	return (
+		<div className="h-full overflow-auto">
+			<table className="w-full text-sm">
+				<thead className="sticky top-0 z-10 bg-background text-xs uppercase text-muted-foreground shadow-sm">
+					<tr>
+						<HeaderCell
+							label="SSID"
+							sortKey="ssid"
+							currentKey={sortKey}
+							direction={sortDirection}
+							onSort={onSortChange}
+						/>
+						<HeaderCell
+							label="BSSID"
+							sortKey="vendor"
+							currentKey={sortKey}
+							direction={sortDirection}
+							onSort={onSortChange}
+						/>
+						<HeaderCell
+							label="Channel"
+							sortKey="channel"
+							currentKey={sortKey}
+							direction={sortDirection}
+							onSort={onSortChange}
+						/>
+						<HeaderCell
+							label="Band"
+							sortKey="band"
+							currentKey={sortKey}
+							direction={sortDirection}
+							onSort={onSortChange}
+						/>
+						<HeaderCell
+							label="Signal"
+							sortKey="rssi"
+							currentKey={sortKey}
+							direction={sortDirection}
+							onSort={onSortChange}
+						/>
+						<HeaderCell
+							label="Security"
+							sortKey="security"
+							currentKey={sortKey}
+							direction={sortDirection}
+							onSort={onSortChange}
+						/>
+					</tr>
+				</thead>
+				<tbody>
+					{sorted.map((network) => (
+						<NetworkRow
+							key={network.bssid}
+							network={network}
+							hovered={hoveredBssid === network.bssid}
+							onHover={onHover}
+						/>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+}
+
+interface HeaderCellProps {
+	readonly label: string;
+	readonly sortKey: SortKey;
+	readonly currentKey: SortKey;
+	readonly direction: SortDirection;
+	readonly onSort: (key: SortKey) => void;
+}
+
+function HeaderCell({ label, sortKey, currentKey, direction, onSort }: HeaderCellProps) {
+	const isActive = sortKey === currentKey;
+	return (
+		<th className="border-b border-border/40 px-3 py-2 text-left">
+			<button
+				type="button"
+				className={cn(
+					'inline-flex items-center gap-1 transition-colors',
+					isActive ? 'text-foreground' : 'hover:text-foreground'
+				)}
+				onClick={() => onSort(sortKey)}
+				aria-pressed={isActive}
+			>
+				{label}
+				{isActive ? (
+					direction === 'asc' ? (
+						<ChevronUp className="h-3 w-3" />
+					) : (
+						<ChevronDown className="h-3 w-3" />
+					)
+				) : null}
+			</button>
+		</th>
+	);
+}
+
+interface NetworkRowProps {
+	readonly network: WifiNetwork;
+	readonly hovered: boolean;
+	readonly onHover: (bssid: string | null) => void;
+}
+
+function NetworkRow({ network, hovered, onHover }: NetworkRowProps) {
+	const swatchColor = bssidColor(network.bssid);
+	return (
+		<tr
+			className={cn(
+				'border-b border-border/20 transition-colors',
+				hovered ? 'bg-accent/30' : network.isConnected ? 'bg-info/10' : 'hover:bg-accent/10'
+			)}
+			onMouseEnter={() => onHover(network.bssid)}
+			onMouseLeave={() => onHover(null)}
+			onFocus={() => onHover(network.bssid)}
+			onBlur={() => onHover(null)}
+			tabIndex={0}
+		>
+			<td className="px-3 py-2">
+				<div className="flex items-center gap-2">
+					<span
+						className="inline-block h-3 w-3 shrink-0 rounded-sm"
+						style={{ backgroundColor: swatchColor }}
+						aria-hidden
+					/>
+					<span className={cn('truncate', !network.ssid && 'italic text-muted-foreground')}>
+						{displaySsid(network)}
+					</span>
+					{network.isConnected ? (
+						<Badge variant="outline" className="border-info text-info">
+							Connected
+						</Badge>
+					) : null}
+				</div>
+			</td>
+			<td className="px-3 py-2 font-mono text-xs">
+				<div className="flex flex-col gap-0.5">
+					<span>{network.bssid}</span>
+					{network.vendor ? <span className="text-muted-foreground">{network.vendor}</span> : null}
+				</div>
+			</td>
+			<td className="px-3 py-2 tabular-nums">
+				{network.channel}
+				<span className="ml-1 text-xs text-muted-foreground">({network.channelWidthMhz} MHz)</span>
+			</td>
+			<td className="px-3 py-2 text-muted-foreground">{bandLabel(network.band)}</td>
+			<td className="px-3 py-2 tabular-nums">
+				<div className="flex items-center gap-2">
+					<RssiBarsIndicator bars={rssiToBars(network.rssiDbm)} />
+					<span>{network.rssiDbm} dBm</span>
+				</div>
+			</td>
+			<td className="px-3 py-2 text-muted-foreground">{securityLabel(network.security)}</td>
+		</tr>
+	);
+}
+
+const BAR_HEIGHTS: Record<RssiBars, number> = {
+	weak: 1,
+	fair: 2,
+	good: 3,
+	excellent: 4,
+};
+
+const BAR_TONE: Record<RssiBars, string> = {
+	weak: 'bg-destructive/70',
+	fair: 'bg-warning/70',
+	good: 'bg-info/70',
+	excellent: 'bg-success',
+};
+
+function RssiBarsIndicator({ bars }: { readonly bars: RssiBars }) {
+	const filledCount = BAR_HEIGHTS[bars];
+	const tone = BAR_TONE[bars];
+	return (
+		<div
+			className="flex items-end gap-0.5"
+			role="img"
+			aria-label={`Signal strength: ${bars}`}
+			title={`Signal strength: ${bars}`}
+		>
+			{[1, 2, 3, 4].map((idx) => (
+				<span
+					key={idx}
+					className={cn(
+						'w-1 rounded-sm transition-colors',
+						idx <= filledCount ? tone : 'bg-border/60',
+						idx === 1 && 'h-1.5',
+						idx === 2 && 'h-2',
+						idx === 3 && 'h-2.5',
+						idx === 4 && 'h-3'
+					)}
+				/>
+			))}
+		</div>
+	);
+}
+
+function sortNetworks(
+	networks: readonly WifiNetwork[],
+	key: SortKey,
+	direction: SortDirection
+): readonly WifiNetwork[] {
+	const dir = direction === 'asc' ? 1 : -1;
+	return [...networks].sort((a, b) => {
+		const cmp = compareByKey(a, b, key);
+		return cmp * dir;
+	});
+}
+
+function compareByKey(a: WifiNetwork, b: WifiNetwork, key: SortKey): number {
+	switch (key) {
+		case 'rssi':
+			return a.rssiDbm - b.rssiDbm;
+		case 'ssid':
+			return (a.ssid ?? '').localeCompare(b.ssid ?? '');
+		case 'channel':
+			return a.channel - b.channel;
+		case 'band':
+			return compareBand(a.band, b.band);
+		case 'security':
+			return a.security.localeCompare(b.security);
+		case 'vendor':
+			return (a.vendor ?? '').localeCompare(b.vendor ?? '');
+		default:
+			return 0;
+	}
+}
+
+const BAND_ORDER: Record<WifiBand, number> = {
+	band24: 0,
+	band5: 1,
+	band6: 2,
+};
+
+function compareBand(a: WifiBand, b: WifiBand): number {
+	return BAND_ORDER[a] - BAND_ORDER[b];
+}

--- a/src/routes/wifi-analyzer.tsx
+++ b/src/routes/wifi-analyzer.tsx
@@ -20,7 +20,12 @@ import {
 	FormSection,
 	FormSlider,
 } from '@/lib/components/form';
-import { WifiChannelChart } from '@/lib/components/wifi-analyzer';
+import {
+	type SortDirection,
+	type SortKey,
+	WifiChannelChart,
+	WifiNetworkTable,
+} from '@/lib/components/wifi-analyzer';
 import { ToolShell } from '@/lib/components/shell';
 import { EmptyState, ErrorDisplay, StatItem } from '@/lib/components/status';
 import {
@@ -35,8 +40,6 @@ import {
 	type WifiScanEvent,
 	bandLabel,
 	cancelWifiScan,
-	displaySsid,
-	securityLabel,
 	startWifiScan,
 } from '@/lib/services/wifi';
 import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
@@ -45,11 +48,10 @@ export const Route = createFileRoute('/wifi-analyzer')({
 	component: WifiAnalyzerPage,
 });
 
-type WifiSortKey = 'rssi' | 'ssid' | 'channel';
-
 interface WifiAnalyzerOptions {
 	readonly band: WifiBand;
-	readonly sort: WifiSortKey;
+	readonly sortKey: SortKey;
+	readonly sortDirection: SortDirection;
 	readonly filter: string;
 	readonly hideHidden: boolean;
 	readonly highlightConnected: boolean;
@@ -58,7 +60,8 @@ interface WifiAnalyzerOptions {
 
 const DEFAULT_OPTIONS: WifiAnalyzerOptions = {
 	band: 'band24',
-	sort: 'rssi',
+	sortKey: 'rssi',
+	sortDirection: 'desc',
 	filter: '',
 	hideHidden: false,
 	highlightConnected: true,
@@ -76,12 +79,6 @@ const BAND_OPTIONS = [
 	{ value: 'band24', label: '2.4 GHz', description: 'Channels 1–14, 20 MHz primary' },
 	{ value: 'band5', label: '5 GHz', description: 'Channels 36–165' },
 	{ value: 'band6', label: '6 GHz', description: 'Wi-Fi 6E, channels 1–233' },
-] as const;
-
-const SORT_OPTIONS = [
-	{ value: 'rssi', label: 'Signal' },
-	{ value: 'ssid', label: 'SSID' },
-	{ value: 'channel', label: 'Channel' },
 ] as const;
 
 function WifiAnalyzerPage() {
@@ -220,15 +217,6 @@ function WifiAnalyzerPage() {
 						/>
 					</FormSection>
 
-					<FormSection title="Sort">
-						<FormMode<WifiSortKey>
-							layout="stacked"
-							value={prefs.sort}
-							onValueChange={(v) => patch({ sort: v })}
-							options={[...SORT_OPTIONS]}
-						/>
-					</FormSection>
-
 					<FormSection title="About">
 						<FormInfo>
 							Reads the OS Wi-Fi cache via CoreWLAN (macOS), NetworkManager DBus (Linux), or the
@@ -268,8 +256,17 @@ function WifiAnalyzerPage() {
 				</ResizablePanel>
 				<ResizableHandle />
 				<ResizablePanel defaultSize={40} minSize={20}>
-					<PlaceholderTable
+					<WifiNetworkTable
 						networks={filtered}
+						sortKey={prefs.sortKey}
+						sortDirection={prefs.sortDirection}
+						onSortChange={(key) =>
+							patch(
+								key === prefs.sortKey
+									? { sortDirection: prefs.sortDirection === 'asc' ? 'desc' : 'asc' }
+									: { sortKey: key, sortDirection: key === 'rssi' ? 'desc' : 'asc' }
+							)
+						}
 						hoveredBssid={hoveredBssid}
 						onHover={setHoveredBssid}
 					/>
@@ -284,7 +281,7 @@ function applyFilters(
 	prefs: WifiAnalyzerOptions
 ): readonly WifiNetwork[] {
 	const needle = prefs.filter.trim().toLowerCase();
-	const filtered = networks.filter((n) => {
+	return networks.filter((n) => {
 		if (prefs.hideHidden && !n.ssid) return false;
 		if (needle.length > 0) {
 			const haystack = (n.ssid ?? '').toLowerCase();
@@ -292,68 +289,4 @@ function applyFilters(
 		}
 		return true;
 	});
-	return [...filtered].sort((a, b) => {
-		switch (prefs.sort) {
-			case 'rssi':
-				return b.rssiDbm - a.rssiDbm;
-			case 'ssid':
-				return (a.ssid ?? '').localeCompare(b.ssid ?? '');
-			case 'channel':
-				return a.channel - b.channel;
-			default:
-				return 0;
-		}
-	});
-}
-
-interface PlaceholderTableProps {
-	readonly networks: readonly WifiNetwork[];
-	readonly hoveredBssid: string | null;
-	readonly onHover: (bssid: string | null) => void;
-}
-
-/**
- * Minimal raw-HTML table so PR 2 can ship without the polished sort
- * UI. PR 3 replaces this with `WifiNetworkTable` (sortable columns,
- * vendor badges, RSSI bars).
- */
-function PlaceholderTable({ networks, hoveredBssid, onHover }: PlaceholderTableProps) {
-	return (
-		<div className="h-full overflow-auto p-3">
-			<table className="w-full text-sm">
-				<thead className="text-xs uppercase text-muted-foreground">
-					<tr>
-						<th className="px-2 py-1 text-left">SSID</th>
-						<th className="px-2 py-1 text-left">BSSID</th>
-						<th className="px-2 py-1 text-left">Channel</th>
-						<th className="px-2 py-1 text-left">RSSI</th>
-						<th className="px-2 py-1 text-left">Security</th>
-						<th className="px-2 py-1 text-left">Vendor</th>
-					</tr>
-				</thead>
-				<tbody>
-					{networks.map((n) => (
-						<tr
-							key={n.bssid}
-							className={
-								hoveredBssid === n.bssid ? 'bg-accent/30' : n.isConnected ? 'bg-info/10' : ''
-							}
-							onMouseEnter={() => onHover(n.bssid)}
-							onMouseLeave={() => onHover(null)}
-						>
-							<td className="px-2 py-1">{displaySsid(n)}</td>
-							<td className="px-2 py-1 font-mono text-xs">{n.bssid}</td>
-							<td className="px-2 py-1">
-								{n.channel}
-								<span className="ml-1 text-muted-foreground">({n.channelWidthMhz} MHz)</span>
-							</td>
-							<td className="px-2 py-1">{n.rssiDbm} dBm</td>
-							<td className="px-2 py-1">{securityLabel(n.security)}</td>
-							<td className="px-2 py-1 text-muted-foreground">{n.vendor ?? '—'}</td>
-						</tr>
-					))}
-				</tbody>
-			</table>
-		</div>
-	);
 }


### PR DESCRIPTION
## Summary

- Replace the PR #365 placeholder table with `WifiNetworkTable`: sortable column headers, RSSI bar indicator, vendor display, and a "Connected" badge for the currently-associated AP.
- Wire shared `hoveredBssid` state between the table rows and the chart curves; focusing a row via keyboard also lifts the matching curve.
- Persist `sortKey` + `sortDirection` separately so the column the user last clicked survives reloads.

## Changes

### Added

- `src/lib/components/wifi-analyzer/network-table.tsx` — `WifiNetworkTable` component with clickable `<HeaderCell>` headers, `<NetworkRow>` keyboard-focusable rows (`tabIndex={0}` + `onFocus` / `onBlur` hover bridge), `RssiBarsIndicator` (4-bar SVG-free div meter color-coded by signal tier), and a deterministic `bssidColor` swatch beside each SSID.
- `SortKey` and `SortDirection` types exported from `src/lib/components/wifi-analyzer/index.ts`.

### Changed

- `src/routes/wifi-analyzer.tsx` — drops the placeholder table component, drops the Sort `FormMode` rail control, and persists `sortKey` + `sortDirection` instead of a flat `sort` enum. Header-click toggles direction; switching to a different column starts the new sort ascending (except `rssi`, which defaults to descending so strongest networks appear first).
- `src/lib/components/wifi-analyzer/index.ts` — exports the new table component and sort types.

## Why

PR 2 shipped the chart and a raw-HTML table good enough for visual development but missing the actual ergonomics: no sort UI, no signal-strength visualization beyond raw dBm, no vendor surface, no connected-AP cue. PR 3 closes those gaps and links the table to the chart through a single shared `hoveredBssid` state so the user can drill into any AP from either side and see the corresponding piece in both panels.

The table follows the same `cn()` + Tailwind tone-map pattern used by `drive-info` and `network-interfaces`. The RSSI bar indicator is a tiny 4-bar div meter sized via `h-1.5 / h-2 / h-2.5 / h-3` and tinted from the existing semantic palette (`bg-destructive/70` → `bg-warning/70` → `bg-info/70` → `bg-success`), so it matches the rest of the app without introducing a new color scheme.

## Test Plan

- [x] `bun run check` — types, page validation, design audit pass.
- [x] `bun run format` — no diff after format.
- [x] `bun run lint` — no new errors (only the pre-existing 27 warnings).
- [ ] Manual smoke (fixture mode): `KOGU_WIFI_FIXTURES=1 bun run tauri dev`, navigate to `/wifi-analyzer`, click Scan. Click each column header; verify chevron direction flips and rows reorder. Hover a chart curve; the matching row gets `bg-accent/30`. Tab through rows; the matching chart curve lifts on focus.
- [ ] Manual smoke (real Wi-Fi): same flow on macOS with Location Services granted; verify the connected AP shows the "Connected" badge and `bg-info/10` row tint.

## Scope

PR 3 of 3 in the Wi-Fi Analyzer rollout. Closes the feature; the Windows scanner stub remains for a separate follow-up PR (referenced in the PR #364 description).
