### PR TITLE
refactor(encoders): adopt DetectedInfo for detected-state panels

### DIFF
--- a/src/routes/base64-encoder.tsx
+++ b/src/routes/base64-encoder.tsx
@@ -8,14 +8,13 @@ import { getErrorMessage } from '@/lib/utils';
 import {
 	FormCheckbox,
 	FormCheckboxGroup,
-	FormInfo,
 	FormMode,
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
 import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
-import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { DetectedInfo, EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
 import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import {
@@ -277,30 +276,21 @@ function Base64EncoderPage() {
 								</FormCheckboxGroup>
 							</FormSection>
 
-							{detectedVariant || detectedDataUrl ? (
-								<FormSection title="Detected">
-									<FormInfo showIcon={false}>
-										{detectedVariant ? (
-											<p>
-												<strong>Variant:</strong>{' '}
-												{detectedVariant === 'url-safe' ? 'URL-safe (-_)' : 'Standard (+/)'}
-											</p>
-										) : null}
-										{detectedDataUrl ? (
-											<>
-												<p className="mt-1">
-													<strong>Format:</strong> Data URL
-												</p>
-												{detectedMimeType ? (
-													<p className="mt-1">
-														<strong>MIME:</strong> {detectedMimeType}
-													</p>
-												) : null}
-											</>
-										) : null}
-									</FormInfo>
-								</FormSection>
-							) : null}
+							<DetectedInfo
+								items={[
+									{
+										show: Boolean(detectedVariant),
+										label: 'Variant',
+										value: detectedVariant === 'url-safe' ? 'URL-safe (-_)' : 'Standard (+/)',
+									},
+									{ show: detectedDataUrl, label: 'Format', value: 'Data URL' },
+									{
+										show: detectedDataUrl && Boolean(detectedMimeType),
+										label: 'MIME',
+										value: detectedMimeType ?? '',
+									},
+								]}
+							/>
 						</>
 					)}
 

--- a/src/routes/url-encoder.tsx
+++ b/src/routes/url-encoder.tsx
@@ -18,7 +18,7 @@ import {
 import { SplitPane } from '@/lib/components/layout';
 import { Rail } from '@/lib/components/ui/rail';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
-import { StatItem } from '@/lib/components/status';
+import { DetectedInfo, StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { Input } from '@/lib/components/ui/input';
@@ -354,22 +354,20 @@ function UrlEncoderPage() {
 							) : null}
 						</FormSection>
 
-						{detectedDoubleEncoded || detectedEncodingDepth > 1 ? (
-							<FormSection title="Detected">
-								<FormInfo showIcon={false}>
-									{detectedDoubleEncoded ? (
-										<p>
-											<strong>Warning:</strong> Double-encoded content detected
-										</p>
-									) : null}
-									{detectedEncodingDepth > 1 ? (
-										<p className="mt-1">
-											<strong>Encoding Depth:</strong> {detectedEncodingDepth} layers
-										</p>
-									) : null}
-								</FormInfo>
-							</FormSection>
-						) : null}
+						<DetectedInfo
+							items={[
+								{
+									show: detectedDoubleEncoded,
+									label: 'Warning',
+									value: 'Double-encoded content detected',
+								},
+								{
+									show: detectedEncodingDepth > 1,
+									label: 'Encoding Depth',
+									value: `${detectedEncodingDepth} layers`,
+								},
+							]}
+						/>
 					</>
 				)}
 


### PR DESCRIPTION
## Summary

The base64 and URL encoders rendered their "Detected" rail panels as
hand-rolled `FormSection`/`FormInfo` markup with per-paragraph spacing and
an outer conditional wrapper. This change replaces both with the shared
`DetectedInfo` component.

## Changes

- base64-encoder: convert the variant / data-URL / MIME panel to
  `DetectedInfo` items; drop the now-unused `FormInfo` import.
- url-encoder: convert the double-encoded / encoding-depth panel to
  `DetectedInfo` items; keep `FormInfo` (still used by the Info section).

`DetectedInfo` filters items by a `show` flag and renders nothing when all
are hidden, so the outer conditional wrapper is absorbed and the
detected-state treatment is uniform across encoders.

## Verification

- `bun run check` — clean
- `bun run lint` — no new warnings (base64 cognitive complexity drops
  from 45 to 32 as nested ternaries become a declarative array)
- `bun run format:check` — clean
