### PR TITLE
refactor(ui): route inline destructive errors through ErrorDisplay

### DIFF
--- a/src/routes/dns-lookup.tsx
+++ b/src/routes/dns-lookup.tsx
@@ -14,7 +14,7 @@ import {
 	FormSlider,
 } from '@/lib/components/form';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
-import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { EmbeddedEmptyState, ErrorDisplay, StatItem } from '@/lib/components/status';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { ToneBadge } from '@/lib/components/ui/tone-badge';
@@ -410,12 +410,7 @@ function DnsLookupMain({
 								</>
 							) : null}
 						</div>
-						{error ? (
-							<div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-2.5 py-1.5 text-xs text-destructive">
-								<AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-								<span>{error}</span>
-							</div>
-						) : null}
+						{error ? <ErrorDisplay variant="banner" icon={AlertCircle} message={error} /> : null}
 					</CardContent>
 				</Card>
 
@@ -469,10 +464,7 @@ function TypeResultCard({ typeResult }: TypeResultCardProps) {
 			</CardHeader>
 			<CardContent className="space-y-2">
 				{hasError ? (
-					<div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-2.5 py-1.5 text-xs text-destructive">
-						<AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-						<span className="break-all">{error}</span>
-					</div>
+					<ErrorDisplay variant="banner" icon={AlertCircle} message={error} />
 				) : records.length === 0 ? (
 					<p className="text-xs text-muted-foreground">
 						No records returned for this type (NOERROR / NXDOMAIN).

--- a/src/routes/hash-generator.tsx
+++ b/src/routes/hash-generator.tsx
@@ -32,7 +32,12 @@ import {
 import { SectionHeader, SectionLabel } from '@/lib/components/layout';
 import { StatusBar, ToolFooter, ToolShell } from '@/lib/components/shell';
 import { Rail } from '@/lib/components/ui/rail';
-import { EmbeddedEmptyState, LiveStatusRegion, StatItem } from '@/lib/components/status';
+import {
+	EmbeddedEmptyState,
+	ErrorDisplay,
+	LiveStatusRegion,
+	StatItem,
+} from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
@@ -829,9 +834,8 @@ function FileRow({ entry, enabledHashes, busy, onRemove }: FileRowProps) {
 			<div className="break-all font-mono text-2xs text-muted-foreground">{entry.path}</div>
 
 			{entry.result?.error ? (
-				<div className="mt-2 flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-2 text-2xs text-destructive">
-					<AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-					<span>{entry.result.error}</span>
+				<div className="mt-2">
+					<ErrorDisplay variant="banner" message={entry.result.error} />
 				</div>
 			) : null}
 

--- a/src/routes/wifi-analyzer.tsx
+++ b/src/routes/wifi-analyzer.tsx
@@ -133,7 +133,6 @@ function WifiAnalyzerPage() {
 		<ToolShell
 			showRail={showRail}
 			onShowRailChange={setShowRail}
-			error={error ?? undefined}
 			statusContent={
 				<>
 					<StatItem label="Networks" value={filtered.length.toLocaleString()} />


### PR DESCRIPTION
## Summary

- Convert hand-rolled destructive error banners to the shared `ErrorDisplay` banner variant
- Remove a redundant double-report so each failure is surfaced through one channel

## Changes

### Changed

- `hash-generator`: per-file hash error now renders `ErrorDisplay variant="banner"` (AlertTriangle is the default icon)
- `dns-lookup`: the top-level lookup error and the per-record-type error now render `ErrorDisplay variant="banner"` with the `AlertCircle` icon
- `wifi-analyzer`: drop the `ToolShell` `error` prop; the scan failure is already shown by the body `ErrorDisplay`, so the status-bar slot was a duplicate

### Out of scope (intentionally left)

- `rsa-tools` destructive cards use a destructive-title + muted-body layout `ErrorDisplay` cannot reproduce
- `semver-tools` already uses `FormError` (field-validation) and a structured timeline row
- `jwt-decoder` expired-token banner is a warning tone, not destructive

## Test Plan

- [x] `bun run check` passes
- [x] `bun run lint` passes
- [x] `bun run test` passes (156 tests)
