### PR TITLE
fix(a11y): give icon-only CopyButton an accessible name

### DIFF
--- a/src/lib/components/action/copy-button.tsx
+++ b/src/lib/components/action/copy-button.tsx
@@ -48,7 +48,7 @@ export function CopyButton({
 			onClick={handleCopy}
 		>
 			<Copy className={size === 'icon' ? 'h-4 w-4' : 'h-3 w-3'} />
-			{showLabel && size !== 'icon' ? label : null}
+			{showLabel && size !== 'icon' ? label : <span className="sr-only">{label}</span>}
 		</Button>
 	);
 }


### PR DESCRIPTION
## Summary

- Give icon-only `CopyButton` instances an accessible name so screen readers announce the action

## Changes

### Changed

- `copy-button.tsx`: when the visible label is suppressed (`size="icon"` or `showLabel={false}`), render an `sr-only` `<span>{label}</span>` instead of nothing. Previously those buttons exposed only the Copy glyph with no accessible name

This is a primitive-level fix, so every icon-only CopyButton caller (per-row copy buttons, generated lists, gpg-key-generator) gains an accessible name without per-route changes.

## Test Plan

- [x] `bun run check` / `lint` / `test` (156) pass
- [x] Purely additive (sr-only span); no visual change to any caller
