### PR TITLE
refactor(ui): unify copy and paste toast wording

### DIFF
--- a/src/lib/components/editor/code/tree-view.tsx
+++ b/src/lib/components/editor/code/tree-view.tsx
@@ -350,7 +350,7 @@ export function TreeView({
 			if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
 			copyTimerRef.current = setTimeout(() => setJustCopied(null), 1500);
 		} catch {
-			toast.error('Copy failed');
+			toast.error('Failed to copy to clipboard');
 		}
 	};
 
@@ -358,9 +358,9 @@ export function TreeView({
 		e.stopPropagation();
 		try {
 			await navigator.clipboard.writeText(node.path);
-			toast.success(`Copied: ${node.path}`);
+			toast.success('Path copied to clipboard');
 		} catch {
-			toast.error('Copy failed');
+			toast.error('Failed to copy to clipboard');
 		}
 	};
 

--- a/src/lib/components/formatter-tabs/json/schema-tab.tsx
+++ b/src/lib/components/formatter-tabs/json/schema-tab.tsx
@@ -158,7 +158,7 @@ export function SchemaTab({ input, onInputChange, onStatsChange }: SchemaTabProp
 			const text = await navigator.clipboard.readText();
 			if (text) {
 				setSchemaDefinition(text);
-				toast.success('Pasted');
+				toast.success('Pasted from clipboard');
 			}
 		} catch {
 			// Clipboard access denied.

--- a/src/lib/components/formatter-tabs/xml/schema-tab.tsx
+++ b/src/lib/components/formatter-tabs/xml/schema-tab.tsx
@@ -252,7 +252,7 @@ export function SchemaTab({ input, onInputChange, onStatsChange }: SchemaTabProp
 			const text = await navigator.clipboard.readText();
 			if (text) {
 				setSchemaDefinition(text);
-				toast.success('Pasted');
+				toast.success('Pasted from clipboard');
 			}
 		} catch {
 			// Clipboard access denied.

--- a/src/lib/components/formatter-tabs/yaml/schema-tab.tsx
+++ b/src/lib/components/formatter-tabs/yaml/schema-tab.tsx
@@ -178,7 +178,7 @@ export function SchemaTab({ input, onInputChange, onStatsChange }: SchemaTabProp
 			const text = await navigator.clipboard.readText();
 			if (text) {
 				setSchemaDefinition(text);
-				toast.success('Pasted');
+				toast.success('Pasted from clipboard');
 			}
 		} catch {
 			// Clipboard access denied.

--- a/src/lib/components/network-scanner/unified-host-detail-panel.tsx
+++ b/src/lib/components/network-scanner/unified-host-detail-panel.tsx
@@ -186,7 +186,7 @@ const getServiceName = (port: PortInfo): string => {
 
 const copyToClipboard = async (text: string, label: string) => {
 	await navigator.clipboard.writeText(text);
-	toast.success(`${label} copied`);
+	toast.success(`${label} copied to clipboard`);
 };
 
 const getConfidenceLabel = (classification: DeviceClassification | null): string | null => {

--- a/src/lib/utils/file-operations.ts
+++ b/src/lib/utils/file-operations.ts
@@ -152,9 +152,9 @@ export const copyToClipboard = async (content: string): Promise<void> => {
 
 	try {
 		await writeText(content);
-		toast.success('Copied');
+		toast.success('Copied to clipboard');
 	} catch {
-		toast.error('Copy failed');
+		toast.error('Failed to copy to clipboard');
 	}
 };
 
@@ -164,10 +164,10 @@ export const copyToClipboard = async (content: string): Promise<void> => {
 export const pasteFromClipboard = async (): Promise<string | null> => {
 	try {
 		const text = await readText();
-		toast.success('Pasted');
+		toast.success('Pasted from clipboard');
 		return text;
 	} catch {
-		toast.error('Paste failed');
+		toast.error('Failed to paste from clipboard');
 		return null;
 	}
 };

--- a/src/routes/cidr-calculator.tsx
+++ b/src/routes/cidr-calculator.tsx
@@ -140,7 +140,7 @@ function CidrCalculatorPage() {
 		const text = exportDetails(result.details, exportFormat);
 		try {
 			await navigator.clipboard.writeText(text);
-			toast.success(`Copied details as ${exportFormat.toUpperCase()}`);
+			toast.success(`${exportFormat.toUpperCase()} details copied to clipboard`);
 		} catch {
 			toast.error('Failed to copy to clipboard');
 		}

--- a/src/routes/csv-tool.tsx
+++ b/src/routes/csv-tool.tsx
@@ -218,7 +218,7 @@ function CsvToolPage() {
 				toast.success('Pasted from clipboard');
 			}
 		} catch {
-			toast.error('Could not read clipboard');
+			toast.error('Failed to paste from clipboard');
 		}
 	};
 
@@ -280,7 +280,7 @@ function CsvToolPage() {
 			toast.success('Output copied to clipboard');
 		} catch (e) {
 			const message = e instanceof Error ? e.message : String(e);
-			toast.error('Failed to copy output', { description: message });
+			toast.error('Failed to copy to clipboard', { description: message });
 		}
 	};
 

--- a/src/routes/date-timestamp-converter.tsx
+++ b/src/routes/date-timestamp-converter.tsx
@@ -182,7 +182,11 @@ function DateTimestampConverterPage() {
 		if (cronExpression.trim().length > 0) {
 			navigator.clipboard
 				.writeText(cronExpression)
-				.then(() => toast.success('Cron expression copied — paste it into the Parse tab.'))
+				.then(() =>
+					toast.success('Cron expression copied to clipboard', {
+						description: 'Paste it into the Parse tab.',
+					})
+				)
 				.catch(() => undefined);
 		}
 	};

--- a/src/routes/dns-lookup.tsx
+++ b/src/routes/dns-lookup.tsx
@@ -144,9 +144,9 @@ function DnsLookupPage() {
 	const handleCopyDig = async () => {
 		try {
 			await navigator.clipboard.writeText(exportAsDig(effectiveRequest));
-			toast.success('Copied dig command');
+			toast.success('dig command copied to clipboard');
 		} catch {
-			toast.error('Failed to copy dig command');
+			toast.error('Failed to copy to clipboard');
 		}
 	};
 

--- a/src/routes/encoding-converter.tsx
+++ b/src/routes/encoding-converter.tsx
@@ -205,10 +205,10 @@ function EncodingConverterPage() {
 		if (!targetBytes) return;
 		try {
 			await navigator.clipboard.writeText(bytesToBase64(targetBytes));
-			toast.success('Copied base64 to clipboard');
+			toast.success('Base64 copied to clipboard');
 		} catch (e) {
 			const message = e instanceof Error ? e.message : String(e);
-			toast.error('Failed to copy', { description: message });
+			toast.error('Failed to copy to clipboard', { description: message });
 		}
 	};
 

--- a/src/routes/file-inspector.tsx
+++ b/src/routes/file-inspector.tsx
@@ -351,10 +351,10 @@ function FileInspectorPage() {
 		};
 		try {
 			await navigator.clipboard.writeText(JSON.stringify(payload, null, 2));
-			toast.success('Copied metadata as JSON');
+			toast.success('Metadata copied to clipboard');
 		} catch (e) {
 			const message = e instanceof Error ? e.message : String(e);
-			toast.error('Failed to copy', { description: message });
+			toast.error('Failed to copy to clipboard', { description: message });
 		}
 	}, [audioInfo, detectedMime, hashes, imagePreview, mimeInfo, result]);
 

--- a/src/routes/folder-tree-visualizer.tsx
+++ b/src/routes/folder-tree-visualizer.tsx
@@ -235,10 +235,10 @@ function FolderTreeVisualizerPage() {
 	const copyText = useCallback(async (text: string, label: string) => {
 		try {
 			await navigator.clipboard.writeText(text);
-			toast.success(`Copied ${label}`);
+			toast.success(`${label} copied to clipboard`);
 		} catch (e) {
 			const message = e instanceof Error ? e.message : String(e);
-			toast.error('Failed to copy', { description: message });
+			toast.error('Failed to copy to clipboard', { description: message });
 		}
 	}, []);
 

--- a/src/routes/hash-generator.tsx
+++ b/src/routes/hash-generator.tsx
@@ -470,10 +470,10 @@ function BatchHashTab() {
 	const handleCopyShasum = async () => {
 		try {
 			await navigator.clipboard.writeText(shasumBlock);
-			toast.success(`Copied ${prefs.shasumAlgorithm.toUpperCase()} block`);
+			toast.success(`${prefs.shasumAlgorithm.toUpperCase()} block copied to clipboard`);
 		} catch (e) {
 			const message = e instanceof Error ? e.message : String(e);
-			toast.error('Failed to copy', { description: message });
+			toast.error('Failed to copy to clipboard', { description: message });
 		}
 	};
 

--- a/src/routes/path-tool.tsx
+++ b/src/routes/path-tool.tsx
@@ -130,7 +130,7 @@ function PathToolPage() {
 			if (text.length > 0) setInput(text);
 		} catch (e) {
 			const message = e instanceof Error ? e.message : String(e);
-			toast.error('Failed to read clipboard', { description: message });
+			toast.error('Failed to paste from clipboard', { description: message });
 		}
 	}, []);
 


### PR DESCRIPTION
## Summary

Canonicalize clipboard toast wording across the app so every copy and paste
action surfaces the same message, matching the form already emitted by the
`CopyButton` / `ResultBlock` primitives and documented in the layout rules.

- Copy success → `<Subject> copied to clipboard`
- Copy failure → `Failed to copy to clipboard` (diagnostic `description` kept)
- Paste success → `Pasted from clipboard`
- Paste failure → `Failed to paste from clipboard`

This continues the direction of #384 (`normalize output-copy toast wording`)
and extends it to the shared helper layer and every remaining drift site.

## Changes

### Changed

- Fix the two shared helpers first, so the wording propagates to every
  consumer in a single edit:
  - `lib/utils/file-operations.ts` (`copyToClipboard` / `pasteFromClipboard`)
    — reaches the formatter family, `escape-tool`, and the
    `use-clipboard-actions` hook
  - `lib/components/editor/code/tree-view.tsx` (copy path / value)
  - `lib/components/network-scanner/unified-host-detail-panel.tsx`
- Resolve per-route drift (verb-first and abbreviated variants):
  `cidr-calculator`, `dns-lookup`, `encoding-converter`, `file-inspector`,
  `folder-tree-visualizer`, `hash-generator`, `csv-tool`, `path-tool`
- Normalize the `json` / `xml` / `yaml` schema-tab paste toast
- Recompose the `date-timestamp-converter` cron hand-off toast as a canonical
  headline plus a `description`, keeping the "paste into the Parse tab" hint

## Test Plan

- [x] `bun run check` (tsc + validate-pages + audit-design) passes
- [x] `bun run test` — 156/156 pass
- [x] `bun run lint` — exit 0 (only pre-existing complexity warnings)
- [x] `bun run format` applied; pre-commit hook reports all files unchanged
- [x] Grep confirms zero remaining non-canonical copy/paste toast strings
