### PR TITLE
refactor(ui): adopt EmptyOutputPane for formatter output panes

### DIFF
--- a/src/routes/base64-encoder.tsx
+++ b/src/routes/base64-encoder.tsx
@@ -12,9 +12,9 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SectionHeader, SplitPane } from '@/lib/components/layout';
+import { SplitPane } from '@/lib/components/layout';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
-import { DetectedInfo, EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { DetectedInfo, EmptyOutputPane, StatItem } from '@/lib/components/status';
 import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
 import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import {
@@ -333,21 +333,16 @@ function Base64EncoderPage() {
 				}
 				right={
 					!input.trim() ? (
-						<div className="flex h-full flex-col overflow-hidden">
-							<SectionHeader title={mode === 'encode' ? 'Base64 Output' : 'Decoded Text'} />
-							<div className="flex-1">
-								<EmbeddedEmptyState
-									icon={Code2}
-									title={mode === 'encode' ? 'Enter text to encode' : 'Paste Base64 to decode'}
-									description={
-										mode === 'encode'
-											? 'The Base64-encoded result will appear here.'
-											: 'The decoded plain text will appear here.'
-									}
-									fillHeight
-								/>
-							</div>
-						</div>
+						<EmptyOutputPane
+							headerTitle={mode === 'encode' ? 'Base64 Output' : 'Decoded Text'}
+							icon={Code2}
+							title={mode === 'encode' ? 'Enter text to encode' : 'Paste Base64 to decode'}
+							description={
+								mode === 'encode'
+									? 'The Base64-encoded result will appear here.'
+									: 'The decoded plain text will appear here.'
+							}
+						/>
 					) : (
 						<CodeEditor
 							title={mode === 'encode' ? 'Base64 Output' : 'Decoded Text'}

--- a/src/routes/sql-formatter.tsx
+++ b/src/routes/sql-formatter.tsx
@@ -13,9 +13,9 @@ import {
 	FormSection,
 	FormSelect,
 } from '@/lib/components/form';
-import { SectionHeader, SplitPane } from '@/lib/components/layout';
+import { SplitPane } from '@/lib/components/layout';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
-import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { EmptyOutputPane, StatItem } from '@/lib/components/status';
 import { useDocumentTitle } from '@/lib/hooks';
 import { usePersistedRail } from '@/lib/stores';
 import {
@@ -298,17 +298,12 @@ function SqlFormatterPage() {
 				}
 				right={
 					!input.trim() ? (
-						<div className="flex h-full flex-col overflow-hidden">
-							<SectionHeader title="Output" />
-							<div className="flex-1">
-								<EmbeddedEmptyState
-									icon={Database}
-									title="Enter SQL to format"
-									description="The formatted (or minified) statement will appear here."
-									fillHeight
-								/>
-							</div>
-						</div>
+						<EmptyOutputPane
+							headerTitle="Output"
+							icon={Database}
+							title="Enter SQL to format"
+							description="The formatted (or minified) statement will appear here."
+						/>
 					) : (
 						<CodeEditor
 							title="Output"


### PR DESCRIPTION
## Summary

- Adopt the previously-unused `EmptyOutputPane` primitive in the two routes whose output-pane empty state matches its exact structure

## Changes

### Changed

- `base64-encoder`, `sql-formatter`: replace the hand-rolled `flex h-full flex-col overflow-hidden` wrapper + `SectionHeader` + `flex-1` + `EmbeddedEmptyState fillHeight` with a single `EmptyOutputPane({ headerTitle, icon, title, description })` call; drop the now-unused `SectionHeader` / `EmbeddedEmptyState` imports

## Test Plan

- [x] `bun run check` / `lint` / `test` (156) pass
- [x] Output-pane empty state renders identically (EmptyOutputPane wraps the same SectionHeader + EmbeddedEmptyState fillHeight)
