### PR TITLE
refactor(ui): adopt EmbeddedEmptyState for empty output placeholders

### DIFF
--- a/src/routes/csv-tool.tsx
+++ b/src/routes/csv-tool.tsx
@@ -1011,8 +1011,13 @@ function OutputPane({ output, outputFormat, onCopy, onSave }: OutputPaneProps) {
 						{output}
 					</pre>
 				) : (
-					<div className="flex h-full items-center justify-center p-6 text-2xs text-muted-foreground">
-						Output appears here once a table is loaded.
+					<div className="flex h-full items-center justify-center p-6">
+						<EmbeddedEmptyState
+							icon={TableIcon}
+							title="No output yet"
+							description="Output appears here once a table is loaded."
+							fillHeight
+						/>
 					</div>
 				)}
 			</CardContent>

--- a/src/routes/escape-tool.tsx
+++ b/src/routes/escape-tool.tsx
@@ -23,7 +23,7 @@ import {
 } from '@/lib/components/form';
 import { SplitPane } from '@/lib/components/layout';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
-import { StatItem } from '@/lib/components/status';
+import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
 import { IconTooltip } from '@/lib/components/ui/icon-tooltip';
 import { Textarea } from '@/lib/components/ui/textarea';
@@ -464,8 +464,13 @@ function EscapeToolPage() {
 	const renderHighlightOverlay = () => {
 		if (segments.length === 0) {
 			return (
-				<div className="pointer-events-none flex h-full items-center justify-center text-xs text-muted-foreground">
-					Enter raw input above to see the escaped output and highlighted changes.
+				<div className="pointer-events-none h-full">
+					<EmbeddedEmptyState
+						icon={FileCode}
+						title="No escaped output yet"
+						description="Enter raw input above to see the escaped output and highlighted changes."
+						fillHeight
+					/>
 				</div>
 			);
 		}


### PR DESCRIPTION
## Summary

- Replace the hand-rolled centered muted placeholder divs in two routes with the shared `EmbeddedEmptyState` primitive
- Aligns both empty states with the icon-chip + title + description pattern already used elsewhere in the same files

## Changes

### Changed

- `csv-tool`: output-pane empty branch now renders `EmbeddedEmptyState` (TableIcon) instead of a bare `text-2xs` div
- `escape-tool`: highlight-overlay empty branch now renders `EmbeddedEmptyState` (FileCode); the `pointer-events-none` non-interactive overlay is preserved via the wrapper

### Out of scope

- `jwt-decoder`: its empty branch already uses `EmptyState`, and its error branch belongs to the error-display theme

## Test Plan

- [x] `bun run check` passes
- [x] `bun run lint` passes
- [x] `bun run test` passes (156 tests)
