### PR TITLE
ci(release): remove Apple env forwarding to unblock release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,19 +123,6 @@ jobs:
         uses: tauri-apps/tauri-action@v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Apple Developer ID signing + notarization. Each secret is
-          # gated on the macOS runner so the credentials never enter the
-          # Linux or Windows job environments. The Tauri bundler signs
-          # and notarizes macOS builds when every value is set; missing
-          # values fall back to the ad-hoc signing path declared in
-          # tauri.conf.json, so forks and unconfigured repos still
-          # produce DMG artifacts.
-          APPLE_CERTIFICATE: ${{ matrix.settings.os == 'macos-latest' && secrets.APPLE_CERTIFICATE || '' }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ matrix.settings.os == 'macos-latest' && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
-          APPLE_SIGNING_IDENTITY: ${{ matrix.settings.os == 'macos-latest' && secrets.APPLE_SIGNING_IDENTITY || '' }}
-          APPLE_ID: ${{ matrix.settings.os == 'macos-latest' && secrets.APPLE_ID || '' }}
-          APPLE_PASSWORD: ${{ matrix.settings.os == 'macos-latest' && secrets.APPLE_PASSWORD || '' }}
-          APPLE_TEAM_ID: ${{ matrix.settings.os == 'macos-latest' && secrets.APPLE_TEAM_ID || '' }}
         with:
           tagName: nightly
           releaseName: 'Nightly Build'
@@ -154,12 +141,6 @@ jobs:
         uses: tauri-apps/tauri-action@v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPLE_CERTIFICATE: ${{ matrix.settings.os == 'macos-latest' && secrets.APPLE_CERTIFICATE || '' }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ matrix.settings.os == 'macos-latest' && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
-          APPLE_SIGNING_IDENTITY: ${{ matrix.settings.os == 'macos-latest' && secrets.APPLE_SIGNING_IDENTITY || '' }}
-          APPLE_ID: ${{ matrix.settings.os == 'macos-latest' && secrets.APPLE_ID || '' }}
-          APPLE_PASSWORD: ${{ matrix.settings.os == 'macos-latest' && secrets.APPLE_PASSWORD || '' }}
-          APPLE_TEAM_ID: ${{ matrix.settings.os == 'macos-latest' && secrets.APPLE_TEAM_ID || '' }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: 'Kogu ${{ github.ref_name }}'

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -1,17 +1,22 @@
 # Release Signing and Notarization
 
-This document explains how Kogu's release workflow signs and notarizes
-macOS builds. Without these secrets configured, the workflow still
-produces DMG artifacts using ad-hoc signing (the fallback declared in
-`src-tauri/tauri.conf.json` via `signingIdentity: "-"`). Ad-hoc-signed
-DMGs trigger a Gatekeeper warning on first launch; signed and
-notarized DMGs install cleanly.
+This document explains how Kogu can sign and notarize macOS builds.
+The release workflow currently produces DMGs with **ad-hoc signing**
+(`signingIdentity: "-"` in `src-tauri/tauri.conf.json`); enabling
+Developer ID signing requires both configuring the secrets below and
+re-wiring `.github/workflows/release.yml` to forward them to
+`tauri-apps/tauri-action`. The forwarding step was removed because
+GitHub Actions expressions cannot toggle env keys based on secret
+presence, so passing empty strings caused `security import` to fail
+in repositories where the secrets are not configured. See the
+"Re-enabling signing" section below for the rewire pattern that
+works.
 
 ## Required GitHub repository secrets
 
-The `Build and release` step in `.github/workflows/release.yml` forwards
-the following secrets to `tauri-apps/tauri-action`, which passes them
-to the Tauri bundler. All values are case-sensitive.
+To sign and notarize macOS DMGs, configure the following secrets and
+then re-enable the forwarding step (see below). All values are
+case-sensitive.
 
 | Secret                       | Value                                                                                                                                       |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -22,13 +27,47 @@ to the Tauri bundler. All values are case-sensitive.
 | `APPLE_PASSWORD`             | App-specific password generated at <https://appleid.apple.com> for the `APPLE_ID` account.                                                  |
 | `APPLE_TEAM_ID`              | Ten-character team identifier shown in the Apple Developer portal.                                                                          |
 
-When any one of these is missing, the bundler skips both signing and
-notarization for that build and falls back to ad-hoc signing.
+## Re-enabling signing once the secrets are set
 
-The secrets are gated on the macOS matrix legs in the workflow, so
-they are never forwarded to the Linux or Windows runners. This limits
-the credentials' reachable surface to the job that actually consumes
-them.
+Once every secret above is configured, restore the forwarding by
+adding a precheck step that flips an output flag when the credentials
+are available, then guard the `tauri-action` step on that flag. This
+keeps env keys absent when secrets are missing, which `tauri-action`
+treats as "skip signing" instead of "import the empty cert":
+
+```yaml
+- name: Check Apple signing secrets
+  id: apple-signing
+  if: runner.os == 'macOS'
+  shell: bash
+  env:
+    HAS_CERT: ${{ secrets.APPLE_CERTIFICATE != '' }}
+  run: echo "available=$HAS_CERT" >> "$GITHUB_OUTPUT"
+
+- name: Build and release (macOS, signed)
+  if: |
+    runner.os == 'macOS' &&
+    steps.apple-signing.outputs.available == 'true'
+  uses: tauri-apps/tauri-action@v0.6.2
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+    # ... rest of APPLE_* secrets ...
+  with:
+    # ...
+
+- name: Build and release (unsigned)
+  if: |
+    runner.os != 'macOS' ||
+    steps.apple-signing.outputs.available != 'true'
+  uses: tauri-apps/tauri-action@v0.6.2
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    # ...
+```
+
+The remainder of this document covers preparing each secret.
 
 ## Preparing the certificate
 


### PR DESCRIPTION
## Summary

- Remove the `APPLE_*` env forwarding from both `tauri-action` invocations in `.github/workflows/release.yml` to unblock the release workflow, which has been failing on every push since PR #360.
- Update `docs/release-signing.md` with the correct pattern for re-enabling Developer ID signing (precheck step + step-level `if:` guards) so future operators can re-add it cleanly once the secrets are configured.

## Why the workflow was failing

PR #360 forwarded six `APPLE_*` secrets through `tauri-action`'s `env:` using the workflow expression `${{ matrix.settings.os == 'macos-latest' && secrets.APPLE_CERTIFICATE || '' }}`. The intent was to keep the secrets off non-macOS runners.

But GitHub Actions workflow expressions cannot conditionally omit an env key based on secret presence — they can only substitute the value. In repositories where the secrets have not been configured (which is the current state), `secrets.APPLE_CERTIFICATE` evaluates to an empty string, and the env key `APPLE_CERTIFICATE=""` is still considered "set" by `tauri-action` and the Tauri bundler. The bundler then tries to import the empty certificate via `security import` and fails:

```
security: SecKeychainItemImport: One or more parameters passed to a function were not valid.
failed to bundle project failed codesign application: failed to run command security import: failed to import keychain certificate
```

This has produced **failure on every nightly release since 2026-05-27T16:49Z** (20+ consecutive runs).

## Fix

Strip the `APPLE_*` env from both the nightly and stable `tauri-action` steps. macOS builds revert to ad-hoc signing per `tauri.conf.json::macOS::signingIdentity = "-"`, matching the configuration that produced successful releases through 2026-05-26.

## How to re-enable signing later

The previous "single env block with empty-string fallback" pattern cannot work. `docs/release-signing.md` now documents the working pattern: a precheck step that emits `available=true/false` based on `secrets.APPLE_CERTIFICATE != ''`, followed by two mutually-exclusive `tauri-action` steps — one signed (with the env block) gated on `available == 'true'`, and one unsigned (no env block) gated on the negation. Because env keys are only present on the branch that has the secrets, the bundler is never asked to import an empty cert.

## Changes

### Changed

- `.github/workflows/release.yml` — removed 12 lines of `APPLE_*` env from both `Build and release (nightly)` and `Build and release (stable)`.
- `docs/release-signing.md` — replaced the "currently active" framing with "currently disabled, here is how to re-enable" framing and added the precheck + dual-step pattern.

## Test Plan

- [x] `bun run format` — clean.
- [ ] Once merged, observe the next push to `main` triggers a nightly release that produces DMG artifacts on macOS (ad-hoc signed). The workflow should be green for the first time since 2026-05-27.

## Scope

Hotfix for the continuously-failing release workflow. The signing
groundwork laid in PR #360 is preserved in documentation; re-enabling
it is a separate operator action once `APPLE_*` secrets are configured.
