### PR TITLE
fix(wifi-analyzer): keep curves inside the chart, close them on the axis, and wrap related-rail reasons

### DIFF
--- a/src/lib/components/layout/related-tools.tsx
+++ b/src/lib/components/layout/related-tools.tsx
@@ -34,7 +34,9 @@ export function RelatedTools({ items }: RelatedToolsProps) {
 						<div className="min-w-0 flex-1">
 							<div className="truncate font-medium text-foreground">{page.title}</div>
 							{item.reason ? (
-								<div className="truncate text-2xs text-muted-foreground">{item.reason}</div>
+								<div className="line-clamp-2 text-2xs leading-snug text-muted-foreground">
+									{item.reason}
+								</div>
 							) : null}
 						</div>
 					</Link>

--- a/src/lib/services/wifi.ts
+++ b/src/lib/services/wifi.ts
@@ -93,11 +93,18 @@ export const BAND_X_DOMAIN: Record<WifiBand, readonly [number, number]> = {
 	band6: [0, 234],
 };
 
-/** Domain bounds used by the chart's Y axis (RSSI in dBm). */
-export const RSSI_DOMAIN: readonly [number, number] = [-100, -30];
+/**
+ * Domain bounds used by the chart's Y axis (RSSI in dBm). The upper
+ * bound sits at -20 dBm so APs in the same room (which routinely
+ * report -15 to -25 dBm) keep their curve peaks inside the visible
+ * plot area. Without this headroom, the quadratic Bezier control
+ * point lands above the SVG viewport and the curve renders as a
+ * vertical spike that overshoots the chart frame.
+ */
+export const RSSI_DOMAIN: readonly [number, number] = [-100, -20];
 
 /** Y-axis tick marks in dBm, top to bottom. */
-export const RSSI_TICKS: readonly number[] = [-30, -40, -50, -60, -70, -80, -90, -100];
+export const RSSI_TICKS: readonly number[] = [-20, -30, -40, -50, -60, -70, -80, -90, -100];
 
 /**
  * Baseline value where the AP bell curve touches zero on the Y axis.

--- a/src/lib/services/wifi.ts
+++ b/src/lib/services/wifi.ts
@@ -107,10 +107,13 @@ export const RSSI_DOMAIN: readonly [number, number] = [-100, -20];
 export const RSSI_TICKS: readonly number[] = [-20, -30, -40, -50, -60, -70, -80, -90, -100];
 
 /**
- * Baseline value where the AP bell curve touches zero on the Y axis.
- * Slightly below the minimum tick so the curve visually closes.
+ * Baseline value where the AP bell curve closes on the Y axis. Set
+ * to the minimum tick so the curve tail sits exactly on the bottom
+ * axis line — using a value above the minimum (e.g., -95 with a
+ * domain bottom of -100) leaves a visible gap between the curve
+ * tail and the axis.
  */
-export const BASELINE_DBM = -95;
+export const BASELINE_DBM = -100;
 
 // =============================================================================
 // Pure helpers


### PR DESCRIPTION
## Summary

Three Wi-Fi Analyzer chart / rail visual regressions, all bundled because they overlap (same component touched, all surfaced in the same production-build screenshot):

1. **Bell curves overshoot the chart frame** when an AP reports a signal stronger than the domain top (e.g., `-23 dBm`).
2. **Bell curves close 5 dBm above the bottom X axis**, leaving a visible gap between every curve tail and the axis line.
3. **Related rail card descriptions get truncated mid-word** because they used one-line ellipsis.

## Root causes

### 1. Curve overshoot (`RSSI_DOMAIN` upper bound)

The chart draws each AP as a quadratic Bezier (`M (x0, yBase) Q (xc, yControl) (x1, yBase)`). PR #371 introduced control-point compensation so the curve's *visual* apex lands at the actual RSSI:

```ts
const yControl = 2 * yPeak - yBase;
```

When `yPeak` falls *above* the domain top (`yScale` extrapolates to a negative SVG-y), the compensation doubles that negativity. `yControl` lands far above the SVG viewport and the path renders as a vertical spike.

**Fix**: extend `RSSI_DOMAIN` upper bound `-30` → `-20 dBm` and add a matching `-20 dBm` Y tick. Real-world indoor measurements rarely exceed `-15 dBm`, so this domain covers typical close-range readings without compressing the rest of the scale.

### 2. Curves not touching the bottom axis (`BASELINE_DBM`)

`BASELINE_DBM = -95` was 5 dBm above the domain minimum (`-100`). Every curve closed at `yScale(-95)` instead of `yScale(-100)`, leaving a constant ~7% gap (5/70 of the inner height) between every curve tail and the X axis line. The docstring claimed the value should be "slightly below the minimum tick" but the actual number was above it.

**Fix**: pin `BASELINE_DBM` to `-100` so curve tails sit exactly on the axis.

### 3. Related rail truncation

`RelatedTools` rendered the `reason` text inside `<div className="truncate text-2xs ...">`. `truncate` is `white-space: nowrap; overflow: hidden; text-overflow: ellipsis` — fine when text fits, ugly when it overflows mid-word with no ellipsis room. "Probe hosts and open ports on the same network" was visibly cut to "…same netw" at the standard rail width.

**Fix**: swap `truncate` for `line-clamp-2 leading-snug`. Reasons up to ~80 characters now wrap to two lines inside the same card height; longer ones still ellipsize on the second line.

## Changes

### Changed

- `src/lib/services/wifi.ts`
  - `RSSI_DOMAIN` upper bound `-30` → `-20`
  - `RSSI_TICKS` prepends `-20`
  - `BASELINE_DBM` `-95` → `-100`
  - Comments rewritten to explain the Bezier-compensation headroom and the bottom-axis alignment.
- `src/lib/components/layout/related-tools.tsx` — reason text class swap, `truncate` → `line-clamp-2 leading-snug`. Affects every route's Related FormSection card (~22 routes after PR #372).

## Why all three surfaced now

PR #371 fixed the Bezier math at the baseline but didn't audit:
- Whether the *post-compensation* control point stays inside the SVG viewport for high signals (it doesn't, hence #1).
- Whether the curve tail closes on the X axis (it doesn't, hence #2).

Both were latent until the user ran the production build at close range to a router that reported `-23 dBm`.

The Related rail truncation has been present since PR #371 added the wifi-analyzer Related section, but was not visible until reasons in that PR exceeded the standard rail width. The fix is component-wide (`RelatedTools` is shared), so any future Related entry inherits the wrapping behavior.

## Test Plan

- [x] `bun run check` — TypeScript + validate-pages + design audit pass.
- [x] `bun run format` — no diff after the fix.
- [x] `bun run lint` — no new errors (28 pre-existing warnings unchanged).
- [ ] Manual: open `/wifi-analyzer` near an AP reporting `-15 to -25 dBm`. Confirm (a) the bell curve peaks inside the chart frame at the correct RSSI, (b) the curve tail sits exactly on the bottom axis line, (c) the Related rail cards show full peer-tool descriptions wrapped to two lines.
