### PR TITLE
refactor(ui): adopt ToneBadge for certificate expiry badges

### DIFF
--- a/src/routes/tls-inspector.tsx
+++ b/src/routes/tls-inspector.tsx
@@ -21,6 +21,7 @@ import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { Input } from '@/lib/components/ui/input';
 import { Label } from '@/lib/components/ui/label';
+import { ToneBadge } from '@/lib/components/ui/tone-badge';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
 	buildPemBundle,
@@ -81,13 +82,6 @@ const SAN_TYPE_TONE: Readonly<
 };
 
 type ExpiryTone = 'success' | 'info' | 'warning' | 'destructive';
-
-const TONE_BADGE_CLASS: Readonly<Record<ExpiryTone, string>> = {
-	success: 'bg-success/10 text-success border-success/30',
-	info: 'bg-info/10 text-info border-info/30',
-	warning: 'bg-warning/10 text-warning border-warning/30',
-	destructive: 'bg-destructive/10 text-destructive border-destructive/30',
-};
 
 const formatDate = (date: Date): string => date.toLocaleString();
 
@@ -500,7 +494,9 @@ function ChainCertificateCard({ cert, base64Der, role, now }: ChainCertificateCa
 						) : null}
 					</div>
 					<div className="flex items-center gap-2">
-						<Badge className={cn('font-medium', TONE_BADGE_CLASS[badge.tone])}>{badge.label}</Badge>
+						<ToneBadge tone={badge.tone} className="font-medium">
+							{badge.label}
+						</ToneBadge>
 						<CopyButton text={pem} toastLabel="Certificate PEM" size="sm" />
 					</div>
 				</div>

--- a/src/routes/x509-decoder.tsx
+++ b/src/routes/x509-decoder.tsx
@@ -32,6 +32,7 @@ import {
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { ToneBadge } from '@/lib/components/ui/tone-badge';
 import { useDocumentTitle } from '@/lib/hooks';
 import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import {
@@ -107,13 +108,6 @@ const buildExpiryBadge = (
 	if (days <= severeDays) return { label: `Expires in ${days} days`, tone: 'destructive' };
 	if (days <= warnDays) return { label: `Expires in ${days} days`, tone: 'warning' };
 	return { label: `Valid (${days} days left)`, tone: 'success' };
-};
-
-const TONE_BADGE_CLASS: Readonly<Record<ExpiryTone, string>> = {
-	success: 'bg-success/10 text-success border-success/30',
-	info: 'bg-info/10 text-info border-info/30',
-	warning: 'bg-warning/10 text-warning border-warning/30',
-	destructive: 'bg-destructive/10 text-destructive border-destructive/30',
 };
 
 const TONE_TIMELINE_CLASS: Readonly<Record<ExpiryTone, string>> = {
@@ -423,7 +417,9 @@ function CertificateCard({ cert, now, prefs }: CertificateCardProps) {
 							SN {serialPreview}
 						</Badge>
 					</div>
-					<Badge className={cn('font-medium', TONE_BADGE_CLASS[badge.tone])}>{badge.label}</Badge>
+					<ToneBadge tone={badge.tone} className="font-medium">
+						{badge.label}
+					</ToneBadge>
 				</div>
 			</CardHeader>
 			<CardContent className="space-y-4">
@@ -662,9 +658,9 @@ function ExtensionRow({ extension }: ExtensionRowProps) {
 					<span className="text-xs font-medium">{extension.name}</span>
 					<span className="font-mono text-2xs text-muted-foreground">{extension.oid}</span>
 					{extension.critical ? (
-						<Badge className={cn('font-mono text-2xs', TONE_BADGE_CLASS.destructive)}>
+						<ToneBadge tone="destructive" className="font-mono text-2xs">
 							Critical
-						</Badge>
+						</ToneBadge>
 					) : null}
 				</div>
 				<ExtensionBody extension={extension} />


### PR DESCRIPTION
## Summary

Adopt the shared `ToneBadge` primitive for the certificate expiry/validity
pills in the X.509 decoder and TLS inspector, removing the byte-identical
`TONE_BADGE_CLASS` constant duplicated across both routes.

- The certificate `ExpiryTone` union (`success | info | warning |
  destructive`) matches `ToneBadge`'s `tone` one-to-one, so the validity badge
  and the X.509 "Critical" extension badge map directly.
- `ToneBadge` now owns the `bg-{tone}/10 text-{tone}` surface in a single
  place.

This is the first slice of the broader "adopt ToneBadge" consistency theme; it
targets the duplication the audit specifically flagged (identical
`TONE_BADGE_CLASS` in both files).

## Changes

### Changed

- `x509-decoder.tsx`: validity badge and "Critical" extension badge →
  `ToneBadge`; delete `TONE_BADGE_CLASS`
- `tls-inspector.tsx`: validity badge → `ToneBadge`; delete `TONE_BADGE_CLASS`

### Intentionally left as-is

- `SAN_TYPE_TONE` — SAN badges use `primary` and `muted` tints outside
  ToneBadge's four-tone vocabulary
- `TONE_TIMELINE_CLASS` — uses fill/stroke classes for the timeline, not a
  badge surface

## Test Plan

- [x] `bun run check` (tsc + validate-pages + audit-design) passes
- [x] `bun run test` — 156/156 pass
- [x] `bun run lint` — exit 0 (only pre-existing complexity warnings)
- [x] Grep confirms `TONE_BADGE_CLASS` removed and `ExpiryTone` still
      referenced in both files
