### PR TITLE
refactor(ui): adopt DefinitionList for the archive summary grid

### DIFF
--- a/src/routes/archive-inspector.tsx
+++ b/src/routes/archive-inspector.tsx
@@ -22,7 +22,7 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SectionLabel } from '@/lib/components/layout';
+import { DefinitionList, SectionLabel } from '@/lib/components/layout';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
@@ -701,23 +701,27 @@ function ArchiveBanner({ archive, filename, filteredCount }: ArchiveBannerProps)
 				</CardTitle>
 			</CardHeader>
 			<CardContent>
-				<dl className="grid grid-cols-[140px_1fr] gap-x-3 gap-y-1 text-xs">
-					<dt className="text-muted-foreground">Entries</dt>
-					<dd className="font-mono">
-						{archive.entries.length.toLocaleString()}
-						{filteredCount !== archive.entries.length
-							? ` (${filteredCount.toLocaleString()} shown)`
-							: ''}
-					</dd>
-					<dt className="text-muted-foreground">Uncompressed</dt>
-					<dd className="font-mono">
-						{humanSize(archive.totalUncompressed)} ({archive.totalUncompressed.toLocaleString()} B)
-					</dd>
-					<dt className="text-muted-foreground">Compressed</dt>
-					<dd className="font-mono">
-						{humanSize(archive.totalCompressed)} ({archive.totalCompressed.toLocaleString()} B)
-					</dd>
-				</dl>
+				<DefinitionList
+					keyColumn="140px"
+					items={[
+						{
+							key: 'Entries',
+							value:
+								archive.entries.length.toLocaleString() +
+								(filteredCount !== archive.entries.length
+									? ` (${filteredCount.toLocaleString()} shown)`
+									: ''),
+						},
+						{
+							key: 'Uncompressed',
+							value: `${humanSize(archive.totalUncompressed)} (${archive.totalUncompressed.toLocaleString()} B)`,
+						},
+						{
+							key: 'Compressed',
+							value: `${humanSize(archive.totalCompressed)} (${archive.totalCompressed.toLocaleString()} B)`,
+						},
+					]}
+				/>
 			</CardContent>
 		</Card>
 	);


### PR DESCRIPTION
## Summary

Replace the hand-built `<dl className="grid grid-cols-[140px_1fr]">` archive-summary grid with the shared `DefinitionList` primitive (continues #391).

## Changes

### Changed

- `archive-inspector.tsx`: archive summary (Entries / Uncompressed / Compressed) → `DefinitionList keyColumn="140px"`. The conditional `(N shown)` suffix on Entries is folded into the value expression.

This completes the DefinitionList exact-clone sweep:
- Migrated: hex-editor, rsa-tools (#391), archive-inspector (this PR).
- Already on DefinitionList: file-inspector.
- Left intentionally: csv-tool's column-stats popover (a deliberately dense `opacity-70` / `gap-y-0.5` / `text-2xs` variant, not a generic detail grid).

## Test Plan

- [x] `bun run check` (tsc + validate-pages + audit-design) passes
- [x] `bun run test` — 156/156 pass
- [x] `bun run lint` — exit 0 (pre-existing warnings only)
