### PR TITLE
refactor(routes): roll out ToolFooter to remaining tool rails

### DIFF
--- a/src/routes/base64-encoder.tsx
+++ b/src/routes/base64-encoder.tsx
@@ -14,7 +14,7 @@ import {
 	FormSelect,
 } from '@/lib/components/form';
 import { SectionHeader, SplitPane } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
 import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
@@ -251,18 +251,6 @@ function Base64EncoderPage() {
 									</div>
 								) : null}
 							</FormSection>
-
-							<FormSection title="Info" open={false}>
-								<FormInfo title="Standard vs URL-safe">
-									<p>
-										<strong>Standard:</strong> Uses <code>+</code> and <code>/</code> characters.
-									</p>
-									<p className="mt-1">
-										<strong>URL-safe:</strong> Uses <code>-</code> and <code>_</code> instead, safe
-										for URLs and filenames.
-									</p>
-								</FormInfo>
-							</FormSection>
 						</>
 					) : (
 						<>
@@ -315,6 +303,23 @@ function Base64EncoderPage() {
 							) : null}
 						</>
 					)}
+
+					<ToolFooter
+						relatedItems={[
+							{ id: 'url-encoder', reason: 'Percent-encode text for URLs' },
+							{ id: 'jwt-decoder', reason: 'Decode Base64URL-encoded JWT segments' },
+							{ id: 'hash-generator', reason: 'Hash text or files' },
+						]}
+						aboutText={
+							<>
+								Encodes and decodes Base64 with UTF-8 support. The Standard variant uses{' '}
+								<code>+</code> and <code>/</code> (RFC 4648 §4); the URL-safe variant uses{' '}
+								<code>-</code> and <code>_</code> (RFC 4648 §5), safe for URLs and filenames. Output
+								can be wrapped at PEM (64) or MIME (76) line widths and emitted as a Data URL with a
+								selectable MIME type.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/bcrypt-generator.tsx
+++ b/src/routes/bcrypt-generator.tsx
@@ -7,7 +7,7 @@ import { ActionButton, CopyButton } from '@/lib/components/action';
 import { getErrorMessage } from '@/lib/utils';
 import { FormInfo, FormInput, FormMode, FormSection, FormSlider } from '@/lib/components/form';
 import { SectionHeader } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import {
 	EmptyState,
 	ErrorDisplay,
@@ -325,17 +325,6 @@ function BcryptGeneratorPage() {
 						</>
 					)}
 
-					<FormSection title="About BCrypt">
-						<FormInfo>
-							<ul className="list-inside list-disc space-y-0.5">
-								<li>Password hashing algorithm</li>
-								<li>Salted and adaptive</li>
-								<li>Cost factor controls security/speed tradeoff</li>
-								<li>Recommended cost: 10-12 for most use cases</li>
-							</ul>
-						</FormInfo>
-					</FormSection>
-
 					<FormSection title="Cost Recommendations">
 						<FormInfo showIcon={false}>
 							<div className="space-y-0.5">
@@ -362,6 +351,22 @@ function BcryptGeneratorPage() {
 							</div>
 						</FormInfo>
 					</FormSection>
+
+					<ToolFooter
+						relatedItems={[
+							{ id: 'password-generator', reason: 'Generate a strong password to hash' },
+							{ id: 'hash-generator', reason: 'Compute MD5 / SHA digests' },
+							{ id: 'uuid-generator', reason: 'Generate unique identifiers' },
+						]}
+						aboutText={
+							<>
+								BCrypt is an adaptive, salted password-hashing function. The cost factor controls
+								the work per hash, trading speed for resistance to brute-force attacks. A cost of
+								10-12 suits most use cases. Verify checks a password against an existing{' '}
+								<code className="font-mono">$2b$</code> hash.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/cron-expression-builder.tsx
+++ b/src/routes/cron-expression-builder.tsx
@@ -4,7 +4,7 @@ import { Calendar, Check, Clock, FlaskConical, Pencil, Search, Sparkles, X } fro
 
 import { CopyButton } from '@/lib/components/action';
 import { FormError, FormInfo, FormInput, FormSection } from '@/lib/components/form';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -538,6 +538,22 @@ function CronExpressionBuilderPage() {
 					match, not both. Schedules are evaluated in UTC unless your runtime says otherwise.
 				</FormInfo>
 			</FormSection>
+
+			<ToolFooter
+				relatedItems={[
+					{
+						id: 'date-timestamp-converter',
+						reason: 'Convert a next-execution time across formats and zones',
+					},
+				]}
+				aboutText={
+					<>
+						Builds and parses 5-field cron expressions and previews the next executions for each.
+						The Build tab composes fields with validation; the Parse tab decodes an existing
+						expression. Step, range, and list syntax are supported.
+					</>
+				}
+			/>
 		</>
 	);
 

--- a/src/routes/curl-builder.tsx
+++ b/src/routes/curl-builder.tsx
@@ -21,7 +21,7 @@ import {
 	FormSelect,
 	FormTextarea,
 } from '@/lib/components/form';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -804,6 +804,21 @@ function CurlBuilderPage() {
 					</ul>
 				</FormInfo>
 			</FormSection>
+
+			<ToolFooter
+				relatedItems={[
+					{ id: 'rest-client', reason: 'Send the request and inspect the response' },
+					{ id: 'websocket-tester', reason: 'Test ws:// or wss:// endpoints interactively' },
+					{ id: 'url-encoder', reason: 'Encode query parameters and form values' },
+				]}
+				aboutText={
+					<>
+						Builds, parses, and converts cURL commands. The Build tab composes a request from form
+						controls, the Parse tab decodes an existing command, and the Code tab emits fetch,
+						Python, and Go snippets. cURL is never executed; the command is generated for copy.
+					</>
+				}
+			/>
 		</>
 	);
 

--- a/src/routes/gpg-key-generator.tsx
+++ b/src/routes/gpg-key-generator.tsx
@@ -15,7 +15,7 @@ import {
 	FormSelect,
 } from '@/lib/components/form';
 import { SectionHeader } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import {
 	EmptyState,
 	ErrorDisplay,
@@ -298,17 +298,6 @@ function GpgKeyGeneratorPage() {
 						</div>
 					</FormSection>
 
-					<FormSection title="About GPG Keys">
-						<FormInfo>
-							<ul className="list-inside list-disc space-y-0.5">
-								<li>GPG keys enable encryption and digital signatures</li>
-								<li>RSA: Wide compatibility, proven security</li>
-								<li>ECDSA: Smaller keys, faster operations</li>
-								<li>Passphrase protects private key at rest</li>
-							</ul>
-						</FormInfo>
-					</FormSection>
-
 					<FormSection title="Algorithm Comparison">
 						<FormInfo showIcon={false}>
 							<div className="space-y-0.5">
@@ -344,6 +333,23 @@ function GpgKeyGeneratorPage() {
 							<p className="mt-1.5">The User ID identifies the key owner. Comment is optional.</p>
 						</FormInfo>
 					</FormSection>
+
+					<ToolFooter
+						relatedItems={[
+							{ id: 'ssh-key-generator', reason: 'Generate SSH key pairs for authentication' },
+							{ id: 'rsa-tools', reason: 'Encrypt, decrypt, sign, and verify with RSA keys' },
+							{ id: 'x509-decoder', reason: 'Decode X.509 / PEM certificates' },
+						]}
+						aboutText={
+							<>
+								Generates GPG/PGP key pairs for encryption and digital signatures. RSA offers wide
+								compatibility and proven security, while ECDSA produces smaller keys with faster
+								operations. An optional passphrase protects the private key at rest. Generation runs
+								through the bundled library or a local <code className="font-mono">gpg</code> when
+								available.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/jwt-decoder.tsx
+++ b/src/routes/jwt-decoder.tsx
@@ -6,7 +6,7 @@ import { CopyButton } from '@/lib/components/action';
 import { CodeEditor } from '@/lib/components/editor';
 import { FormInfo, FormSection } from '@/lib/components/form';
 import { SectionHeader, SplitPane } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmptyState, LiveStatusRegion } from '@/lib/components/status';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { IconTooltip } from '@/lib/components/ui/icon-tooltip';
@@ -128,17 +128,6 @@ function JwtDecoderPage() {
 			}
 			rail={
 				<>
-					<FormSection title="About JWT">
-						<FormInfo>
-							<ul className="list-inside list-disc space-y-0.5">
-								<li>JSON Web Token</li>
-								<li>Compact, URL-safe format</li>
-								<li>Three parts: Header.Payload.Signature</li>
-								<li>Self-contained authentication</li>
-							</ul>
-						</FormInfo>
-					</FormSection>
-
 					<FormSection title="Structure">
 						<FormInfo showIcon={false}>
 							<div className="space-y-1.5">
@@ -160,6 +149,22 @@ function JwtDecoderPage() {
 							</div>
 						</FormInfo>
 					</FormSection>
+
+					<ToolFooter
+						relatedItems={[
+							{ id: 'base64-encoder', reason: 'Decode the Base64URL parts manually' },
+							{ id: 'x509-decoder', reason: 'Inspect certificates carrying signing keys' },
+							{ id: 'rsa-tools', reason: 'Verify RS / PS signatures with a PEM key' },
+						]}
+						aboutText={
+							<>
+								Decodes a JSON Web Token (JWT) into its header, payload, and signature. The compact,
+								URL-safe format carries self-contained claims across three Base64URL-encoded parts
+								joined by dots. Decoding is client-side only — signature verification requires the
+								secret or public key and is not performed here.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/semver-tools.tsx
+++ b/src/routes/semver-tools.tsx
@@ -21,7 +21,7 @@ import {
 
 import { CopyButton } from '@/lib/components/action';
 import { FormError, FormInfo, FormInput, FormSection, FormTextarea } from '@/lib/components/form';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
@@ -866,32 +866,6 @@ function SemverToolsPage() {
 
 	const rail = (
 		<>
-			<FormSection title="About SemVer">
-				<FormInfo>
-					Semantic Versioning 2.0.0 — every version is{' '}
-					<code className="font-mono">major.minor.patch</code> with an optional{' '}
-					<code className="font-mono">-prerelease</code> and{' '}
-					<code className="font-mono">+buildmetadata</code>.
-					<ul className="mt-1 list-inside list-disc space-y-0.5">
-						<li>
-							<strong>major</strong> — backwards-incompatible API changes
-						</li>
-						<li>
-							<strong>minor</strong> — backwards-compatible features
-						</li>
-						<li>
-							<strong>patch</strong> — backwards-compatible fixes
-						</li>
-						<li>
-							<strong>prerelease</strong> — lower precedence than the release
-						</li>
-						<li>
-							<strong>build</strong> — metadata, ignored in precedence
-						</li>
-					</ul>
-				</FormInfo>
-			</FormSection>
-
 			<FormSection title="Range syntax">
 				<FormInfo>
 					<ul className="list-inside list-disc space-y-0.5">
@@ -939,13 +913,24 @@ function SemverToolsPage() {
 				</Button>
 			</FormSection>
 
-			<FormSection title="Precedence rules">
-				<FormInfo>
-					Build metadata (everything after <code className="font-mono">+</code>) is ignored when
-					comparing versions. A prerelease (e.g. <code className="font-mono">1.0.0-rc.1</code>) has
-					lower precedence than the same version without one.
-				</FormInfo>
-			</FormSection>
+			<ToolFooter
+				relatedItems={[
+					{ id: 'diff-viewer', reason: 'Diff two version strings or changelogs' },
+					{ id: 'json-formatter', reason: 'Inspect version fields in package manifests' },
+					{ id: 'list-comparer', reason: 'Compare two lists of version tags' },
+				]}
+				aboutText={
+					<>
+						Parses, compares, range-tests, and bumps versions following Semantic Versioning 2.0.0 —{' '}
+						<code className="font-mono">major.minor.patch</code> with an optional{' '}
+						<code className="font-mono">-prerelease</code> and{' '}
+						<code className="font-mono">+buildmetadata</code>. Major marks breaking changes, minor
+						adds backwards-compatible features, and patch covers backwards-compatible fixes. Build
+						metadata is ignored when comparing precedence, and a prerelease ranks below the same
+						version without one.
+					</>
+				}
+			/>
 		</>
 	);
 

--- a/src/routes/sql-formatter.tsx
+++ b/src/routes/sql-formatter.tsx
@@ -14,7 +14,7 @@ import {
 	FormSelect,
 } from '@/lib/components/form';
 import { SectionHeader, SplitPane } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { useDocumentTitle } from '@/lib/hooks';
 import { usePersistedRail } from '@/lib/stores';
@@ -263,6 +263,21 @@ function SqlFormatterPage() {
 							/>
 						</FormCheckboxGroup>
 					</FormSection>
+
+					<ToolFooter
+						relatedItems={[
+							{ id: 'json-formatter', reason: 'Format and query JSON documents' },
+							{ id: 'xml-formatter', reason: 'Format and validate XML documents' },
+							{ id: 'yaml-formatter', reason: 'Format and convert YAML documents' },
+						]}
+						aboutText={
+							<>
+								Formats and minifies SQL across 18+ dialects. Dialect, keyword case, indentation,
+								and operator spacing are configurable. Formatting is lexical, so malformed SQL is
+								reformatted on a best-effort basis rather than rejected.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/ssh-key-generator.tsx
+++ b/src/routes/ssh-key-generator.tsx
@@ -14,7 +14,7 @@ import {
 	FormSelect,
 } from '@/lib/components/form';
 import { SectionHeader } from '@/lib/components/layout';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import {
 	EmptyState,
 	ErrorDisplay,
@@ -271,17 +271,6 @@ function SshKeyGeneratorPage() {
 						</div>
 					</FormSection>
 
-					<FormSection title="About SSH Keys">
-						<FormInfo>
-							<ul className="list-inside list-disc space-y-0.5">
-								<li>Ed25519: Modern, fast, compact (recommended)</li>
-								<li>ECDSA: Good balance of security and compatibility</li>
-								<li>RSA: Wide compatibility, larger key sizes</li>
-								<li>Passphrase encrypts private key at rest</li>
-							</ul>
-						</FormInfo>
-					</FormSection>
-
 					<FormSection title="Algorithm Comparison">
 						<FormInfo showIcon={false}>
 							<div className="space-y-0.5">
@@ -308,6 +297,23 @@ function SshKeyGeneratorPage() {
 							</div>
 						</FormInfo>
 					</FormSection>
+
+					<ToolFooter
+						relatedItems={[
+							{ id: 'gpg-key-generator', reason: 'Generate GPG/PGP keys for signing' },
+							{ id: 'rsa-tools', reason: 'Encrypt, decrypt, sign, and verify with RSA keys' },
+							{ id: 'x509-decoder', reason: 'Decode X.509 / PEM certificates' },
+						]}
+						aboutText={
+							<>
+								Generates SSH key pairs for authentication. Ed25519 is modern, fast, and compact,
+								and is recommended for most use cases; ECDSA balances security and compatibility,
+								while RSA offers the widest compatibility at larger key sizes. An optional
+								passphrase encrypts the private key at rest. Generation runs through the bundled
+								library or a local <code className="font-mono">ssh-keygen</code> when available.
+							</>
+						}
+					/>
 				</>
 			}
 		>

--- a/src/routes/url-encoder.tsx
+++ b/src/routes/url-encoder.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/lib/components/form';
 import { SplitPane } from '@/lib/components/layout';
 import { Rail } from '@/lib/components/ui/rail';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
@@ -312,26 +312,6 @@ function UrlEncoderPage() {
 								</FormInfo>
 							</FormSection>
 						) : null}
-
-						<FormSection title="Info" open={false}>
-							<FormInfo title="Encoding Modes">
-								<p>
-									<strong>Component:</strong> Encodes all special chars including /, ?, &amp;, =, #
-								</p>
-								<p className="mt-1">
-									<strong>URI:</strong> Preserves URL structure characters (/, ?, &amp;, =, #, :)
-								</p>
-								<p className="mt-1">
-									<strong>Form:</strong> Like component but uses + for spaces
-								</p>
-								<p className="mt-1">
-									<strong>Path:</strong> Preserves / but encodes other special chars
-								</p>
-								<p className="mt-1">
-									<strong>Custom:</strong> Configure preserved characters manually
-								</p>
-							</FormInfo>
-						</FormSection>
 					</>
 				) : (
 					<>
@@ -390,22 +370,26 @@ function UrlEncoderPage() {
 								</FormInfo>
 							</FormSection>
 						) : null}
-
-						<FormSection title="Info" open={false}>
-							<FormInfo title="Decoding Options">
-								<p>
-									<strong>+ as space:</strong> Treats + as space (form data format)
-								</p>
-								<p className="mt-1">
-									<strong>Invalid sequences:</strong> How to handle malformed % sequences
-								</p>
-								<p className="mt-1">
-									<strong>Multiple layers:</strong> Recursively decode double/triple encoded content
-								</p>
-							</FormInfo>
-						</FormSection>
 					</>
 				)}
+
+				<ToolFooter
+					relatedItems={[
+						{ id: 'base64-encoder', reason: 'Encode and decode Base64 text' },
+						{ id: 'escape-tool', reason: 'Escape and unescape across other flavors' },
+						{ id: 'curl-builder', reason: 'Build requests with encoded query parameters' },
+					]}
+					aboutText={
+						<>
+							Encodes, decodes, parses, and builds URLs. Encoding modes range from strict{' '}
+							<strong>Component</strong> (encodes all reserved characters) through{' '}
+							<strong>URI</strong>, <strong>Form</strong>, <strong>Path segment</strong>, and a{' '}
+							<strong>Custom</strong> mode with configurable preserved characters. Space encoding,
+							hex case, newline handling, and non-ASCII encoding are all configurable, and decoding
+							can recursively unwrap multiple encoding layers.
+						</>
+					}
+				/>
 			</Rail>
 
 			<SplitPane

--- a/src/routes/uuid-generator.tsx
+++ b/src/routes/uuid-generator.tsx
@@ -8,14 +8,13 @@ import { getErrorMessage } from '@/lib/utils';
 import {
 	FormCheckbox,
 	FormCheckboxGroup,
-	FormInfo,
 	FormInput,
 	FormSection,
 	FormSelect,
 	FormSlider,
 } from '@/lib/components/form';
 import { GeneratedListPanel } from '@/lib/components/panel';
-import { ToolShell } from '@/lib/components/shell';
+import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { StatItem } from '@/lib/components/status';
 import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import { useDocumentTitle } from '@/lib/hooks';
@@ -228,16 +227,21 @@ function UuidGeneratorPage() {
 						</div>
 					</FormSection>
 
-					<FormSection title="About UUID">
-						<FormInfo>
-							<ul className="list-inside list-disc space-y-0.5">
-								<li>Universally Unique Identifier (RFC 9562)</li>
-								<li>v4 random is the most common choice</li>
-								<li>v7 is time-ordered, ideal for DB primary keys</li>
-								<li>v3 / v5 are deterministic from namespace + name</li>
-							</ul>
-						</FormInfo>
-					</FormSection>
+					<ToolFooter
+						relatedItems={[
+							{ id: 'hash-generator', reason: 'Hash inputs for v3 / v5 namespacing' },
+							{ id: 'password-generator', reason: 'Generate other secure random values' },
+							{ id: 'test-data-generator', reason: 'Embed identifiers in synthetic datasets' },
+						]}
+						aboutText={
+							<>
+								Generates Universally Unique Identifiers (UUIDs) per RFC 9562. v4 is fully random
+								and the most common choice; v7 is time-ordered and well suited to database primary
+								keys; v1 is timestamp-based; v3 and v5 are deterministic from a namespace and name.
+								Casing, hyphens, and surrounding braces are configurable.
+							</>
+						}
+					/>
 				</>
 			}
 		>


### PR DESCRIPTION
## Summary

Eleven routes still rendered their Related/About rail footers as
hand-rolled markup or omitted them entirely, leaving the footer
treatment inconsistent across the tool surface. This change replaces
those with the shared `ToolFooter` component so every rail closes with
the same Related-then-About pair.

## Affected routes

`base64-encoder`, `bcrypt-generator`, `cron-expression-builder`,
`curl-builder`, `gpg-key-generator`, `jwt-decoder`, `semver-tools`,
`sql-formatter`, `ssh-key-generator`, `url-encoder`, `uuid-generator`.

Tool-specific reference sections (cost recommendations, algorithm
comparisons, syntax guides) are preserved alongside the new footer.

## Verification

- `bun run check` — tsc, page validation, design audit all clean
- `bun run lint` — 28 warnings (all pre-existing `noExcessiveCognitiveComplexity`), 0 errors
- `bun run format:check` — clean
