### PR TITLE
refactor(ui): adopt DefinitionList for hex-editor and rsa-tools detail grids

### DIFF
--- a/src/routes/hex-editor.tsx
+++ b/src/routes/hex-editor.tsx
@@ -26,6 +26,7 @@ import {
 import { toast } from 'sonner';
 
 import { FormCheckbox, FormInput, FormMode, FormSection } from '@/lib/components/form';
+import { DefinitionList } from '@/lib/components/layout';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
@@ -924,24 +925,20 @@ function FileBanner({ file, detectedMime, magicHex, dirty, pendingCount }: FileB
 				</CardTitle>
 			</CardHeader>
 			<CardContent>
-				<dl className="grid grid-cols-[110px_1fr] gap-x-3 gap-y-1 text-xs">
-					<dt className="text-muted-foreground">Size</dt>
-					<dd className="font-mono">
-						{humanSize(file.sizeBytes)} ({file.sizeBytes.toLocaleString()} B)
-					</dd>
-					<dt className="text-muted-foreground">Modified</dt>
-					<dd className="font-mono">
-						{file.modifiedMs ? new Date(file.modifiedMs).toLocaleString() : '—'}
-					</dd>
-					<dt className="text-muted-foreground">Detected MIME</dt>
-					<dd className="font-mono">{detectedMime ?? '(unknown)'}</dd>
-					{magicHex ? (
-						<>
-							<dt className="text-muted-foreground">Magic bytes</dt>
-							<dd className="font-mono">{magicHex}</dd>
-						</>
-					) : null}
-				</dl>
+				<DefinitionList
+					items={[
+						{
+							key: 'Size',
+							value: `${humanSize(file.sizeBytes)} (${file.sizeBytes.toLocaleString()} B)`,
+						},
+						{
+							key: 'Modified',
+							value: file.modifiedMs ? new Date(file.modifiedMs).toLocaleString() : '—',
+						},
+						{ key: 'Detected MIME', value: detectedMime ?? '(unknown)' },
+						...(magicHex ? [{ key: 'Magic bytes', value: magicHex }] : []),
+					]}
+				/>
 			</CardContent>
 		</Card>
 	);

--- a/src/routes/rsa-tools.tsx
+++ b/src/routes/rsa-tools.tsx
@@ -16,6 +16,7 @@ import { toast } from 'sonner';
 
 import { CopyButton } from '@/lib/components/action';
 import { FormSection, FormSelect, FormTextarea, type SelectOption } from '@/lib/components/form';
+import { DefinitionList } from '@/lib/components/layout';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
@@ -459,18 +460,16 @@ function KeyInfoPanel({ info }: KeyInfoPanelProps) {
 	}
 	const fingerprintShort = info.fingerprint.replace(/:/g, '').slice(0, 16);
 	return (
-		<dl className="grid grid-cols-[88px_1fr] gap-x-3 gap-y-1 text-xs">
-			<dt className="font-mono text-muted-foreground">Algorithm</dt>
-			<dd className="font-mono">{info.algorithm}</dd>
-			<dt className="font-mono text-muted-foreground">Type</dt>
-			<dd className="font-mono">{info.type}</dd>
-			<dt className="font-mono text-muted-foreground">Bit length</dt>
-			<dd className="font-mono tabular-nums">{info.bitLength}</dd>
-			<dt className="font-mono text-muted-foreground">Format</dt>
-			<dd className="font-mono uppercase">{info.format}</dd>
-			<dt className="font-mono text-muted-foreground">SHA-256</dt>
-			<dd className="break-all font-mono">{fingerprintShort}…</dd>
-		</dl>
+		<DefinitionList
+			keyColumn="88px"
+			items={[
+				{ key: 'Algorithm', value: info.algorithm },
+				{ key: 'Type', value: info.type },
+				{ key: 'Bit length', value: <span className="tabular-nums">{info.bitLength}</span> },
+				{ key: 'Format', value: <span className="uppercase">{info.format}</span> },
+				{ key: 'SHA-256', value: `${fingerprintShort}…`, break: true },
+			]}
+		/>
 	);
 }
 


### PR DESCRIPTION
## Summary

Replace the hand-built `<dl className="grid grid-cols-[Npx_1fr]">` key/value grids in two routes with the shared `DefinitionList` primitive.

## Changes

### Changed

- `hex-editor.tsx`: file-detail grid → `DefinitionList` (Size / Modified / Detected MIME / Magic bytes; the conditional Magic-bytes row is a spread item).
- `rsa-tools.tsx`: key-detail grid → `DefinitionList keyColumn="88px"`. `tabular-nums` (Bit length) and `uppercase` (Format) are preserved via span values; the previously mono `dt` labels normalize to DefinitionList's canonical muted non-mono keys.

## Test Plan

- [x] `bun run check` (tsc + validate-pages + audit-design) passes
- [x] `bun run test` — 156/156 pass
- [x] `bun run lint` — exit 0 (pre-existing warnings only)
- [x] Grep confirms no hand-built `grid-cols-[...]` dl remains in the two files
