### PR TITLE
refactor(ui): adopt CopyButton for synchronous copy actions

### DIFF
--- a/src/routes/cidr-calculator.tsx
+++ b/src/routes/cidr-calculator.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { Combine, Globe2, Network } from 'lucide-react';
 import { type CSSProperties, useMemo, useState } from 'react';
-import { toast } from 'sonner';
 
 import { ActionButton, CopyButton } from '@/lib/components/action';
 import { FormError, FormInfo, FormInput, FormMode, FormSection } from '@/lib/components/form';
@@ -135,17 +134,6 @@ function CidrCalculatorPage() {
 		return splitIntoSubnets(result.parsed, childPrefix);
 	}, [result, childPrefix]);
 
-	const handleCopyExport = async () => {
-		if (!result.ok) return;
-		const text = exportDetails(result.details, exportFormat);
-		try {
-			await navigator.clipboard.writeText(text);
-			toast.success(`${exportFormat.toUpperCase()} details copied to clipboard`);
-		} catch {
-			toast.error('Failed to copy to clipboard');
-		}
-	};
-
 	const handleLoadSampleV4 = () => setInput(SAMPLE_V4);
 	const handleLoadSampleV6 = () => setInput(SAMPLE_V6);
 	const handleClear = () => setInput('');
@@ -271,11 +259,7 @@ function CidrCalculatorPage() {
 						<>
 							<DetailsGrid details={result.details} />
 							<BitGridCard parsed={result.parsed} />
-							<ExportCard
-								details={result.details}
-								format={exportFormat}
-								onCopy={handleCopyExport}
-							/>
+							<ExportCard details={result.details} format={exportFormat} />
 							<SubnettingPanel
 								parsed={result.parsed}
 								childPrefixText={childPrefixText}
@@ -447,19 +431,20 @@ function BitGridCard({ parsed }: BitGridCardProps) {
 interface ExportCardProps {
 	readonly details: CidrDetails;
 	readonly format: ExportFormat;
-	readonly onCopy: () => void;
 }
 
-function ExportCard({ details, format, onCopy }: ExportCardProps) {
+function ExportCard({ details, format }: ExportCardProps) {
 	const text = useMemo(() => exportDetails(details, format), [details, format]);
 
 	return (
 		<Card density="compact">
 			<CardHeader className="flex flex-row items-center justify-between gap-2 pb-2">
 				<CardTitle>Export ({format.toUpperCase()})</CardTitle>
-				<Button variant="outline" size="sm" onClick={onCopy}>
-					Copy as {format.toUpperCase()}
-				</Button>
+				<CopyButton
+					text={text}
+					label={`Copy as ${format.toUpperCase()}`}
+					toastLabel={`${format.toUpperCase()} details`}
+				/>
 			</CardHeader>
 			<CardContent>
 				<pre className="overflow-x-auto rounded-md border bg-muted/30 p-2 font-mono text-2xs leading-relaxed">

--- a/src/routes/csv-tool.tsx
+++ b/src/routes/csv-tool.tsx
@@ -5,7 +5,6 @@ import {
 	ArrowDown,
 	ArrowUp,
 	ArrowUpDown,
-	ClipboardCopy,
 	ClipboardPaste,
 	FlaskConical,
 	FolderOpen,
@@ -27,6 +26,7 @@ import {
 } from 'react';
 import { toast } from 'sonner';
 
+import { CopyButton } from '@/lib/components/action';
 import { FormCheckbox, FormInput, FormMode, FormSection, FormSelect } from '@/lib/components/form';
 import { SectionLabel } from '@/lib/components/layout';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
@@ -273,17 +273,6 @@ function CsvToolPage() {
 		setIsDragOver(false);
 	};
 
-	const handleCopyOutput = async () => {
-		if (!output) return;
-		try {
-			await navigator.clipboard.writeText(output);
-			toast.success('Output copied to clipboard');
-		} catch (e) {
-			const message = e instanceof Error ? e.message : String(e);
-			toast.error('Failed to copy to clipboard', { description: message });
-		}
-	};
-
 	const handleSaveOutput = async () => {
 		if (!output) {
 			toast.error('No output to save');
@@ -432,10 +421,13 @@ function CsvToolPage() {
 
 					<FormSection title="Save">
 						<div className="flex flex-col gap-2">
-							<Button variant="outline" size="sm" onClick={handleCopyOutput} disabled={!output}>
-								<ClipboardCopy className="h-3.5 w-3.5" />
-								Copy output
-							</Button>
+							<CopyButton
+								text={output}
+								label="Copy output"
+								toastLabel="Output"
+								className="w-full justify-center"
+								disabled={!output}
+							/>
 							<Button variant="outline" size="sm" onClick={handleSaveOutput} disabled={!output}>
 								<Save className="h-3.5 w-3.5" />
 								Save as file…
@@ -483,7 +475,6 @@ function CsvToolPage() {
 				onRemoveColumn={handleRemoveColumn}
 				output={output}
 				outputFormat={prefs.outputFormat}
-				onCopyOutput={handleCopyOutput}
 				onSaveOutput={handleSaveOutput}
 				isDragOver={isDragOver}
 				onDrop={handleDrop}
@@ -529,7 +520,6 @@ interface MainPaneProps {
 	readonly onRemoveColumn: (colIndex: number) => void;
 	readonly output: string;
 	readonly outputFormat: OutputFormat;
-	readonly onCopyOutput: () => void;
 	readonly onSaveOutput: () => void;
 	readonly isDragOver: boolean;
 	readonly onDrop: (e: DragEvent<HTMLDivElement>) => void;
@@ -563,7 +553,6 @@ function MainPane({
 	onRemoveColumn,
 	output,
 	outputFormat,
-	onCopyOutput,
 	onSaveOutput,
 	isDragOver,
 	onDrop,
@@ -635,12 +624,7 @@ function MainPane({
 				</section>
 
 				<section className="flex min-h-0 flex-1 flex-col overflow-hidden">
-					<OutputPane
-						output={output}
-						outputFormat={outputFormat}
-						onCopy={onCopyOutput}
-						onSave={onSaveOutput}
-					/>
+					<OutputPane output={output} outputFormat={outputFormat} onSave={onSaveOutput} />
 				</section>
 			</div>
 		</div>
@@ -983,11 +967,10 @@ function ColumnStatsTooltip({ stats }: ColumnStatsTooltipProps) {
 interface OutputPaneProps {
 	readonly output: string;
 	readonly outputFormat: OutputFormat;
-	readonly onCopy: () => void;
 	readonly onSave: () => void;
 }
 
-function OutputPane({ output, outputFormat, onCopy, onSave }: OutputPaneProps) {
+function OutputPane({ output, outputFormat, onSave }: OutputPaneProps) {
 	const formatLabel =
 		OUTPUT_FORMAT_OPTIONS.find((opt) => opt.value === outputFormat)?.label ?? outputFormat;
 	return (
@@ -995,10 +978,7 @@ function OutputPane({ output, outputFormat, onCopy, onSave }: OutputPaneProps) {
 			<CardHeader className="flex shrink-0 flex-row items-center justify-between gap-2 border-b">
 				<CardTitle className="text-sm">Output — {formatLabel}</CardTitle>
 				<div className="flex items-center gap-1">
-					<Button variant="outline" size="sm" onClick={onCopy} disabled={!output}>
-						<ClipboardCopy className="h-3 w-3" />
-						Copy
-					</Button>
+					<CopyButton text={output} toastLabel="Output" disabled={!output} />
 					<Button variant="outline" size="sm" onClick={onSave} disabled={!output}>
 						<Save className="h-3 w-3" />
 						Save

--- a/src/routes/dns-lookup.tsx
+++ b/src/routes/dns-lookup.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { AlertCircle, Globe, Search, ShieldCheck, Terminal } from 'lucide-react';
+import { AlertCircle, Globe, Search, ShieldCheck } from 'lucide-react';
 import { useMemo, useState } from 'react';
-import { toast } from 'sonner';
 
 import { ActionButton, CopyButton } from '@/lib/components/action';
 import {
@@ -141,15 +140,6 @@ function DnsLookupPage() {
 		patch({ recordTypes: ordered });
 	};
 
-	const handleCopyDig = async () => {
-		try {
-			await navigator.clipboard.writeText(exportAsDig(effectiveRequest));
-			toast.success('dig command copied to clipboard');
-		} catch {
-			toast.error('Failed to copy to clipboard');
-		}
-	};
-
 	const handleLoadSampleDomain = () => {
 		setName(SAMPLE_DOMAIN);
 		setResult(null);
@@ -187,7 +177,7 @@ function DnsLookupPage() {
 					onTimeoutChange={(v) => patch({ timeoutMs: v })}
 					onLoadSampleDomain={handleLoadSampleDomain}
 					onLoadReverseSample={handleLoadReverseSample}
-					onCopyDig={handleCopyDig}
+					digCommand={exportAsDig(effectiveRequest)}
 					onResetOptions={reset}
 				/>
 			}
@@ -239,7 +229,7 @@ interface RailProps {
 	readonly onTimeoutChange: (value: number) => void;
 	readonly onLoadSampleDomain: () => void;
 	readonly onLoadReverseSample: () => void;
-	readonly onCopyDig: () => void;
+	readonly digCommand: string;
 	readonly onResetOptions: () => void;
 }
 
@@ -255,7 +245,7 @@ function DnsLookupRail({
 	onTimeoutChange,
 	onLoadSampleDomain,
 	onLoadReverseSample,
-	onCopyDig,
+	digCommand,
 	onResetOptions,
 }: RailProps) {
 	return (
@@ -324,10 +314,12 @@ function DnsLookupRail({
 			</FormSection>
 
 			<FormSection title="Export">
-				<Button variant="outline" size="sm" className="w-full" onClick={onCopyDig}>
-					<Terminal className="mr-1.5 h-3.5 w-3.5" />
-					Copy as dig
-				</Button>
+				<CopyButton
+					text={digCommand}
+					label="Copy as dig"
+					toastLabel="dig command"
+					className="w-full justify-center"
+				/>
 			</FormSection>
 
 			<ToolFooter

--- a/src/routes/encoding-converter.tsx
+++ b/src/routes/encoding-converter.tsx
@@ -1,10 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { open as openDialog, save as saveDialog } from '@tauri-apps/plugin-dialog';
 import { readFile, writeFile } from '@tauri-apps/plugin-fs';
-import { ClipboardCopy, FolderOpen, Languages, Loader2, Save, Trash2 } from 'lucide-react';
+import { FolderOpen, Languages, Loader2, Save, Trash2 } from 'lucide-react';
 import { useCallback, useMemo, useState, type DragEvent } from 'react';
 import { toast } from 'sonner';
 
+import { CopyButton } from '@/lib/components/action';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { Badge } from '@/lib/components/ui/badge';
@@ -201,17 +202,6 @@ function EncodingConverterPage() {
 		setIsDragOver(false);
 	};
 
-	const handleCopyBase64 = async () => {
-		if (!targetBytes) return;
-		try {
-			await navigator.clipboard.writeText(bytesToBase64(targetBytes));
-			toast.success('Base64 copied to clipboard');
-		} catch (e) {
-			const message = e instanceof Error ? e.message : String(e);
-			toast.error('Failed to copy to clipboard', { description: message });
-		}
-	};
-
 	const handleSave = async () => {
 		if (!targetBytes) return;
 		try {
@@ -356,15 +346,13 @@ function EncodingConverterPage() {
 								<Save className="h-3.5 w-3.5" />
 								Save bytes…
 							</Button>
-							<Button
-								variant="outline"
-								size="sm"
-								onClick={handleCopyBase64}
+							<CopyButton
+								text={targetBytes ? bytesToBase64(targetBytes) : ''}
+								label="Copy as base64"
+								toastLabel="Base64"
+								className="w-full justify-center"
 								disabled={!hasContent || !targetBytes}
-							>
-								<ClipboardCopy className="h-3.5 w-3.5" />
-								Copy as base64
-							</Button>
+							/>
 						</div>
 					</FormSection>
 

--- a/src/routes/folder-tree-visualizer.tsx
+++ b/src/routes/folder-tree-visualizer.tsx
@@ -3,7 +3,6 @@ import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import {
 	ChevronDown,
 	ChevronRight,
-	ClipboardCopy,
 	File as FileIcon,
 	FileCode,
 	FileText,
@@ -19,6 +18,7 @@ import {
 import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
 import { toast } from 'sonner';
 
+import { CopyButton } from '@/lib/components/action';
 import {
 	FormCheckbox,
 	FormFolderPicker,
@@ -232,26 +232,6 @@ function FolderTreeVisualizerPage() {
 		}
 	}, []);
 
-	const copyText = useCallback(async (text: string, label: string) => {
-		try {
-			await navigator.clipboard.writeText(text);
-			toast.success(`${label} copied to clipboard`);
-		} catch (e) {
-			const message = e instanceof Error ? e.message : String(e);
-			toast.error('Failed to copy to clipboard', { description: message });
-		}
-	}, []);
-
-	const handleCopyText = useCallback(() => {
-		if (!sortedRoot) return;
-		copyText(exportAsText(sortedRoot), 'tree as text').catch(() => undefined);
-	}, [sortedRoot, copyText]);
-
-	const handleCopyJson = useCallback(() => {
-		if (!sortedRoot) return;
-		copyText(exportAsJson(sortedRoot), 'tree as JSON').catch(() => undefined);
-	}, [sortedRoot, copyText]);
-
 	const hasRoot = sortedRoot !== null;
 
 	const sortOptions = useMemo(
@@ -368,14 +348,20 @@ function FolderTreeVisualizerPage() {
 
 					<FormSection title="Export">
 						<div className="flex flex-col gap-2">
-							<Button variant="outline" size="sm" onClick={handleCopyText} disabled={!hasRoot}>
-								<ClipboardCopy className="h-3.5 w-3.5" />
-								Copy as text
-							</Button>
-							<Button variant="outline" size="sm" onClick={handleCopyJson} disabled={!hasRoot}>
-								<ClipboardCopy className="h-3.5 w-3.5" />
-								Copy as JSON
-							</Button>
+							<CopyButton
+								text={sortedRoot ? exportAsText(sortedRoot) : ''}
+								label="Copy as text"
+								toastLabel="tree as text"
+								className="w-full justify-center"
+								disabled={!hasRoot}
+							/>
+							<CopyButton
+								text={sortedRoot ? exportAsJson(sortedRoot) : ''}
+								label="Copy as JSON"
+								toastLabel="tree as JSON"
+								className="w-full justify-center"
+								disabled={!hasRoot}
+							/>
 						</div>
 					</FormSection>
 

--- a/src/routes/tls-inspector.tsx
+++ b/src/routes/tls-inspector.tsx
@@ -162,16 +162,6 @@ function TlsInspectorPage() {
 		setError(null);
 	};
 
-	const handleCopyChain = async () => {
-		if (!result) return;
-		try {
-			await navigator.clipboard.writeText(buildPemBundle(result.peerChainBase64));
-			toast.success('Full chain PEM copied to clipboard');
-		} catch {
-			toast.error('Failed to copy to clipboard');
-		}
-	};
-
 	const now = useMemo(() => new Date(), [result]);
 
 	return (
@@ -242,15 +232,13 @@ function TlsInspectorPage() {
 					</FormSection>
 
 					<FormSection title="Export">
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={handleCopyChain}
+						<CopyButton
+							text={result ? buildPemBundle(result.peerChainBase64) : ''}
+							label="Copy full chain as PEM"
+							toastLabel="Full chain PEM"
+							className="w-full justify-center"
 							disabled={!result || result.peerChainBase64.length === 0}
-							className="w-full"
-						>
-							Copy full chain as PEM
-						</Button>
+						/>
 					</FormSection>
 
 					<ToolFooter


### PR DESCRIPTION
## Summary

- Replace hand-rolled copy buttons (`Button` + `navigator.clipboard` + `toast`) with the shared `CopyButton` across six routes where the copied text is computed synchronously at render
- Net result: ~74 fewer lines and removal of `onCopy` callback plumbing across four component boundaries

## Changes

### Changed

- `folder-tree-visualizer`: the two Export buttons (text / JSON) now use `CopyButton`; drops the `copyText` helper and both handlers
- `cidr-calculator`: `ExportCard` copies via `CopyButton`; `onCopy` removed from `ExportCardProps`
- `tls-inspector`: full-chain PEM export now uses `CopyButton`
- `dns-lookup`: dig-command export now uses `CopyButton`; `DnsLookupRail` takes a `digCommand` string instead of an `onCopyDig` callback; `Terminal` / `toast` imports dropped
- `encoding-converter`: base64 export now uses `CopyButton`
- `csv-tool`: rail and output-pane copy buttons now use `CopyButton`; `onCopyOutput` / `onCopy` plumbing removed from `MainPane` and `OutputPane`

### Out of scope (intentionally left)

- `url-encoder`, `sql-formatter`, `base64-encoder`: output copy routes through the `CodeEditor` internal toolbar callback, not a swappable route-level button
- `file-inspector`, `hash-generator`, `markdown-editor`: copy text is produced asynchronously (Tauri / hashing), so the static `CopyButton` `text` prop does not fit

## Test Plan

- [x] `bun run check` passes
- [x] `bun run lint` passes
- [x] `bun run test` passes (156 tests)
