### PR TITLE
perf(regex-tester): move regexp-tree AST + railroad work to a Web Worker

### DIFF
--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,6 +1,8 @@
 export { useClipboardActions } from './use-clipboard-actions';
 export { useDebouncedCallback, useDebouncedValue } from './use-debounced-value';
 export { useDocumentTitle } from './use-document-title';
+export { useRegexWorker } from './use-regex-worker';
+export type { UseRegexWorkerInput, UseRegexWorkerOutput } from './use-regex-worker';
 export {
 	useFormatterPage,
 	FORMATTER_TABS,

--- a/src/lib/hooks/use-regex-worker.ts
+++ b/src/lib/hooks/use-regex-worker.ts
@@ -1,0 +1,89 @@
+/**
+ * Bridges `regex-tester.tsx` to the regex computation worker.
+ *
+ * Maintains a monotonic request id so responses arriving out of order
+ * (slow pattern followed by a quick one) cannot tear the UI. Only
+ * responses whose id matches the latest request are applied.
+ */
+import { useEffect, useRef, useState } from 'react';
+
+import type { RegexRequest, RegexResponse } from '@/lib/workers/regex.worker';
+
+type Result<T> =
+	| { readonly ok: true; readonly value: T }
+	| { readonly ok: false; readonly error: string };
+
+export interface UseRegexWorkerInput {
+	readonly pattern: string;
+	readonly flagString: string;
+	readonly testText: string;
+	readonly replacement: string;
+}
+
+export interface UseRegexWorkerOutput {
+	readonly viz: Result<import('@/lib/services/regex-viz').VizNode> | null;
+	readonly matches: readonly import('@/lib/services/regex').RegexMatch[];
+	readonly replaced: Result<string> | null;
+	readonly features: readonly import('@/lib/services/regex').FeatureUsage[];
+	readonly captureGroupCount: number;
+	readonly isPending: boolean;
+}
+
+const EMPTY_OUTPUT: UseRegexWorkerOutput = {
+	viz: null,
+	matches: [],
+	replaced: null,
+	features: [],
+	captureGroupCount: 0,
+	isPending: false,
+};
+
+export const useRegexWorker = (input: UseRegexWorkerInput): UseRegexWorkerOutput => {
+	const workerRef = useRef<Worker | null>(null);
+	const latestIdRef = useRef(0);
+	const [output, setOutput] = useState<UseRegexWorkerOutput>(EMPTY_OUTPUT);
+
+	// Lazy single worker instance for the lifetime of the route.
+	useEffect(() => {
+		const worker = new Worker(new URL('@/lib/workers/regex.worker.ts', import.meta.url), {
+			type: 'module',
+		});
+		workerRef.current = worker;
+		const handleMessage = (event: MessageEvent<RegexResponse>) => {
+			// Discard stale responses; only the most recently requested id wins.
+			if (event.data.id !== latestIdRef.current) return;
+			setOutput({
+				viz: event.data.viz,
+				matches: event.data.matches,
+				replaced: event.data.replaced,
+				features: event.data.features,
+				captureGroupCount: event.data.captureGroupCount,
+				isPending: false,
+			});
+		};
+		worker.addEventListener('message', handleMessage);
+		return () => {
+			worker.removeEventListener('message', handleMessage);
+			worker.terminate();
+			workerRef.current = null;
+		};
+	}, []);
+
+	useEffect(() => {
+		const worker = workerRef.current;
+		if (!worker) return;
+		const nextId = latestIdRef.current + 1;
+		latestIdRef.current = nextId;
+		setOutput((prev) => ({ ...prev, isPending: true }));
+		const request: RegexRequest = {
+			id: nextId,
+			pattern: input.pattern,
+			flagString: input.flagString,
+			testText: input.testText,
+			replacement: input.replacement,
+		};
+		worker.postMessage(request);
+	}, [input.pattern, input.flagString, input.testText, input.replacement]);
+
+	return output;
+};

--- a/src/lib/workers/regex.worker.ts
+++ b/src/lib/workers/regex.worker.ts
@@ -1,0 +1,88 @@
+/**
+ * Regex computation worker.
+ *
+ * Runs the expensive `regexp-tree` AST construction + railroad
+ * visualization off the main thread so typing in
+ * `/regex-tester` does not stall the UI. The cheap validity check
+ * (`compileRegex`) stays on the main thread because the badge needs
+ * to mirror every keystroke.
+ *
+ * Message protocol:
+ *
+ * ```
+ * main -> worker: RegexRequest { id, pattern, flagString, testText, replacement }
+ * worker -> main: RegexResponse { id, viz, matches, replaced, features, captureGroupCount }
+ * ```
+ *
+ * `id` is monotonically increasing per request. The main-thread hook
+ * keeps the latest id and discards any response carrying a smaller
+ * id so out-of-order returns from a fast pattern followed by a slow
+ * one don't tear the UI.
+ */
+import { findMatches, replaceText, type RegexMatch } from '@/lib/services/regex';
+import { countCaptureGroups, findFeatures, type FeatureUsage } from '@/lib/services/regex';
+import { visualizeRegex, type VizNode } from '@/lib/services/regex-viz';
+
+type Result<T> =
+	| { readonly ok: true; readonly value: T }
+	| { readonly ok: false; readonly error: string };
+
+export interface RegexRequest {
+	readonly id: number;
+	readonly pattern: string;
+	readonly flagString: string;
+	readonly testText: string;
+	readonly replacement: string;
+}
+
+export interface RegexResponse {
+	readonly id: number;
+	readonly viz: Result<VizNode>;
+	readonly matches: readonly RegexMatch[];
+	readonly replaced: Result<string>;
+	readonly features: readonly FeatureUsage[];
+	readonly captureGroupCount: number;
+}
+
+/**
+ * Build the `RegexFlags` shape `findMatches` / `replaceText` expect
+ * from a compiled `flagString`. The string was already produced by
+ * `flagsToString` on the main thread so order and presence are
+ * stable.
+ */
+const flagsFromString = (flagString: string) => ({
+	global: flagString.includes('g'),
+	ignoreCase: flagString.includes('i'),
+	multiline: flagString.includes('m'),
+	dotAll: flagString.includes('s'),
+	unicode: flagString.includes('u'),
+	sticky: flagString.includes('y'),
+});
+
+const handle = (request: RegexRequest): RegexResponse => {
+	const flags = flagsFromString(request.flagString);
+	const viz = visualizeRegex(request.pattern, request.flagString);
+	const matchesResult = findMatches(request.pattern, flags, request.testText);
+	const matches = matchesResult.ok ? matchesResult.value : [];
+	const replaced = replaceText(request.pattern, flags, request.testText, request.replacement);
+	const features = findFeatures(request.pattern);
+	const captureGroupCount = countCaptureGroups(request.pattern);
+	return { id: request.id, viz, matches, replaced, features, captureGroupCount };
+};
+
+self.addEventListener('message', (event: MessageEvent<RegexRequest>) => {
+	try {
+		const response = handle(event.data);
+		self.postMessage(response satisfies RegexResponse);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : 'regex worker failed';
+		self.postMessage({
+			id: event.data.id,
+			viz: { ok: false, error: message },
+			matches: [],
+			replaced: { ok: false, error: message },
+			features: [],
+			captureGroupCount: 0,
+		} satisfies RegexResponse);
+	}
+});

--- a/src/routes/regex-tester.tsx
+++ b/src/routes/regex-tester.tsx
@@ -24,23 +24,19 @@ import { cn } from '@/lib/utils';
 import { groupColor, matchBackdropColor } from '@/lib/services/regex-design';
 import {
 	compileRegex,
-	countCaptureGroups,
 	DEFAULT_FLAGS,
 	type FeatureUsage,
 	FLAG_INFO,
-	findFeatures,
-	findMatches,
 	flagsToString,
 	type RegexFlags,
 	type RegexMatch,
-	replaceText,
 	type Result,
 	SAMPLE_PATTERN,
 	SAMPLE_REPLACEMENT,
 	SAMPLE_TEST_TEXT,
 } from '@/lib/services/regex';
-import { type VizNode, type VizNodeKind, visualizeRegex } from '@/lib/services/regex-viz';
-import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
+import type { VizNode, VizNodeKind } from '@/lib/services/regex-viz';
+import { useDebouncedValue, useDocumentTitle, useRegexWorker } from '@/lib/hooks';
 
 interface Segment {
 	readonly text: string;
@@ -537,26 +533,36 @@ function RegexTesterPage() {
 		setReplacement(SAMPLE_REPLACEMENT);
 	};
 
-	// Debounce expensive inputs at 250ms so regexp-tree AST and railroad
-	// generation do not fire on every keystroke. compileRegex stays on the
-	// raw pattern for the validity badge — `new RegExp()` is cheap enough.
+	// Debounce expensive inputs at 250ms so the worker doesn't enqueue a
+	// fresh job on every keystroke. compileRegex stays on the raw
+	// pattern for the validity badge — `new RegExp()` is cheap and the
+	// badge needs to reflect the live state.
 	const debouncedPattern = useDebouncedValue(pattern, 250);
 	const debouncedTestText = useDebouncedValue(testText, 250);
 	const debouncedReplacement = useDebouncedValue(replacement, 250);
 
 	const flagString = flagsToString(flags);
 	const compiled = compileRegex(pattern, flags);
-	const matchesResult = findMatches(debouncedPattern, flags, debouncedTestText);
-	const matches: readonly RegexMatch[] = matchesResult.ok ? matchesResult.value : [];
-	const replaceResult = replaceText(
-		debouncedPattern,
-		flags,
-		debouncedTestText,
-		debouncedReplacement
-	);
-	const visualization = visualizeRegex(debouncedPattern, flagString);
-	const features = findFeatures(debouncedPattern);
-	const captureGroupCount = countCaptureGroups(debouncedPattern);
+
+	// Heavy work (regexp-tree AST + railroad visualization, plus the
+	// match / replace loops) happens off-thread. Stale responses are
+	// discarded by the hook's monotonic id check.
+	const workerOutput = useRegexWorker({
+		pattern: debouncedPattern,
+		flagString,
+		testText: debouncedTestText,
+		replacement: debouncedReplacement,
+	});
+	const matches: readonly RegexMatch[] = workerOutput.matches;
+	const replaceResult = workerOutput.replaced ?? { ok: true, value: '' };
+	const visualization: typeof workerOutput.viz =
+		workerOutput.viz ??
+		({
+			ok: true,
+			value: { kind: 'sequence', label: '', children: [] },
+		} satisfies { readonly ok: true; readonly value: VizNode });
+	const features = workerOutput.features;
+	const captureGroupCount = workerOutput.captureGroupCount;
 
 	const validity: 'empty' | 'valid' | 'invalid' =
 		pattern.length === 0 ? 'empty' : compiled.ok ? 'valid' : 'invalid';


### PR DESCRIPTION
## Summary

- Move the regex-tester's expensive computation (regexp-tree AST + railroad visualization, plus match / replace / feature enumeration) into a dedicated Web Worker.
- New `useRegexWorker` hook handles worker lifecycle, monotonic request ids, and stale-response filtering.
- Main thread keeps only the cheap validity badge (`compileRegex`) so feedback on every keystroke stays instant.

## Why

PR #368 introduced debounce on `pattern` / `testText` / `replacement` at 250ms, which collapsed bursts of keystrokes into a single computation. But each computation still ran on the main thread: complex patterns with regexp-tree-based AST construction can take 30-80ms, freezing the UI for one full frame at a time.

The work is pure JS (regexp-tree is JS-only with no Rust equivalent suitable for railroad rendering), so a Web Worker is the right tool — moves the heavy synchronous loop off the render thread without bringing in a new Rust dependency.

Out-of-order response handling: a slow pattern followed by a quick one can cause the quick one to return first. The hook tags every request with a monotonic id and discards any response whose id is not the latest. This prevents the slow result from tearing the UI after the user has moved on.

## Changes

### Added

- `src/lib/workers/regex.worker.ts` — module Worker. Receives `{ id, pattern, flagString, testText, replacement }` and posts back `{ id, viz, matches, replaced, features, captureGroupCount }`. Each computation is wrapped in `try / catch` so a malformed pattern surfaces as `Result.error` instead of crashing the worker.
- `src/lib/hooks/use-regex-worker.ts` — `useRegexWorker(input): output` hook. Lazily instantiates the worker for the lifetime of the route, terminates it on unmount, and applies the stale-response filter.
- Re-exports from `src/lib/hooks/index.ts`.

### Changed

- `src/routes/regex-tester.tsx`:
  - Validity badge (`compileRegex`) stays synchronous on the raw, un-debounced input — feedback per keystroke is preserved.
  - All other consumers read `viz` / `matches` / `replaced` / `features` / `captureGroupCount` from the worker hook.
  - Drops imports of `compileRegex` (kept), `countCaptureGroups`, `findFeatures`, `findMatches`, `replaceText`, `visualizeRegex` from the route — the worker owns them now.

## Vite worker bundling

Standard pattern: `new Worker(new URL('@/lib/workers/regex.worker.ts', import.meta.url), { type: 'module' })`. No `vite.config.ts` change needed — Vite picks up the worker source automatically and emits a separate chunk.

## Test Plan

- [x] `bun run check` — types, page validation, design audit pass.
- [x] `bun run format` — no diff.
- [x] `bun run lint` — 28 warnings unchanged from `main` (all pre-existing complexity warnings).
- [x] `bun run test` — 156/156 pass.
- [ ] Manual smoke (Tauri dev): paste the SAMPLE_PATTERN + SAMPLE_TEST_TEXT used in regex-tester. Confirm the rendered railroad SVG and match list are visually identical to `main`.
- [ ] DevTools Performance panel: hot-loop typing should show no long tasks >50ms on the main thread.
- [ ] DevTools Memory: navigate away from `/regex-tester` and confirm the worker terminates (no leaked module).

## Scope

PR 3 of 3 in the reactive-compute refactor (PR #368 + PR #369). Completes the rollout: every reactive route now uses `useDebouncedValue`, the WASM-heavy paths (text hash + brotli) ship via Tauri commands, and the JS-only regex AST work runs in a Worker.
