### PR TITLE
fix(ui): use percentage units for resizable panel default sizes

### DIFF
--- a/src/lib/components/layout/split-pane.tsx
+++ b/src/lib/components/layout/split-pane.tsx
@@ -26,16 +26,16 @@ export function SplitPane({
 	return (
 		<ResizablePanelGroup orientation={direction} className={cn('h-full flex-1', className)}>
 			<ResizablePanel
-				defaultSize={defaultSizes[0]}
-				minSize={minSizes[0]}
+				defaultSize={String(defaultSizes[0])}
+				minSize={String(minSizes[0])}
 				className="flex h-full flex-col overflow-hidden"
 			>
 				{firstSlot}
 			</ResizablePanel>
 			<ResizableHandle withHandle />
 			<ResizablePanel
-				defaultSize={defaultSizes[1]}
-				minSize={minSizes[1]}
+				defaultSize={String(defaultSizes[1])}
+				minSize={String(minSizes[1])}
 				className="flex h-full flex-col overflow-hidden"
 			>
 				{secondSlot}

--- a/src/routes/wifi-analyzer.tsx
+++ b/src/routes/wifi-analyzer.tsx
@@ -239,7 +239,7 @@ function WifiAnalyzerPage() {
 			}
 		>
 			<ResizablePanelGroup orientation="vertical" className="h-full">
-				<ResizablePanel defaultSize={60} minSize={20}>
+				<ResizablePanel defaultSize="60" minSize="20">
 					{error ? (
 						<div className="flex h-full items-center justify-center p-4">
 							<ErrorDisplay title="Wi-Fi scan failed" message={error} />
@@ -263,7 +263,7 @@ function WifiAnalyzerPage() {
 					)}
 				</ResizablePanel>
 				<ResizableHandle />
-				<ResizablePanel defaultSize={40} minSize={20}>
+				<ResizablePanel defaultSize="40" minSize="20">
 					<WifiNetworkTable
 						networks={filtered}
 						sortKey={prefs.sortKey}


### PR DESCRIPTION
## Summary

`react-resizable-panels` v4 interprets a **numeric** size as **pixels** and a **unitless string** as a **percentage**. Verified directly in the library's size parser:

```js
case "number": return [e, "px"];   // 60   -> 60px
case "string": ... : [t, "%"];     // "60" -> 60%
```

- The Wi-Fi analyzer's vertical split passed bare numbers (`defaultSize={60}` / `{40}`, `minSize={20}`), collapsing the panels to **60px / 40px** instead of 60% / 40%.
- `SplitPane` had the same latent bug for **every** consumer (jwt-decoder, regex-tester, ...), forwarding its numeric `defaultSizes` / `minSizes` straight through.

This matches the convention already used correctly by the code editor and network-interfaces panels (which pass string sizes).

## Changes

### Fixed

- `wifi-analyzer.tsx`: quote the vertical split sizes (`defaultSize="60"/"40"`, `minSize="20"`).
- `split-pane.tsx`: stringify `defaultSizes` / `minSizes` at the call site so all SplitPane consumers get percentage sizing.

## Test Plan

- [x] `bun run check` (tsc + validate-pages + audit-design) passes
- [x] `bun run test` — 156/156 pass
- [x] `bun run lint` — exit 0 (pre-existing warnings only)
