### PR TITLE
fix(ui): keep About terminal in the string-case-converter rail

### DIFF
--- a/src/routes/string-case-converter.tsx
+++ b/src/routes/string-case-converter.tsx
@@ -134,17 +134,6 @@ function StringCaseConverterPage() {
 						</FormCheckboxGroup>
 					</FormSection>
 
-					<ToolFooter
-						aboutText={
-							<ul className="list-inside list-disc space-y-0.5">
-								<li>Converts text to 17+ case formats</li>
-								<li>Handles camelCase, PascalCase, snake_case</li>
-								<li>Supports kebab-case, CONSTANT_CASE, Title Case</li>
-								<li>Automatically detects word boundaries</li>
-							</ul>
-						}
-					/>
-
 					<FormSection title="Supported Formats">
 						<FormInfo showIcon={false}>
 							<div className="grid grid-cols-2 gap-x-4 gap-y-0.5 text-xs">
@@ -157,6 +146,17 @@ function StringCaseConverterPage() {
 							</div>
 						</FormInfo>
 					</FormSection>
+
+					<ToolFooter
+						aboutText={
+							<ul className="list-inside list-disc space-y-0.5">
+								<li>Converts text to 17+ case formats</li>
+								<li>Handles camelCase, PascalCase, snake_case</li>
+								<li>Supports kebab-case, CONSTANT_CASE, Title Case</li>
+								<li>Automatically detects word boundaries</li>
+							</ul>
+						}
+					/>
 				</>
 			}
 		>


### PR DESCRIPTION
## Summary

The string-case-converter rail rendered a "Supported Formats" `FormSection` **after** `ToolFooter`, demoting the About/Related block from the terminal rail position that `ToolFooter` exists to guarantee (every other tool ends its rail with `ToolFooter`).

## Changes

### Fixed

- `string-case-converter.tsx`: move the "Supported Formats" section above `ToolFooter` so About stays last (pure reorder; no content change).

## Test Plan

- [x] `bun run check` passes
- [x] `bun run test` — 156/156 pass
- [x] Confirmed `ToolFooter` is now the terminal rail element
