### PR TITLE
refactor(ui): finish inline error-display normalization

### DIFF
--- a/src/routes/dns-lookup.tsx
+++ b/src/routes/dns-lookup.tsx
@@ -158,7 +158,6 @@ function DnsLookupPage() {
 	return (
 		<ToolShell
 			valid={validity}
-			error={error ?? undefined}
 			showRail={showRail}
 			onShowRailChange={setShowRail}
 			primaryAction={{

--- a/src/routes/jwt-decoder.tsx
+++ b/src/routes/jwt-decoder.tsx
@@ -7,7 +7,7 @@ import { CodeEditor } from '@/lib/components/editor';
 import { FormInfo, FormSection } from '@/lib/components/form';
 import { SectionHeader, SplitPane } from '@/lib/components/layout';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
-import { EmptyState, LiveStatusRegion } from '@/lib/components/status';
+import { EmptyState, ErrorDisplay, LiveStatusRegion } from '@/lib/components/status';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { IconTooltip } from '@/lib/components/ui/icon-tooltip';
 import { CodeBlock } from '@/lib/components/ui/code-block';
@@ -192,13 +192,10 @@ function JwtDecoderPage() {
 						{decoded ? (
 							<LiveStatusRegion className="flex-1 space-y-4 overflow-auto p-4">
 								{decoded.isExpired ? (
-									<div className="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
-										<AlertTriangle className="h-4 w-4" />
-										<span>
-											This token has expired
-											{decoded.expiresAt ? ` on ${formatDate(decoded.expiresAt)}` : ''}
-										</span>
-									</div>
+									<ErrorDisplay
+										variant="banner"
+										message={`This token has expired${decoded.expiresAt ? ` on ${formatDate(decoded.expiresAt)}` : ''}`}
+									/>
 								) : null}
 
 								<Card density="compact">


### PR DESCRIPTION
## Summary

- Resolve the dns-lookup double-report so a lookup failure surfaces once, not twice
- Route the last hand-built destructive banner (jwt-decoder expired token) through the shared `ErrorDisplay`

## Changes

### Changed

- `dns-lookup`: drop the `ToolShell` `error` prop; the failure is already shown by the in-card `ErrorDisplay` banner, and the status-bar validity badge is still driven by `valid`. Mirrors the wifi-analyzer fix in #399
- `jwt-decoder`: the expired-token banner now renders `ErrorDisplay variant="banner"` (default AlertTriangle icon, same destructive styling)

## Test Plan

- [x] `bun run check` / `lint` / `test` (156) pass
- [x] dns-lookup error shown once (in-card banner); jwt expired banner unchanged visually
