### PR TITLE
refactor(ui): adopt ToneBadge for drive and file-watch status pills

### DIFF
--- a/src/routes/drive-info.tsx
+++ b/src/routes/drive-info.tsx
@@ -20,6 +20,7 @@ import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { Progress } from '@/lib/components/ui/progress';
+import { ToneBadge, type ToneBadgeTone } from '@/lib/components/ui/tone-badge';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
 	type DriveInfo,
@@ -57,10 +58,10 @@ const TIER_TEXT_CLASS: Record<UsageTier, string> = {
 	critical: 'text-destructive',
 };
 
-const TIER_BADGE_CLASS: Record<UsageTier, string> = {
-	normal: 'border-success/40 bg-success/10 text-success',
-	warning: 'border-warning/40 bg-warning/10 text-warning',
-	critical: 'border-destructive/40 bg-destructive/10 text-destructive',
+const TIER_TONE: Record<UsageTier, ToneBadgeTone> = {
+	normal: 'success',
+	warning: 'warning',
+	critical: 'destructive',
 };
 
 export const Route = createFileRoute('/drive-info')({
@@ -329,14 +330,13 @@ function DriveCard({ drive }: { readonly drive: DriveInfo }) {
 				<Progress value={percent} className={cn('h-1.5', TIER_PROGRESS_CLASS[tier])} />
 				<div className="flex items-center justify-between text-xs">
 					<span className={cn('font-mono', TIER_TEXT_CLASS[tier])}>{percent.toFixed(1)}% used</span>
-					<Badge variant="outline" className={cn('font-mono text-2xs', TIER_BADGE_CLASS[tier])}>
-						{tier === 'critical' ? (
-							<ShieldAlert className="h-3 w-3" />
-						) : (
-							<HardDrive className="h-3 w-3" />
-						)}
+					<ToneBadge
+						tone={TIER_TONE[tier]}
+						icon={tier === 'critical' ? ShieldAlert : HardDrive}
+						className="font-mono text-2xs"
+					>
 						{humanSize(drive.availableBytes)} free
-					</Badge>
+					</ToneBadge>
 				</div>
 				<DefinitionList
 					items={[

--- a/src/routes/file-watch.tsx
+++ b/src/routes/file-watch.tsx
@@ -12,9 +12,9 @@ import {
 } from '@/lib/components/form';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
-import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
+import { ToneBadge, type ToneBadgeTone } from '@/lib/components/ui/tone-badge';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
 	EVENT_RING_CAPACITY,
@@ -23,7 +23,6 @@ import {
 	useFileWatch,
 } from '@/lib/services/file-watch';
 import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
-import { cn } from '@/lib/utils';
 
 const ALL_KINDS: readonly FileWatchEventKind[] = ['create', 'modify', 'delete', 'rename'];
 
@@ -35,11 +34,11 @@ const KIND_LABEL: Readonly<Record<FileWatchEventKind, string>> = {
 };
 
 // Distinct tones per event kind so a long log remains scannable.
-const KIND_BADGE_CLASS: Readonly<Record<FileWatchEventKind, string>> = {
-	create: 'border-success/40 bg-success/10 text-success',
-	modify: 'border-info/40 bg-info/10 text-info',
-	delete: 'border-destructive/40 bg-destructive/10 text-destructive',
-	rename: 'border-warning/40 bg-warning/10 text-warning',
+const KIND_TONE: Readonly<Record<FileWatchEventKind, ToneBadgeTone>> = {
+	create: 'success',
+	modify: 'info',
+	delete: 'destructive',
+	rename: 'warning',
 };
 
 interface FileWatchPrefs {
@@ -239,15 +238,12 @@ function EventLog({ events }: EventLogProps) {
 						<time className="w-24 shrink-0 font-mono text-2xs text-muted-foreground">
 							{formatTime(event.timestamp)}
 						</time>
-						<Badge
-							variant="outline"
-							className={cn(
-								'w-16 shrink-0 justify-center font-mono text-2xs',
-								KIND_BADGE_CLASS[event.kind]
-							)}
+						<ToneBadge
+							tone={KIND_TONE[event.kind]}
+							className="w-16 shrink-0 justify-center font-mono text-2xs"
 						>
 							{KIND_LABEL[event.kind]}
-						</Badge>
+						</ToneBadge>
 						<span className="min-w-0 flex-1 truncate font-mono text-2xs" title={event.path}>
 							{event.path}
 						</span>


### PR DESCRIPTION
## Summary

Continue the "adopt ToneBadge" consistency theme by migrating the per-route
class-map tone constants in the drive info and file watch tools to the shared
`ToneBadge` primitive.

Both constants mapped only to the four semantic tones, so the migration is
faithful and `ToneBadge` now owns the `bg-{tone}/10 text-{tone}` surface in a
single place.

## Changes

### Changed

- `drive-info.tsx`: `TIER_BADGE_CLASS` → `TIER_TONE`
  (normal/warning/critical → success/warning/destructive). The usage badge
  passes its conditional `HardDrive` / `ShieldAlert` glyph via ToneBadge's
  `icon` prop.
- `file-watch.tsx`: `KIND_BADGE_CLASS` → `KIND_TONE`
  (create/modify/delete/rename → success/info/destructive/warning). Drop the
  now-unused `Badge` and `cn` imports.

## Test Plan

- [x] `bun run check` (tsc + validate-pages + audit-design) passes
- [x] `bun run test` — 156/156 pass
- [x] `bun run lint` — exit 0 (only pre-existing complexity warnings)
- [x] Grep confirms the old class-map constants are removed
