### PR TITLE
refactor(ui): adopt FormInput for the bitwise operand input

### DIFF
--- a/src/routes/number-base-converter.tsx
+++ b/src/routes/number-base-converter.tsx
@@ -6,6 +6,7 @@ import {
 	FormCheckbox,
 	FormCheckboxGroup,
 	FormInfo,
+	FormInput,
 	FormMode,
 	FormSection,
 	FormSelect,
@@ -23,7 +24,6 @@ import {
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { Input } from '@/lib/components/ui/input';
-import { Label } from '@/lib/components/ui/label';
 import { ToneBadge } from '@/lib/components/ui/tone-badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/lib/components/ui/tooltip';
 import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
@@ -338,19 +338,15 @@ function NumberBaseConverterPage() {
 					</FormSection>
 
 					<FormSection title="Bitwise Operand B">
-						<div className="space-y-1">
-							<Label htmlFor="operand-b" className="text-xs text-muted-foreground">
-								Operand B ({BASE_LABEL[primaryBase].toLowerCase()})
-							</Label>
-							<Input
-								id="operand-b"
-								value={draftsB ?? baseFormatted(maskedB, primaryBase)}
-								placeholder={operandBPlaceholder}
-								onChange={(e) => handleOperandBChange(e.target.value)}
-								onBlur={() => setDraftsB(null)}
-								className="h-7 font-mono text-xs"
-							/>
-						</div>
+						<FormInput
+							label={`Operand B (${BASE_LABEL[primaryBase].toLowerCase()})`}
+							value={draftsB ?? baseFormatted(maskedB, primaryBase)}
+							placeholder={operandBPlaceholder}
+							onValueChange={handleOperandBChange}
+							onBlur={() => setDraftsB(null)}
+							size="compact"
+							className="font-mono"
+						/>
 						<FormSlider
 							label="Shift amount (n)"
 							value={clampedShift}


### PR DESCRIPTION
## Summary

- Replace the hand-paired `Label` + `Input` for the bitwise Operand B field with the shared `FormInput` wrapper
- Remove the now-unused `Label` import

## Changes

### Changed

- `number-base-converter`: Operand B now uses `FormInput` (size `compact`, `font-mono`); behavior preserved (`onValueChange` mirrors the previous `onChange`, `onBlur` unchanged)

### Out of scope (intentionally left raw)

- Per-base grid input and IEEE-754 float input are not `Label`+`Input` pairs (their label is a `CardTitle` / sibling caption)
- `websocket-tester` URL, `tls-inspector` host/port wire Enter-to-submit via `onKeyDown`, which `FormInput` does not expose; the port also relies on `type="number"`

## Test Plan

- [x] `bun run check` passes
- [x] `bun run lint` passes
- [x] `bun run test` passes (156 tests)
