### PR TITLE
feat(ui): wire Cmd+Enter to the scan and convert actions

### DIFF
--- a/src/routes/image-converter.tsx
+++ b/src/routes/image-converter.tsx
@@ -255,6 +255,10 @@ function ImageConverterPage() {
 		<ToolShell
 			showRail={showRail}
 			onShowRailChange={setShowRail}
+			primaryAction={{
+				run: () => handleConvert().catch(() => undefined),
+				canRun: Boolean(source) && prefs.targets.length > 0 && !converting,
+			}}
 			statusContent={
 				<>
 					<StatItem label="Source" value={source ? `${source.width}×${source.height}` : '—'} />
@@ -442,6 +446,7 @@ function ImageConverterPage() {
 								label={converting ? 'Converting…' : 'Convert'}
 								icon={Sparkles}
 								disabled={!source || prefs.targets.length === 0 || converting}
+								shortcutHint
 								onClick={() => {
 									handleConvert().catch(() => undefined);
 								}}

--- a/src/routes/wifi-analyzer.tsx
+++ b/src/routes/wifi-analyzer.tsx
@@ -133,6 +133,7 @@ function WifiAnalyzerPage() {
 		<ToolShell
 			showRail={showRail}
 			onShowRailChange={setShowRail}
+			primaryAction={{ run: () => runScan().catch(() => undefined), canRun: !scanning }}
 			statusContent={
 				<>
 					<StatItem label="Networks" value={filtered.length.toLocaleString()} />
@@ -158,6 +159,7 @@ function WifiAnalyzerPage() {
 								icon={scanning ? Loader2 : Play}
 								loading={scanning}
 								loadingLabel="Scanning…"
+								shortcutHint
 								onClick={() => {
 									runScan().catch(() => undefined);
 								}}


### PR DESCRIPTION
## Summary

- Wire `ToolShell.primaryAction` on two run-driven routes so the primary action fires on Cmd/Ctrl+Enter
- Mark the corresponding `ActionButton` with `shortcutHint` to render the `⏎` badge without registering a duplicate window listener

## Changes

### Changed

- `wifi-analyzer`: `primaryAction` runs `runScan()` when `!scanning`; Scan button gains `shortcutHint`
- `image-converter`: `primaryAction` runs `handleConvert()` when a source image and at least one target format are present and not converting; Convert button gains `shortcutHint`

## Test Plan

- [x] `bun run check` / `lint` / `test` (156) pass
- [x] Cmd/Ctrl+Enter triggers scan / convert; disabled while running and IME-safe (shell-owned listener)
