### PR TITLE
refactor(ui): add related-tool footers where peers exist

### DIFF
--- a/src/routes/diff-viewer.tsx
+++ b/src/routes/diff-viewer.tsx
@@ -373,6 +373,11 @@ function DiffViewerPage() {
 					</FormSection>
 
 					<ToolFooter
+						relatedItems={[
+							{ id: 'list-comparer', reason: 'Set operations on two lists' },
+							{ id: 'duplicate-finder', reason: 'Find duplicate files by content' },
+							{ id: 'markdown-editor', reason: 'Edit text with live preview' },
+						]}
 						aboutText={
 							<ul className="list-inside list-disc space-y-0.5">
 								<li>LCS algorithm for line diff</li>

--- a/src/routes/escape-tool.tsx
+++ b/src/routes/escape-tool.tsx
@@ -410,7 +410,14 @@ function EscapeToolPage() {
 				</Button>
 			</FormSection>
 
-			<ToolFooter aboutText={FLAVOR_DESCRIPTIONS[activeFlavor]} />
+			<ToolFooter
+				relatedItems={[
+					{ id: 'base64-encoder', reason: 'Encode and decode Base64 text' },
+					{ id: 'url-encoder', reason: 'Percent-encode and decode URLs' },
+					{ id: 'string-compressor', reason: 'Compress and decompress text' },
+				]}
+				aboutText={FLAVOR_DESCRIPTIONS[activeFlavor]}
+			/>
 		</>
 	);
 

--- a/src/routes/hash-generator.tsx
+++ b/src/routes/hash-generator.tsx
@@ -697,6 +697,11 @@ function FileHashRail({
 			</FormSection>
 
 			<ToolFooter
+				relatedItems={[
+					{ id: 'bcrypt-generator', reason: 'Hash and verify passwords with BCrypt' },
+					{ id: 'password-generator', reason: 'Generate secure random passwords' },
+					{ id: 'uuid-generator', reason: 'Generate unique identifiers' },
+				]}
 				aboutText={
 					<ul className="list-inside list-disc space-y-0.5">
 						<li>Drop files or pick them from the dialog.</li>

--- a/src/routes/http-status-codes.tsx
+++ b/src/routes/http-status-codes.tsx
@@ -198,6 +198,10 @@ function HttpStatusCodesPage() {
 					</FormSection>
 
 					<ToolFooter
+						relatedItems={[
+							{ id: 'rest-client', reason: 'Send requests and read response codes' },
+							{ id: 'curl-builder', reason: 'Build and parse cURL commands' },
+						]}
 						aboutText={
 							<>
 								Status codes are primarily defined in RFC 9110 (HTTP Semantics, June 2022). WebDAV

--- a/src/routes/list-comparer.tsx
+++ b/src/routes/list-comparer.tsx
@@ -321,6 +321,10 @@ function ListComparerPage() {
 			</FormSection>
 
 			<ToolFooter
+				relatedItems={[
+					{ id: 'diff-viewer', reason: 'Line and character diff of two texts' },
+					{ id: 'duplicate-finder', reason: 'Find duplicate files by content' },
+				]}
 				aboutText={
 					<ul className="list-inside list-disc space-y-0.5">
 						<li>Set operations on two newline-separated lists</li>

--- a/src/routes/lorem-ipsum.tsx
+++ b/src/routes/lorem-ipsum.tsx
@@ -199,6 +199,11 @@ function LoremIpsumPage() {
 					</FormSection>
 
 					<ToolFooter
+						relatedItems={[
+							{ id: 'test-data-generator', reason: 'Generate synthetic datasets' },
+							{ id: 'markdown-editor', reason: 'Edit and preview generated text' },
+							{ id: 'string-case-converter', reason: 'Reformat text into other cases' },
+						]}
 						aboutText={
 							<ul className="list-inside list-disc space-y-0.5">
 								<li>Six word banks: Latin, food, hipster, pirate, cyberpunk, Japanese</li>

--- a/src/routes/mac-lookup.tsx
+++ b/src/routes/mac-lookup.tsx
@@ -287,7 +287,14 @@ function MacLookupRail({
 				</FormSection>
 			) : null}
 
-			<ToolFooter aboutText="Vendor lookup uses the bundled IEEE OUI database via a Tauri command. All processing happens locally; no network calls." />
+			<ToolFooter
+				relatedItems={[
+					{ id: 'network-interfaces', reason: 'View local interface MAC addresses' },
+					{ id: 'ip-converter', reason: 'Convert IPv4 ↔ IPv6 addresses' },
+					{ id: 'cidr-calculator', reason: 'Calculate subnets from CIDR notation' },
+				]}
+				aboutText="Vendor lookup uses the bundled IEEE OUI database via a Tauri command. All processing happens locally; no network calls."
+			/>
 		</>
 	);
 }

--- a/src/routes/markdown-editor.tsx
+++ b/src/routes/markdown-editor.tsx
@@ -524,6 +524,11 @@ function MarkdownEditorPage() {
 					) : null}
 
 					<ToolFooter
+						relatedItems={[
+							{ id: 'diff-viewer', reason: 'Compare two versions of text' },
+							{ id: 'string-case-converter', reason: 'Reformat text into other cases' },
+							{ id: 'lorem-ipsum', reason: 'Generate placeholder body text' },
+						]}
 						aboutText={
 							<ul className="list-inside list-disc space-y-0.5">
 								<li>Monaco editor with syntax highlighting</li>

--- a/src/routes/mime-types.tsx
+++ b/src/routes/mime-types.tsx
@@ -206,6 +206,10 @@ function MimeTypesPage() {
 					</FormSection>
 
 					<ToolFooter
+						relatedItems={[
+							{ id: 'file-inspector', reason: 'Detect MIME from real file bytes' },
+							{ id: 'encoding-converter', reason: 'Detect and convert text encoding' },
+						]}
 						aboutText={
 							<ul className="list-inside list-disc space-y-0.5">
 								<li>Catalog of {MIME_ENTRIES.length} commonly-encountered MIME types.</li>

--- a/src/routes/password-generator.tsx
+++ b/src/routes/password-generator.tsx
@@ -229,6 +229,11 @@ function PasswordGeneratorPage() {
 					</FormSection>
 
 					<ToolFooter
+						relatedItems={[
+							{ id: 'bcrypt-generator', reason: 'Hash and verify passwords' },
+							{ id: 'hash-generator', reason: 'Generate MD5/SHA hashes' },
+							{ id: 'uuid-generator', reason: 'Generate unique identifiers' },
+						]}
 						aboutText={
 							<ul className="list-inside list-disc space-y-0.5">
 								<li>Cryptographically secure (Web Crypto)</li>

--- a/src/routes/rsa-tools.tsx
+++ b/src/routes/rsa-tools.tsx
@@ -362,6 +362,11 @@ function RsaToolsPage() {
 			</FormSection>
 
 			<ToolFooter
+				relatedItems={[
+					{ id: 'ssh-key-generator', reason: 'Generate SSH key pairs' },
+					{ id: 'gpg-key-generator', reason: 'Generate GPG/PGP key pairs' },
+					{ id: 'x509-decoder', reason: 'Decode X.509 / PEM certificates' },
+				]}
 				aboutText={
 					<>
 						All processing happens in your browser. Keys never leave the device. PKCS#1 v1.5

--- a/src/routes/string-case-converter.tsx
+++ b/src/routes/string-case-converter.tsx
@@ -148,6 +148,11 @@ function StringCaseConverterPage() {
 					</FormSection>
 
 					<ToolFooter
+						relatedItems={[
+							{ id: 'regex-tester', reason: 'Match and replace text patterns' },
+							{ id: 'diff-viewer', reason: 'Compare two versions of text' },
+							{ id: 'lorem-ipsum', reason: 'Generate placeholder text' },
+						]}
 						aboutText={
 							<ul className="list-inside list-disc space-y-0.5">
 								<li>Converts text to 17+ case formats</li>

--- a/src/routes/string-compressor.tsx
+++ b/src/routes/string-compressor.tsx
@@ -435,6 +435,11 @@ function StringCompressorPage() {
 					</FormSection>
 
 					<ToolFooter
+						relatedItems={[
+							{ id: 'base64-encoder', reason: 'Encode and decode Base64 text' },
+							{ id: 'url-encoder', reason: 'Percent-encode and decode URLs' },
+							{ id: 'escape-tool', reason: 'Escape and unescape multi-flavor text' },
+						]}
 						aboutText={
 							<>
 								<p>

--- a/src/routes/websocket-tester.tsx
+++ b/src/routes/websocket-tester.tsx
@@ -417,6 +417,11 @@ function WebSocketTesterRail({
 			</FormSection>
 
 			<ToolFooter
+				relatedItems={[
+					{ id: 'rest-client', reason: 'Build and send HTTP requests' },
+					{ id: 'curl-builder', reason: 'Build and parse cURL commands' },
+					{ id: 'webhook-receiver', reason: 'Inspect incoming HTTP requests' },
+				]}
 				aboutText={
 					<>
 						Local WebSocket client. Connections go directly from your machine. Custom request


### PR DESCRIPTION
## Summary

- Extend the Related rail footer to 14 tool routes that previously rendered an About-only footer
- Each route links two or three genuine peers via the shared `relatedItems` API for consistent cross-tool navigation
- Keep `image-converter` and `number-base-converter` About-only (candidate peers too weak to justify a forced link)

## Changes

### Changed

- `relatedItems` added to: diff-viewer, escape-tool, hash-generator, http-status-codes, list-comparer, lorem-ipsum, mac-lookup, markdown-editor, mime-types, password-generator, rsa-tools, string-case-converter, string-compressor, websocket-tester
- Peers chosen by tool family: encoders, generators (secret/hashing + public-key clusters), text, comparison, network, and reference

## Test Plan

- [x] `bun run check` (tsc + validate-pages + audit-design) passes
- [x] `bun run lint` passes
- [x] `bun run test` passes (156 tests)
- [x] All `relatedItems` ids verified against the `PAGES` registry
