### PR TITLE
feat(ui): wire Cmd+Enter to the network run actions

### DIFF
--- a/src/routes/dns-lookup.tsx
+++ b/src/routes/dns-lookup.tsx
@@ -161,6 +161,10 @@ function DnsLookupPage() {
 			error={error ?? undefined}
 			showRail={showRail}
 			onShowRailChange={setShowRail}
+			primaryAction={{
+				run: () => handleLookup().catch(() => undefined),
+				canRun: !loading && name.trim().length > 0,
+			}}
 			statusContent={
 				<DnsLookupStatus result={result} totalRecords={totalRecords} errorCount={errorCount} />
 			}

--- a/src/routes/rest-client.tsx
+++ b/src/routes/rest-client.tsx
@@ -212,6 +212,7 @@ function RestClientPage() {
 		<ToolShell
 			valid={error ? false : response ? true : null}
 			error={error ?? undefined}
+			primaryAction={{ run: () => handleSend().catch(() => undefined), canRun: canSend }}
 			rail={rail}
 			statusContent={statusContent}
 		>

--- a/src/routes/tls-inspector.tsx
+++ b/src/routes/tls-inspector.tsx
@@ -168,6 +168,7 @@ function TlsInspectorPage() {
 		<ToolShell
 			showRail={showRail}
 			onShowRailChange={setShowRail}
+			primaryAction={{ run: () => handleRun().catch(() => undefined), canRun }}
 			statusContent={
 				<>
 					<StatItem label="Version" value={result?.negotiatedVersion ?? '—'} />


### PR DESCRIPTION
## Summary

- Wire `ToolShell.primaryAction` on three run-driven network tools so the primary action fires on Cmd/Ctrl+Enter, matching the generator tools
- The shell owns the keyboard listener (IME-safe, gated by `canRun`); the existing buttons remain click-driven

## Changes

### Changed

- `tls-inspector`: `primaryAction` runs `handleRun()` when a host is present and not already running (`canRun`)
- `dns-lookup`: `primaryAction` runs `handleLookup()` when a name is present and not loading
- `rest-client`: `primaryAction` runs `handleSend()` when `canSend` (URL present, not sending)

## Test Plan

- [x] `bun run check` / `lint` / `test` (156) pass
- [x] Cmd/Ctrl+Enter triggers inspect / lookup / send; no-ops while running or when input is empty
