### PR TITLE
refactor(ui): adopt ToneBadge for date and cron day status pills

### DIFF
--- a/src/routes/cron-expression-builder.tsx
+++ b/src/routes/cron-expression-builder.tsx
@@ -6,7 +6,6 @@ import { CopyButton } from '@/lib/components/action';
 import { FormError, FormInfo, FormInput, FormSection } from '@/lib/components/form';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
-import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
 import {
 	Card,
@@ -15,6 +14,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from '@/lib/components/ui/card';
+import { ToneBadge, type ToneBadgeTone } from '@/lib/components/ui/tone-badge';
 import { useActiveTab, useTabStore } from '@/lib/stores';
 import { cn } from '@/lib/utils';
 import { useDocumentTitle } from '@/lib/hooks';
@@ -45,10 +45,10 @@ export const Route = createFileRoute('/cron-expression-builder')({
 	component: CronExpressionBuilderPage,
 });
 
-const dayBadgeClass = (dayIndex: number, isWeekend: boolean): string => {
-	if (isWeekend) return 'bg-warning/10 text-warning border-warning/30';
-	if (dayIndex === 1) return 'bg-info/10 text-info border-info/30';
-	return 'bg-success/10 text-success border-success/30';
+const dayTone = (dayIndex: number, isWeekend: boolean): ToneBadgeTone => {
+	if (isWeekend) return 'warning';
+	if (dayIndex === 1) return 'info';
+	return 'success';
 };
 
 function CronExpressionBuilderPage() {
@@ -195,14 +195,12 @@ function CronExpressionBuilderPage() {
 													<span className="w-6 text-xs tabular-nums text-muted-foreground">
 														{idx + 1}.
 													</span>
-													<Badge
-														className={cn(
-															'text-2xs font-mono',
-															dayBadgeClass(fmt.dayIndex, fmt.isWeekend)
-														)}
+													<ToneBadge
+														tone={dayTone(fmt.dayIndex, fmt.isWeekend)}
+														className="text-2xs font-mono"
 													>
 														{fmt.dayLabel}
-													</Badge>
+													</ToneBadge>
 													<span className="font-mono text-sm tabular-nums">{fmt.date}</span>
 													<span className="font-mono text-sm tabular-nums text-muted-foreground">
 														{fmt.time}
@@ -391,14 +389,12 @@ function CronExpressionBuilderPage() {
 															<span className="w-6 text-xs tabular-nums text-muted-foreground">
 																{idx + 1}.
 															</span>
-															<Badge
-																className={cn(
-																	'text-2xs font-mono',
-																	dayBadgeClass(fmt.dayIndex, fmt.isWeekend)
-																)}
+															<ToneBadge
+																tone={dayTone(fmt.dayIndex, fmt.isWeekend)}
+																className="text-2xs font-mono"
 															>
 																{fmt.dayLabel}
-															</Badge>
+															</ToneBadge>
 															<span className="font-mono text-sm tabular-nums">{fmt.date}</span>
 															<span className="font-mono text-sm tabular-nums text-muted-foreground">
 																{fmt.time}

--- a/src/routes/date-timestamp-converter.tsx
+++ b/src/routes/date-timestamp-converter.tsx
@@ -30,6 +30,7 @@ import {
 	CardTitle,
 } from '@/lib/components/ui/card';
 import { Calendar } from '@/lib/components/ui/calendar';
+import { ToneBadge, type ToneBadgeTone } from '@/lib/components/ui/tone-badge';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
 	DEFAULT_TIMEZONES,
@@ -46,7 +47,6 @@ import {
 	zonedClock,
 } from '@/lib/services/date-timestamp';
 import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
-import { cn } from '@/lib/utils';
 
 interface DateTimestampOptions {
 	readonly timezones: readonly string[];
@@ -69,17 +69,14 @@ export const Route = createFileRoute('/date-timestamp-converter')({
 	component: DateTimestampConverterPage,
 });
 
-const KIND_BADGE: Record<ParsedInput['kind'], { label: string; tone: string }> = {
-	'unix-s': { label: 'Unix seconds', tone: 'bg-info/10 text-info border-info/30' },
-	'unix-ms': { label: 'Unix milliseconds', tone: 'bg-info/10 text-info border-info/30' },
-	'unix-us': { label: 'Unix microseconds', tone: 'bg-info/10 text-info border-info/30' },
-	'unix-ns': { label: 'Unix nanoseconds', tone: 'bg-info/10 text-info border-info/30' },
-	iso: { label: 'ISO 8601', tone: 'bg-success/10 text-success border-success/30' },
-	rfc2822: { label: 'RFC 2822', tone: 'bg-success/10 text-success border-success/30' },
-	invalid: {
-		label: 'Unrecognized',
-		tone: 'bg-destructive/10 text-destructive border-destructive/30',
-	},
+const KIND_BADGE: Record<ParsedInput['kind'], { label: string; tone: ToneBadgeTone }> = {
+	'unix-s': { label: 'Unix seconds', tone: 'info' },
+	'unix-ms': { label: 'Unix milliseconds', tone: 'info' },
+	'unix-us': { label: 'Unix microseconds', tone: 'info' },
+	'unix-ns': { label: 'Unix nanoseconds', tone: 'info' },
+	iso: { label: 'ISO 8601', tone: 'success' },
+	rfc2822: { label: 'RFC 2822', tone: 'success' },
+	invalid: { label: 'Unrecognized', tone: 'destructive' },
 };
 
 function DateTimestampConverterPage() {
@@ -210,9 +207,9 @@ function DateTimestampConverterPage() {
 					className="font-mono"
 				/>
 				<div className="flex items-center gap-2">
-					<Badge className={cn('text-2xs', KIND_BADGE[parsed.kind].tone)}>
+					<ToneBadge tone={KIND_BADGE[parsed.kind].tone} className="text-2xs">
 						{KIND_BADGE[parsed.kind].label}
-					</Badge>
+					</ToneBadge>
 					{parsed.ms !== null ? (
 						<span className="font-mono text-2xs text-muted-foreground">ms = {parsed.ms}</span>
 					) : null}


### PR DESCRIPTION
## Summary

Continue the "adopt ToneBadge" consistency theme with two more pure-four-tone
status maps. Both maps used only the four semantic tones, so the migration is
faithful and `ToneBadge` now owns the `bg-{tone}/10 text-{tone}` surface.

## Changes

### Changed

- `date-timestamp-converter.tsx`: `KIND_BADGE`'s class-string `tone` field
  becomes a `ToneBadgeTone` (unix → info, iso/rfc2822 → success, invalid →
  destructive); the detected-kind badge renders via `ToneBadge`. Drop the
  now-unused `cn` import.
- `cron-expression-builder.tsx`: `dayBadgeClass` becomes `dayTone` returning a
  `ToneBadgeTone` (weekend → warning, Monday → info, else → success); both
  next-execution day badges render via `ToneBadge`. Drop the now-unused `Badge`
  import.

## Test Plan

- [x] `bun run check` (tsc + validate-pages + audit-design) passes
- [x] `bun run test` — 156/156 pass
- [x] `bun run lint` — exit 0 (only pre-existing complexity warnings)
- [x] Grep confirms the old class-map constants are removed
