### PR TITLE
refactor(ui): route inline tool errors through FormError

### DIFF
--- a/src/routes/cidr-calculator.tsx
+++ b/src/routes/cidr-calculator.tsx
@@ -4,7 +4,7 @@ import { type CSSProperties, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 import { ActionButton, CopyButton } from '@/lib/components/action';
-import { FormInfo, FormInput, FormMode, FormSection } from '@/lib/components/form';
+import { FormError, FormInfo, FormInput, FormMode, FormSection } from '@/lib/components/form';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import {
@@ -236,7 +236,7 @@ function CidrCalculatorPage() {
 								size="default"
 							/>
 							{!result.ok && input.trim().length > 0 ? (
-								<p className="mt-2 text-xs text-destructive">{result.error}</p>
+								<FormError message={result.error} className="mt-2" />
 							) : null}
 							{result.ok && result.reserved.length > 0 ? (
 								<div className="mt-3 flex flex-wrap gap-1.5">
@@ -525,7 +525,7 @@ function SubnettingPanel({
 								</div>
 							</div>
 							{splitError ? (
-								<p className="text-xs text-destructive">{splitError}</p>
+								<FormError message={splitError} />
 							) : visibleRows && visibleRows.length > 0 ? (
 								<div className="overflow-x-auto">
 									<table className="w-full min-w-max border-collapse text-xs">
@@ -600,7 +600,7 @@ function SubnettingPanel({
 								size="compact"
 							/>
 							{aggregateResult?.error ? (
-								<p className="text-xs text-destructive">{aggregateResult.error}</p>
+								<FormError message={aggregateResult.error} />
 							) : aggregateResult?.cidr ? (
 								<div className="flex items-center justify-between gap-2 rounded-md border bg-success/5 px-2.5 py-1.5">
 									<div className="font-mono text-sm">{aggregateResult.cidr}</div>

--- a/src/routes/cron-expression-builder.tsx
+++ b/src/routes/cron-expression-builder.tsx
@@ -220,7 +220,7 @@ function CronExpressionBuilderPage() {
 									/>
 								)
 							) : (
-								<p className="text-sm text-destructive">{buildNextRuns.error}</p>
+								<FormError message={buildNextRuns.error} className="text-sm" />
 							)}
 						</CardContent>
 					</Card>
@@ -362,7 +362,7 @@ function CronExpressionBuilderPage() {
 									{parseDescription.ok ? (
 										<p className="text-sm">{parseDescription.value}</p>
 									) : (
-										<p className="text-sm text-destructive">{parseDescription.error}</p>
+										<FormError message={parseDescription.error} className="text-sm" />
 									)}
 								</CardContent>
 							</Card>
@@ -410,7 +410,7 @@ function CronExpressionBuilderPage() {
 											<p className="text-sm text-muted-foreground">No upcoming executions.</p>
 										)
 									) : (
-										<p className="text-sm text-destructive">{parseNextRuns.error}</p>
+										<FormError message={parseNextRuns.error} className="text-sm" />
 									)}
 								</CardContent>
 							</Card>

--- a/src/routes/image-converter.tsx
+++ b/src/routes/image-converter.tsx
@@ -7,6 +7,7 @@ import { ActionButton } from '@/lib/components/action';
 import {
 	FormCheckbox,
 	FormCheckboxGroup,
+	FormError,
 	FormInfo,
 	FormInput,
 	FormSection,
@@ -521,7 +522,7 @@ function ImageConverterPage() {
 						{error ? (
 							<Card density="compact">
 								<CardContent>
-									<p className="text-sm text-destructive">{error}</p>
+									<FormError message={error} className="text-sm" />
 								</CardContent>
 							</Card>
 						) : null}

--- a/src/routes/regex-tester.tsx
+++ b/src/routes/regex-tester.tsx
@@ -291,7 +291,7 @@ function StructureAccordion({ visualization }: StructureAccordionProps) {
 				{visualization.ok ? (
 					<RenderNode node={visualization.value} depth={0} />
 				) : (
-					<p className="text-xs text-destructive">{visualization.error}</p>
+					<FormError message={visualization.error} />
 				)}
 			</AccordionContent>
 		</AccordionItem>
@@ -505,7 +505,7 @@ function ReplaceCardBody({
 					</div>
 				</>
 			) : (
-				<p className="text-sm text-destructive">{replaceResult.error}</p>
+				<FormError message={replaceResult.error} className="text-sm" />
 			)}
 		</>
 	);


### PR DESCRIPTION
## Summary

Replace raw `<p className="...text-destructive">{...error}</p>` inline error text with the shared `FormError` primitive (`role="alert"` + `AlertCircle` icon) across four tools. This adds consistent error styling and an a11y live-region role, and matches the pattern `cron` and `regex-tester` already used for their *other* errors (internally inconsistent before).

## Changes

### Changed

- `cron-expression-builder.tsx`: build next-runs, parse description, parse next-runs errors.
- `cidr-calculator.tsx`: parse / split / aggregate errors (+ `FormError` import).
- `regex-tester.tsx`: visualization and replace errors.
- `image-converter.tsx`: conversion error (+ `FormError` import).

`text-sm` sites pass `className="text-sm"`; FormError's default is `text-xs`.

## Test Plan

- [x] `bun run check` (tsc + validate-pages + audit-design) passes
- [x] `bun run test` — 156/156 pass
- [x] `bun run lint` — exit 0 (pre-existing warnings only)
- [x] Grep confirms no raw `text-destructive` error `<p>` remains in the four files
