### PR TITLE
refactor(ui): adopt SubsectionLabel for cron preset-category headings

### DIFF
--- a/src/routes/cron-expression-builder.tsx
+++ b/src/routes/cron-expression-builder.tsx
@@ -4,6 +4,7 @@ import { Calendar, Check, Clock, FlaskConical, Pencil, Search, Sparkles, X } fro
 
 import { CopyButton } from '@/lib/components/action';
 import { FormError, FormInfo, FormInput, FormSection } from '@/lib/components/form';
+import { SubsectionLabel } from '@/lib/components/layout';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
@@ -235,9 +236,7 @@ function CronExpressionBuilderPage() {
 						<CardContent className="space-y-4">
 							{CRON_PRESET_CATEGORIES.map((category) => (
 								<div key={category.label}>
-									<h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-										{category.label}
-									</h4>
+									<SubsectionLabel className="mb-2">{category.label}</SubsectionLabel>
 									<div className="flex flex-wrap gap-2">
 										{category.presets.map((preset) => (
 											<Button
@@ -427,9 +426,7 @@ function CronExpressionBuilderPage() {
 						<CardContent className="space-y-4">
 							{CRON_PRESET_CATEGORIES.map((category) => (
 								<div key={category.label}>
-									<h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-										{category.label}
-									</h4>
+									<SubsectionLabel className="mb-2">{category.label}</SubsectionLabel>
 									<div className="flex flex-wrap gap-2">
 										{category.presets.map((preset) => (
 											<Button


### PR DESCRIPTION
## Summary

Replace the two byte-identical hand-built preset-category headings in the cron builder with `SubsectionLabel`, whose default styling (`text-xs font-semibold uppercase tracking-wide text-muted-foreground`) matches the hand-built `<h4>` exactly — a clean drop-in.

## Changes

### Changed

- `cron-expression-builder.tsx`: the build-tab and parse-tab preset-category `<h4>` headings → `<SubsectionLabel className="mb-2">`.

## Test Plan

- [x] `bun run check` passes
- [x] `bun run test` — 156/156 pass
- [x] `bun run lint` — exit 0
