### PR TITLE
refactor(ui): normalize generator success toast wording

### DIFF
--- a/src/routes/bcrypt-generator.tsx
+++ b/src/routes/bcrypt-generator.tsx
@@ -111,7 +111,7 @@ function BcryptGeneratorPage() {
 			if (!generateCancelledRef.current) {
 				setHashResult(result);
 				setFlashCounter((c) => c + 1);
-				toast.success('BCrypt hash generated successfully');
+				toast.success('Generated BCrypt hash');
 			}
 		} catch (e) {
 			if (!generateCancelledRef.current) {

--- a/src/routes/gpg-key-generator.tsx
+++ b/src/routes/gpg-key-generator.tsx
@@ -117,7 +117,7 @@ function GpgKeyGeneratorPage() {
 			if (!isCancelledRef.current) {
 				setKeyResult(result);
 				setFlashCounter((c) => c + 1);
-				toast.success('GPG key pair generated successfully');
+				toast.success('Generated GPG key pair');
 			}
 		} catch (e) {
 			if (!isCancelledRef.current) {

--- a/src/routes/ssh-key-generator.tsx
+++ b/src/routes/ssh-key-generator.tsx
@@ -116,7 +116,7 @@ function SshKeyGeneratorPage() {
 			if (!isCancelledRef.current) {
 				setKeyResult(result);
 				setFlashCounter((c) => c + 1);
-				toast.success('SSH key pair generated successfully');
+				toast.success('Generated SSH key pair');
 			}
 		} catch (e) {
 			if (!isCancelledRef.current) {

--- a/src/routes/uuid-generator.tsx
+++ b/src/routes/uuid-generator.tsx
@@ -106,7 +106,7 @@ function UuidGeneratorPage() {
 			const message = getErrorMessage(e);
 			setError(message);
 			setResults([]);
-			toast.error('Failed to generate UUID', { description: message });
+			toast.error('Failed to generate UUIDs', { description: message });
 		}
 	};
 


### PR DESCRIPTION
## Summary

Align the key/hash generator success toasts with the canonical `Generated <thing>` form already used by the password and UUID generators (continues the toast-wording normalization from #385).

## Changes

### Changed

- `bcrypt-generator`, `gpg-key-generator`, `ssh-key-generator`: `"<thing> generated successfully"` → `"Generated <thing>"`.
- `uuid-generator`: pluralize the failure noun → `"Failed to generate UUIDs"` (the tool generates a batch).

## Test Plan

- [x] `bun run check` passes
- [x] `bun run test` — 156/156 pass
