### PR TITLE
feat(wifi): gate macOS scan on Location Services authorization

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -643,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.3"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -2949,7 +2949,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3448,6 +3448,7 @@ dependencies = [
  "netdev",
  "notify",
  "objc2 0.6.4",
+ "objc2-core-location 0.3.2",
  "objc2-core-wlan",
  "objc2-foundation 0.3.2",
  "pgp",
@@ -4186,6 +4187,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-contacts"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b034b578389f89a85c055eacc8d8b368be5f04a6c1b07f672bf3aec21d0ef621"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-core-data"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4263,7 +4274,7 @@ checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-contacts",
+ "objc2-contacts 0.2.2",
  "objc2-foundation 0.2.2",
 ]
 
@@ -4273,7 +4284,10 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
 dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
  "objc2 0.6.4",
+ "objc2-contacts 0.3.2",
  "objc2-foundation 0.3.2",
 ]
 
@@ -6286,7 +6300,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6560,9 +6574,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.3"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
+checksum = "14311e7e9a03114cd4b65eedd54e8fed2945e17f08586ae97ef53bc0669f9581"
 dependencies = [
  "libc",
  "objc2-core-foundation",
@@ -7099,7 +7113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.52.0",
@@ -7733,9 +7747,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -127,6 +127,7 @@ sysinfo = { version = "0.39", default-features = false, features = ["disk"] }
 objc2 = "0.6"
 objc2-foundation = "0.3"
 objc2-core-wlan = "0.3"
+objc2-core-location = "0.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62", features = [

--- a/src-tauri/src/network/wifi/macos.rs
+++ b/src-tauri/src/network/wifi/macos.rs
@@ -13,11 +13,91 @@
 //! keys in `src-tauri/resources/macos/Info.plist` drive the OS prompt
 //! on the first scan.
 
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use objc2_core_location::{CLAuthorizationStatus, CLLocationManager};
 use objc2_core_wlan::{CWChannelBand, CWChannelWidth, CWSecurity, CWWiFiClient};
 
 use super::channels::freq_mhz_to_channel;
 use super::types::{WifiBand, WifiError, WifiNetwork, WifiSecurity};
 use crate::network::oui;
+
+/// Process-wide singleton `CLLocationManager`. macOS requires the
+/// instance to outlive the authorization request; storing it as a
+/// raw pointer in a `OnceLock` (and never freeing it) keeps the
+/// prompt alive across scan calls without fighting `Retained`'s
+/// non-`Send` constraint.
+fn shared_location_manager() -> &'static CLLocationManager {
+    static MANAGER_PTR: OnceLock<usize> = OnceLock::new();
+    let raw = MANAGER_PTR.get_or_init(|| {
+        let manager = unsafe { CLLocationManager::new() };
+        // Convert to raw and intentionally leak — released on process exit.
+        objc2::rc::Retained::into_raw(manager) as usize
+    });
+    unsafe { &*((*raw) as *const CLLocationManager) }
+}
+
+fn status_name(status: CLAuthorizationStatus) -> &'static str {
+    match status {
+        CLAuthorizationStatus::NotDetermined => "NotDetermined",
+        CLAuthorizationStatus::Restricted => "Restricted",
+        CLAuthorizationStatus::Denied => "Denied",
+        CLAuthorizationStatus::AuthorizedAlways => "AuthorizedAlways",
+        CLAuthorizationStatus::AuthorizedWhenInUse => "AuthorizedWhenInUse",
+        _ => "Unknown",
+    }
+}
+
+/// Synchronously gate the scan path on Location Services. macOS 14+
+/// withholds SSID and BSSID from CoreWLAN callers without "Location
+/// When In Use" authorization, so we explicitly request it via
+/// `CLLocationManager` and poll the status until the user resolves
+/// the prompt (10-second cap).
+fn ensure_location_authorization() -> Result<(), WifiError> {
+    let manager = shared_location_manager();
+    let status = unsafe { manager.authorizationStatus() };
+    if matches!(
+        status,
+        CLAuthorizationStatus::AuthorizedAlways | CLAuthorizationStatus::AuthorizedWhenInUse
+    ) {
+        return Ok(());
+    }
+    if matches!(
+        status,
+        CLAuthorizationStatus::Denied | CLAuthorizationStatus::Restricted
+    ) {
+        return Err(WifiError::ScanFailed(format!(
+            "Location Services {} for Kogu. Open System Settings > Privacy & Security > Location Services and enable Kogu (or click the entry to grant access).",
+            status_name(status)
+        )));
+    }
+
+    // NotDetermined — fire the request and poll.
+    unsafe { manager.requestWhenInUseAuthorization() };
+    for _ in 0..100 {
+        std::thread::sleep(Duration::from_millis(100));
+        let next = unsafe { manager.authorizationStatus() };
+        if matches!(
+            next,
+            CLAuthorizationStatus::AuthorizedAlways | CLAuthorizationStatus::AuthorizedWhenInUse
+        ) {
+            return Ok(());
+        }
+        if matches!(
+            next,
+            CLAuthorizationStatus::Denied | CLAuthorizationStatus::Restricted
+        ) {
+            return Err(WifiError::ScanFailed(format!(
+                "Location Services {} for Kogu after request. Open System Settings > Privacy & Security > Location Services and enable Kogu.",
+                status_name(next)
+            )));
+        }
+    }
+    Err(WifiError::ScanFailed(
+        "Location Services request timed out (no dialog response). On macOS dev builds, the system dialog may not fire — try the release build or manually enable Kogu in System Settings > Privacy & Security > Location Services.".to_string(),
+    ))
+}
 
 pub async fn scan() -> Result<Vec<WifiNetwork>, WifiError> {
     tokio::task::spawn_blocking(scan_blocking)
@@ -26,6 +106,11 @@ pub async fn scan() -> Result<Vec<WifiNetwork>, WifiError> {
 }
 
 fn scan_blocking() -> Result<Vec<WifiNetwork>, WifiError> {
+    // Without "Location When In Use" authorization, macOS 14+ returns
+    // CoreWLAN scan entries with empty `bssid` / `ssid`. Request the
+    // permission first; the dialog fires on the very first call.
+    ensure_location_authorization()?;
+
     // Safety: CoreWLAN API is safe to call from any thread, but the
     // resulting NSObjects must be kept alive on the caller frame, which
     // Retained handles automatically.
@@ -50,7 +135,9 @@ fn scan_blocking() -> Result<Vec<WifiNetwork>, WifiError> {
         }
     };
 
+    let raw_count = networks.count();
     let mut out = Vec::new();
+    let mut all_bssids_empty = true;
     for net in &networks {
         let Some(channel_obj) = (unsafe { net.wlanChannel() }) else {
             continue;
@@ -77,14 +164,18 @@ fn scan_blocking() -> Result<Vec<WifiNetwork>, WifiError> {
         let bssid = unsafe { net.bssid() }
             .map(|s| s.to_string().to_uppercase())
             .unwrap_or_default();
+        if !bssid.is_empty() {
+            all_bssids_empty = false;
+        }
         if bssid.is_empty() {
-            // CoreWLAN occasionally returns BSSID-less entries; skip them.
+            // CoreWLAN withholds BSSID + SSID without Location
+            // Services. Skip per-entry; the "all empty" check below
+            // surfaces a single PermissionDenied for the whole batch.
             continue;
         }
         let ssid = unsafe { net.ssid() }.map(|s| s.to_string());
         let rssi = unsafe { net.rssiValue() } as i32;
         let security = map_security(unsafe { net.supportsSecurity(CWSecurity::None) }, &net);
-
         let is_connected = current_bssid.as_ref().is_some_and(|cur| cur == &bssid);
 
         out.push(WifiNetwork {
@@ -103,6 +194,13 @@ fn scan_blocking() -> Result<Vec<WifiNetwork>, WifiError> {
         // with the canonical IEEE mapping; CoreWLAN can occasionally
         // misreport vendor-specific channels.
         let _ = freq_mhz_to_channel;
+    }
+
+    // The radio saw N networks but every entry was redacted — this is
+    // the macOS 14+ "Location Services not granted" signature. Surface
+    // the actionable error rather than an empty list.
+    if raw_count > 0 && all_bssids_empty {
+        return Err(WifiError::PermissionDenied);
     }
     Ok(out)
 }


### PR DESCRIPTION
## Summary

macOS 14+ withholds SSID and BSSID from CoreWLAN callers that lack
"Location When In Use" authorization, so the Wi-Fi scan returns a list of
redacted, unusable entries. This change requests the permission
explicitly and surfaces an actionable error when it is missing.

## Changes

- Add a process-wide `CLLocationManager` singleton (leaked into a
  `OnceLock` as a raw pointer) so the instance outlives the asynchronous
  authorization request without fighting `Retained`'s non-`Send`
  constraint.
- Call `ensure_location_authorization()` at the start of `scan_blocking`:
  return early when already authorized, fail fast with guidance when
  denied or restricted, and otherwise fire `requestWhenInUseAuthorization`
  and poll the status (10-second cap).
- Map an all-redacted scan result (`raw_count > 0 && all_bssids_empty`)
  to a single `PermissionDenied` instead of an empty list.
- Add the `objc2-core-location` dependency.

## Verification

- `cargo check` — clean
- `cargo clippy --all-targets` — clean
- `cargo test --lib` — 238 passed, 0 failed
