### PR TITLE
refactor(routes): persist base64-encoder and url-encoder options across reload

### DIFF
--- a/src/routes/base64-encoder.tsx
+++ b/src/routes/base64-encoder.tsx
@@ -17,7 +17,7 @@ import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
-import { usePersistedRail } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import {
 	BASE64_MIME_TYPES,
 	type Base64DecodeOptions,
@@ -37,30 +37,50 @@ import {
 
 type Mode = 'encode' | 'decode';
 
+interface Base64Prefs {
+	readonly mode: Mode;
+	readonly variant: Base64Variant;
+	readonly padding: boolean;
+	readonly lineBreak: Base64LineBreak;
+	readonly dataUrl: boolean;
+	readonly mimeType: string;
+	readonly ignoreWhitespace: boolean;
+	readonly ignoreInvalidChars: boolean;
+	readonly autoDetectVariant: boolean;
+}
+
+const useBase64Prefs = createToolOptionsStore<Base64Prefs>('base64-encoder', {
+	mode: 'encode',
+	variant: defaultBase64EncodeOptions.variant,
+	padding: defaultBase64EncodeOptions.padding,
+	lineBreak: defaultBase64EncodeOptions.lineBreak,
+	dataUrl: defaultBase64EncodeOptions.dataUrl,
+	mimeType: defaultBase64EncodeOptions.mimeType,
+	ignoreWhitespace: defaultBase64DecodeOptions.ignoreWhitespace,
+	ignoreInvalidChars: defaultBase64DecodeOptions.ignoreInvalidChars,
+	autoDetectVariant: defaultBase64DecodeOptions.autoDetectVariant,
+});
+
 export const Route = createFileRoute('/base64-encoder')({
 	component: Base64EncoderPage,
 });
 
 function Base64EncoderPage() {
-	const [mode, setMode] = useState<Mode>('encode');
+	const { value: prefs, patch } = useBase64Prefs();
+	const {
+		mode,
+		variant,
+		padding,
+		lineBreak,
+		dataUrl,
+		mimeType,
+		ignoreWhitespace,
+		ignoreInvalidChars,
+		autoDetectVariant,
+	} = prefs;
+
 	const [input, setInput] = useState('');
 	const [showOptions, setShowOptions] = usePersistedRail('base64-encoder');
-
-	const [variant, setVariant] = useState<Base64Variant>(defaultBase64EncodeOptions.variant);
-	const [padding, setPadding] = useState(defaultBase64EncodeOptions.padding);
-	const [lineBreak, setLineBreak] = useState<Base64LineBreak>(defaultBase64EncodeOptions.lineBreak);
-	const [dataUrl, setDataUrl] = useState(defaultBase64EncodeOptions.dataUrl);
-	const [mimeType, setMimeType] = useState(defaultBase64EncodeOptions.mimeType);
-
-	const [ignoreWhitespace, setIgnoreWhitespace] = useState(
-		defaultBase64DecodeOptions.ignoreWhitespace
-	);
-	const [ignoreInvalidChars, setIgnoreInvalidChars] = useState(
-		defaultBase64DecodeOptions.ignoreInvalidChars
-	);
-	const [autoDetectVariant, setAutoDetectVariant] = useState(
-		defaultBase64DecodeOptions.autoDetectVariant
-	);
 
 	useDocumentTitle('Base64 Encoder');
 
@@ -135,7 +155,7 @@ function Base64EncoderPage() {
 	const handleSample = () => setInput(SAMPLE_TEXT_FOR_BASE64);
 
 	const handleModeChange = (newMode: Mode) => {
-		setMode(newMode);
+		patch({ mode: newMode });
 		setInput('');
 	};
 
@@ -176,7 +196,7 @@ function Base64EncoderPage() {
 								<FormSelect
 									label="Variant"
 									value={variant}
-									onValueChange={(v) => setVariant(v as Base64Variant)}
+									onValueChange={(v) => patch({ variant: v as Base64Variant })}
 									options={[
 										{
 											value: 'standard',
@@ -194,7 +214,7 @@ function Base64EncoderPage() {
 								<FormSelect
 									label="Line Break"
 									value={lineBreak}
-									onValueChange={(v) => setLineBreak(v as Base64LineBreak)}
+									onValueChange={(v) => patch({ lineBreak: v as Base64LineBreak })}
 									options={[
 										{ value: 'none', label: 'None', description: 'Single continuous line' },
 										{ value: '64', label: '64 chars', description: 'PEM convention' },
@@ -206,7 +226,7 @@ function Base64EncoderPage() {
 									<FormCheckbox
 										label="Include padding (=)"
 										checked={padding}
-										onCheckedChange={setPadding}
+										onCheckedChange={(v) => patch({ padding: v })}
 										size="compact"
 									/>
 								</div>
@@ -216,7 +236,7 @@ function Base64EncoderPage() {
 								<FormCheckbox
 									label="Output as Data URL"
 									checked={dataUrl}
-									onCheckedChange={setDataUrl}
+									onCheckedChange={(v) => patch({ dataUrl: v })}
 									size="compact"
 								/>
 								{dataUrl ? (
@@ -224,7 +244,7 @@ function Base64EncoderPage() {
 										<FormSelect
 											label="MIME Type"
 											value={mimeType}
-											onValueChange={setMimeType}
+											onValueChange={(v) => patch({ mimeType: v })}
 											options={[...BASE64_MIME_TYPES]}
 											size="compact"
 										/>
@@ -251,19 +271,19 @@ function Base64EncoderPage() {
 									<FormCheckbox
 										label="Ignore whitespace"
 										checked={ignoreWhitespace}
-										onCheckedChange={setIgnoreWhitespace}
+										onCheckedChange={(v) => patch({ ignoreWhitespace: v })}
 										size="compact"
 									/>
 									<FormCheckbox
 										label="Ignore invalid characters"
 										checked={ignoreInvalidChars}
-										onCheckedChange={setIgnoreInvalidChars}
+										onCheckedChange={(v) => patch({ ignoreInvalidChars: v })}
 										size="compact"
 									/>
 									<FormCheckbox
 										label="Auto-detect URL-safe variant"
 										checked={autoDetectVariant}
-										onCheckedChange={setAutoDetectVariant}
+										onCheckedChange={(v) => patch({ autoDetectVariant: v })}
 										size="compact"
 									/>
 								</FormCheckboxGroup>

--- a/src/routes/url-encoder.tsx
+++ b/src/routes/url-encoder.tsx
@@ -24,7 +24,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/ca
 import { Input } from '@/lib/components/ui/input';
 import { IconTooltip } from '@/lib/components/ui/icon-tooltip';
 import { CodeBlock } from '@/lib/components/ui/code-block';
-import { useActiveTab, useTabStore, usePersistedRail } from '@/lib/stores';
+import { createToolOptionsStore, useActiveTab, useTabStore, usePersistedRail } from '@/lib/stores';
 import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
 import {
 	buildUrl,
@@ -50,6 +50,34 @@ import {
 type Tab = 'encode' | 'parse' | 'build' | 'reference';
 type Mode = 'encode' | 'decode';
 
+interface UrlEncoderPrefs {
+	readonly mode: Mode;
+	readonly encodeMode: UrlEncodeMode;
+	readonly spaceEncoding: UrlSpaceEncoding;
+	readonly hexCase: UrlHexCase;
+	readonly newlineHandling: UrlNewlineHandling;
+	readonly preserveChars: string;
+	readonly encodeNonAscii: boolean;
+	readonly plusAsSpace: boolean;
+	readonly invalidHandling: UrlInvalidHandling;
+	readonly decodeMultiple: boolean;
+	readonly maxIterations: number;
+}
+
+const useUrlEncoderPrefs = createToolOptionsStore<UrlEncoderPrefs>('url-encoder', {
+	mode: 'encode',
+	encodeMode: defaultUrlEncodeOptions.mode,
+	spaceEncoding: defaultUrlEncodeOptions.spaceEncoding,
+	hexCase: defaultUrlEncodeOptions.hexCase,
+	newlineHandling: defaultUrlEncodeOptions.newlineHandling,
+	preserveChars: defaultUrlEncodeOptions.preserveChars,
+	encodeNonAscii: defaultUrlEncodeOptions.encodeNonAscii,
+	plusAsSpace: defaultUrlDecodeOptions.plusAsSpace,
+	invalidHandling: defaultUrlDecodeOptions.invalidHandling,
+	decodeMultiple: defaultUrlDecodeOptions.decodeMultiple,
+	maxIterations: defaultUrlDecodeOptions.maxIterations,
+});
+
 const TABS = [
 	{ id: 'encode' as const, label: 'Encode/Decode', icon: ArrowRightLeft },
 	{ id: 'parse' as const, label: 'Parse URL', icon: Link2 },
@@ -69,31 +97,23 @@ function UrlEncoderPage() {
 	const activeTab: Tab = (persistedTab as Tab | undefined) ?? 'encode';
 	const handleTabChange = (tab: string) => setActive(PERSIST_KEY, tab);
 
-	const [mode, setMode] = useState<Mode>('encode');
+	const { value: prefs, patch } = useUrlEncoderPrefs();
+	const {
+		mode,
+		encodeMode,
+		spaceEncoding,
+		hexCase,
+		newlineHandling,
+		preserveChars,
+		encodeNonAscii,
+		plusAsSpace,
+		invalidHandling,
+		decodeMultiple,
+		maxIterations,
+	} = prefs;
+
 	const [input, setInput] = useState('');
 	const [showOptions, setShowOptions] = usePersistedRail('url-encoder');
-
-	const [encodeMode, setEncodeMode] = useState<UrlEncodeMode>(defaultUrlEncodeOptions.mode);
-	const [spaceEncoding, setSpaceEncoding] = useState<UrlSpaceEncoding>(
-		defaultUrlEncodeOptions.spaceEncoding
-	);
-	const [hexCase, setHexCase] = useState<UrlHexCase>(defaultUrlEncodeOptions.hexCase);
-	const [newlineHandling, setNewlineHandling] = useState<UrlNewlineHandling>(
-		defaultUrlEncodeOptions.newlineHandling
-	);
-	const [preserveChars, setPreserveChars] = useState(defaultUrlEncodeOptions.preserveChars);
-	const [encodeNonAscii, setEncodeNonAscii] = useState<boolean>(
-		defaultUrlEncodeOptions.encodeNonAscii
-	);
-
-	const [plusAsSpace, setPlusAsSpace] = useState<boolean>(defaultUrlDecodeOptions.plusAsSpace);
-	const [invalidHandling, setInvalidHandling] = useState<UrlInvalidHandling>(
-		defaultUrlDecodeOptions.invalidHandling
-	);
-	const [decodeMultiple, setDecodeMultiple] = useState<boolean>(
-		defaultUrlDecodeOptions.decodeMultiple
-	);
-	const [maxIterations, setMaxIterations] = useState(defaultUrlDecodeOptions.maxIterations);
 
 	const [parseInput, setParseInput] = useState('');
 	const [baseUrl, setBaseUrl] = useState('https://example.com/path');
@@ -194,7 +214,7 @@ function UrlEncoderPage() {
 					<FormMode
 						value={mode}
 						onValueChange={(v) => {
-							setMode(v);
+							patch({ mode: v });
 							setInput('');
 						}}
 						options={[
@@ -210,7 +230,7 @@ function UrlEncoderPage() {
 							<FormSelect
 								label="Mode"
 								value={encodeMode}
-								onValueChange={(v) => setEncodeMode(v as UrlEncodeMode)}
+								onValueChange={(v) => patch({ encodeMode: v as UrlEncodeMode })}
 								options={[
 									{
 										value: 'component',
@@ -235,7 +255,7 @@ function UrlEncoderPage() {
 							<FormSelect
 								label="Space Encoding"
 								value={spaceEncoding}
-								onValueChange={(v) => setSpaceEncoding(v as UrlSpaceEncoding)}
+								onValueChange={(v) => patch({ spaceEncoding: v as UrlSpaceEncoding })}
 								options={[
 									{ value: 'percent', label: '%20', description: 'RFC 3986 standard' },
 									{
@@ -249,7 +269,7 @@ function UrlEncoderPage() {
 							<FormSelect
 								label="Hex Case"
 								value={hexCase}
-								onValueChange={(v) => setHexCase(v as UrlHexCase)}
+								onValueChange={(v) => patch({ hexCase: v as UrlHexCase })}
 								options={[
 									{ value: 'upper', label: 'Uppercase (%2F)' },
 									{ value: 'lower', label: 'Lowercase (%2f)' },
@@ -259,7 +279,7 @@ function UrlEncoderPage() {
 							<FormSelect
 								label="Newline Handling"
 								value={newlineHandling}
-								onValueChange={(v) => setNewlineHandling(v as UrlNewlineHandling)}
+								onValueChange={(v) => patch({ newlineHandling: v as UrlNewlineHandling })}
 								options={[
 									{ value: 'encode', label: 'Encode as-is' },
 									{ value: 'crlf', label: 'Convert to CRLF' },
@@ -272,7 +292,7 @@ function UrlEncoderPage() {
 								<FormCheckbox
 									label="Encode non-ASCII characters"
 									checked={encodeNonAscii}
-									onCheckedChange={setEncodeNonAscii}
+									onCheckedChange={(v) => patch({ encodeNonAscii: v })}
 									size="compact"
 								/>
 							</div>
@@ -283,7 +303,7 @@ function UrlEncoderPage() {
 								<FormInput
 									label="Preserve Characters"
 									value={preserveChars}
-									onValueChange={setPreserveChars}
+									onValueChange={(v) => patch({ preserveChars: v })}
 									placeholder="e.g., -_.~"
 									size="compact"
 								/>
@@ -319,13 +339,13 @@ function UrlEncoderPage() {
 							<FormCheckbox
 								label="Treat + as space"
 								checked={plusAsSpace}
-								onCheckedChange={setPlusAsSpace}
+								onCheckedChange={(v) => patch({ plusAsSpace: v })}
 								size="compact"
 							/>
 							<FormSelect
 								label="Invalid Sequences"
 								value={invalidHandling}
-								onValueChange={(v) => setInvalidHandling(v as UrlInvalidHandling)}
+								onValueChange={(v) => patch({ invalidHandling: v as UrlInvalidHandling })}
 								options={[
 									{ value: 'error', label: 'Throw error' },
 									{ value: 'skip', label: 'Skip (remove)' },
@@ -336,7 +356,7 @@ function UrlEncoderPage() {
 							<FormCheckbox
 								label="Decode multiple layers"
 								checked={decodeMultiple}
-								onCheckedChange={setDecodeMultiple}
+								onCheckedChange={(v) => patch({ decodeMultiple: v })}
 								size="compact"
 							/>
 							{decodeMultiple ? (
@@ -344,7 +364,7 @@ function UrlEncoderPage() {
 									<FormSlider
 										label="Max Iterations"
 										value={maxIterations}
-										onValueChange={setMaxIterations}
+										onValueChange={(v) => patch({ maxIterations: v })}
 										min={1}
 										max={10}
 										step={1}


### PR DESCRIPTION
## Summary

Both `base64-encoder.tsx` and `url-encoder.tsx` stored their option state in plain `useState`, so every user-selected option was lost on page reload. Peer routes (`regex-tester`, `hash-generator`, `password-generator`, `wifi-analyzer`, `image-converter`) all use `createToolOptionsStore` which writes through to a persisted Zustand store. This PR brings the two outliers in line with the convention.

## Why this matters

A user who switches the URL Encoder from `Percent encoding` to `Plus-as-space` and bumps `Max iterations` to 5 expects those choices to stick — at minimum across page reloads, and ideally across app launches. With plain `useState` they reset to defaults every time the route is mounted. The deep drift audit flagged this as **HIGH severity / clear regression / affects UX immediately**.

## Changes

### Changed

- `src/routes/base64-encoder.tsx`
  - New `Base64Prefs` interface (9 fields): `mode`, `variant`, `padding`, `lineBreak`, `dataUrl`, `mimeType`, `ignoreWhitespace`, `ignoreInvalidChars`, `autoDetectVariant`.
  - Store registered: `createToolOptionsStore<Base64Prefs>('base64-encoder', { ... })`.
  - Defaults sourced from existing `defaultBase64EncodeOptions` / `defaultBase64DecodeOptions`.
  - Every `setX(v)` rewritten as `patch({ x: v })`. Per-session `input` stays on `useState`.

- `src/routes/url-encoder.tsx`
  - New `UrlEncoderPrefs` interface (11 fields): `mode`, `encodeMode`, `spaceEncoding`, `hexCase`, `newlineHandling`, `preserveChars`, `encodeNonAscii`, `plusAsSpace`, `invalidHandling`, `decodeMultiple`, `maxIterations`.
  - Store registered: `createToolOptionsStore<UrlEncoderPrefs>('url-encoder', { ... })`.
  - Defaults sourced from existing `defaultUrlEncodeOptions` / `defaultUrlDecodeOptions`.
  - Every `setX(v)` rewritten as `patch({ x: v })`. Per-session `input`, `parseInput`, `baseUrl`, `queryParams` stay on `useState`.

## Out of scope

The same audit also flagged `sql-formatter.tsx`, `diff-viewer.tsx`, and `qr-code-generator.tsx` with the same anti-pattern. Those will follow in a separate PR; this PR is contained to the two encoder routes for ease of review.

## Test Plan

- [x] `bun run check` — TypeScript + validate-pages + design audit pass.
- [x] `bun run format` — no diff after the fix.
- [x] `bun run lint` — no new errors (28 pre-existing warnings unchanged).
- [ ] Manual: open `/base64-encoder`, switch the variant to `URL-safe`, toggle `Include padding` off, reload the page → those preferences should still be applied. Same for `/url-encoder` with `Plus-as-space` and `Max iterations`.

## How it was produced

A deep drift audit identified the persistence regression. A general-purpose sub-agent then performed the mechanical migration (replacing each `useState` with destructured `prefs` access and rewriting `setX(v)` as `patch({ x: v })`). No non-mechanical fixes required.
