### PR TITLE
refactor(routes): normalize output-copy toast wording

### DIFF
--- a/src/routes/base64-encoder.tsx
+++ b/src/routes/base64-encoder.tsx
@@ -145,7 +145,7 @@ function Base64EncoderPage() {
 	const handleCopy = async () => {
 		try {
 			await navigator.clipboard.writeText(output);
-			toast.success('Copied to clipboard');
+			toast.success('Output copied to clipboard');
 		} catch {
 			toast.error('Failed to copy to clipboard');
 		}

--- a/src/routes/sql-formatter.tsx
+++ b/src/routes/sql-formatter.tsx
@@ -122,7 +122,7 @@ function SqlFormatterPage() {
 	const handleCopy = async () => {
 		try {
 			await navigator.clipboard.writeText(output);
-			toast.success('Copied to clipboard');
+			toast.success('Output copied to clipboard');
 		} catch {
 			toast.error('Failed to copy to clipboard');
 		}

--- a/src/routes/url-encoder.tsx
+++ b/src/routes/url-encoder.tsx
@@ -186,7 +186,7 @@ function UrlEncoderPage() {
 	const handleCopy = async () => {
 		try {
 			await navigator.clipboard.writeText(output);
-			toast.success('Copied to clipboard');
+			toast.success('Output copied to clipboard');
 		} catch {
 			toast.error('Failed to copy to clipboard');
 		}


### PR DESCRIPTION
## Summary

The base64, URL, and SQL tools reported a successful output copy with a
bare "Copied to clipboard", while every other route already names the
copied subject (for example "Output copied to clipboard" in the CSV tool
and "cURL command copied to clipboard" in the REST client).

## Changes

- Align base64-encoder, url-encoder, and sql-formatter on "Output copied
  to clipboard" so the success toast names its subject consistently.

The `StatItem` size/length labels were intentionally left unchanged:
"Size", "Bytes", "Length", and "Characters" denote different measured
quantities per route, so collapsing them risks mislabeling a character
count as a byte size.

## Verification

- `bun run check` — clean
- `bun run lint` / `format:check` — clean (pre-existing complexity
  warnings only)
