### PR TITLE
feat(hooks): add useDebouncedValue and apply to reactive routes

### DIFF
--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useClipboardActions } from './use-clipboard-actions';
+export { useDebouncedCallback, useDebouncedValue } from './use-debounced-value';
 export { useDocumentTitle } from './use-document-title';
 export {
 	useFormatterPage,

--- a/src/lib/hooks/use-debounced-value.ts
+++ b/src/lib/hooks/use-debounced-value.ts
@@ -1,0 +1,82 @@
+/**
+ * Project-wide debounce primitives for reactive input-driven
+ * computations.
+ *
+ * Use [`useDebouncedValue`] to throttle a piece of state that drives a
+ * downstream effect (Tauri `invoke`, Web Worker `postMessage`, WASM
+ * call, network request, or any expensive sync computation). Use
+ * [`useDebouncedCallback`] for click / change handlers whose body
+ * performs the same kind of work.
+ *
+ * Picking between debounce and React 19's `useDeferredValue`:
+ *
+ * - **`useDebouncedValue` (this hook)** — for state that flows into an
+ *   `useEffect` performing I/O. `useDeferredValue` does not delay
+ *   effects; it only marks the current frame as transitional, so the
+ *   effect still fires on every keystroke with the latest value.
+ * - **`useDeferredValue`** — for *synchronous* derived JSX where you
+ *   want React to keep the previous render visible while computing
+ *   the new one. Cheaper to integrate (no `useState` indirection) but
+ *   does nothing for effects.
+ *
+ * Delay defaults: 100ms for cheap formatters, 150ms for medium-cost
+ * routes, 200-250ms for expensive (regex AST, WASM compress, etc.).
+ * The hook accepts an explicit `delayMs` so per-route tuning stays
+ * one number; the default mirrors the medium-cost case.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Return a debounced mirror of `value`. The returned value lags
+ * `value` by `delayMs` milliseconds and only updates after `value`
+ * has settled — successive changes inside the window collapse into a
+ * single update.
+ */
+export const useDebouncedValue = <T>(value: T, delayMs = 200): T => {
+	const [debounced, setDebounced] = useState<T>(value);
+	useEffect(() => {
+		const handle = window.setTimeout(() => setDebounced(value), delayMs);
+		return () => window.clearTimeout(handle);
+	}, [value, delayMs]);
+	return debounced;
+};
+
+/**
+ * Return a debounced wrapper around `fn`. Successive calls inside
+ * `delayMs` collapse into a single trailing invocation. The wrapper
+ * keeps a stable identity across renders (safe to use as an effect
+ * dependency or pass to memoized children).
+ */
+export const useDebouncedCallback = <Args extends readonly unknown[]>(
+	fn: (...args: Args) => void,
+	delayMs = 200
+): ((...args: Args) => void) => {
+	const fnRef = useRef(fn);
+	const timerRef = useRef<number | null>(null);
+
+	useEffect(() => {
+		fnRef.current = fn;
+	}, [fn]);
+
+	useEffect(
+		() => () => {
+			if (timerRef.current !== null) {
+				window.clearTimeout(timerRef.current);
+			}
+		},
+		[]
+	);
+
+	return useCallback(
+		(...args: Args) => {
+			if (timerRef.current !== null) {
+				window.clearTimeout(timerRef.current);
+			}
+			timerRef.current = window.setTimeout(() => {
+				timerRef.current = null;
+				fnRef.current(...args);
+			}, delayMs);
+		},
+		[delayMs]
+	);
+};

--- a/src/lib/hooks/use-formatter-page.ts
+++ b/src/lib/hooks/use-formatter-page.ts
@@ -3,6 +3,8 @@ import { useLocation, useNavigate } from '@tanstack/react-router';
 
 import { useActiveTab, useTabStore } from '@/lib/stores';
 
+import { useDebouncedValue } from './use-debounced-value';
+
 export interface TabStats {
 	readonly input: string;
 	readonly valid: boolean | null;
@@ -141,15 +143,20 @@ export const useFormatterPage = <TStats>(
 		[tabStatsHandlers]
 	);
 
+	// Debounce stats recomputation so parsing large JSON / XML / YAML
+	// payloads only fires after the user pauses typing. Parse cost on
+	// medium documents is ~10-30ms; 150ms is invisible to typing but
+	// collapses bursts into a single call.
+	const debouncedSharedInput = useDebouncedValue(sharedInput, 150);
 	const liveStats = useMemo<TStats | null>(() => {
-		const input = sharedInput.trim();
+		const input = debouncedSharedInput.trim();
 		if (!input) return null;
 		try {
 			return calculateStats(input);
 		} catch {
 			return null;
 		}
-	}, [sharedInput, calculateStats]);
+	}, [debouncedSharedInput, calculateStats]);
 
 	useEffect(() => {
 		if (persistKey) setStoredTab(persistKey, activeTab);

--- a/src/routes/base64-encoder.tsx
+++ b/src/routes/base64-encoder.tsx
@@ -16,7 +16,7 @@ import {
 import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
-import { useDocumentTitle } from '@/lib/hooks';
+import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
 import { usePersistedRail } from '@/lib/stores';
 import {
 	BASE64_MIME_TYPES,
@@ -78,17 +78,25 @@ function Base64EncoderPage() {
 		autoDetectVariant,
 	};
 
-	const detectedVariant = mode === 'decode' && input.trim() ? detectBase64Variant(input) : null;
-	const detectedDataUrl = mode === 'decode' && input.trim() ? isDataUrl(input) : false;
-	const detectedMimeType = detectedDataUrl ? extractMimeType(input) : null;
+	// Debounce the input feeding the encode / decode pipeline so typing
+	// large payloads (data URLs, base64 blobs) does not retrigger the
+	// transform on every keystroke. 100ms is invisible to typing but
+	// collapses fast bursts.
+	const debouncedInput = useDebouncedValue(input, 100);
+
+	const detectedVariant =
+		mode === 'decode' && debouncedInput.trim() ? detectBase64Variant(debouncedInput) : null;
+	const detectedDataUrl =
+		mode === 'decode' && debouncedInput.trim() ? isDataUrl(debouncedInput) : false;
+	const detectedMimeType = detectedDataUrl ? extractMimeType(debouncedInput) : null;
 
 	const { output, error } = ((): { output: string; error: string } => {
-		if (!input.trim()) return { output: '', error: '' };
+		if (!debouncedInput.trim()) return { output: '', error: '' };
 		try {
 			const result =
 				mode === 'encode'
-					? encodeToBase64(input, encodeOptions)
-					: decodeFromBase64(input, decodeOptions);
+					? encodeToBase64(debouncedInput, encodeOptions)
+					: decodeFromBase64(debouncedInput, decodeOptions);
 			return { output: result, error: '' };
 		} catch (e) {
 			return { output: '', error: getErrorMessage(e, 'Invalid input') };

--- a/src/routes/escape-tool.tsx
+++ b/src/routes/escape-tool.tsx
@@ -27,7 +27,7 @@ import { StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
 import { IconTooltip } from '@/lib/components/ui/icon-tooltip';
 import { Textarea } from '@/lib/components/ui/textarea';
-import { useDocumentTitle } from '@/lib/hooks';
+import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
 import { createToolOptionsStore, useActiveTab, useTabStore } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 import { pasteFromClipboard } from '@/lib/utils/file-operations';
@@ -132,23 +132,35 @@ function EscapeToolPage() {
 	const raw = rawByFlavor[activeFlavor];
 	const escaped = escapedByFlavor[activeFlavor];
 
+	// Debounce the textareas separately so character-by-character processing
+	// (escapeByFlavor / unescapeByFlavor traverse every input character) does
+	// not run on every keystroke. Typing remains instant in the textarea
+	// (which renders `raw` / `escaped` directly); only the cross-side sync
+	// lags by 150ms.
+	const debouncedRaw = useDebouncedValue(raw, 150);
+	const debouncedEscaped = useDebouncedValue(escaped, 150);
+
 	// Sync: when the raw side or options change after a raw edit, recompute the
 	// escaped side. Symmetrically, after an escaped edit recompute the raw
-	// side. Driven by `[activeFlavor, persisted.options, raw, escaped]` so
-	// option toggles take effect immediately.
+	// side. Driven by `[activeFlavor, persisted.options, debouncedRaw,
+	// debouncedEscaped]` so option toggles take effect immediately.
 	useEffect(() => {
 		if (lastEditedSideRef.current === 'raw') {
-			const nextEscaped = escapeByFlavor(activeFlavor, raw, persisted.options);
-			if (nextEscaped !== escaped) {
+			const nextEscaped = escapeByFlavor(activeFlavor, debouncedRaw, persisted.options);
+			if (nextEscaped !== escapedByFlavor[activeFlavor]) {
 				setEscapedByFlavor((prev) => ({ ...prev, [activeFlavor]: nextEscaped }));
 			}
 		} else {
-			const nextRaw = unescapeByFlavor(activeFlavor, escaped, persisted.options);
-			if (nextRaw !== raw) {
+			const nextRaw = unescapeByFlavor(activeFlavor, debouncedEscaped, persisted.options);
+			if (nextRaw !== rawByFlavor[activeFlavor]) {
 				setRawByFlavor((prev) => ({ ...prev, [activeFlavor]: nextRaw }));
 			}
 		}
-	}, [activeFlavor, persisted.options, raw, escaped]);
+		// rawByFlavor / escapedByFlavor read inside the effect intentionally
+		// skip the dep array to avoid cycling on the very state this effect
+		// writes; the debounced reads above already provide the trigger.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [activeFlavor, persisted.options, debouncedRaw, debouncedEscaped]);
 
 	const updateRaw = (value: string) => {
 		lastEditedSideRef.current = 'raw';

--- a/src/routes/hash-generator.tsx
+++ b/src/routes/hash-generator.tsx
@@ -38,7 +38,7 @@ import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { CodeBlock } from '@/lib/components/ui/code-block';
 import { ToneBadge } from '@/lib/components/ui/tone-badge';
-import { useDocumentTitle } from '@/lib/hooks';
+import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
 import {
 	BATCH_HASH_ALGO_LABELS,
 	BATCH_HASH_ALGO_SECURE,
@@ -129,11 +129,12 @@ function HashGeneratorPage() {
 
 function TextHashTab() {
 	const [textInput, setTextInput] = useState('');
+	const debouncedTextInput = useDebouncedValue(textInput, 150);
 
 	const textHashes = useMemo(() => {
-		if (!textInput.trim()) return [];
-		return generateAllHashes(textInput);
-	}, [textInput]);
+		if (!debouncedTextInput.trim()) return [];
+		return generateAllHashes(debouncedTextInput);
+	}, [debouncedTextInput]);
 
 	const handlePaste = async () => {
 		try {

--- a/src/routes/http-status-codes.tsx
+++ b/src/routes/http-status-codes.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { AlertTriangle, BookOpen, ExternalLink, Search, X } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import { ActionButton, CopyButton } from '@/lib/components/action';
 import {
@@ -17,7 +17,7 @@ import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { ToneBadge } from '@/lib/components/ui/tone-badge';
-import { useDocumentTitle } from '@/lib/hooks';
+import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
 import {
 	ALL_CATEGORIES,
 	CATEGORY_LABELS,
@@ -66,13 +66,8 @@ function HttpStatusCodesPage() {
 	const { query, categories, includeNonStandard, misuseOnly, selectedCode } = options;
 
 	const [showRail, setShowRail] = usePersistedRail('http-status-codes');
-	const [debouncedQuery, setDebouncedQuery] = useState(query);
-
 	// Debounce text input by 100ms so typing does not thrash the grid.
-	useEffect(() => {
-		const handle = window.setTimeout(() => setDebouncedQuery(query), 100);
-		return () => window.clearTimeout(handle);
-	}, [query]);
+	const debouncedQuery = useDebouncedValue(query, 100);
 
 	const categorySet = useMemo<ReadonlySet<StatusCategory>>(() => new Set(categories), [categories]);
 

--- a/src/routes/markdown-editor.tsx
+++ b/src/routes/markdown-editor.tsx
@@ -54,7 +54,7 @@ import {
 } from '@/lib/components/ui/dropdown-menu';
 import { ListItemButton } from '@/lib/components/ui/list-item-button';
 import { IconTooltip } from '@/lib/components/ui/icon-tooltip';
-import { useDocumentTitle } from '@/lib/hooks';
+import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
 import { usePersistedRail } from '@/lib/stores';
 import {
 	applyFormat,
@@ -272,12 +272,17 @@ function MarkdownEditorPage() {
 	const toc = useMemo(() => generateToc(input), [input]);
 	const valid: boolean | null = input.trim() ? true : null;
 
+	// Debounce the input feeding the preview pipeline so Mermaid / KaTeX /
+	// Lowlight do not recompile on every keystroke. 200ms is short enough to
+	// feel live and long enough to collapse rapid typing into one render.
+	const debouncedInput = useDebouncedValue(input, 200);
+
 	// Render HTML preview asynchronously to support TeX and diagrams. The
 	// cancellation flag lives in a const ref so the cleanup closure can flip
 	// it without a `let` binding.
 	useEffect(() => {
 		const lifecycle = { cancelled: false };
-		markdownToHtmlAsync(input)
+		markdownToHtmlAsync(debouncedInput)
 			.then((result) => {
 				if (!lifecycle.cancelled) setHtmlOutput(result);
 			})
@@ -285,7 +290,7 @@ function MarkdownEditorPage() {
 		return () => {
 			lifecycle.cancelled = true;
 		};
-	}, [input]);
+	}, [debouncedInput]);
 
 	// Mirror markdown into Vizel whenever the source-of-truth string changes
 	// from outside Vizel (Monaco edits, paste, sample, TOC insert, etc.).

--- a/src/routes/qr-code-generator.tsx
+++ b/src/routes/qr-code-generator.tsx
@@ -34,7 +34,7 @@ import { EmbeddedEmptyState, LiveStatusRegion, StatItem } from '@/lib/components
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { IconTooltip } from '@/lib/components/ui/icon-tooltip';
-import { useDocumentTitle } from '@/lib/hooks';
+import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
 import { usePersistedRail } from '@/lib/stores';
 import {
 	CONTENT_KINDS,
@@ -120,7 +120,11 @@ function QrCodeGeneratorPage() {
 	useDocumentTitle('QR Code Generator');
 
 	const currentContent = contents[activeKind];
-	const encodedData = encodeQrContent(currentContent);
+	// Debounce the content payload before the qr-code-styling render so
+	// typing a long URL or vCard does not re-render the canvas on every
+	// keystroke. Validity stays on the raw content for instant feedback.
+	const debouncedEncodedData = useDebouncedValue(encodeQrContent(currentContent), 200);
+	const encodedData = debouncedEncodedData;
 	const valid = isContentValid(currentContent);
 	const colorsValid =
 		isValidHexColor(style.foregroundColor) &&

--- a/src/routes/regex-tester.tsx
+++ b/src/routes/regex-tester.tsx
@@ -40,7 +40,7 @@ import {
 	SAMPLE_TEST_TEXT,
 } from '@/lib/services/regex';
 import { type VizNode, type VizNodeKind, visualizeRegex } from '@/lib/services/regex-viz';
-import { useDocumentTitle } from '@/lib/hooks';
+import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
 
 interface Segment {
 	readonly text: string;
@@ -537,14 +537,26 @@ function RegexTesterPage() {
 		setReplacement(SAMPLE_REPLACEMENT);
 	};
 
+	// Debounce expensive inputs at 250ms so regexp-tree AST and railroad
+	// generation do not fire on every keystroke. compileRegex stays on the
+	// raw pattern for the validity badge — `new RegExp()` is cheap enough.
+	const debouncedPattern = useDebouncedValue(pattern, 250);
+	const debouncedTestText = useDebouncedValue(testText, 250);
+	const debouncedReplacement = useDebouncedValue(replacement, 250);
+
 	const flagString = flagsToString(flags);
 	const compiled = compileRegex(pattern, flags);
-	const matchesResult = findMatches(pattern, flags, testText);
+	const matchesResult = findMatches(debouncedPattern, flags, debouncedTestText);
 	const matches: readonly RegexMatch[] = matchesResult.ok ? matchesResult.value : [];
-	const replaceResult = replaceText(pattern, flags, testText, replacement);
-	const visualization = visualizeRegex(pattern, flagString);
-	const features = findFeatures(pattern);
-	const captureGroupCount = countCaptureGroups(pattern);
+	const replaceResult = replaceText(
+		debouncedPattern,
+		flags,
+		debouncedTestText,
+		debouncedReplacement
+	);
+	const visualization = visualizeRegex(debouncedPattern, flagString);
+	const features = findFeatures(debouncedPattern);
+	const captureGroupCount = countCaptureGroups(debouncedPattern);
 
 	const validity: 'empty' | 'valid' | 'invalid' =
 		pattern.length === 0 ? 'empty' : compiled.ok ? 'valid' : 'invalid';

--- a/src/routes/string-compressor.tsx
+++ b/src/routes/string-compressor.tsx
@@ -21,7 +21,7 @@ import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { Textarea } from '@/lib/components/ui/textarea';
-import { useDocumentTitle } from '@/lib/hooks';
+import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
 import {
 	type CompressionAlgorithm,
 	type CompressResult,
@@ -225,8 +225,14 @@ function StringCompressorPage() {
 		setDetectedAlgorithm(null);
 	};
 
+	// Debounce the input through the shared hook so compress / decompress
+	// only fire after the user pauses typing. Option toggles (direction /
+	// algorithm / level / outputFormat / autoDetect) flow through the same
+	// effect but do not need debouncing — they change once per click.
+	const debouncedInput = useDebouncedValue(inputText, DEBOUNCE_MS);
+
 	useEffect(() => {
-		const trimmed = inputText.trim();
+		const trimmed = debouncedInput.trim();
 		const apply = (state: DerivedState) => {
 			setOutputText(state.output);
 			setError(state.error);
@@ -243,20 +249,19 @@ function StringCompressorPage() {
 		let cancelled = false;
 		setBusy(true);
 
-		const timer = window.setTimeout(async () => {
+		(async () => {
 			const next =
 				direction === 'compress'
-					? await runCompress(inputText, algorithm, level, outputFormat)
-					: await runDecompress(inputText, algorithm, autoDetect);
+					? await runCompress(debouncedInput, algorithm, level, outputFormat)
+					: await runDecompress(debouncedInput, algorithm, autoDetect);
 			if (cancelled) return;
 			apply(next);
-		}, DEBOUNCE_MS);
+		})();
 
 		return () => {
 			cancelled = true;
-			window.clearTimeout(timer);
 		};
-	}, [inputText, direction, algorithm, level, outputFormat, autoDetect]);
+	}, [debouncedInput, direction, algorithm, level, outputFormat, autoDetect]);
 
 	const valid: boolean | null = inputText.trim().length === 0 ? null : error === null;
 

--- a/src/routes/url-encoder.tsx
+++ b/src/routes/url-encoder.tsx
@@ -25,7 +25,7 @@ import { Input } from '@/lib/components/ui/input';
 import { IconTooltip } from '@/lib/components/ui/icon-tooltip';
 import { CodeBlock } from '@/lib/components/ui/code-block';
 import { useActiveTab, useTabStore, usePersistedRail } from '@/lib/stores';
-import { useDocumentTitle } from '@/lib/hooks';
+import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
 import {
 	buildUrl,
 	decodeUrlWithOptions,
@@ -120,16 +120,23 @@ function UrlEncoderPage() {
 		maxIterations,
 	};
 
-	const detectedDoubleEncoded = mode === 'decode' && input.trim() ? isDoubleEncoded(input) : false;
-	const detectedEncodingDepth = mode === 'decode' && input.trim() ? getEncodingDepth(input) : 0;
+	// Debounce input feeding the encode / decode helpers so detection and
+	// transform calls do not retrigger on every keystroke. 100ms matches
+	// the cheap-route default for consistency across the app.
+	const debouncedInput = useDebouncedValue(input, 100);
+
+	const detectedDoubleEncoded =
+		mode === 'decode' && debouncedInput.trim() ? isDoubleEncoded(debouncedInput) : false;
+	const detectedEncodingDepth =
+		mode === 'decode' && debouncedInput.trim() ? getEncodingDepth(debouncedInput) : 0;
 
 	const { output, error } = ((): { output: string; error: string } => {
-		if (!input.trim()) return { output: '', error: '' };
+		if (!debouncedInput.trim()) return { output: '', error: '' };
 		try {
 			const result =
 				mode === 'encode'
-					? encodeUrlWithOptions(input, encodeOptions)
-					: decodeUrlWithOptions(input, decodeOptions);
+					? encodeUrlWithOptions(debouncedInput, encodeOptions)
+					: decodeUrlWithOptions(debouncedInput, decodeOptions);
 			return { output: result, error: '' };
 		} catch (e) {
 			return { output: '', error: getErrorMessage(e, 'Invalid input') };


### PR DESCRIPTION
## Summary

- Add `useDebouncedValue` and `useDebouncedCallback` in `src/lib/hooks/use-debounced-value.ts` as the project-wide pattern for input-driven computations.
- Apply across every reactive route — regex-tester, markdown-editor, string-compressor, hash-generator, qr-code-generator, base64-encoder, url-encoder, escape-tool, http-status-codes — plus `useFormatterPage` so the entire formatter family inherits it.
- Replace two hand-rolled `setTimeout` patterns (string-compressor, http-status-codes) with the shared hook so the codebase has a single debounce mechanism.

## Why

Every reactive input-driven route in Kogu previously recomputed its full pipeline on every keystroke, on the render thread. The worst offenders ran `regexp-tree` AST + railroad SVG generation directly in the function body (regex-tester) or fired Mermaid / KaTeX / Lowlight compile inside a `useEffect` without batching (markdown-editor). Even the cheap formatters parsed JSON / XML / YAML on every key press.

This PR establishes debounce as the **project standard**, applied uniformly so future routes know what to do. Delays follow the cost-tier table from the approved plan: 100ms for cheap, 150ms for medium (parse / format), 200–250ms for expensive (regex / WASM / Mermaid). Tunable per route via the `delayMs` argument.

`useDebouncedValue` is preferred over React 19's `useDeferredValue` here because the downstream consumers are **effects performing I/O** — Tauri `invoke`, future Web Worker `postMessage`, async WASM. `useDeferredValue` does not delay effects; the JSDoc documents this trade-off so contributors pick the right tool.

## Changes

### Added

- `src/lib/hooks/use-debounced-value.ts` — `useDebouncedValue<T>(value, delayMs?)` returns a debounced mirror; `useDebouncedCallback<Args>(fn, delayMs?)` returns a debounced wrapper with stable identity.
- Re-export from `src/lib/hooks/index.ts`.

### Changed

- `src/lib/hooks/use-formatter-page.ts` — debounces `sharedInput` at 150ms before `calculateStats`; the formatter family (json / xml / yaml / sql / csv / etc.) inherits the throttle.
- `src/routes/regex-tester.tsx` — 250ms on `pattern`, `testText`, `replacement`; validity badge stays on raw input.
- `src/routes/markdown-editor.tsx` — 200ms on `input` before `markdownToHtmlAsync`.
- `src/routes/string-compressor.tsx` — replaces local `setTimeout(..., DEBOUNCE_MS)` with the shared hook at the same 200ms delay.
- `src/routes/hash-generator.tsx` — 150ms on `textInput` before `generateAllHashes`.
- `src/routes/qr-code-generator.tsx` — 200ms on encoded content before qr-code-styling render.
- `src/routes/base64-encoder.tsx` — 100ms on `input` before encode / decode / detection helpers.
- `src/routes/url-encoder.tsx` — 100ms on `input` before encode / decode / detection helpers.
- `src/routes/escape-tool.tsx` — 150ms on both raw and escaped sides of the bidirectional sync; textarea typing remains instant.
- `src/routes/http-status-codes.tsx` — replaces local `setDebouncedQuery` + `setTimeout` with the shared hook at the same 100ms delay.

## Test Plan

- [x] `bun run check` — types, page validation, design audit pass.
- [x] `bun run format` — no diff after format.
- [x] `bun run lint` — no new errors (27 pre-existing warnings unchanged).
- [ ] Manual smoke per route: type fast into the primary input, confirm output appears within the debounce window (~200ms) and no per-keystroke recompute. DevTools Performance panel: long tasks should drop from "one per keystroke" to "one per debounce window".
- [ ] Behavior diff: paste a fixed input (e.g. `SAMPLE_TEST_TEXT` for regex-tester) and capture the rendered output. Switch to `main`, repeat. Outputs must be byte-identical.

## Scope

PR 1 of 3 in the reactive-compute refactor. PR 2 moves hashing + compression to the Tauri backend (drops `crypto-js` / `brotli-wasm`). PR 3 moves the regex AST + railroad work to a Web Worker.
