### PR TITLE
refactor(shell): extract ToolFooter and unify rail footer across all routes

### DIFF
--- a/src/lib/components/shell/index.ts
+++ b/src/lib/components/shell/index.ts
@@ -2,5 +2,7 @@ export { StatusBar } from './status-bar';
 export type { StatusBarProps } from './status-bar';
 export { ToolBar } from './tool-bar';
 export type { ToolBarProps } from './tool-bar';
+export { ToolFooter } from './tool-footer';
+export type { ToolFooterProps } from './tool-footer';
 export { ToolShell } from './tool-shell';
 export type { ToolShellProps, TabDefinition, ShellLayout } from './tool-shell';

--- a/src/lib/components/shell/tool-footer.tsx
+++ b/src/lib/components/shell/tool-footer.tsx
@@ -1,0 +1,45 @@
+/**
+ * Canonical rail footer pair: Related → About.
+ *
+ * Every tool route is expected to end its rail with these two sections
+ * in this order. `ToolFooter` encodes that contract so individual
+ * routes cannot accidentally reorder them, drop one, or skip both.
+ * The component renders nothing when both `aboutText` and
+ * `relatedItems` are absent, so it is safe to drop in unconditionally.
+ *
+ * For tool routes with no peer tools, omit `relatedItems` and only the
+ * About section renders. For routes whose About copy contains rich
+ * inline structure (links, code spans), pass it as `aboutText` —
+ * `FormInfo` renders plain text or React nodes.
+ */
+import type { ReactNode } from 'react';
+
+import { FormInfo, FormSection } from '@/lib/components/form';
+import { RelatedTools, type RelatedToolItem } from '@/lib/components/layout';
+
+interface ToolFooterProps {
+	readonly aboutText?: ReactNode;
+	readonly relatedItems?: readonly RelatedToolItem[];
+}
+
+export function ToolFooter({ aboutText, relatedItems }: ToolFooterProps) {
+	const hasAbout = aboutText !== undefined;
+	const hasRelated = relatedItems !== undefined && relatedItems.length > 0;
+	if (!hasAbout && !hasRelated) return null;
+	return (
+		<>
+			{hasRelated ? (
+				<FormSection title="Related">
+					<RelatedTools items={relatedItems} />
+				</FormSection>
+			) : null}
+			{hasAbout ? (
+				<FormSection title="About">
+					<FormInfo>{aboutText}</FormInfo>
+				</FormSection>
+			) : null}
+		</>
+	);
+}
+
+export type { ToolFooterProps };

--- a/src/route-tree.gen.ts
+++ b/src/route-tree.gen.ts
@@ -8,1211 +8,1211 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as YamlFormatterRouteImport } from './routes/yaml-formatter'
-import { Route as XmlFormatterRouteImport } from './routes/xml-formatter'
-import { Route as X509DecoderRouteImport } from './routes/x509-decoder'
-import { Route as WifiAnalyzerRouteImport } from './routes/wifi-analyzer'
-import { Route as WebsocketTesterRouteImport } from './routes/websocket-tester'
-import { Route as WebhookReceiverRouteImport } from './routes/webhook-receiver'
-import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator'
-import { Route as UrlEncoderRouteImport } from './routes/url-encoder'
-import { Route as TlsInspectorRouteImport } from './routes/tls-inspector'
-import { Route as TestDataGeneratorRouteImport } from './routes/test-data-generator'
-import { Route as StringCompressorRouteImport } from './routes/string-compressor'
-import { Route as StringCaseConverterRouteImport } from './routes/string-case-converter'
-import { Route as SshKeyGeneratorRouteImport } from './routes/ssh-key-generator'
-import { Route as SqlFormatterRouteImport } from './routes/sql-formatter'
-import { Route as SettingsRouteImport } from './routes/settings'
-import { Route as SemverToolsRouteImport } from './routes/semver-tools'
-import { Route as RsaToolsRouteImport } from './routes/rsa-tools'
-import { Route as RestClientRouteImport } from './routes/rest-client'
-import { Route as RegexTesterRouteImport } from './routes/regex-tester'
-import { Route as QrCodeGeneratorRouteImport } from './routes/qr-code-generator'
-import { Route as PathToolRouteImport } from './routes/path-tool'
-import { Route as PasswordGeneratorRouteImport } from './routes/password-generator'
-import { Route as NumberBaseConverterRouteImport } from './routes/number-base-converter'
-import { Route as NetworkScannerRouteImport } from './routes/network-scanner'
-import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces'
-import { Route as MimeTypesRouteImport } from './routes/mime-types'
-import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor'
-import { Route as MacLookupRouteImport } from './routes/mac-lookup'
-import { Route as LoremIpsumRouteImport } from './routes/lorem-ipsum'
-import { Route as ListComparerRouteImport } from './routes/list-comparer'
-import { Route as JwtDecoderRouteImport } from './routes/jwt-decoder'
-import { Route as JsonFormatterRouteImport } from './routes/json-formatter'
-import { Route as IpConverterRouteImport } from './routes/ip-converter'
-import { Route as ImageConverterRouteImport } from './routes/image-converter'
-import { Route as HttpStatusCodesRouteImport } from './routes/http-status-codes'
-import { Route as HexEditorRouteImport } from './routes/hex-editor'
-import { Route as HashGeneratorRouteImport } from './routes/hash-generator'
-import { Route as GpgKeyGeneratorRouteImport } from './routes/gpg-key-generator'
-import { Route as FolderTreeVisualizerRouteImport } from './routes/folder-tree-visualizer'
-import { Route as FileWatchRouteImport } from './routes/file-watch'
-import { Route as FileInspectorRouteImport } from './routes/file-inspector'
-import { Route as EscapeToolRouteImport } from './routes/escape-tool'
-import { Route as EncodingConverterRouteImport } from './routes/encoding-converter'
-import { Route as DuplicateFinderRouteImport } from './routes/duplicate-finder'
-import { Route as DriveInfoRouteImport } from './routes/drive-info'
-import { Route as DnsLookupRouteImport } from './routes/dns-lookup'
-import { Route as DiffViewerRouteImport } from './routes/diff-viewer'
-import { Route as DateTimestampConverterRouteImport } from './routes/date-timestamp-converter'
-import { Route as CurlBuilderRouteImport } from './routes/curl-builder'
-import { Route as CsvToolRouteImport } from './routes/csv-tool'
-import { Route as CronExpressionBuilderRouteImport } from './routes/cron-expression-builder'
-import { Route as CidrCalculatorRouteImport } from './routes/cidr-calculator'
-import { Route as BcryptGeneratorRouteImport } from './routes/bcrypt-generator'
-import { Route as Base64EncoderRouteImport } from './routes/base64-encoder'
-import { Route as ArchiveInspectorRouteImport } from './routes/archive-inspector'
-import { Route as IndexRouteImport } from './routes/index'
+import { Route as rootRouteImport } from './routes/__root';
+import { Route as YamlFormatterRouteImport } from './routes/yaml-formatter';
+import { Route as XmlFormatterRouteImport } from './routes/xml-formatter';
+import { Route as X509DecoderRouteImport } from './routes/x509-decoder';
+import { Route as WifiAnalyzerRouteImport } from './routes/wifi-analyzer';
+import { Route as WebsocketTesterRouteImport } from './routes/websocket-tester';
+import { Route as WebhookReceiverRouteImport } from './routes/webhook-receiver';
+import { Route as UuidGeneratorRouteImport } from './routes/uuid-generator';
+import { Route as UrlEncoderRouteImport } from './routes/url-encoder';
+import { Route as TlsInspectorRouteImport } from './routes/tls-inspector';
+import { Route as TestDataGeneratorRouteImport } from './routes/test-data-generator';
+import { Route as StringCompressorRouteImport } from './routes/string-compressor';
+import { Route as StringCaseConverterRouteImport } from './routes/string-case-converter';
+import { Route as SshKeyGeneratorRouteImport } from './routes/ssh-key-generator';
+import { Route as SqlFormatterRouteImport } from './routes/sql-formatter';
+import { Route as SettingsRouteImport } from './routes/settings';
+import { Route as SemverToolsRouteImport } from './routes/semver-tools';
+import { Route as RsaToolsRouteImport } from './routes/rsa-tools';
+import { Route as RestClientRouteImport } from './routes/rest-client';
+import { Route as RegexTesterRouteImport } from './routes/regex-tester';
+import { Route as QrCodeGeneratorRouteImport } from './routes/qr-code-generator';
+import { Route as PathToolRouteImport } from './routes/path-tool';
+import { Route as PasswordGeneratorRouteImport } from './routes/password-generator';
+import { Route as NumberBaseConverterRouteImport } from './routes/number-base-converter';
+import { Route as NetworkScannerRouteImport } from './routes/network-scanner';
+import { Route as NetworkInterfacesRouteImport } from './routes/network-interfaces';
+import { Route as MimeTypesRouteImport } from './routes/mime-types';
+import { Route as MarkdownEditorRouteImport } from './routes/markdown-editor';
+import { Route as MacLookupRouteImport } from './routes/mac-lookup';
+import { Route as LoremIpsumRouteImport } from './routes/lorem-ipsum';
+import { Route as ListComparerRouteImport } from './routes/list-comparer';
+import { Route as JwtDecoderRouteImport } from './routes/jwt-decoder';
+import { Route as JsonFormatterRouteImport } from './routes/json-formatter';
+import { Route as IpConverterRouteImport } from './routes/ip-converter';
+import { Route as ImageConverterRouteImport } from './routes/image-converter';
+import { Route as HttpStatusCodesRouteImport } from './routes/http-status-codes';
+import { Route as HexEditorRouteImport } from './routes/hex-editor';
+import { Route as HashGeneratorRouteImport } from './routes/hash-generator';
+import { Route as GpgKeyGeneratorRouteImport } from './routes/gpg-key-generator';
+import { Route as FolderTreeVisualizerRouteImport } from './routes/folder-tree-visualizer';
+import { Route as FileWatchRouteImport } from './routes/file-watch';
+import { Route as FileInspectorRouteImport } from './routes/file-inspector';
+import { Route as EscapeToolRouteImport } from './routes/escape-tool';
+import { Route as EncodingConverterRouteImport } from './routes/encoding-converter';
+import { Route as DuplicateFinderRouteImport } from './routes/duplicate-finder';
+import { Route as DriveInfoRouteImport } from './routes/drive-info';
+import { Route as DnsLookupRouteImport } from './routes/dns-lookup';
+import { Route as DiffViewerRouteImport } from './routes/diff-viewer';
+import { Route as DateTimestampConverterRouteImport } from './routes/date-timestamp-converter';
+import { Route as CurlBuilderRouteImport } from './routes/curl-builder';
+import { Route as CsvToolRouteImport } from './routes/csv-tool';
+import { Route as CronExpressionBuilderRouteImport } from './routes/cron-expression-builder';
+import { Route as CidrCalculatorRouteImport } from './routes/cidr-calculator';
+import { Route as BcryptGeneratorRouteImport } from './routes/bcrypt-generator';
+import { Route as Base64EncoderRouteImport } from './routes/base64-encoder';
+import { Route as ArchiveInspectorRouteImport } from './routes/archive-inspector';
+import { Route as IndexRouteImport } from './routes/index';
 
 const YamlFormatterRoute = YamlFormatterRouteImport.update({
-  id: '/yaml-formatter',
-  path: '/yaml-formatter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/yaml-formatter',
+	path: '/yaml-formatter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const XmlFormatterRoute = XmlFormatterRouteImport.update({
-  id: '/xml-formatter',
-  path: '/xml-formatter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/xml-formatter',
+	path: '/xml-formatter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const X509DecoderRoute = X509DecoderRouteImport.update({
-  id: '/x509-decoder',
-  path: '/x509-decoder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/x509-decoder',
+	path: '/x509-decoder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const WifiAnalyzerRoute = WifiAnalyzerRouteImport.update({
-  id: '/wifi-analyzer',
-  path: '/wifi-analyzer',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/wifi-analyzer',
+	path: '/wifi-analyzer',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const WebsocketTesterRoute = WebsocketTesterRouteImport.update({
-  id: '/websocket-tester',
-  path: '/websocket-tester',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/websocket-tester',
+	path: '/websocket-tester',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const WebhookReceiverRoute = WebhookReceiverRouteImport.update({
-  id: '/webhook-receiver',
-  path: '/webhook-receiver',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/webhook-receiver',
+	path: '/webhook-receiver',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const UuidGeneratorRoute = UuidGeneratorRouteImport.update({
-  id: '/uuid-generator',
-  path: '/uuid-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/uuid-generator',
+	path: '/uuid-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const UrlEncoderRoute = UrlEncoderRouteImport.update({
-  id: '/url-encoder',
-  path: '/url-encoder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/url-encoder',
+	path: '/url-encoder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const TlsInspectorRoute = TlsInspectorRouteImport.update({
-  id: '/tls-inspector',
-  path: '/tls-inspector',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/tls-inspector',
+	path: '/tls-inspector',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const TestDataGeneratorRoute = TestDataGeneratorRouteImport.update({
-  id: '/test-data-generator',
-  path: '/test-data-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/test-data-generator',
+	path: '/test-data-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const StringCompressorRoute = StringCompressorRouteImport.update({
-  id: '/string-compressor',
-  path: '/string-compressor',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/string-compressor',
+	path: '/string-compressor',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const StringCaseConverterRoute = StringCaseConverterRouteImport.update({
-  id: '/string-case-converter',
-  path: '/string-case-converter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/string-case-converter',
+	path: '/string-case-converter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const SshKeyGeneratorRoute = SshKeyGeneratorRouteImport.update({
-  id: '/ssh-key-generator',
-  path: '/ssh-key-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/ssh-key-generator',
+	path: '/ssh-key-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const SqlFormatterRoute = SqlFormatterRouteImport.update({
-  id: '/sql-formatter',
-  path: '/sql-formatter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/sql-formatter',
+	path: '/sql-formatter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const SettingsRoute = SettingsRouteImport.update({
-  id: '/settings',
-  path: '/settings',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/settings',
+	path: '/settings',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const SemverToolsRoute = SemverToolsRouteImport.update({
-  id: '/semver-tools',
-  path: '/semver-tools',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/semver-tools',
+	path: '/semver-tools',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const RsaToolsRoute = RsaToolsRouteImport.update({
-  id: '/rsa-tools',
-  path: '/rsa-tools',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/rsa-tools',
+	path: '/rsa-tools',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const RestClientRoute = RestClientRouteImport.update({
-  id: '/rest-client',
-  path: '/rest-client',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/rest-client',
+	path: '/rest-client',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const RegexTesterRoute = RegexTesterRouteImport.update({
-  id: '/regex-tester',
-  path: '/regex-tester',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/regex-tester',
+	path: '/regex-tester',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const QrCodeGeneratorRoute = QrCodeGeneratorRouteImport.update({
-  id: '/qr-code-generator',
-  path: '/qr-code-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/qr-code-generator',
+	path: '/qr-code-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const PathToolRoute = PathToolRouteImport.update({
-  id: '/path-tool',
-  path: '/path-tool',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/path-tool',
+	path: '/path-tool',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const PasswordGeneratorRoute = PasswordGeneratorRouteImport.update({
-  id: '/password-generator',
-  path: '/password-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/password-generator',
+	path: '/password-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const NumberBaseConverterRoute = NumberBaseConverterRouteImport.update({
-  id: '/number-base-converter',
-  path: '/number-base-converter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/number-base-converter',
+	path: '/number-base-converter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const NetworkScannerRoute = NetworkScannerRouteImport.update({
-  id: '/network-scanner',
-  path: '/network-scanner',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/network-scanner',
+	path: '/network-scanner',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const NetworkInterfacesRoute = NetworkInterfacesRouteImport.update({
-  id: '/network-interfaces',
-  path: '/network-interfaces',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/network-interfaces',
+	path: '/network-interfaces',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const MimeTypesRoute = MimeTypesRouteImport.update({
-  id: '/mime-types',
-  path: '/mime-types',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/mime-types',
+	path: '/mime-types',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const MarkdownEditorRoute = MarkdownEditorRouteImport.update({
-  id: '/markdown-editor',
-  path: '/markdown-editor',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/markdown-editor',
+	path: '/markdown-editor',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const MacLookupRoute = MacLookupRouteImport.update({
-  id: '/mac-lookup',
-  path: '/mac-lookup',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/mac-lookup',
+	path: '/mac-lookup',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const LoremIpsumRoute = LoremIpsumRouteImport.update({
-  id: '/lorem-ipsum',
-  path: '/lorem-ipsum',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/lorem-ipsum',
+	path: '/lorem-ipsum',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const ListComparerRoute = ListComparerRouteImport.update({
-  id: '/list-comparer',
-  path: '/list-comparer',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/list-comparer',
+	path: '/list-comparer',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const JwtDecoderRoute = JwtDecoderRouteImport.update({
-  id: '/jwt-decoder',
-  path: '/jwt-decoder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/jwt-decoder',
+	path: '/jwt-decoder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const JsonFormatterRoute = JsonFormatterRouteImport.update({
-  id: '/json-formatter',
-  path: '/json-formatter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/json-formatter',
+	path: '/json-formatter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const IpConverterRoute = IpConverterRouteImport.update({
-  id: '/ip-converter',
-  path: '/ip-converter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/ip-converter',
+	path: '/ip-converter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const ImageConverterRoute = ImageConverterRouteImport.update({
-  id: '/image-converter',
-  path: '/image-converter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/image-converter',
+	path: '/image-converter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const HttpStatusCodesRoute = HttpStatusCodesRouteImport.update({
-  id: '/http-status-codes',
-  path: '/http-status-codes',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/http-status-codes',
+	path: '/http-status-codes',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const HexEditorRoute = HexEditorRouteImport.update({
-  id: '/hex-editor',
-  path: '/hex-editor',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/hex-editor',
+	path: '/hex-editor',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const HashGeneratorRoute = HashGeneratorRouteImport.update({
-  id: '/hash-generator',
-  path: '/hash-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/hash-generator',
+	path: '/hash-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const GpgKeyGeneratorRoute = GpgKeyGeneratorRouteImport.update({
-  id: '/gpg-key-generator',
-  path: '/gpg-key-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/gpg-key-generator',
+	path: '/gpg-key-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const FolderTreeVisualizerRoute = FolderTreeVisualizerRouteImport.update({
-  id: '/folder-tree-visualizer',
-  path: '/folder-tree-visualizer',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/folder-tree-visualizer',
+	path: '/folder-tree-visualizer',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const FileWatchRoute = FileWatchRouteImport.update({
-  id: '/file-watch',
-  path: '/file-watch',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/file-watch',
+	path: '/file-watch',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const FileInspectorRoute = FileInspectorRouteImport.update({
-  id: '/file-inspector',
-  path: '/file-inspector',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/file-inspector',
+	path: '/file-inspector',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const EscapeToolRoute = EscapeToolRouteImport.update({
-  id: '/escape-tool',
-  path: '/escape-tool',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/escape-tool',
+	path: '/escape-tool',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const EncodingConverterRoute = EncodingConverterRouteImport.update({
-  id: '/encoding-converter',
-  path: '/encoding-converter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/encoding-converter',
+	path: '/encoding-converter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const DuplicateFinderRoute = DuplicateFinderRouteImport.update({
-  id: '/duplicate-finder',
-  path: '/duplicate-finder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/duplicate-finder',
+	path: '/duplicate-finder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const DriveInfoRoute = DriveInfoRouteImport.update({
-  id: '/drive-info',
-  path: '/drive-info',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/drive-info',
+	path: '/drive-info',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const DnsLookupRoute = DnsLookupRouteImport.update({
-  id: '/dns-lookup',
-  path: '/dns-lookup',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/dns-lookup',
+	path: '/dns-lookup',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const DiffViewerRoute = DiffViewerRouteImport.update({
-  id: '/diff-viewer',
-  path: '/diff-viewer',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/diff-viewer',
+	path: '/diff-viewer',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const DateTimestampConverterRoute = DateTimestampConverterRouteImport.update({
-  id: '/date-timestamp-converter',
-  path: '/date-timestamp-converter',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/date-timestamp-converter',
+	path: '/date-timestamp-converter',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const CurlBuilderRoute = CurlBuilderRouteImport.update({
-  id: '/curl-builder',
-  path: '/curl-builder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/curl-builder',
+	path: '/curl-builder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const CsvToolRoute = CsvToolRouteImport.update({
-  id: '/csv-tool',
-  path: '/csv-tool',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/csv-tool',
+	path: '/csv-tool',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const CronExpressionBuilderRoute = CronExpressionBuilderRouteImport.update({
-  id: '/cron-expression-builder',
-  path: '/cron-expression-builder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/cron-expression-builder',
+	path: '/cron-expression-builder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const CidrCalculatorRoute = CidrCalculatorRouteImport.update({
-  id: '/cidr-calculator',
-  path: '/cidr-calculator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/cidr-calculator',
+	path: '/cidr-calculator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const BcryptGeneratorRoute = BcryptGeneratorRouteImport.update({
-  id: '/bcrypt-generator',
-  path: '/bcrypt-generator',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/bcrypt-generator',
+	path: '/bcrypt-generator',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const Base64EncoderRoute = Base64EncoderRouteImport.update({
-  id: '/base64-encoder',
-  path: '/base64-encoder',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/base64-encoder',
+	path: '/base64-encoder',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const ArchiveInspectorRoute = ArchiveInspectorRouteImport.update({
-  id: '/archive-inspector',
-  path: '/archive-inspector',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/archive-inspector',
+	path: '/archive-inspector',
+	getParentRoute: () => rootRouteImport,
+} as any);
 const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: '/',
+	path: '/',
+	getParentRoute: () => rootRouteImport,
+} as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/archive-inspector': typeof ArchiveInspectorRoute
-  '/base64-encoder': typeof Base64EncoderRoute
-  '/bcrypt-generator': typeof BcryptGeneratorRoute
-  '/cidr-calculator': typeof CidrCalculatorRoute
-  '/cron-expression-builder': typeof CronExpressionBuilderRoute
-  '/csv-tool': typeof CsvToolRoute
-  '/curl-builder': typeof CurlBuilderRoute
-  '/date-timestamp-converter': typeof DateTimestampConverterRoute
-  '/diff-viewer': typeof DiffViewerRoute
-  '/dns-lookup': typeof DnsLookupRoute
-  '/drive-info': typeof DriveInfoRoute
-  '/duplicate-finder': typeof DuplicateFinderRoute
-  '/encoding-converter': typeof EncodingConverterRoute
-  '/escape-tool': typeof EscapeToolRoute
-  '/file-inspector': typeof FileInspectorRoute
-  '/file-watch': typeof FileWatchRoute
-  '/folder-tree-visualizer': typeof FolderTreeVisualizerRoute
-  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
-  '/hash-generator': typeof HashGeneratorRoute
-  '/hex-editor': typeof HexEditorRoute
-  '/http-status-codes': typeof HttpStatusCodesRoute
-  '/image-converter': typeof ImageConverterRoute
-  '/ip-converter': typeof IpConverterRoute
-  '/json-formatter': typeof JsonFormatterRoute
-  '/jwt-decoder': typeof JwtDecoderRoute
-  '/list-comparer': typeof ListComparerRoute
-  '/lorem-ipsum': typeof LoremIpsumRoute
-  '/mac-lookup': typeof MacLookupRoute
-  '/markdown-editor': typeof MarkdownEditorRoute
-  '/mime-types': typeof MimeTypesRoute
-  '/network-interfaces': typeof NetworkInterfacesRoute
-  '/network-scanner': typeof NetworkScannerRoute
-  '/number-base-converter': typeof NumberBaseConverterRoute
-  '/password-generator': typeof PasswordGeneratorRoute
-  '/path-tool': typeof PathToolRoute
-  '/qr-code-generator': typeof QrCodeGeneratorRoute
-  '/regex-tester': typeof RegexTesterRoute
-  '/rest-client': typeof RestClientRoute
-  '/rsa-tools': typeof RsaToolsRoute
-  '/semver-tools': typeof SemverToolsRoute
-  '/settings': typeof SettingsRoute
-  '/sql-formatter': typeof SqlFormatterRoute
-  '/ssh-key-generator': typeof SshKeyGeneratorRoute
-  '/string-case-converter': typeof StringCaseConverterRoute
-  '/string-compressor': typeof StringCompressorRoute
-  '/test-data-generator': typeof TestDataGeneratorRoute
-  '/tls-inspector': typeof TlsInspectorRoute
-  '/url-encoder': typeof UrlEncoderRoute
-  '/uuid-generator': typeof UuidGeneratorRoute
-  '/webhook-receiver': typeof WebhookReceiverRoute
-  '/websocket-tester': typeof WebsocketTesterRoute
-  '/wifi-analyzer': typeof WifiAnalyzerRoute
-  '/x509-decoder': typeof X509DecoderRoute
-  '/xml-formatter': typeof XmlFormatterRoute
-  '/yaml-formatter': typeof YamlFormatterRoute
+	'/': typeof IndexRoute;
+	'/archive-inspector': typeof ArchiveInspectorRoute;
+	'/base64-encoder': typeof Base64EncoderRoute;
+	'/bcrypt-generator': typeof BcryptGeneratorRoute;
+	'/cidr-calculator': typeof CidrCalculatorRoute;
+	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
+	'/csv-tool': typeof CsvToolRoute;
+	'/curl-builder': typeof CurlBuilderRoute;
+	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
+	'/diff-viewer': typeof DiffViewerRoute;
+	'/dns-lookup': typeof DnsLookupRoute;
+	'/drive-info': typeof DriveInfoRoute;
+	'/duplicate-finder': typeof DuplicateFinderRoute;
+	'/encoding-converter': typeof EncodingConverterRoute;
+	'/escape-tool': typeof EscapeToolRoute;
+	'/file-inspector': typeof FileInspectorRoute;
+	'/file-watch': typeof FileWatchRoute;
+	'/folder-tree-visualizer': typeof FolderTreeVisualizerRoute;
+	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
+	'/hash-generator': typeof HashGeneratorRoute;
+	'/hex-editor': typeof HexEditorRoute;
+	'/http-status-codes': typeof HttpStatusCodesRoute;
+	'/image-converter': typeof ImageConverterRoute;
+	'/ip-converter': typeof IpConverterRoute;
+	'/json-formatter': typeof JsonFormatterRoute;
+	'/jwt-decoder': typeof JwtDecoderRoute;
+	'/list-comparer': typeof ListComparerRoute;
+	'/lorem-ipsum': typeof LoremIpsumRoute;
+	'/mac-lookup': typeof MacLookupRoute;
+	'/markdown-editor': typeof MarkdownEditorRoute;
+	'/mime-types': typeof MimeTypesRoute;
+	'/network-interfaces': typeof NetworkInterfacesRoute;
+	'/network-scanner': typeof NetworkScannerRoute;
+	'/number-base-converter': typeof NumberBaseConverterRoute;
+	'/password-generator': typeof PasswordGeneratorRoute;
+	'/path-tool': typeof PathToolRoute;
+	'/qr-code-generator': typeof QrCodeGeneratorRoute;
+	'/regex-tester': typeof RegexTesterRoute;
+	'/rest-client': typeof RestClientRoute;
+	'/rsa-tools': typeof RsaToolsRoute;
+	'/semver-tools': typeof SemverToolsRoute;
+	'/settings': typeof SettingsRoute;
+	'/sql-formatter': typeof SqlFormatterRoute;
+	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
+	'/string-case-converter': typeof StringCaseConverterRoute;
+	'/string-compressor': typeof StringCompressorRoute;
+	'/test-data-generator': typeof TestDataGeneratorRoute;
+	'/tls-inspector': typeof TlsInspectorRoute;
+	'/url-encoder': typeof UrlEncoderRoute;
+	'/uuid-generator': typeof UuidGeneratorRoute;
+	'/webhook-receiver': typeof WebhookReceiverRoute;
+	'/websocket-tester': typeof WebsocketTesterRoute;
+	'/wifi-analyzer': typeof WifiAnalyzerRoute;
+	'/x509-decoder': typeof X509DecoderRoute;
+	'/xml-formatter': typeof XmlFormatterRoute;
+	'/yaml-formatter': typeof YamlFormatterRoute;
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/archive-inspector': typeof ArchiveInspectorRoute
-  '/base64-encoder': typeof Base64EncoderRoute
-  '/bcrypt-generator': typeof BcryptGeneratorRoute
-  '/cidr-calculator': typeof CidrCalculatorRoute
-  '/cron-expression-builder': typeof CronExpressionBuilderRoute
-  '/csv-tool': typeof CsvToolRoute
-  '/curl-builder': typeof CurlBuilderRoute
-  '/date-timestamp-converter': typeof DateTimestampConverterRoute
-  '/diff-viewer': typeof DiffViewerRoute
-  '/dns-lookup': typeof DnsLookupRoute
-  '/drive-info': typeof DriveInfoRoute
-  '/duplicate-finder': typeof DuplicateFinderRoute
-  '/encoding-converter': typeof EncodingConverterRoute
-  '/escape-tool': typeof EscapeToolRoute
-  '/file-inspector': typeof FileInspectorRoute
-  '/file-watch': typeof FileWatchRoute
-  '/folder-tree-visualizer': typeof FolderTreeVisualizerRoute
-  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
-  '/hash-generator': typeof HashGeneratorRoute
-  '/hex-editor': typeof HexEditorRoute
-  '/http-status-codes': typeof HttpStatusCodesRoute
-  '/image-converter': typeof ImageConverterRoute
-  '/ip-converter': typeof IpConverterRoute
-  '/json-formatter': typeof JsonFormatterRoute
-  '/jwt-decoder': typeof JwtDecoderRoute
-  '/list-comparer': typeof ListComparerRoute
-  '/lorem-ipsum': typeof LoremIpsumRoute
-  '/mac-lookup': typeof MacLookupRoute
-  '/markdown-editor': typeof MarkdownEditorRoute
-  '/mime-types': typeof MimeTypesRoute
-  '/network-interfaces': typeof NetworkInterfacesRoute
-  '/network-scanner': typeof NetworkScannerRoute
-  '/number-base-converter': typeof NumberBaseConverterRoute
-  '/password-generator': typeof PasswordGeneratorRoute
-  '/path-tool': typeof PathToolRoute
-  '/qr-code-generator': typeof QrCodeGeneratorRoute
-  '/regex-tester': typeof RegexTesterRoute
-  '/rest-client': typeof RestClientRoute
-  '/rsa-tools': typeof RsaToolsRoute
-  '/semver-tools': typeof SemverToolsRoute
-  '/settings': typeof SettingsRoute
-  '/sql-formatter': typeof SqlFormatterRoute
-  '/ssh-key-generator': typeof SshKeyGeneratorRoute
-  '/string-case-converter': typeof StringCaseConverterRoute
-  '/string-compressor': typeof StringCompressorRoute
-  '/test-data-generator': typeof TestDataGeneratorRoute
-  '/tls-inspector': typeof TlsInspectorRoute
-  '/url-encoder': typeof UrlEncoderRoute
-  '/uuid-generator': typeof UuidGeneratorRoute
-  '/webhook-receiver': typeof WebhookReceiverRoute
-  '/websocket-tester': typeof WebsocketTesterRoute
-  '/wifi-analyzer': typeof WifiAnalyzerRoute
-  '/x509-decoder': typeof X509DecoderRoute
-  '/xml-formatter': typeof XmlFormatterRoute
-  '/yaml-formatter': typeof YamlFormatterRoute
+	'/': typeof IndexRoute;
+	'/archive-inspector': typeof ArchiveInspectorRoute;
+	'/base64-encoder': typeof Base64EncoderRoute;
+	'/bcrypt-generator': typeof BcryptGeneratorRoute;
+	'/cidr-calculator': typeof CidrCalculatorRoute;
+	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
+	'/csv-tool': typeof CsvToolRoute;
+	'/curl-builder': typeof CurlBuilderRoute;
+	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
+	'/diff-viewer': typeof DiffViewerRoute;
+	'/dns-lookup': typeof DnsLookupRoute;
+	'/drive-info': typeof DriveInfoRoute;
+	'/duplicate-finder': typeof DuplicateFinderRoute;
+	'/encoding-converter': typeof EncodingConverterRoute;
+	'/escape-tool': typeof EscapeToolRoute;
+	'/file-inspector': typeof FileInspectorRoute;
+	'/file-watch': typeof FileWatchRoute;
+	'/folder-tree-visualizer': typeof FolderTreeVisualizerRoute;
+	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
+	'/hash-generator': typeof HashGeneratorRoute;
+	'/hex-editor': typeof HexEditorRoute;
+	'/http-status-codes': typeof HttpStatusCodesRoute;
+	'/image-converter': typeof ImageConverterRoute;
+	'/ip-converter': typeof IpConverterRoute;
+	'/json-formatter': typeof JsonFormatterRoute;
+	'/jwt-decoder': typeof JwtDecoderRoute;
+	'/list-comparer': typeof ListComparerRoute;
+	'/lorem-ipsum': typeof LoremIpsumRoute;
+	'/mac-lookup': typeof MacLookupRoute;
+	'/markdown-editor': typeof MarkdownEditorRoute;
+	'/mime-types': typeof MimeTypesRoute;
+	'/network-interfaces': typeof NetworkInterfacesRoute;
+	'/network-scanner': typeof NetworkScannerRoute;
+	'/number-base-converter': typeof NumberBaseConverterRoute;
+	'/password-generator': typeof PasswordGeneratorRoute;
+	'/path-tool': typeof PathToolRoute;
+	'/qr-code-generator': typeof QrCodeGeneratorRoute;
+	'/regex-tester': typeof RegexTesterRoute;
+	'/rest-client': typeof RestClientRoute;
+	'/rsa-tools': typeof RsaToolsRoute;
+	'/semver-tools': typeof SemverToolsRoute;
+	'/settings': typeof SettingsRoute;
+	'/sql-formatter': typeof SqlFormatterRoute;
+	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
+	'/string-case-converter': typeof StringCaseConverterRoute;
+	'/string-compressor': typeof StringCompressorRoute;
+	'/test-data-generator': typeof TestDataGeneratorRoute;
+	'/tls-inspector': typeof TlsInspectorRoute;
+	'/url-encoder': typeof UrlEncoderRoute;
+	'/uuid-generator': typeof UuidGeneratorRoute;
+	'/webhook-receiver': typeof WebhookReceiverRoute;
+	'/websocket-tester': typeof WebsocketTesterRoute;
+	'/wifi-analyzer': typeof WifiAnalyzerRoute;
+	'/x509-decoder': typeof X509DecoderRoute;
+	'/xml-formatter': typeof XmlFormatterRoute;
+	'/yaml-formatter': typeof YamlFormatterRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/archive-inspector': typeof ArchiveInspectorRoute
-  '/base64-encoder': typeof Base64EncoderRoute
-  '/bcrypt-generator': typeof BcryptGeneratorRoute
-  '/cidr-calculator': typeof CidrCalculatorRoute
-  '/cron-expression-builder': typeof CronExpressionBuilderRoute
-  '/csv-tool': typeof CsvToolRoute
-  '/curl-builder': typeof CurlBuilderRoute
-  '/date-timestamp-converter': typeof DateTimestampConverterRoute
-  '/diff-viewer': typeof DiffViewerRoute
-  '/dns-lookup': typeof DnsLookupRoute
-  '/drive-info': typeof DriveInfoRoute
-  '/duplicate-finder': typeof DuplicateFinderRoute
-  '/encoding-converter': typeof EncodingConverterRoute
-  '/escape-tool': typeof EscapeToolRoute
-  '/file-inspector': typeof FileInspectorRoute
-  '/file-watch': typeof FileWatchRoute
-  '/folder-tree-visualizer': typeof FolderTreeVisualizerRoute
-  '/gpg-key-generator': typeof GpgKeyGeneratorRoute
-  '/hash-generator': typeof HashGeneratorRoute
-  '/hex-editor': typeof HexEditorRoute
-  '/http-status-codes': typeof HttpStatusCodesRoute
-  '/image-converter': typeof ImageConverterRoute
-  '/ip-converter': typeof IpConverterRoute
-  '/json-formatter': typeof JsonFormatterRoute
-  '/jwt-decoder': typeof JwtDecoderRoute
-  '/list-comparer': typeof ListComparerRoute
-  '/lorem-ipsum': typeof LoremIpsumRoute
-  '/mac-lookup': typeof MacLookupRoute
-  '/markdown-editor': typeof MarkdownEditorRoute
-  '/mime-types': typeof MimeTypesRoute
-  '/network-interfaces': typeof NetworkInterfacesRoute
-  '/network-scanner': typeof NetworkScannerRoute
-  '/number-base-converter': typeof NumberBaseConverterRoute
-  '/password-generator': typeof PasswordGeneratorRoute
-  '/path-tool': typeof PathToolRoute
-  '/qr-code-generator': typeof QrCodeGeneratorRoute
-  '/regex-tester': typeof RegexTesterRoute
-  '/rest-client': typeof RestClientRoute
-  '/rsa-tools': typeof RsaToolsRoute
-  '/semver-tools': typeof SemverToolsRoute
-  '/settings': typeof SettingsRoute
-  '/sql-formatter': typeof SqlFormatterRoute
-  '/ssh-key-generator': typeof SshKeyGeneratorRoute
-  '/string-case-converter': typeof StringCaseConverterRoute
-  '/string-compressor': typeof StringCompressorRoute
-  '/test-data-generator': typeof TestDataGeneratorRoute
-  '/tls-inspector': typeof TlsInspectorRoute
-  '/url-encoder': typeof UrlEncoderRoute
-  '/uuid-generator': typeof UuidGeneratorRoute
-  '/webhook-receiver': typeof WebhookReceiverRoute
-  '/websocket-tester': typeof WebsocketTesterRoute
-  '/wifi-analyzer': typeof WifiAnalyzerRoute
-  '/x509-decoder': typeof X509DecoderRoute
-  '/xml-formatter': typeof XmlFormatterRoute
-  '/yaml-formatter': typeof YamlFormatterRoute
+	__root__: typeof rootRouteImport;
+	'/': typeof IndexRoute;
+	'/archive-inspector': typeof ArchiveInspectorRoute;
+	'/base64-encoder': typeof Base64EncoderRoute;
+	'/bcrypt-generator': typeof BcryptGeneratorRoute;
+	'/cidr-calculator': typeof CidrCalculatorRoute;
+	'/cron-expression-builder': typeof CronExpressionBuilderRoute;
+	'/csv-tool': typeof CsvToolRoute;
+	'/curl-builder': typeof CurlBuilderRoute;
+	'/date-timestamp-converter': typeof DateTimestampConverterRoute;
+	'/diff-viewer': typeof DiffViewerRoute;
+	'/dns-lookup': typeof DnsLookupRoute;
+	'/drive-info': typeof DriveInfoRoute;
+	'/duplicate-finder': typeof DuplicateFinderRoute;
+	'/encoding-converter': typeof EncodingConverterRoute;
+	'/escape-tool': typeof EscapeToolRoute;
+	'/file-inspector': typeof FileInspectorRoute;
+	'/file-watch': typeof FileWatchRoute;
+	'/folder-tree-visualizer': typeof FolderTreeVisualizerRoute;
+	'/gpg-key-generator': typeof GpgKeyGeneratorRoute;
+	'/hash-generator': typeof HashGeneratorRoute;
+	'/hex-editor': typeof HexEditorRoute;
+	'/http-status-codes': typeof HttpStatusCodesRoute;
+	'/image-converter': typeof ImageConverterRoute;
+	'/ip-converter': typeof IpConverterRoute;
+	'/json-formatter': typeof JsonFormatterRoute;
+	'/jwt-decoder': typeof JwtDecoderRoute;
+	'/list-comparer': typeof ListComparerRoute;
+	'/lorem-ipsum': typeof LoremIpsumRoute;
+	'/mac-lookup': typeof MacLookupRoute;
+	'/markdown-editor': typeof MarkdownEditorRoute;
+	'/mime-types': typeof MimeTypesRoute;
+	'/network-interfaces': typeof NetworkInterfacesRoute;
+	'/network-scanner': typeof NetworkScannerRoute;
+	'/number-base-converter': typeof NumberBaseConverterRoute;
+	'/password-generator': typeof PasswordGeneratorRoute;
+	'/path-tool': typeof PathToolRoute;
+	'/qr-code-generator': typeof QrCodeGeneratorRoute;
+	'/regex-tester': typeof RegexTesterRoute;
+	'/rest-client': typeof RestClientRoute;
+	'/rsa-tools': typeof RsaToolsRoute;
+	'/semver-tools': typeof SemverToolsRoute;
+	'/settings': typeof SettingsRoute;
+	'/sql-formatter': typeof SqlFormatterRoute;
+	'/ssh-key-generator': typeof SshKeyGeneratorRoute;
+	'/string-case-converter': typeof StringCaseConverterRoute;
+	'/string-compressor': typeof StringCompressorRoute;
+	'/test-data-generator': typeof TestDataGeneratorRoute;
+	'/tls-inspector': typeof TlsInspectorRoute;
+	'/url-encoder': typeof UrlEncoderRoute;
+	'/uuid-generator': typeof UuidGeneratorRoute;
+	'/webhook-receiver': typeof WebhookReceiverRoute;
+	'/websocket-tester': typeof WebsocketTesterRoute;
+	'/wifi-analyzer': typeof WifiAnalyzerRoute;
+	'/x509-decoder': typeof X509DecoderRoute;
+	'/xml-formatter': typeof XmlFormatterRoute;
+	'/yaml-formatter': typeof YamlFormatterRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths:
-    | '/'
-    | '/archive-inspector'
-    | '/base64-encoder'
-    | '/bcrypt-generator'
-    | '/cidr-calculator'
-    | '/cron-expression-builder'
-    | '/csv-tool'
-    | '/curl-builder'
-    | '/date-timestamp-converter'
-    | '/diff-viewer'
-    | '/dns-lookup'
-    | '/drive-info'
-    | '/duplicate-finder'
-    | '/encoding-converter'
-    | '/escape-tool'
-    | '/file-inspector'
-    | '/file-watch'
-    | '/folder-tree-visualizer'
-    | '/gpg-key-generator'
-    | '/hash-generator'
-    | '/hex-editor'
-    | '/http-status-codes'
-    | '/image-converter'
-    | '/ip-converter'
-    | '/json-formatter'
-    | '/jwt-decoder'
-    | '/list-comparer'
-    | '/lorem-ipsum'
-    | '/mac-lookup'
-    | '/markdown-editor'
-    | '/mime-types'
-    | '/network-interfaces'
-    | '/network-scanner'
-    | '/number-base-converter'
-    | '/password-generator'
-    | '/path-tool'
-    | '/qr-code-generator'
-    | '/regex-tester'
-    | '/rest-client'
-    | '/rsa-tools'
-    | '/semver-tools'
-    | '/settings'
-    | '/sql-formatter'
-    | '/ssh-key-generator'
-    | '/string-case-converter'
-    | '/string-compressor'
-    | '/test-data-generator'
-    | '/tls-inspector'
-    | '/url-encoder'
-    | '/uuid-generator'
-    | '/webhook-receiver'
-    | '/websocket-tester'
-    | '/wifi-analyzer'
-    | '/x509-decoder'
-    | '/xml-formatter'
-    | '/yaml-formatter'
-  fileRoutesByTo: FileRoutesByTo
-  to:
-    | '/'
-    | '/archive-inspector'
-    | '/base64-encoder'
-    | '/bcrypt-generator'
-    | '/cidr-calculator'
-    | '/cron-expression-builder'
-    | '/csv-tool'
-    | '/curl-builder'
-    | '/date-timestamp-converter'
-    | '/diff-viewer'
-    | '/dns-lookup'
-    | '/drive-info'
-    | '/duplicate-finder'
-    | '/encoding-converter'
-    | '/escape-tool'
-    | '/file-inspector'
-    | '/file-watch'
-    | '/folder-tree-visualizer'
-    | '/gpg-key-generator'
-    | '/hash-generator'
-    | '/hex-editor'
-    | '/http-status-codes'
-    | '/image-converter'
-    | '/ip-converter'
-    | '/json-formatter'
-    | '/jwt-decoder'
-    | '/list-comparer'
-    | '/lorem-ipsum'
-    | '/mac-lookup'
-    | '/markdown-editor'
-    | '/mime-types'
-    | '/network-interfaces'
-    | '/network-scanner'
-    | '/number-base-converter'
-    | '/password-generator'
-    | '/path-tool'
-    | '/qr-code-generator'
-    | '/regex-tester'
-    | '/rest-client'
-    | '/rsa-tools'
-    | '/semver-tools'
-    | '/settings'
-    | '/sql-formatter'
-    | '/ssh-key-generator'
-    | '/string-case-converter'
-    | '/string-compressor'
-    | '/test-data-generator'
-    | '/tls-inspector'
-    | '/url-encoder'
-    | '/uuid-generator'
-    | '/webhook-receiver'
-    | '/websocket-tester'
-    | '/wifi-analyzer'
-    | '/x509-decoder'
-    | '/xml-formatter'
-    | '/yaml-formatter'
-  id:
-    | '__root__'
-    | '/'
-    | '/archive-inspector'
-    | '/base64-encoder'
-    | '/bcrypt-generator'
-    | '/cidr-calculator'
-    | '/cron-expression-builder'
-    | '/csv-tool'
-    | '/curl-builder'
-    | '/date-timestamp-converter'
-    | '/diff-viewer'
-    | '/dns-lookup'
-    | '/drive-info'
-    | '/duplicate-finder'
-    | '/encoding-converter'
-    | '/escape-tool'
-    | '/file-inspector'
-    | '/file-watch'
-    | '/folder-tree-visualizer'
-    | '/gpg-key-generator'
-    | '/hash-generator'
-    | '/hex-editor'
-    | '/http-status-codes'
-    | '/image-converter'
-    | '/ip-converter'
-    | '/json-formatter'
-    | '/jwt-decoder'
-    | '/list-comparer'
-    | '/lorem-ipsum'
-    | '/mac-lookup'
-    | '/markdown-editor'
-    | '/mime-types'
-    | '/network-interfaces'
-    | '/network-scanner'
-    | '/number-base-converter'
-    | '/password-generator'
-    | '/path-tool'
-    | '/qr-code-generator'
-    | '/regex-tester'
-    | '/rest-client'
-    | '/rsa-tools'
-    | '/semver-tools'
-    | '/settings'
-    | '/sql-formatter'
-    | '/ssh-key-generator'
-    | '/string-case-converter'
-    | '/string-compressor'
-    | '/test-data-generator'
-    | '/tls-inspector'
-    | '/url-encoder'
-    | '/uuid-generator'
-    | '/webhook-receiver'
-    | '/websocket-tester'
-    | '/wifi-analyzer'
-    | '/x509-decoder'
-    | '/xml-formatter'
-    | '/yaml-formatter'
-  fileRoutesById: FileRoutesById
+	fileRoutesByFullPath: FileRoutesByFullPath;
+	fullPaths:
+		| '/'
+		| '/archive-inspector'
+		| '/base64-encoder'
+		| '/bcrypt-generator'
+		| '/cidr-calculator'
+		| '/cron-expression-builder'
+		| '/csv-tool'
+		| '/curl-builder'
+		| '/date-timestamp-converter'
+		| '/diff-viewer'
+		| '/dns-lookup'
+		| '/drive-info'
+		| '/duplicate-finder'
+		| '/encoding-converter'
+		| '/escape-tool'
+		| '/file-inspector'
+		| '/file-watch'
+		| '/folder-tree-visualizer'
+		| '/gpg-key-generator'
+		| '/hash-generator'
+		| '/hex-editor'
+		| '/http-status-codes'
+		| '/image-converter'
+		| '/ip-converter'
+		| '/json-formatter'
+		| '/jwt-decoder'
+		| '/list-comparer'
+		| '/lorem-ipsum'
+		| '/mac-lookup'
+		| '/markdown-editor'
+		| '/mime-types'
+		| '/network-interfaces'
+		| '/network-scanner'
+		| '/number-base-converter'
+		| '/password-generator'
+		| '/path-tool'
+		| '/qr-code-generator'
+		| '/regex-tester'
+		| '/rest-client'
+		| '/rsa-tools'
+		| '/semver-tools'
+		| '/settings'
+		| '/sql-formatter'
+		| '/ssh-key-generator'
+		| '/string-case-converter'
+		| '/string-compressor'
+		| '/test-data-generator'
+		| '/tls-inspector'
+		| '/url-encoder'
+		| '/uuid-generator'
+		| '/webhook-receiver'
+		| '/websocket-tester'
+		| '/wifi-analyzer'
+		| '/x509-decoder'
+		| '/xml-formatter'
+		| '/yaml-formatter';
+	fileRoutesByTo: FileRoutesByTo;
+	to:
+		| '/'
+		| '/archive-inspector'
+		| '/base64-encoder'
+		| '/bcrypt-generator'
+		| '/cidr-calculator'
+		| '/cron-expression-builder'
+		| '/csv-tool'
+		| '/curl-builder'
+		| '/date-timestamp-converter'
+		| '/diff-viewer'
+		| '/dns-lookup'
+		| '/drive-info'
+		| '/duplicate-finder'
+		| '/encoding-converter'
+		| '/escape-tool'
+		| '/file-inspector'
+		| '/file-watch'
+		| '/folder-tree-visualizer'
+		| '/gpg-key-generator'
+		| '/hash-generator'
+		| '/hex-editor'
+		| '/http-status-codes'
+		| '/image-converter'
+		| '/ip-converter'
+		| '/json-formatter'
+		| '/jwt-decoder'
+		| '/list-comparer'
+		| '/lorem-ipsum'
+		| '/mac-lookup'
+		| '/markdown-editor'
+		| '/mime-types'
+		| '/network-interfaces'
+		| '/network-scanner'
+		| '/number-base-converter'
+		| '/password-generator'
+		| '/path-tool'
+		| '/qr-code-generator'
+		| '/regex-tester'
+		| '/rest-client'
+		| '/rsa-tools'
+		| '/semver-tools'
+		| '/settings'
+		| '/sql-formatter'
+		| '/ssh-key-generator'
+		| '/string-case-converter'
+		| '/string-compressor'
+		| '/test-data-generator'
+		| '/tls-inspector'
+		| '/url-encoder'
+		| '/uuid-generator'
+		| '/webhook-receiver'
+		| '/websocket-tester'
+		| '/wifi-analyzer'
+		| '/x509-decoder'
+		| '/xml-formatter'
+		| '/yaml-formatter';
+	id:
+		| '__root__'
+		| '/'
+		| '/archive-inspector'
+		| '/base64-encoder'
+		| '/bcrypt-generator'
+		| '/cidr-calculator'
+		| '/cron-expression-builder'
+		| '/csv-tool'
+		| '/curl-builder'
+		| '/date-timestamp-converter'
+		| '/diff-viewer'
+		| '/dns-lookup'
+		| '/drive-info'
+		| '/duplicate-finder'
+		| '/encoding-converter'
+		| '/escape-tool'
+		| '/file-inspector'
+		| '/file-watch'
+		| '/folder-tree-visualizer'
+		| '/gpg-key-generator'
+		| '/hash-generator'
+		| '/hex-editor'
+		| '/http-status-codes'
+		| '/image-converter'
+		| '/ip-converter'
+		| '/json-formatter'
+		| '/jwt-decoder'
+		| '/list-comparer'
+		| '/lorem-ipsum'
+		| '/mac-lookup'
+		| '/markdown-editor'
+		| '/mime-types'
+		| '/network-interfaces'
+		| '/network-scanner'
+		| '/number-base-converter'
+		| '/password-generator'
+		| '/path-tool'
+		| '/qr-code-generator'
+		| '/regex-tester'
+		| '/rest-client'
+		| '/rsa-tools'
+		| '/semver-tools'
+		| '/settings'
+		| '/sql-formatter'
+		| '/ssh-key-generator'
+		| '/string-case-converter'
+		| '/string-compressor'
+		| '/test-data-generator'
+		| '/tls-inspector'
+		| '/url-encoder'
+		| '/uuid-generator'
+		| '/webhook-receiver'
+		| '/websocket-tester'
+		| '/wifi-analyzer'
+		| '/x509-decoder'
+		| '/xml-formatter'
+		| '/yaml-formatter';
+	fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  ArchiveInspectorRoute: typeof ArchiveInspectorRoute
-  Base64EncoderRoute: typeof Base64EncoderRoute
-  BcryptGeneratorRoute: typeof BcryptGeneratorRoute
-  CidrCalculatorRoute: typeof CidrCalculatorRoute
-  CronExpressionBuilderRoute: typeof CronExpressionBuilderRoute
-  CsvToolRoute: typeof CsvToolRoute
-  CurlBuilderRoute: typeof CurlBuilderRoute
-  DateTimestampConverterRoute: typeof DateTimestampConverterRoute
-  DiffViewerRoute: typeof DiffViewerRoute
-  DnsLookupRoute: typeof DnsLookupRoute
-  DriveInfoRoute: typeof DriveInfoRoute
-  DuplicateFinderRoute: typeof DuplicateFinderRoute
-  EncodingConverterRoute: typeof EncodingConverterRoute
-  EscapeToolRoute: typeof EscapeToolRoute
-  FileInspectorRoute: typeof FileInspectorRoute
-  FileWatchRoute: typeof FileWatchRoute
-  FolderTreeVisualizerRoute: typeof FolderTreeVisualizerRoute
-  GpgKeyGeneratorRoute: typeof GpgKeyGeneratorRoute
-  HashGeneratorRoute: typeof HashGeneratorRoute
-  HexEditorRoute: typeof HexEditorRoute
-  HttpStatusCodesRoute: typeof HttpStatusCodesRoute
-  ImageConverterRoute: typeof ImageConverterRoute
-  IpConverterRoute: typeof IpConverterRoute
-  JsonFormatterRoute: typeof JsonFormatterRoute
-  JwtDecoderRoute: typeof JwtDecoderRoute
-  ListComparerRoute: typeof ListComparerRoute
-  LoremIpsumRoute: typeof LoremIpsumRoute
-  MacLookupRoute: typeof MacLookupRoute
-  MarkdownEditorRoute: typeof MarkdownEditorRoute
-  MimeTypesRoute: typeof MimeTypesRoute
-  NetworkInterfacesRoute: typeof NetworkInterfacesRoute
-  NetworkScannerRoute: typeof NetworkScannerRoute
-  NumberBaseConverterRoute: typeof NumberBaseConverterRoute
-  PasswordGeneratorRoute: typeof PasswordGeneratorRoute
-  PathToolRoute: typeof PathToolRoute
-  QrCodeGeneratorRoute: typeof QrCodeGeneratorRoute
-  RegexTesterRoute: typeof RegexTesterRoute
-  RestClientRoute: typeof RestClientRoute
-  RsaToolsRoute: typeof RsaToolsRoute
-  SemverToolsRoute: typeof SemverToolsRoute
-  SettingsRoute: typeof SettingsRoute
-  SqlFormatterRoute: typeof SqlFormatterRoute
-  SshKeyGeneratorRoute: typeof SshKeyGeneratorRoute
-  StringCaseConverterRoute: typeof StringCaseConverterRoute
-  StringCompressorRoute: typeof StringCompressorRoute
-  TestDataGeneratorRoute: typeof TestDataGeneratorRoute
-  TlsInspectorRoute: typeof TlsInspectorRoute
-  UrlEncoderRoute: typeof UrlEncoderRoute
-  UuidGeneratorRoute: typeof UuidGeneratorRoute
-  WebhookReceiverRoute: typeof WebhookReceiverRoute
-  WebsocketTesterRoute: typeof WebsocketTesterRoute
-  WifiAnalyzerRoute: typeof WifiAnalyzerRoute
-  X509DecoderRoute: typeof X509DecoderRoute
-  XmlFormatterRoute: typeof XmlFormatterRoute
-  YamlFormatterRoute: typeof YamlFormatterRoute
+	IndexRoute: typeof IndexRoute;
+	ArchiveInspectorRoute: typeof ArchiveInspectorRoute;
+	Base64EncoderRoute: typeof Base64EncoderRoute;
+	BcryptGeneratorRoute: typeof BcryptGeneratorRoute;
+	CidrCalculatorRoute: typeof CidrCalculatorRoute;
+	CronExpressionBuilderRoute: typeof CronExpressionBuilderRoute;
+	CsvToolRoute: typeof CsvToolRoute;
+	CurlBuilderRoute: typeof CurlBuilderRoute;
+	DateTimestampConverterRoute: typeof DateTimestampConverterRoute;
+	DiffViewerRoute: typeof DiffViewerRoute;
+	DnsLookupRoute: typeof DnsLookupRoute;
+	DriveInfoRoute: typeof DriveInfoRoute;
+	DuplicateFinderRoute: typeof DuplicateFinderRoute;
+	EncodingConverterRoute: typeof EncodingConverterRoute;
+	EscapeToolRoute: typeof EscapeToolRoute;
+	FileInspectorRoute: typeof FileInspectorRoute;
+	FileWatchRoute: typeof FileWatchRoute;
+	FolderTreeVisualizerRoute: typeof FolderTreeVisualizerRoute;
+	GpgKeyGeneratorRoute: typeof GpgKeyGeneratorRoute;
+	HashGeneratorRoute: typeof HashGeneratorRoute;
+	HexEditorRoute: typeof HexEditorRoute;
+	HttpStatusCodesRoute: typeof HttpStatusCodesRoute;
+	ImageConverterRoute: typeof ImageConverterRoute;
+	IpConverterRoute: typeof IpConverterRoute;
+	JsonFormatterRoute: typeof JsonFormatterRoute;
+	JwtDecoderRoute: typeof JwtDecoderRoute;
+	ListComparerRoute: typeof ListComparerRoute;
+	LoremIpsumRoute: typeof LoremIpsumRoute;
+	MacLookupRoute: typeof MacLookupRoute;
+	MarkdownEditorRoute: typeof MarkdownEditorRoute;
+	MimeTypesRoute: typeof MimeTypesRoute;
+	NetworkInterfacesRoute: typeof NetworkInterfacesRoute;
+	NetworkScannerRoute: typeof NetworkScannerRoute;
+	NumberBaseConverterRoute: typeof NumberBaseConverterRoute;
+	PasswordGeneratorRoute: typeof PasswordGeneratorRoute;
+	PathToolRoute: typeof PathToolRoute;
+	QrCodeGeneratorRoute: typeof QrCodeGeneratorRoute;
+	RegexTesterRoute: typeof RegexTesterRoute;
+	RestClientRoute: typeof RestClientRoute;
+	RsaToolsRoute: typeof RsaToolsRoute;
+	SemverToolsRoute: typeof SemverToolsRoute;
+	SettingsRoute: typeof SettingsRoute;
+	SqlFormatterRoute: typeof SqlFormatterRoute;
+	SshKeyGeneratorRoute: typeof SshKeyGeneratorRoute;
+	StringCaseConverterRoute: typeof StringCaseConverterRoute;
+	StringCompressorRoute: typeof StringCompressorRoute;
+	TestDataGeneratorRoute: typeof TestDataGeneratorRoute;
+	TlsInspectorRoute: typeof TlsInspectorRoute;
+	UrlEncoderRoute: typeof UrlEncoderRoute;
+	UuidGeneratorRoute: typeof UuidGeneratorRoute;
+	WebhookReceiverRoute: typeof WebhookReceiverRoute;
+	WebsocketTesterRoute: typeof WebsocketTesterRoute;
+	WifiAnalyzerRoute: typeof WifiAnalyzerRoute;
+	X509DecoderRoute: typeof X509DecoderRoute;
+	XmlFormatterRoute: typeof XmlFormatterRoute;
+	YamlFormatterRoute: typeof YamlFormatterRoute;
 }
 
 declare module '@tanstack/react-router' {
-  interface FileRoutesByPath {
-    '/yaml-formatter': {
-      id: '/yaml-formatter'
-      path: '/yaml-formatter'
-      fullPath: '/yaml-formatter'
-      preLoaderRoute: typeof YamlFormatterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/xml-formatter': {
-      id: '/xml-formatter'
-      path: '/xml-formatter'
-      fullPath: '/xml-formatter'
-      preLoaderRoute: typeof XmlFormatterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/x509-decoder': {
-      id: '/x509-decoder'
-      path: '/x509-decoder'
-      fullPath: '/x509-decoder'
-      preLoaderRoute: typeof X509DecoderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/wifi-analyzer': {
-      id: '/wifi-analyzer'
-      path: '/wifi-analyzer'
-      fullPath: '/wifi-analyzer'
-      preLoaderRoute: typeof WifiAnalyzerRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/websocket-tester': {
-      id: '/websocket-tester'
-      path: '/websocket-tester'
-      fullPath: '/websocket-tester'
-      preLoaderRoute: typeof WebsocketTesterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/webhook-receiver': {
-      id: '/webhook-receiver'
-      path: '/webhook-receiver'
-      fullPath: '/webhook-receiver'
-      preLoaderRoute: typeof WebhookReceiverRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/uuid-generator': {
-      id: '/uuid-generator'
-      path: '/uuid-generator'
-      fullPath: '/uuid-generator'
-      preLoaderRoute: typeof UuidGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/url-encoder': {
-      id: '/url-encoder'
-      path: '/url-encoder'
-      fullPath: '/url-encoder'
-      preLoaderRoute: typeof UrlEncoderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/tls-inspector': {
-      id: '/tls-inspector'
-      path: '/tls-inspector'
-      fullPath: '/tls-inspector'
-      preLoaderRoute: typeof TlsInspectorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/test-data-generator': {
-      id: '/test-data-generator'
-      path: '/test-data-generator'
-      fullPath: '/test-data-generator'
-      preLoaderRoute: typeof TestDataGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/string-compressor': {
-      id: '/string-compressor'
-      path: '/string-compressor'
-      fullPath: '/string-compressor'
-      preLoaderRoute: typeof StringCompressorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/string-case-converter': {
-      id: '/string-case-converter'
-      path: '/string-case-converter'
-      fullPath: '/string-case-converter'
-      preLoaderRoute: typeof StringCaseConverterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/ssh-key-generator': {
-      id: '/ssh-key-generator'
-      path: '/ssh-key-generator'
-      fullPath: '/ssh-key-generator'
-      preLoaderRoute: typeof SshKeyGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/sql-formatter': {
-      id: '/sql-formatter'
-      path: '/sql-formatter'
-      fullPath: '/sql-formatter'
-      preLoaderRoute: typeof SqlFormatterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/settings': {
-      id: '/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof SettingsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/semver-tools': {
-      id: '/semver-tools'
-      path: '/semver-tools'
-      fullPath: '/semver-tools'
-      preLoaderRoute: typeof SemverToolsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/rsa-tools': {
-      id: '/rsa-tools'
-      path: '/rsa-tools'
-      fullPath: '/rsa-tools'
-      preLoaderRoute: typeof RsaToolsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/rest-client': {
-      id: '/rest-client'
-      path: '/rest-client'
-      fullPath: '/rest-client'
-      preLoaderRoute: typeof RestClientRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/regex-tester': {
-      id: '/regex-tester'
-      path: '/regex-tester'
-      fullPath: '/regex-tester'
-      preLoaderRoute: typeof RegexTesterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/qr-code-generator': {
-      id: '/qr-code-generator'
-      path: '/qr-code-generator'
-      fullPath: '/qr-code-generator'
-      preLoaderRoute: typeof QrCodeGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/path-tool': {
-      id: '/path-tool'
-      path: '/path-tool'
-      fullPath: '/path-tool'
-      preLoaderRoute: typeof PathToolRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/password-generator': {
-      id: '/password-generator'
-      path: '/password-generator'
-      fullPath: '/password-generator'
-      preLoaderRoute: typeof PasswordGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/number-base-converter': {
-      id: '/number-base-converter'
-      path: '/number-base-converter'
-      fullPath: '/number-base-converter'
-      preLoaderRoute: typeof NumberBaseConverterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/network-scanner': {
-      id: '/network-scanner'
-      path: '/network-scanner'
-      fullPath: '/network-scanner'
-      preLoaderRoute: typeof NetworkScannerRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/network-interfaces': {
-      id: '/network-interfaces'
-      path: '/network-interfaces'
-      fullPath: '/network-interfaces'
-      preLoaderRoute: typeof NetworkInterfacesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/mime-types': {
-      id: '/mime-types'
-      path: '/mime-types'
-      fullPath: '/mime-types'
-      preLoaderRoute: typeof MimeTypesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/markdown-editor': {
-      id: '/markdown-editor'
-      path: '/markdown-editor'
-      fullPath: '/markdown-editor'
-      preLoaderRoute: typeof MarkdownEditorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/mac-lookup': {
-      id: '/mac-lookup'
-      path: '/mac-lookup'
-      fullPath: '/mac-lookup'
-      preLoaderRoute: typeof MacLookupRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/lorem-ipsum': {
-      id: '/lorem-ipsum'
-      path: '/lorem-ipsum'
-      fullPath: '/lorem-ipsum'
-      preLoaderRoute: typeof LoremIpsumRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/list-comparer': {
-      id: '/list-comparer'
-      path: '/list-comparer'
-      fullPath: '/list-comparer'
-      preLoaderRoute: typeof ListComparerRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/jwt-decoder': {
-      id: '/jwt-decoder'
-      path: '/jwt-decoder'
-      fullPath: '/jwt-decoder'
-      preLoaderRoute: typeof JwtDecoderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/json-formatter': {
-      id: '/json-formatter'
-      path: '/json-formatter'
-      fullPath: '/json-formatter'
-      preLoaderRoute: typeof JsonFormatterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/ip-converter': {
-      id: '/ip-converter'
-      path: '/ip-converter'
-      fullPath: '/ip-converter'
-      preLoaderRoute: typeof IpConverterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/image-converter': {
-      id: '/image-converter'
-      path: '/image-converter'
-      fullPath: '/image-converter'
-      preLoaderRoute: typeof ImageConverterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/http-status-codes': {
-      id: '/http-status-codes'
-      path: '/http-status-codes'
-      fullPath: '/http-status-codes'
-      preLoaderRoute: typeof HttpStatusCodesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/hex-editor': {
-      id: '/hex-editor'
-      path: '/hex-editor'
-      fullPath: '/hex-editor'
-      preLoaderRoute: typeof HexEditorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/hash-generator': {
-      id: '/hash-generator'
-      path: '/hash-generator'
-      fullPath: '/hash-generator'
-      preLoaderRoute: typeof HashGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/gpg-key-generator': {
-      id: '/gpg-key-generator'
-      path: '/gpg-key-generator'
-      fullPath: '/gpg-key-generator'
-      preLoaderRoute: typeof GpgKeyGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/folder-tree-visualizer': {
-      id: '/folder-tree-visualizer'
-      path: '/folder-tree-visualizer'
-      fullPath: '/folder-tree-visualizer'
-      preLoaderRoute: typeof FolderTreeVisualizerRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/file-watch': {
-      id: '/file-watch'
-      path: '/file-watch'
-      fullPath: '/file-watch'
-      preLoaderRoute: typeof FileWatchRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/file-inspector': {
-      id: '/file-inspector'
-      path: '/file-inspector'
-      fullPath: '/file-inspector'
-      preLoaderRoute: typeof FileInspectorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/escape-tool': {
-      id: '/escape-tool'
-      path: '/escape-tool'
-      fullPath: '/escape-tool'
-      preLoaderRoute: typeof EscapeToolRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/encoding-converter': {
-      id: '/encoding-converter'
-      path: '/encoding-converter'
-      fullPath: '/encoding-converter'
-      preLoaderRoute: typeof EncodingConverterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/duplicate-finder': {
-      id: '/duplicate-finder'
-      path: '/duplicate-finder'
-      fullPath: '/duplicate-finder'
-      preLoaderRoute: typeof DuplicateFinderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/drive-info': {
-      id: '/drive-info'
-      path: '/drive-info'
-      fullPath: '/drive-info'
-      preLoaderRoute: typeof DriveInfoRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/dns-lookup': {
-      id: '/dns-lookup'
-      path: '/dns-lookup'
-      fullPath: '/dns-lookup'
-      preLoaderRoute: typeof DnsLookupRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/diff-viewer': {
-      id: '/diff-viewer'
-      path: '/diff-viewer'
-      fullPath: '/diff-viewer'
-      preLoaderRoute: typeof DiffViewerRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/date-timestamp-converter': {
-      id: '/date-timestamp-converter'
-      path: '/date-timestamp-converter'
-      fullPath: '/date-timestamp-converter'
-      preLoaderRoute: typeof DateTimestampConverterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/curl-builder': {
-      id: '/curl-builder'
-      path: '/curl-builder'
-      fullPath: '/curl-builder'
-      preLoaderRoute: typeof CurlBuilderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/csv-tool': {
-      id: '/csv-tool'
-      path: '/csv-tool'
-      fullPath: '/csv-tool'
-      preLoaderRoute: typeof CsvToolRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/cron-expression-builder': {
-      id: '/cron-expression-builder'
-      path: '/cron-expression-builder'
-      fullPath: '/cron-expression-builder'
-      preLoaderRoute: typeof CronExpressionBuilderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/cidr-calculator': {
-      id: '/cidr-calculator'
-      path: '/cidr-calculator'
-      fullPath: '/cidr-calculator'
-      preLoaderRoute: typeof CidrCalculatorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/bcrypt-generator': {
-      id: '/bcrypt-generator'
-      path: '/bcrypt-generator'
-      fullPath: '/bcrypt-generator'
-      preLoaderRoute: typeof BcryptGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/base64-encoder': {
-      id: '/base64-encoder'
-      path: '/base64-encoder'
-      fullPath: '/base64-encoder'
-      preLoaderRoute: typeof Base64EncoderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/archive-inspector': {
-      id: '/archive-inspector'
-      path: '/archive-inspector'
-      fullPath: '/archive-inspector'
-      preLoaderRoute: typeof ArchiveInspectorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-  }
+	interface FileRoutesByPath {
+		'/yaml-formatter': {
+			id: '/yaml-formatter';
+			path: '/yaml-formatter';
+			fullPath: '/yaml-formatter';
+			preLoaderRoute: typeof YamlFormatterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/xml-formatter': {
+			id: '/xml-formatter';
+			path: '/xml-formatter';
+			fullPath: '/xml-formatter';
+			preLoaderRoute: typeof XmlFormatterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/x509-decoder': {
+			id: '/x509-decoder';
+			path: '/x509-decoder';
+			fullPath: '/x509-decoder';
+			preLoaderRoute: typeof X509DecoderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/wifi-analyzer': {
+			id: '/wifi-analyzer';
+			path: '/wifi-analyzer';
+			fullPath: '/wifi-analyzer';
+			preLoaderRoute: typeof WifiAnalyzerRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/websocket-tester': {
+			id: '/websocket-tester';
+			path: '/websocket-tester';
+			fullPath: '/websocket-tester';
+			preLoaderRoute: typeof WebsocketTesterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/webhook-receiver': {
+			id: '/webhook-receiver';
+			path: '/webhook-receiver';
+			fullPath: '/webhook-receiver';
+			preLoaderRoute: typeof WebhookReceiverRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/uuid-generator': {
+			id: '/uuid-generator';
+			path: '/uuid-generator';
+			fullPath: '/uuid-generator';
+			preLoaderRoute: typeof UuidGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/url-encoder': {
+			id: '/url-encoder';
+			path: '/url-encoder';
+			fullPath: '/url-encoder';
+			preLoaderRoute: typeof UrlEncoderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/tls-inspector': {
+			id: '/tls-inspector';
+			path: '/tls-inspector';
+			fullPath: '/tls-inspector';
+			preLoaderRoute: typeof TlsInspectorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/test-data-generator': {
+			id: '/test-data-generator';
+			path: '/test-data-generator';
+			fullPath: '/test-data-generator';
+			preLoaderRoute: typeof TestDataGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/string-compressor': {
+			id: '/string-compressor';
+			path: '/string-compressor';
+			fullPath: '/string-compressor';
+			preLoaderRoute: typeof StringCompressorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/string-case-converter': {
+			id: '/string-case-converter';
+			path: '/string-case-converter';
+			fullPath: '/string-case-converter';
+			preLoaderRoute: typeof StringCaseConverterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/ssh-key-generator': {
+			id: '/ssh-key-generator';
+			path: '/ssh-key-generator';
+			fullPath: '/ssh-key-generator';
+			preLoaderRoute: typeof SshKeyGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/sql-formatter': {
+			id: '/sql-formatter';
+			path: '/sql-formatter';
+			fullPath: '/sql-formatter';
+			preLoaderRoute: typeof SqlFormatterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/settings': {
+			id: '/settings';
+			path: '/settings';
+			fullPath: '/settings';
+			preLoaderRoute: typeof SettingsRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/semver-tools': {
+			id: '/semver-tools';
+			path: '/semver-tools';
+			fullPath: '/semver-tools';
+			preLoaderRoute: typeof SemverToolsRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/rsa-tools': {
+			id: '/rsa-tools';
+			path: '/rsa-tools';
+			fullPath: '/rsa-tools';
+			preLoaderRoute: typeof RsaToolsRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/rest-client': {
+			id: '/rest-client';
+			path: '/rest-client';
+			fullPath: '/rest-client';
+			preLoaderRoute: typeof RestClientRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/regex-tester': {
+			id: '/regex-tester';
+			path: '/regex-tester';
+			fullPath: '/regex-tester';
+			preLoaderRoute: typeof RegexTesterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/qr-code-generator': {
+			id: '/qr-code-generator';
+			path: '/qr-code-generator';
+			fullPath: '/qr-code-generator';
+			preLoaderRoute: typeof QrCodeGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/path-tool': {
+			id: '/path-tool';
+			path: '/path-tool';
+			fullPath: '/path-tool';
+			preLoaderRoute: typeof PathToolRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/password-generator': {
+			id: '/password-generator';
+			path: '/password-generator';
+			fullPath: '/password-generator';
+			preLoaderRoute: typeof PasswordGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/number-base-converter': {
+			id: '/number-base-converter';
+			path: '/number-base-converter';
+			fullPath: '/number-base-converter';
+			preLoaderRoute: typeof NumberBaseConverterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/network-scanner': {
+			id: '/network-scanner';
+			path: '/network-scanner';
+			fullPath: '/network-scanner';
+			preLoaderRoute: typeof NetworkScannerRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/network-interfaces': {
+			id: '/network-interfaces';
+			path: '/network-interfaces';
+			fullPath: '/network-interfaces';
+			preLoaderRoute: typeof NetworkInterfacesRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/mime-types': {
+			id: '/mime-types';
+			path: '/mime-types';
+			fullPath: '/mime-types';
+			preLoaderRoute: typeof MimeTypesRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/markdown-editor': {
+			id: '/markdown-editor';
+			path: '/markdown-editor';
+			fullPath: '/markdown-editor';
+			preLoaderRoute: typeof MarkdownEditorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/mac-lookup': {
+			id: '/mac-lookup';
+			path: '/mac-lookup';
+			fullPath: '/mac-lookup';
+			preLoaderRoute: typeof MacLookupRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/lorem-ipsum': {
+			id: '/lorem-ipsum';
+			path: '/lorem-ipsum';
+			fullPath: '/lorem-ipsum';
+			preLoaderRoute: typeof LoremIpsumRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/list-comparer': {
+			id: '/list-comparer';
+			path: '/list-comparer';
+			fullPath: '/list-comparer';
+			preLoaderRoute: typeof ListComparerRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/jwt-decoder': {
+			id: '/jwt-decoder';
+			path: '/jwt-decoder';
+			fullPath: '/jwt-decoder';
+			preLoaderRoute: typeof JwtDecoderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/json-formatter': {
+			id: '/json-formatter';
+			path: '/json-formatter';
+			fullPath: '/json-formatter';
+			preLoaderRoute: typeof JsonFormatterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/ip-converter': {
+			id: '/ip-converter';
+			path: '/ip-converter';
+			fullPath: '/ip-converter';
+			preLoaderRoute: typeof IpConverterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/image-converter': {
+			id: '/image-converter';
+			path: '/image-converter';
+			fullPath: '/image-converter';
+			preLoaderRoute: typeof ImageConverterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/http-status-codes': {
+			id: '/http-status-codes';
+			path: '/http-status-codes';
+			fullPath: '/http-status-codes';
+			preLoaderRoute: typeof HttpStatusCodesRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/hex-editor': {
+			id: '/hex-editor';
+			path: '/hex-editor';
+			fullPath: '/hex-editor';
+			preLoaderRoute: typeof HexEditorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/hash-generator': {
+			id: '/hash-generator';
+			path: '/hash-generator';
+			fullPath: '/hash-generator';
+			preLoaderRoute: typeof HashGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/gpg-key-generator': {
+			id: '/gpg-key-generator';
+			path: '/gpg-key-generator';
+			fullPath: '/gpg-key-generator';
+			preLoaderRoute: typeof GpgKeyGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/folder-tree-visualizer': {
+			id: '/folder-tree-visualizer';
+			path: '/folder-tree-visualizer';
+			fullPath: '/folder-tree-visualizer';
+			preLoaderRoute: typeof FolderTreeVisualizerRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/file-watch': {
+			id: '/file-watch';
+			path: '/file-watch';
+			fullPath: '/file-watch';
+			preLoaderRoute: typeof FileWatchRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/file-inspector': {
+			id: '/file-inspector';
+			path: '/file-inspector';
+			fullPath: '/file-inspector';
+			preLoaderRoute: typeof FileInspectorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/escape-tool': {
+			id: '/escape-tool';
+			path: '/escape-tool';
+			fullPath: '/escape-tool';
+			preLoaderRoute: typeof EscapeToolRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/encoding-converter': {
+			id: '/encoding-converter';
+			path: '/encoding-converter';
+			fullPath: '/encoding-converter';
+			preLoaderRoute: typeof EncodingConverterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/duplicate-finder': {
+			id: '/duplicate-finder';
+			path: '/duplicate-finder';
+			fullPath: '/duplicate-finder';
+			preLoaderRoute: typeof DuplicateFinderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/drive-info': {
+			id: '/drive-info';
+			path: '/drive-info';
+			fullPath: '/drive-info';
+			preLoaderRoute: typeof DriveInfoRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/dns-lookup': {
+			id: '/dns-lookup';
+			path: '/dns-lookup';
+			fullPath: '/dns-lookup';
+			preLoaderRoute: typeof DnsLookupRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/diff-viewer': {
+			id: '/diff-viewer';
+			path: '/diff-viewer';
+			fullPath: '/diff-viewer';
+			preLoaderRoute: typeof DiffViewerRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/date-timestamp-converter': {
+			id: '/date-timestamp-converter';
+			path: '/date-timestamp-converter';
+			fullPath: '/date-timestamp-converter';
+			preLoaderRoute: typeof DateTimestampConverterRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/curl-builder': {
+			id: '/curl-builder';
+			path: '/curl-builder';
+			fullPath: '/curl-builder';
+			preLoaderRoute: typeof CurlBuilderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/csv-tool': {
+			id: '/csv-tool';
+			path: '/csv-tool';
+			fullPath: '/csv-tool';
+			preLoaderRoute: typeof CsvToolRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/cron-expression-builder': {
+			id: '/cron-expression-builder';
+			path: '/cron-expression-builder';
+			fullPath: '/cron-expression-builder';
+			preLoaderRoute: typeof CronExpressionBuilderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/cidr-calculator': {
+			id: '/cidr-calculator';
+			path: '/cidr-calculator';
+			fullPath: '/cidr-calculator';
+			preLoaderRoute: typeof CidrCalculatorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/bcrypt-generator': {
+			id: '/bcrypt-generator';
+			path: '/bcrypt-generator';
+			fullPath: '/bcrypt-generator';
+			preLoaderRoute: typeof BcryptGeneratorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/base64-encoder': {
+			id: '/base64-encoder';
+			path: '/base64-encoder';
+			fullPath: '/base64-encoder';
+			preLoaderRoute: typeof Base64EncoderRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/archive-inspector': {
+			id: '/archive-inspector';
+			path: '/archive-inspector';
+			fullPath: '/archive-inspector';
+			preLoaderRoute: typeof ArchiveInspectorRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		'/': {
+			id: '/';
+			path: '/';
+			fullPath: '/';
+			preLoaderRoute: typeof IndexRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+	}
 }
 
 const rootRouteChildren: RootRouteChildren = {
-  IndexRoute: IndexRoute,
-  ArchiveInspectorRoute: ArchiveInspectorRoute,
-  Base64EncoderRoute: Base64EncoderRoute,
-  BcryptGeneratorRoute: BcryptGeneratorRoute,
-  CidrCalculatorRoute: CidrCalculatorRoute,
-  CronExpressionBuilderRoute: CronExpressionBuilderRoute,
-  CsvToolRoute: CsvToolRoute,
-  CurlBuilderRoute: CurlBuilderRoute,
-  DateTimestampConverterRoute: DateTimestampConverterRoute,
-  DiffViewerRoute: DiffViewerRoute,
-  DnsLookupRoute: DnsLookupRoute,
-  DriveInfoRoute: DriveInfoRoute,
-  DuplicateFinderRoute: DuplicateFinderRoute,
-  EncodingConverterRoute: EncodingConverterRoute,
-  EscapeToolRoute: EscapeToolRoute,
-  FileInspectorRoute: FileInspectorRoute,
-  FileWatchRoute: FileWatchRoute,
-  FolderTreeVisualizerRoute: FolderTreeVisualizerRoute,
-  GpgKeyGeneratorRoute: GpgKeyGeneratorRoute,
-  HashGeneratorRoute: HashGeneratorRoute,
-  HexEditorRoute: HexEditorRoute,
-  HttpStatusCodesRoute: HttpStatusCodesRoute,
-  ImageConverterRoute: ImageConverterRoute,
-  IpConverterRoute: IpConverterRoute,
-  JsonFormatterRoute: JsonFormatterRoute,
-  JwtDecoderRoute: JwtDecoderRoute,
-  ListComparerRoute: ListComparerRoute,
-  LoremIpsumRoute: LoremIpsumRoute,
-  MacLookupRoute: MacLookupRoute,
-  MarkdownEditorRoute: MarkdownEditorRoute,
-  MimeTypesRoute: MimeTypesRoute,
-  NetworkInterfacesRoute: NetworkInterfacesRoute,
-  NetworkScannerRoute: NetworkScannerRoute,
-  NumberBaseConverterRoute: NumberBaseConverterRoute,
-  PasswordGeneratorRoute: PasswordGeneratorRoute,
-  PathToolRoute: PathToolRoute,
-  QrCodeGeneratorRoute: QrCodeGeneratorRoute,
-  RegexTesterRoute: RegexTesterRoute,
-  RestClientRoute: RestClientRoute,
-  RsaToolsRoute: RsaToolsRoute,
-  SemverToolsRoute: SemverToolsRoute,
-  SettingsRoute: SettingsRoute,
-  SqlFormatterRoute: SqlFormatterRoute,
-  SshKeyGeneratorRoute: SshKeyGeneratorRoute,
-  StringCaseConverterRoute: StringCaseConverterRoute,
-  StringCompressorRoute: StringCompressorRoute,
-  TestDataGeneratorRoute: TestDataGeneratorRoute,
-  TlsInspectorRoute: TlsInspectorRoute,
-  UrlEncoderRoute: UrlEncoderRoute,
-  UuidGeneratorRoute: UuidGeneratorRoute,
-  WebhookReceiverRoute: WebhookReceiverRoute,
-  WebsocketTesterRoute: WebsocketTesterRoute,
-  WifiAnalyzerRoute: WifiAnalyzerRoute,
-  X509DecoderRoute: X509DecoderRoute,
-  XmlFormatterRoute: XmlFormatterRoute,
-  YamlFormatterRoute: YamlFormatterRoute,
-}
+	IndexRoute: IndexRoute,
+	ArchiveInspectorRoute: ArchiveInspectorRoute,
+	Base64EncoderRoute: Base64EncoderRoute,
+	BcryptGeneratorRoute: BcryptGeneratorRoute,
+	CidrCalculatorRoute: CidrCalculatorRoute,
+	CronExpressionBuilderRoute: CronExpressionBuilderRoute,
+	CsvToolRoute: CsvToolRoute,
+	CurlBuilderRoute: CurlBuilderRoute,
+	DateTimestampConverterRoute: DateTimestampConverterRoute,
+	DiffViewerRoute: DiffViewerRoute,
+	DnsLookupRoute: DnsLookupRoute,
+	DriveInfoRoute: DriveInfoRoute,
+	DuplicateFinderRoute: DuplicateFinderRoute,
+	EncodingConverterRoute: EncodingConverterRoute,
+	EscapeToolRoute: EscapeToolRoute,
+	FileInspectorRoute: FileInspectorRoute,
+	FileWatchRoute: FileWatchRoute,
+	FolderTreeVisualizerRoute: FolderTreeVisualizerRoute,
+	GpgKeyGeneratorRoute: GpgKeyGeneratorRoute,
+	HashGeneratorRoute: HashGeneratorRoute,
+	HexEditorRoute: HexEditorRoute,
+	HttpStatusCodesRoute: HttpStatusCodesRoute,
+	ImageConverterRoute: ImageConverterRoute,
+	IpConverterRoute: IpConverterRoute,
+	JsonFormatterRoute: JsonFormatterRoute,
+	JwtDecoderRoute: JwtDecoderRoute,
+	ListComparerRoute: ListComparerRoute,
+	LoremIpsumRoute: LoremIpsumRoute,
+	MacLookupRoute: MacLookupRoute,
+	MarkdownEditorRoute: MarkdownEditorRoute,
+	MimeTypesRoute: MimeTypesRoute,
+	NetworkInterfacesRoute: NetworkInterfacesRoute,
+	NetworkScannerRoute: NetworkScannerRoute,
+	NumberBaseConverterRoute: NumberBaseConverterRoute,
+	PasswordGeneratorRoute: PasswordGeneratorRoute,
+	PathToolRoute: PathToolRoute,
+	QrCodeGeneratorRoute: QrCodeGeneratorRoute,
+	RegexTesterRoute: RegexTesterRoute,
+	RestClientRoute: RestClientRoute,
+	RsaToolsRoute: RsaToolsRoute,
+	SemverToolsRoute: SemverToolsRoute,
+	SettingsRoute: SettingsRoute,
+	SqlFormatterRoute: SqlFormatterRoute,
+	SshKeyGeneratorRoute: SshKeyGeneratorRoute,
+	StringCaseConverterRoute: StringCaseConverterRoute,
+	StringCompressorRoute: StringCompressorRoute,
+	TestDataGeneratorRoute: TestDataGeneratorRoute,
+	TlsInspectorRoute: TlsInspectorRoute,
+	UrlEncoderRoute: UrlEncoderRoute,
+	UuidGeneratorRoute: UuidGeneratorRoute,
+	WebhookReceiverRoute: WebhookReceiverRoute,
+	WebsocketTesterRoute: WebsocketTesterRoute,
+	WifiAnalyzerRoute: WifiAnalyzerRoute,
+	X509DecoderRoute: X509DecoderRoute,
+	XmlFormatterRoute: XmlFormatterRoute,
+	YamlFormatterRoute: YamlFormatterRoute,
+};
 export const routeTree = rootRouteImport
-  ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+	._addFileChildren(rootRouteChildren)
+	._addFileTypes<FileRouteTypes>();

--- a/src/routes/archive-inspector.tsx
+++ b/src/routes/archive-inspector.tsx
@@ -17,14 +17,13 @@ import { toast } from 'sonner';
 
 import {
 	FormFolderPicker,
-	FormInfo,
 	FormInput,
 	FormMode,
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { RelatedTools, SectionLabel } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { SectionLabel } from '@/lib/components/layout';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -501,21 +500,18 @@ function ArchiveInspectorPage() {
 						</div>
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{ id: 'file-inspector', reason: 'Inspect a single file' },
-								{ id: 'hex-editor', reason: 'View binary content' },
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
-							Read-only browsing plus selective extract. Supports .zip / .tar / .tar.gz / .tar.bz2 /
-							.tar.xz, and identifies .7z (full 7z browsing is deferred).
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'file-inspector', reason: 'Inspect a single file' },
+							{ id: 'hex-editor', reason: 'View binary content' },
+						]}
+						aboutText={
+							<>
+								Read-only browsing plus selective extract. Supports .zip / .tar / .tar.gz / .tar.bz2
+								/ .tar.xz, and identifies .7z (full 7z browsing is deferred).
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/cidr-calculator.tsx
+++ b/src/routes/cidr-calculator.tsx
@@ -5,8 +5,7 @@ import { toast } from 'sonner';
 
 import { ActionButton, CopyButton } from '@/lib/components/action';
 import { FormInfo, FormInput, FormMode, FormSection } from '@/lib/components/form';
-import { RelatedTools } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import {
 	Accordion,
@@ -205,25 +204,20 @@ function CidrCalculatorPage() {
 						/>
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{ id: 'ip-converter', reason: 'Convert IPv4 ↔ IPv6' },
-								{ id: 'dns-lookup', reason: 'Resolve a name to an IP' },
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'ip-converter', reason: 'Convert IPv4 ↔ IPv6' },
+							{ id: 'dns-lookup', reason: 'Resolve a name to an IP' },
+						]}
+						aboutText={
 							<ul className="list-inside list-disc space-y-0.5">
 								<li>All calculations happen in-browser.</li>
 								<li>Supports IPv4 (/0–/32) and IPv6 (/0–/128).</li>
 								<li>Math runs on bigint; no precision loss.</li>
 								<li>Detects RFC 1918 / 6598, loopback, ULA, and more.</li>
 							</ul>
-						</FormInfo>
-					</FormSection>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/csv-tool.tsx
+++ b/src/routes/csv-tool.tsx
@@ -27,16 +27,9 @@ import {
 } from 'react';
 import { toast } from 'sonner';
 
-import {
-	FormCheckbox,
-	FormInfo,
-	FormInput,
-	FormMode,
-	FormSection,
-	FormSelect,
-} from '@/lib/components/form';
-import { RelatedTools, SectionLabel } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { FormCheckbox, FormInput, FormMode, FormSection, FormSelect } from '@/lib/components/form';
+import { SectionLabel } from '@/lib/components/layout';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -450,21 +443,18 @@ function CsvToolPage() {
 						</div>
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{ id: 'file-inspector', reason: 'Inspect raw file' },
-								{ id: 'hex-editor', reason: 'View bytes' },
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
-							Pure local parsing. Drag-drop a CSV / TSV / JSON file, paste text, or open via dialog.
-							Edits update the table in memory; the output preview re-formats live.
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'file-inspector', reason: 'Inspect raw file' },
+							{ id: 'hex-editor', reason: 'View bytes' },
+						]}
+						aboutText={
+							<>
+								Pure local parsing. Drag-drop a CSV / TSV / JSON file, paste text, or open via
+								dialog. Edits update the table in memory; the output preview re-formats live.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/date-timestamp-converter.tsx
+++ b/src/routes/date-timestamp-converter.tsx
@@ -16,9 +16,9 @@ import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 import { ActionButton, CopyButton } from '@/lib/components/action';
-import { FormError, FormInfo, FormInput, FormSection, FormSelect } from '@/lib/components/form';
-import { RelatedTools, SectionLabel } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { FormError, FormInput, FormSection, FormSelect } from '@/lib/components/form';
+import { SectionLabel } from '@/lib/components/layout';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -305,22 +305,17 @@ function DateTimestampConverterPage() {
 				</Button>
 			</FormSection>
 
-			<FormSection title="Related">
-				<RelatedTools
-					items={[{ id: 'cron-expression-builder', reason: 'Edit the cron expression' }]}
-				/>
-			</FormSection>
-
-			<FormSection title="About">
-				<FormInfo>
+			<ToolFooter
+				relatedItems={[{ id: 'cron-expression-builder', reason: 'Edit the cron expression' }]}
+				aboutText={
 					<ul className="list-inside list-disc space-y-0.5">
 						<li>All representations of the same instant, computed on every render.</li>
 						<li>Pick a date in the calendar to set the active timestamp.</li>
 						<li>Multi-timezone cards flag DST boundaries within ±1 hour.</li>
 						<li>Cron preview defers to the Cron Expression Builder for editing.</li>
 					</ul>
-				</FormInfo>
-			</FormSection>
+				}
+			/>
 		</>
 	);
 

--- a/src/routes/diff-viewer.tsx
+++ b/src/routes/diff-viewer.tsx
@@ -12,7 +12,7 @@ import {
 	FormSection,
 	FormSlider,
 } from '@/lib/components/form';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmptyState } from '@/lib/components/status';
 import { useDocumentTitle } from '@/lib/hooks';
 import { usePersistedRail } from '@/lib/stores';
@@ -374,15 +374,15 @@ function DiffViewerPage() {
 						</FormInfo>
 					</FormSection>
 
-					<FormSection title="About">
-						<FormInfo>
+					<ToolFooter
+						aboutText={
 							<ul className="list-inside list-disc space-y-0.5">
 								<li>LCS algorithm for line diff</li>
 								<li>Character-level inline diff</li>
 								<li>Git-style hunk grouping</li>
 							</ul>
-						</FormInfo>
-					</FormSection>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/dns-lookup.tsx
+++ b/src/routes/dns-lookup.tsx
@@ -13,8 +13,7 @@ import {
 	FormSelect,
 	FormSlider,
 } from '@/lib/components/form';
-import { RelatedTools } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
@@ -331,24 +330,21 @@ function DnsLookupRail({
 				</Button>
 			</FormSection>
 
-			<FormSection title="Related">
-				<RelatedTools
-					items={[
-						{ id: 'tls-inspector', reason: 'Inspect TLS of a resolved host' },
-						{ id: 'rest-client', reason: 'Send HTTP request to a resolved host' },
-						{ id: 'cidr-calculator', reason: 'Analyse a resolved IP address' },
-					]}
-				/>
-			</FormSection>
-
-			<FormSection title="About">
-				<FormInfo>
-					Standard DNS over UDP / TCP. DNS-over-HTTPS, multi-resolver compare, and DNSSEC validation
-					are deferred to a follow-up. The AD badge mirrors the upstream{' '}
-					<code className="font-mono">ad</code> header bit — meaningful only when the upstream
-					itself validates.
-				</FormInfo>
-			</FormSection>
+			<ToolFooter
+				relatedItems={[
+					{ id: 'tls-inspector', reason: 'Inspect TLS of a resolved host' },
+					{ id: 'rest-client', reason: 'Send HTTP request to a resolved host' },
+					{ id: 'cidr-calculator', reason: 'Analyse a resolved IP address' },
+				]}
+				aboutText={
+					<>
+						Standard DNS over UDP / TCP. DNS-over-HTTPS, multi-resolver compare, and DNSSEC
+						validation are deferred to a follow-up. The AD badge mirrors the upstream{' '}
+						<code className="font-mono">ad</code> header bit — meaningful only when the upstream
+						itself validates.
+					</>
+				}
+			/>
 		</>
 	);
 }

--- a/src/routes/drive-info.tsx
+++ b/src/routes/drive-info.tsx
@@ -12,9 +12,9 @@ import type { LucideIcon } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
-import { FormCheckbox, FormInfo, FormSection } from '@/lib/components/form';
-import { DefinitionList, RelatedTools, SectionLabel } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { FormCheckbox, FormSection } from '@/lib/components/form';
+import { DefinitionList, SectionLabel } from '@/lib/components/layout';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -167,22 +167,19 @@ function DriveInfoPage() {
 						) : null}
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{ id: 'duplicate-finder', reason: 'Reclaim space by removing duplicates' },
-								{ id: 'folder-tree-visualizer', reason: 'Find the largest folders on a drive' },
-								{ id: 'file-inspector', reason: 'Inspect a file on a drive' },
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
-							Read-only snapshot of every disk the OS reports. Capacity and free space come from a
-							single stat call per drive; click Refresh to re-query.
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'duplicate-finder', reason: 'Reclaim space by removing duplicates' },
+							{ id: 'folder-tree-visualizer', reason: 'Find the largest folders on a drive' },
+							{ id: 'file-inspector', reason: 'Inspect a file on a drive' },
+						]}
+						aboutText={
+							<>
+								Read-only snapshot of every disk the OS reports. Capacity and free space come from a
+								single stat call per drive; click Refresh to re-query.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/duplicate-finder.tsx
+++ b/src/routes/duplicate-finder.tsx
@@ -7,13 +7,11 @@ import { toast } from 'sonner';
 import {
 	FormFolderPicker,
 	FormGlobFilters,
-	FormInfo,
 	FormMode,
 	FormSection,
 	FormSlider,
 } from '@/lib/components/form';
-import { RelatedTools } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -494,26 +492,23 @@ function DuplicateFinderPage() {
 						</div>
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{ id: 'drive-info', reason: 'See how much space the duplicates occupy' },
-								{ id: 'folder-tree-visualizer', reason: 'Inspect the folder structure first' },
-								{ id: 'file-inspector', reason: 'Inspect a single file in depth' },
-								{ id: 'hash-generator', reason: 'Hash arbitrary text or bytes' },
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
-							Files are bucketed by size, then by the SHA-256 / BLAKE3 hash of the first 8 KiB, then
-							by their full-content hash. Scanning, partial hashing, and full hashing all run
-							locally; nothing leaves your machine. Replace-with-link uses a symbolic link on macOS
-							and Linux and a hard link on Windows. Hard links cannot span volumes, so the source
-							and kept file must share the same drive.
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'drive-info', reason: 'See how much space the duplicates occupy' },
+							{ id: 'folder-tree-visualizer', reason: 'Inspect the folder structure first' },
+							{ id: 'file-inspector', reason: 'Inspect a single file in depth' },
+							{ id: 'hash-generator', reason: 'Hash arbitrary text or bytes' },
+						]}
+						aboutText={
+							<>
+								Files are bucketed by size, then by the SHA-256 / BLAKE3 hash of the first 8 KiB,
+								then by their full-content hash. Scanning, partial hashing, and full hashing all run
+								locally; nothing leaves your machine. Replace-with-link uses a symbolic link on
+								macOS and Linux and a hard link on Windows. Hard links cannot span volumes, so the
+								source and kept file must share the same drive.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/encoding-converter.tsx
+++ b/src/routes/encoding-converter.tsx
@@ -16,8 +16,8 @@ import {
 	FormSelect,
 	type SelectOption,
 } from '@/lib/components/form';
-import { RelatedTools, SplitPane } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { SplitPane } from '@/lib/components/layout';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
@@ -368,22 +368,19 @@ function EncodingConverterPage() {
 						</div>
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{ id: 'file-inspector', reason: 'Inspect file metadata and MIME' },
-								{ id: 'hex-editor', reason: 'Edit raw bytes side-by-side' },
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
-							Detection sniffs BOM first, then attempts strict UTF-8, then runs the jschardet
-							heuristic. Shift-JIS, EUC-JP, GBK, and Big5 are read via the platform decoder; their
-							encoders fall back to ASCII-safe placeholders for unmappable characters.
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'file-inspector', reason: 'Inspect file metadata and MIME' },
+							{ id: 'hex-editor', reason: 'Edit raw bytes side-by-side' },
+						]}
+						aboutText={
+							<>
+								Detection sniffs BOM first, then attempts strict UTF-8, then runs the jschardet
+								heuristic. Shift-JIS, EUC-JP, GBK, and Big5 are read via the platform decoder; their
+								encoders fall back to ASCII-safe placeholders for unmappable characters.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/escape-tool.tsx
+++ b/src/routes/escape-tool.tsx
@@ -22,7 +22,7 @@ import {
 	FormSelect,
 } from '@/lib/components/form';
 import { SplitPane } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
 import { IconTooltip } from '@/lib/components/ui/icon-tooltip';
@@ -410,9 +410,7 @@ function EscapeToolPage() {
 				</Button>
 			</FormSection>
 
-			<FormSection title="About">
-				<FormInfo>{FLAVOR_DESCRIPTIONS[activeFlavor]}</FormInfo>
-			</FormSection>
+			<ToolFooter aboutText={FLAVOR_DESCRIPTIONS[activeFlavor]} />
 		</>
 	);
 

--- a/src/routes/file-inspector.tsx
+++ b/src/routes/file-inspector.tsx
@@ -17,15 +17,9 @@ import { useCallback, useEffect, useMemo, useState, type DragEvent } from 'react
 import { toast } from 'sonner';
 
 import { CopyButton } from '@/lib/components/action';
-import {
-	FormCheckbox,
-	FormCheckboxGroup,
-	FormInfo,
-	FormSection,
-	FormSlider,
-} from '@/lib/components/form';
-import { DefinitionList, RelatedTools, SectionLabel } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { FormCheckbox, FormCheckboxGroup, FormSection, FormSlider } from '@/lib/components/form';
+import { DefinitionList, SectionLabel } from '@/lib/components/layout';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -457,22 +451,19 @@ function FileInspectorPage() {
 						</div>
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{ id: 'mime-types', reason: "Look up an extension's MIME" },
-								{ id: 'hash-generator', reason: 'Hash arbitrary text' },
-								{ id: 'x509-decoder', reason: "Decode if it's a cert" },
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
-							Pure local inspection. No upload. Magic-byte detection uses the MIME Type Explorer
-							catalog. Files larger than 500 MB fall back to head-only hashing.
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'mime-types', reason: "Look up an extension's MIME" },
+							{ id: 'hash-generator', reason: 'Hash arbitrary text' },
+							{ id: 'x509-decoder', reason: "Decode if it's a cert" },
+						]}
+						aboutText={
+							<>
+								Pure local inspection. No upload. Magic-byte detection uses the MIME Type Explorer
+								catalog. Files larger than 500 MB fall back to head-only hashing.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/file-watch.tsx
+++ b/src/routes/file-watch.tsx
@@ -8,11 +8,9 @@ import {
 	FormCheckbox,
 	FormCheckboxGroup,
 	FormFolderPicker,
-	FormInfo,
 	FormSection,
 } from '@/lib/components/form';
-import { RelatedTools } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -182,22 +180,19 @@ function FileWatchPage() {
 						</FormCheckboxGroup>
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{ id: 'file-inspector', reason: 'Inspect a changed file in detail' },
-								{ id: 'hex-editor', reason: 'View raw bytes of an updated file' },
-								{ id: 'folder-tree-visualizer', reason: 'See size impact of the watched tree' },
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
-							Recursive filesystem watcher. The most recent {EVENT_RING_CAPACITY} events are
-							buffered in memory; older events are dropped.
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'file-inspector', reason: 'Inspect a changed file in detail' },
+							{ id: 'hex-editor', reason: 'View raw bytes of an updated file' },
+							{ id: 'folder-tree-visualizer', reason: 'See size impact of the watched tree' },
+						]}
+						aboutText={
+							<>
+								Recursive filesystem watcher. The most recent {EVENT_RING_CAPACITY} events are
+								buffered in memory; older events are dropped.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/folder-tree-visualizer.tsx
+++ b/src/routes/folder-tree-visualizer.tsx
@@ -23,13 +23,11 @@ import {
 	FormCheckbox,
 	FormFolderPicker,
 	FormGlobFilters,
-	FormInfo,
 	FormMode,
 	FormSection,
 	FormSlider,
 } from '@/lib/components/form';
-import { RelatedTools } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -381,24 +379,21 @@ function FolderTreeVisualizerPage() {
 						</div>
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{ id: 'duplicate-finder', reason: 'Eliminate duplicates inside the tree' },
-								{ id: 'drive-info', reason: 'See total drive capacity and usage' },
-								{ id: 'file-inspector', reason: 'Drill into a single file' },
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
-							All scanning happens locally. Symlinks are never followed. Filters apply to filenames;
-							excluded directories are pruned before descent so deep `node_modules` trees never
-							enter the walk. Files outside the active filter are also excluded from cumulative
-							sizes, so totals reflect the visible tree.
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'duplicate-finder', reason: 'Eliminate duplicates inside the tree' },
+							{ id: 'drive-info', reason: 'See total drive capacity and usage' },
+							{ id: 'file-inspector', reason: 'Drill into a single file' },
+						]}
+						aboutText={
+							<>
+								All scanning happens locally. Symlinks are never followed. Filters apply to
+								filenames; excluded directories are pruned before descent so deep `node_modules`
+								trees never enter the walk. Files outside the active filter are also excluded from
+								cumulative sizes, so totals reflect the visible tree.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/hash-generator.tsx
+++ b/src/routes/hash-generator.tsx
@@ -30,7 +30,7 @@ import {
 	FormTextarea,
 } from '@/lib/components/form';
 import { SectionHeader, SectionLabel } from '@/lib/components/layout';
-import { StatusBar, ToolShell } from '@/lib/components/shell';
+import { StatusBar, ToolFooter, ToolShell } from '@/lib/components/shell';
 import { Rail } from '@/lib/components/ui/rail';
 import { EmbeddedEmptyState, LiveStatusRegion, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
@@ -679,18 +679,6 @@ function FileHashRail({
 				</div>
 			</FormSection>
 
-			<FormSection title="About">
-				<FormInfo>
-					<ul className="list-inside list-disc space-y-0.5">
-						<li>Drop files or pick them from the dialog.</li>
-						<li>All algorithms compute together via one streaming read per file.</li>
-						<li>
-							Verify mode reads a `&lt;hash&gt; &lt;filename&gt;` block and matches by basename.
-						</li>
-					</ul>
-				</FormInfo>
-			</FormSection>
-
 			<FormSection title="Security">
 				<FormInfo showIcon={false}>
 					<div className="space-y-1">
@@ -707,6 +695,18 @@ function FileHashRail({
 					</div>
 				</FormInfo>
 			</FormSection>
+
+			<ToolFooter
+				aboutText={
+					<ul className="list-inside list-disc space-y-0.5">
+						<li>Drop files or pick them from the dialog.</li>
+						<li>All algorithms compute together via one streaming read per file.</li>
+						<li>
+							Verify mode reads a `&lt;hash&gt; &lt;filename&gt;` block and matches by basename.
+						</li>
+					</ul>
+				}
+			/>
 		</>
 	);
 }

--- a/src/routes/hex-editor.tsx
+++ b/src/routes/hex-editor.tsx
@@ -25,9 +25,8 @@ import {
 } from 'react';
 import { toast } from 'sonner';
 
-import { FormCheckbox, FormInfo, FormInput, FormMode, FormSection } from '@/lib/components/form';
-import { RelatedTools } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { FormCheckbox, FormInput, FormMode, FormSection } from '@/lib/components/form';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -668,22 +667,19 @@ function HexEditorPage() {
 						</Button>
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{ id: 'file-inspector', reason: 'Inspect metadata' },
-								{ id: 'mime-types', reason: 'Decode magic bytes' },
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
-							Virtual scrolling renders only visible rows. Backup .bak is written on save when
-							enabled. Insert / delete operations that change file length are deferred to a future
-							iteration.
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'file-inspector', reason: 'Inspect metadata' },
+							{ id: 'mime-types', reason: 'Decode magic bytes' },
+						]}
+						aboutText={
+							<>
+								Virtual scrolling renders only visible rows. Backup .bak is written on save when
+								enabled. Insert / delete operations that change file length are deferred to a future
+								iteration.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/http-status-codes.tsx
+++ b/src/routes/http-status-codes.tsx
@@ -11,7 +11,7 @@ import {
 	FormSection,
 } from '@/lib/components/form';
 import { MasterDetailLayout, SubsectionLabel } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -197,12 +197,14 @@ function HttpStatusCodesPage() {
 						</div>
 					</FormSection>
 
-					<FormSection title="About">
-						<FormInfo>
-							Status codes are primarily defined in RFC 9110 (HTTP Semantics, June 2022). WebDAV
-							additions come from RFC 4918 / 5842; the IANA registry is the authoritative source.
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						aboutText={
+							<>
+								Status codes are primarily defined in RFC 9110 (HTTP Semantics, June 2022). WebDAV
+								additions come from RFC 4918 / 5842; the IANA registry is the authoritative source.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/image-converter.tsx
+++ b/src/routes/image-converter.tsx
@@ -12,7 +12,7 @@ import {
 	FormSection,
 	FormSlider,
 } from '@/lib/components/form';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -463,12 +463,14 @@ function ImageConverterPage() {
 						</div>
 					</FormSection>
 
-					<FormSection title="About">
-						<FormInfo>
-							All processing happens in your browser. Nothing is uploaded. Canvas re-render strips
-							EXIF metadata inherently.
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						aboutText={
+							<>
+								All processing happens in your browser. Nothing is uploaded. Canvas re-render strips
+								EXIF metadata inherently.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/ip-converter.tsx
+++ b/src/routes/ip-converter.tsx
@@ -4,8 +4,7 @@ import { type CSSProperties, type ReactNode, useMemo, useState } from 'react';
 
 import { ActionButton, CopyButton } from '@/lib/components/action';
 import { FormCheckbox, FormError, FormInfo, FormInput, FormSection } from '@/lib/components/form';
-import { RelatedTools } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
@@ -212,25 +211,20 @@ function IpConverterRail({
 				/>
 			</FormSection>
 
-			<FormSection title="Related">
-				<RelatedTools
-					items={[
-						{ id: 'cidr-calculator', reason: 'Compute subnets and ranges' },
-						{ id: 'dns-lookup', reason: 'Resolve a name to an IP' },
-					]}
-				/>
-			</FormSection>
-
-			<FormSection title="About">
-				<FormInfo>
+			<ToolFooter
+				relatedItems={[
+					{ id: 'cidr-calculator', reason: 'Compute subnets and ranges' },
+					{ id: 'dns-lookup', reason: 'Resolve a name to an IP' },
+				]}
+				aboutText={
 					<ul className="list-inside list-disc space-y-0.5">
 						<li>All conversions happen in-browser; no network calls.</li>
 						<li>IPv6 compressed form follows RFC 5952.</li>
 						<li>Embeddings: IPv4-mapped (RFC 4291), 6to4 (RFC 3056), Teredo (RFC 4380).</li>
 						<li>Math runs on bigint; no precision loss for u128.</li>
 					</ul>
-				</FormInfo>
-			</FormSection>
+				}
+			/>
 		</>
 	);
 }

--- a/src/routes/list-comparer.tsx
+++ b/src/routes/list-comparer.tsx
@@ -11,14 +11,8 @@ import {
 } from 'lucide-react';
 
 import { CopyButton } from '@/lib/components/action';
-import {
-	FormCheckbox,
-	FormCheckboxGroup,
-	FormInfo,
-	FormMode,
-	FormSection,
-} from '@/lib/components/form';
-import { ToolShell } from '@/lib/components/shell';
+import { FormCheckbox, FormCheckboxGroup, FormMode, FormSection } from '@/lib/components/form';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -326,15 +320,15 @@ function ListComparerPage() {
 				</div>
 			</FormSection>
 
-			<FormSection title="About">
-				<FormInfo>
+			<ToolFooter
+				aboutText={
 					<ul className="list-inside list-disc space-y-0.5">
 						<li>Set operations on two newline-separated lists</li>
 						<li>Duplicates are folded; first-seen casing is preserved</li>
 						<li>Venn diagram visualises A-only / common / B-only</li>
 					</ul>
-				</FormInfo>
-			</FormSection>
+				}
+			/>
 		</>
 	);
 

--- a/src/routes/lorem-ipsum.tsx
+++ b/src/routes/lorem-ipsum.tsx
@@ -6,14 +6,13 @@ import { ActionButton, CopyButton } from '@/lib/components/action';
 import {
 	FormCheckbox,
 	FormCheckboxGroup,
-	FormInfo,
 	FormMode,
 	FormSection,
 	FormSelect,
 	FormSlider,
 } from '@/lib/components/form';
 import { SectionHeader } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { LiveStatusRegion, StatItem } from '@/lib/components/status';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { useDocumentTitle } from '@/lib/hooks';
@@ -199,16 +198,16 @@ function LoremIpsumPage() {
 						</div>
 					</FormSection>
 
-					<FormSection title="About">
-						<FormInfo>
+					<ToolFooter
+						aboutText={
 							<ul className="list-inside list-disc space-y-0.5">
 								<li>Six word banks: Latin, food, hipster, pirate, cyberpunk, Japanese</li>
 								<li>Choose unit (paragraphs / sentences / words / bytes) and length</li>
 								<li>Wrap as plain text, HTML, Markdown, JSON, TypeScript, or JSX</li>
 								<li>Status bar reports UTF-8 byte length for accurate CJK / emoji counts</li>
 							</ul>
-						</FormInfo>
-					</FormSection>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/mac-lookup.tsx
+++ b/src/routes/mac-lookup.tsx
@@ -11,7 +11,7 @@ import {
 	FormMode,
 	FormSection,
 } from '@/lib/components/form';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
@@ -276,20 +276,18 @@ function MacLookupRail({
 				</Button>
 			</FormSection>
 
-			<FormSection title="About">
-				<FormInfo>
-					Vendor lookup uses the bundled IEEE OUI database via a Tauri command. All processing
-					happens locally; no network calls.
-				</FormInfo>
-				{dbInfo ? (
+			{dbInfo ? (
+				<FormSection title="Database">
 					<div className="flex items-center gap-2 text-xs text-muted-foreground">
 						<Database className="h-3.5 w-3.5" />
 						<span>
 							{dbInfo.entries.toLocaleString()} entries — updated {dbInfo.updated}
 						</span>
 					</div>
-				) : null}
-			</FormSection>
+				</FormSection>
+			) : null}
+
+			<ToolFooter aboutText="Vendor lookup uses the bundled IEEE OUI database via a Tauri command. All processing happens locally; no network calls." />
 		</>
 	);
 }

--- a/src/routes/markdown-editor.tsx
+++ b/src/routes/markdown-editor.tsx
@@ -35,10 +35,10 @@ import '@vizel/core/styles.css';
 import 'katex/dist/katex.min.css';
 
 import { CodeEditor, type CodeEditorHandle } from '@/lib/components/editor';
-import { FormInfo, FormMode, FormSection } from '@/lib/components/form';
+import { FormMode, FormSection } from '@/lib/components/form';
 import { SplitPane } from '@/lib/components/layout';
 import { MarkdownContextMenuItems, Vizel } from '@/lib/components/markdown';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
 import {
@@ -523,8 +523,8 @@ function MarkdownEditorPage() {
 						</FormSection>
 					) : null}
 
-					<FormSection title="About">
-						<FormInfo>
+					<ToolFooter
+						aboutText={
 							<ul className="list-inside list-disc space-y-0.5">
 								<li>Monaco editor with syntax highlighting</li>
 								<li>Vizel visual editor with rich block content</li>
@@ -533,8 +533,8 @@ function MarkdownEditorPage() {
 								<li>Table of Contents generation</li>
 								<li>Export to HTML</li>
 							</ul>
-						</FormInfo>
-					</FormSection>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/mime-types.tsx
+++ b/src/routes/mime-types.tsx
@@ -11,7 +11,7 @@ import {
 	FormSection,
 } from '@/lib/components/form';
 import { MasterDetailLayout, SubsectionLabel } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
@@ -205,16 +205,16 @@ function MimeTypesPage() {
 						</div>
 					</FormSection>
 
-					<FormSection title="About">
-						<FormInfo>
+					<ToolFooter
+						aboutText={
 							<ul className="list-inside list-disc space-y-0.5">
 								<li>Catalog of {MIME_ENTRIES.length} commonly-encountered MIME types.</li>
 								<li>Magic bytes are the first-N bytes used for file-type sniffing.</li>
 								<li>Alias notes flag deprecated or non-standard variants.</li>
 								<li>All lookups happen in-browser; no external requests.</li>
 							</ul>
-						</FormInfo>
-					</FormSection>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/network-interfaces.tsx
+++ b/src/routes/network-interfaces.tsx
@@ -16,15 +16,9 @@ import {
 import { toast } from 'sonner';
 
 import { CopyButton } from '@/lib/components/action';
-import {
-	FormCheckbox,
-	FormCheckboxGroup,
-	FormInfo,
-	FormSection,
-	FormSelect,
-} from '@/lib/components/form';
-import { RelatedTools, SectionHeader, SectionLabel } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { FormCheckbox, FormCheckboxGroup, FormSection, FormSelect } from '@/lib/components/form';
+import { SectionHeader, SectionLabel } from '@/lib/components/layout';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmptyState, ErrorDisplay, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -257,23 +251,20 @@ function NetworkInterfacesPage() {
 						/>
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{ id: 'ip-converter', reason: 'Convert between IPv4 / IPv6 representations' },
-								{ id: 'cidr-calculator', reason: 'Plan subnet ranges from a base address' },
-								{ id: 'mac-lookup', reason: 'Identify a vendor from a MAC address' },
-								{ id: 'network-scanner', reason: 'Discover hosts on this network' },
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
-							Read-only snapshot of every network interface the OS reports — IPv4, IPv6, MAC, MTU,
-							gateway, traffic counters. Nothing leaves your machine.
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'ip-converter', reason: 'Convert between IPv4 / IPv6 representations' },
+							{ id: 'cidr-calculator', reason: 'Plan subnet ranges from a base address' },
+							{ id: 'mac-lookup', reason: 'Identify a vendor from a MAC address' },
+							{ id: 'network-scanner', reason: 'Discover hosts on this network' },
+						]}
+						aboutText={
+							<>
+								Read-only snapshot of every network interface the OS reports — IPv4, IPv6, MAC, MTU,
+								gateway, traffic counters. Nothing leaves your machine.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/network-scanner.tsx
+++ b/src/routes/network-scanner.tsx
@@ -23,15 +23,13 @@ import {
 	FormCheckbox,
 	FormCheckboxGroup,
 	FormError,
-	FormInfo,
 	FormInput,
 	FormMode,
 	FormSection,
 	FormSlider,
 } from '@/lib/components/form';
-import { RelatedTools } from '@/lib/components/layout';
 import { UnifiedHostDetailPanel, UnifiedHostListItem } from '@/lib/components/network-scanner';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmptyState, ErrorDisplay, LiveStatusRegion, StatItem } from '@/lib/components/status';
 import {
 	Accordion,
@@ -1666,23 +1664,20 @@ function NetworkScannerPage() {
 				/>
 			) : null}
 
-			<FormSection title="Related">
-				<RelatedTools
-					items={[
-						{ id: 'network-interfaces', reason: 'Inspect this machine’s own interfaces' },
-						{ id: 'cidr-calculator', reason: 'Plan ranges before scanning' },
-						{ id: 'dns-lookup', reason: 'Resolve hostnames for discovered hosts' },
-						{ id: 'tls-inspector', reason: 'Inspect TLS on discovered services' },
-					]}
-				/>
-			</FormSection>
-
-			<FormSection title="About">
-				<FormInfo>
-					Discovers live hosts and open ports on a local network. All probes run from this device;
-					scans against networks you don’t administer may violate policies.
-				</FormInfo>
-			</FormSection>
+			<ToolFooter
+				relatedItems={[
+					{ id: 'network-interfaces', reason: 'Inspect this machine’s own interfaces' },
+					{ id: 'cidr-calculator', reason: 'Plan ranges before scanning' },
+					{ id: 'dns-lookup', reason: 'Resolve hostnames for discovered hosts' },
+					{ id: 'tls-inspector', reason: 'Inspect TLS on discovered services' },
+				]}
+				aboutText={
+					<>
+						Discovers live hosts and open ports on a local network. All probes run from this device;
+						scans against networks you don’t administer may violate policies.
+					</>
+				}
+			/>
 		</>
 	);
 

--- a/src/routes/number-base-converter.tsx
+++ b/src/routes/number-base-converter.tsx
@@ -12,7 +12,7 @@ import {
 	FormSlider,
 } from '@/lib/components/form';
 import { useDocumentTitle } from '@/lib/hooks';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { StatItem } from '@/lib/components/status';
 import {
 	Accordion,
@@ -411,16 +411,16 @@ function NumberBaseConverterPage() {
 						</div>
 					</FormSection>
 
-					<FormSection title="About">
-						<FormInfo>
+					<ToolFooter
+						aboutText={
 							<ul className="list-inside list-disc space-y-0.5">
 								<li>Edit any base to update the rest</li>
 								<li>Click bits in the grid to toggle them</li>
 								<li>Signed mode renders two's complement</li>
 								<li>Range: {rangeText}</li>
 							</ul>
-						</FormInfo>
-					</FormSection>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/password-generator.tsx
+++ b/src/routes/password-generator.tsx
@@ -5,15 +5,9 @@ import { toast } from 'sonner';
 
 import { ActionButton } from '@/lib/components/action';
 import { getErrorMessage } from '@/lib/utils';
-import {
-	FormCheckbox,
-	FormCheckboxGroup,
-	FormInfo,
-	FormSection,
-	FormSlider,
-} from '@/lib/components/form';
+import { FormCheckbox, FormCheckboxGroup, FormSection, FormSlider } from '@/lib/components/form';
 import { GeneratedListPanel } from '@/lib/components/panel';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { StatItem } from '@/lib/components/status';
 import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { useDocumentTitle } from '@/lib/hooks';
@@ -234,16 +228,16 @@ function PasswordGeneratorPage() {
 						</div>
 					</FormSection>
 
-					<FormSection title="About">
-						<FormInfo>
+					<ToolFooter
+						aboutText={
 							<ul className="list-inside list-disc space-y-0.5">
 								<li>Cryptographically secure (Web Crypto)</li>
 								<li>Entropy is log2(pool) × length</li>
 								<li>≥ 60 bits resists offline attacks</li>
 								<li>≥ 128 bits is overkill for human use</li>
 							</ul>
-						</FormInfo>
-					</FormSection>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/path-tool.tsx
+++ b/src/routes/path-tool.tsx
@@ -13,15 +13,9 @@ import { useCallback, useMemo, useState, type DragEvent } from 'react';
 import { toast } from 'sonner';
 
 import { CopyButton } from '@/lib/components/action';
-import {
-	FormCheckbox,
-	FormCheckboxGroup,
-	FormInfo,
-	FormInput,
-	FormSection,
-} from '@/lib/components/form';
-import { RelatedTools, SectionLabel } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { FormCheckbox, FormCheckboxGroup, FormInput, FormSection } from '@/lib/components/form';
+import { SectionLabel } from '@/lib/components/layout';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -273,23 +267,20 @@ function PathToolPage() {
 						</FormCheckboxGroup>
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{ id: 'file-inspector', reason: 'Inspect file metadata for this path' },
-								{ id: 'url-encoder', reason: 'Encode / decode generic URLs' },
-								{ id: 'escape-tool', reason: 'Escape strings for shells and code' },
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
-							Pure local parsing. Detection inspects the prefix and separator hints. URL form uses
-							RFC 8089 (`file://`) with percent-encoded segments. Shell escapes target bash /
-							zsh-compatible POSIX shells and PowerShell single-quoted strings.
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'file-inspector', reason: 'Inspect file metadata for this path' },
+							{ id: 'url-encoder', reason: 'Encode / decode generic URLs' },
+							{ id: 'escape-tool', reason: 'Escape strings for shells and code' },
+						]}
+						aboutText={
+							<>
+								Pure local parsing. Detection inspects the prefix and separator hints. URL form uses
+								RFC 8089 (`file://`) with percent-encoded segments. Shell escapes target bash /
+								zsh-compatible POSIX shells and PowerShell single-quoted strings.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/qr-code-generator.tsx
+++ b/src/routes/qr-code-generator.tsx
@@ -28,8 +28,8 @@ import {
 	FormSlider,
 	FormTextarea,
 } from '@/lib/components/form';
-import { RelatedTools, SectionHeader } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { SectionHeader } from '@/lib/components/layout';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, LiveStatusRegion, StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
@@ -675,21 +675,18 @@ function QrCodeGeneratorPage() {
 						/>
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{ id: 'image-converter', reason: 'Re-encode the exported PNG' },
-								{ id: 'url-encoder', reason: 'Encode complex payloads before generation' },
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
-							Generates QR codes locally with configurable dot, corner, and logo styling. Output is
-							rendered as SVG with PNG export — nothing is uploaded.
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'image-converter', reason: 'Re-encode the exported PNG' },
+							{ id: 'url-encoder', reason: 'Encode complex payloads before generation' },
+						]}
+						aboutText={
+							<>
+								Generates QR codes locally with configurable dot, corner, and logo styling. Output
+								is rendered as SVG with PNG export — nothing is uploaded.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/regex-tester.tsx
+++ b/src/routes/regex-tester.tsx
@@ -3,9 +3,9 @@ import { Eye, FlaskConical, GitBranch, Info, Search, Sparkles, Workflow } from '
 
 import { CopyButton } from '@/lib/components/action';
 import { FormError, FormInfo, FormSection, FormTextarea } from '@/lib/components/form';
-import { RelatedTools, SectionHeader, SplitPane } from '@/lib/components/layout';
+import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { PatternEditor, RailroadView } from '@/lib/components/regex';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem, ValidityBadge } from '@/lib/components/status';
 import {
 	Accordion,
@@ -650,23 +650,20 @@ function RegexTesterPage() {
 						</FormInfo>
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{ id: 'string-case-converter', reason: 'Normalize text before matching' },
-								{ id: 'list-comparer', reason: 'Compare sets of matched strings' },
-								{ id: 'diff-viewer', reason: 'Diff the replacement output' },
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
-							Tests JavaScript regular expressions against arbitrary input. The railroad diagram
-							visualizes the pattern; matches, capture groups, and replacement previews are computed
-							locally on every keystroke.
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'string-case-converter', reason: 'Normalize text before matching' },
+							{ id: 'list-comparer', reason: 'Compare sets of matched strings' },
+							{ id: 'diff-viewer', reason: 'Diff the replacement output' },
+						]}
+						aboutText={
+							<>
+								Tests JavaScript regular expressions against arbitrary input. The railroad diagram
+								visualizes the pattern; matches, capture groups, and replacement previews are
+								computed locally on every keystroke.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/rest-client.tsx
+++ b/src/routes/rest-client.tsx
@@ -17,14 +17,12 @@ import { CopyButton } from '@/lib/components/action';
 import {
 	FormCheckbox,
 	FormError,
-	FormInfo,
 	FormInput,
 	FormSection,
 	FormSelect,
 	FormSlider,
 } from '@/lib/components/form';
-import { RelatedTools } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -331,22 +329,19 @@ function RestClientRail({
 				</Button>
 			</FormSection>
 
-			<FormSection title="Related">
-				<RelatedTools
-					items={[
-						{ id: 'http-status-codes', reason: 'Look up a response status code' },
-						{ id: 'mime-types', reason: 'Find a Content-Type or extension' },
-						{ id: 'curl-builder', reason: 'Build or parse a cURL command' },
-					]}
-				/>
-			</FormSection>
-
-			<FormSection title="About">
-				<FormInfo>
-					Local HTTP client. Requests go directly from your machine; not proxied. CORS does not
-					apply (Tauri backend).
-				</FormInfo>
-			</FormSection>
+			<ToolFooter
+				relatedItems={[
+					{ id: 'http-status-codes', reason: 'Look up a response status code' },
+					{ id: 'mime-types', reason: 'Find a Content-Type or extension' },
+					{ id: 'curl-builder', reason: 'Build or parse a cURL command' },
+				]}
+				aboutText={
+					<>
+						Local HTTP client. Requests go directly from your machine; not proxied. CORS does not
+						apply (Tauri backend).
+					</>
+				}
+			/>
 		</>
 	);
 }

--- a/src/routes/rsa-tools.tsx
+++ b/src/routes/rsa-tools.tsx
@@ -15,14 +15,8 @@ import { useEffect, useMemo, useState, type DragEvent, type ReactNode } from 're
 import { toast } from 'sonner';
 
 import { CopyButton } from '@/lib/components/action';
-import {
-	FormInfo,
-	FormSection,
-	FormSelect,
-	FormTextarea,
-	type SelectOption,
-} from '@/lib/components/form';
-import { ToolShell } from '@/lib/components/shell';
+import { FormSection, FormSelect, FormTextarea, type SelectOption } from '@/lib/components/form';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -366,14 +360,16 @@ function RsaToolsPage() {
 				</div>
 			</FormSection>
 
-			<FormSection title="About">
-				<FormInfo>
-					All processing happens in your browser. Keys never leave the device. PKCS#1 v1.5
-					encryption is not exposed by Web Crypto — use OAEP. Legacy{' '}
-					<code className="font-mono">RSA PRIVATE KEY</code> (PKCS#1) PEMs are wrapped into PKCS#8
-					automatically.
-				</FormInfo>
-			</FormSection>
+			<ToolFooter
+				aboutText={
+					<>
+						All processing happens in your browser. Keys never leave the device. PKCS#1 v1.5
+						encryption is not exposed by Web Crypto — use OAEP. Legacy{' '}
+						<code className="font-mono">RSA PRIVATE KEY</code> (PKCS#1) PEMs are wrapped into PKCS#8
+						automatically.
+					</>
+				}
+			/>
 		</>
 	);
 

--- a/src/routes/string-case-converter.tsx
+++ b/src/routes/string-case-converter.tsx
@@ -13,7 +13,7 @@ import {
 	FormSelect,
 } from '@/lib/components/form';
 import { SectionHeader } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Card, CardContent } from '@/lib/components/ui/card';
 import { useDocumentTitle } from '@/lib/hooks';
@@ -134,16 +134,16 @@ function StringCaseConverterPage() {
 						</FormCheckboxGroup>
 					</FormSection>
 
-					<FormSection title="About">
-						<FormInfo>
+					<ToolFooter
+						aboutText={
 							<ul className="list-inside list-disc space-y-0.5">
 								<li>Converts text to 17+ case formats</li>
 								<li>Handles camelCase, PascalCase, snake_case</li>
 								<li>Supports kebab-case, CONSTANT_CASE, Title Case</li>
 								<li>Automatically detects word boundaries</li>
 							</ul>
-						</FormInfo>
-					</FormSection>
+						}
+					/>
 
 					<FormSection title="Supported Formats">
 						<FormInfo showIcon={false}>

--- a/src/routes/test-data-generator.tsx
+++ b/src/routes/test-data-generator.tsx
@@ -21,15 +21,14 @@ import { ActionButton } from '@/lib/components/action';
 import {
 	FormCheckbox,
 	FormError,
-	FormInfo,
 	FormInput,
 	FormSection,
 	FormSelect,
 	FormSlider,
 	FormTextarea,
 } from '@/lib/components/form';
-import { RelatedTools, SectionHeader } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { SectionHeader } from '@/lib/components/layout';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -411,18 +410,13 @@ function TestDataGeneratorPage() {
 						</div>
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{ id: 'lorem-ipsum', reason: 'Generate placeholder text' },
-								{ id: 'uuid-generator', reason: 'Standalone UUIDs' },
-								{ id: 'regex-tester', reason: 'Test regex patterns first' },
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'lorem-ipsum', reason: 'Generate placeholder text' },
+							{ id: 'uuid-generator', reason: 'Standalone UUIDs' },
+							{ id: 'regex-tester', reason: 'Test regex patterns first' },
+						]}
+						aboutText={
 							<ul className="list-inside list-disc space-y-0.5">
 								<li>20+ column types — numeric, text, date, identity, regex, sequence</li>
 								<li>Locale-aware names and addresses (en / ja / fr / de / es)</li>
@@ -430,8 +424,8 @@ function TestDataGeneratorPage() {
 								<li>Export as CSV / TSV / JSON / NDJSON / SQL INSERT</li>
 								<li>Same seed → same data; randomize the seed for fresh output</li>
 							</ul>
-						</FormInfo>
-					</FormSection>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/tls-inspector.tsx
+++ b/src/routes/tls-inspector.tsx
@@ -12,9 +12,9 @@ import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 import { CopyButton } from '@/lib/components/action';
-import { FormError, FormInfo, FormInput, FormSection, FormSlider } from '@/lib/components/form';
-import { DefinitionList, RelatedTools, SectionLabel } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { FormError, FormInput, FormSection, FormSlider } from '@/lib/components/form';
+import { DefinitionList, SectionLabel } from '@/lib/components/layout';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -259,21 +259,18 @@ function TlsInspectorPage() {
 						</Button>
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{ id: 'x509-decoder', reason: 'Drill into a chain certificate' },
-								{ id: 'dns-lookup', reason: 'Resolve a host before handshake' },
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
-							Performs a TLS handshake and dumps the certificate chain. Accepts invalid / expired /
-							self-signed certs for inspection — connections are NOT verified.
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'x509-decoder', reason: 'Drill into a chain certificate' },
+							{ id: 'dns-lookup', reason: 'Resolve a host before handshake' },
+						]}
+						aboutText={
+							<>
+								Performs a TLS handshake and dumps the certificate chain. Accepts invalid / expired
+								/ self-signed certs for inspection — connections are NOT verified.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/webhook-receiver.tsx
+++ b/src/routes/webhook-receiver.tsx
@@ -14,9 +14,9 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 import { CopyButton } from '@/lib/components/action';
-import { FormInfo, FormInput, FormSection, FormTextarea } from '@/lib/components/form';
-import { RelatedTools, SubsectionLabel } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { FormInput, FormSection, FormTextarea } from '@/lib/components/form';
+import { SubsectionLabel } from '@/lib/components/layout';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
@@ -348,16 +348,15 @@ function WebhookRail({
 				</Button>
 			</FormSection>
 
-			<FormSection title="Related">
-				<RelatedTools items={[{ id: 'rest-client', reason: 'Replay a captured request' }]} />
-			</FormSection>
-
-			<FormSection title="About">
-				<FormInfo>
-					Binds to 127.0.0.1 only — never reachable from another machine. Restart the app to reset
-					listener state if a command fails.
-				</FormInfo>
-			</FormSection>
+			<ToolFooter
+				relatedItems={[{ id: 'rest-client', reason: 'Replay a captured request' }]}
+				aboutText={
+					<>
+						Binds to 127.0.0.1 only — never reachable from another machine. Restart the app to reset
+						listener state if a command fails.
+					</>
+				}
+			/>
 		</>
 	);
 }

--- a/src/routes/websocket-tester.tsx
+++ b/src/routes/websocket-tester.tsx
@@ -6,13 +6,12 @@ import { toast } from 'sonner';
 import { ActionButton } from '@/lib/components/action';
 import {
 	FormCheckbox,
-	FormInfo,
 	FormInput,
 	FormMode,
 	FormSection,
 	FormTextarea,
 } from '@/lib/components/form';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -417,12 +416,14 @@ function WebSocketTesterRail({
 				</Button>
 			</FormSection>
 
-			<FormSection title="About">
-				<FormInfo>
-					Local WebSocket client. Connections go directly from your machine. Custom request headers
-					are deferred to a follow-up change.
-				</FormInfo>
-			</FormSection>
+			<ToolFooter
+				aboutText={
+					<>
+						Local WebSocket client. Connections go directly from your machine. Custom request
+						headers are deferred to a follow-up change.
+					</>
+				}
+			/>
 		</>
 	);
 }

--- a/src/routes/wifi-analyzer.tsx
+++ b/src/routes/wifi-analyzer.tsx
@@ -12,22 +12,14 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import { ActionButton } from '@/lib/components/action';
-import {
-	FormCheckbox,
-	FormInfo,
-	FormInput,
-	FormMode,
-	FormSection,
-	FormSlider,
-} from '@/lib/components/form';
+import { FormCheckbox, FormInput, FormMode, FormSection, FormSlider } from '@/lib/components/form';
 import {
 	type SortDirection,
 	type SortKey,
 	WifiChannelChart,
 	WifiNetworkTable,
 } from '@/lib/components/wifi-analyzer';
-import { RelatedTools } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, ErrorDisplay, StatItem } from '@/lib/components/status';
 import {
 	ResizableHandle,
@@ -218,34 +210,31 @@ function WifiAnalyzerPage() {
 						/>
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{
-									id: 'network-scanner',
-									reason: 'Probe hosts and open ports on the same network',
-								},
-								{
-									id: 'network-interfaces',
-									reason: 'Inspect the local interface this scan ran on',
-								},
-								{
-									id: 'mac-lookup',
-									reason: 'Resolve the BSSID vendor in detail',
-								},
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
-							Reads the OS Wi-Fi cache via CoreWLAN (macOS), NetworkManager DBus (Linux), or the
-							Native Wi-Fi API (Windows). No admin or root required. On macOS, the first scan asks
-							for Location Services access; granting once persists across launches. Set{' '}
-							<code>KOGU_WIFI_FIXTURES=1</code> in the launch environment to render a hand-crafted
-							demo network list when no radio is available.
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						relatedItems={[
+							{
+								id: 'network-scanner',
+								reason: 'Probe hosts and open ports on the same network',
+							},
+							{
+								id: 'network-interfaces',
+								reason: 'Inspect the local interface this scan ran on',
+							},
+							{
+								id: 'mac-lookup',
+								reason: 'Resolve the BSSID vendor in detail',
+							},
+						]}
+						aboutText={
+							<>
+								Reads the OS Wi-Fi cache via CoreWLAN (macOS), NetworkManager DBus (Linux), or the
+								Native Wi-Fi API (Windows). No admin or root required. On macOS, the first scan asks
+								for Location Services access; granting once persists across launches. Set{' '}
+								<code>KOGU_WIFI_FIXTURES=1</code> in the launch environment to render a hand-crafted
+								demo network list when no radio is available.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/x509-decoder.tsx
+++ b/src/routes/x509-decoder.tsx
@@ -20,13 +20,8 @@ import {
 	FormSlider,
 	FormTextarea,
 } from '@/lib/components/form';
-import {
-	DefinitionList,
-	type DefinitionItem,
-	RelatedTools,
-	SectionLabel,
-} from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { DefinitionList, type DefinitionItem, SectionLabel } from '@/lib/components/layout';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import {
 	Accordion,
@@ -306,21 +301,18 @@ function X509DecoderPage() {
 						</FormCheckboxGroup>
 					</FormSection>
 
-					<FormSection title="Related">
-						<RelatedTools
-							items={[
-								{ id: 'tls-inspector', reason: 'Fetch a live cert chain from a host' },
-								{ id: 'rsa-tools', reason: 'Verify a signature with the public key' },
-							]}
-						/>
-					</FormSection>
-
-					<FormSection title="About">
-						<FormInfo>
-							All parsing happens in your browser. Nothing is uploaded. Sample certificates are
-							generated locally with fresh keys each time.
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'tls-inspector', reason: 'Fetch a live cert chain from a host' },
+							{ id: 'rsa-tools', reason: 'Verify a signature with the public key' },
+						]}
+						aboutText={
+							<>
+								All parsing happens in your browser. Nothing is uploaded. Sample certificates are
+								generated locally with fresh keys each time.
+							</>
+						}
+					/>
 				</>
 			}
 		>


### PR DESCRIPTION
## Summary

- Extract a new `ToolFooter` shell component that encapsulates the canonical `Related → About` rail footer pair so every tool route ends its rail with the same primitive.
- Migrate all 37 tool routes that render an About (and/or Related) block to use `ToolFooter`, replacing 37 hand-assembled `<FormSection title="Related"> + <FormSection title="About">` block pairs.
- Fix two ordering drifts surfaced by the migration: `wifi-analyzer` was missing a `Related` block, and `hash-generator` rendered its `Security` panel after About.

## Changes

### Added

- `src/lib/components/shell/tool-footer.tsx` — `ToolFooter` component. API:

  ```tsx
  <ToolFooter
    relatedItems={[{ id: 'foo', reason: 'why' }]}
    aboutText={<>About copy.</>}
  />
  ```

  Both props optional. Component renders nothing when both are absent, so it can be dropped in unconditionally and future routes inherit the contract for free.

### Changed

- `src/lib/components/shell/index.ts` — export `ToolFooter` / `ToolFooterProps`.
- 37 routes under `src/routes/`:
  - 22 routes that had both Related and About collapse to one `ToolFooter` with `relatedItems` + `aboutText`.
  - 15 routes that had only About pass `aboutText`; the Related slot is skipped automatically.
  - `mac-lookup` — the database-stats block was previously rendered as a sibling of `<FormInfo>` inside the About `FormSection`. Moved to a dedicated `<FormSection title="Database">` before `ToolFooter` so About remains the last rail item and the stats keep their original visual separation from the info card.
  - `hash-generator` — the `Security` panel was rendering after About. Moved before `ToolFooter` so About is the last item.
- Drop unused `FormInfo` / `RelatedTools` imports from routes that no longer reference them elsewhere; keep them where other sections still use them (`cidr-calculator`, `ip-converter`, `qr-code-generator`, `dns-lookup`, `x509-decoder`).
- `src/route-tree.gen.ts` — incidental regeneration by TanStack Router adding trailing semicolons to import lines. Generator output only; no functional change.

## Why

Hand-assembling the `Related` + `About` pair in every route left ordering, presence checks, and styling up to the route. The result was quiet drift:

- `wifi-analyzer` had no `Related` block at all.
- `hash-generator` rendered a `Security` panel between Sum-block and About, leaving About not-last.
- Several routes used inconsistent capitalization or spacing for the `aboutText` content.

A single `ToolFooter` primitive encodes the contract — Related first, About last, both optional — in the type and JSX shape. New routes pick it up by default; existing routes converged on the same render.

## Test Plan

- [x] `bun run check` — TypeScript, validate-pages, design audit pass.
- [x] `bun run format` — no diff after the migration.
- [x] `bun run lint` — no new errors (10 pre-existing cognitive-complexity warnings in routes unrelated to this refactor).
- [ ] Manual: open a representative sample (`/wifi-analyzer`, `/file-watch`, `/mac-lookup`, `/hash-generator`, `/duplicate-finder`) and confirm the rail still ends with `Related → About` (or just About for routes that have no peers), with no visual regression on the bordered info card.

## Scope

Pure refactor. No behavior changes other than:

1. The two ordering fixes called out above.
2. The implicit fix that `wifi-analyzer` now has a `Related` block listing its peer network tools (this PR is the migration; the `Related` items themselves were added in a prior polish PR and merely move from a hand-rolled `<FormSection>` to `ToolFooter` here).
