### PR TITLE
fix(x509-decoder): drive the status-bar validity badge

### DIFF
--- a/src/routes/x509-decoder.tsx
+++ b/src/routes/x509-decoder.tsx
@@ -220,8 +220,13 @@ function X509DecoderPage() {
 		return min;
 	}, [certificates]);
 
+	// Tri-state validity: a decoded certificate is valid, a parse error
+	// with no certificate is invalid, and an empty input is neutral.
+	const valid: boolean | null = certificates.length > 0 ? true : errors.length > 0 ? false : null;
+
 	return (
 		<ToolShell
+			valid={valid}
 			showRail={showRail}
 			onShowRailChange={setShowRail}
 			statusContent={


### PR DESCRIPTION
## Summary

The X.509 decoder never passed `valid` to `ToolShell`, so the status bar
omitted the validity badge regardless of the decode outcome.

## Changes

- Derive a tri-state validity from the parse result: a decoded
  certificate is valid, a parse error with no certificate is invalid, and
  an empty input stays neutral.
- Pass the derived value to `ToolShell` so the badge reflects state.

## Verification

- `bun run check` — clean
- `bun run lint` / `format:check` — clean (pre-commit hook)
