### PR TITLE
refactor(ui): reciprocate related-tool links for three pairs

### DIFF
--- a/src/routes/base64-encoder.tsx
+++ b/src/routes/base64-encoder.tsx
@@ -299,6 +299,7 @@ function Base64EncoderPage() {
 							{ id: 'url-encoder', reason: 'Percent-encode text for URLs' },
 							{ id: 'jwt-decoder', reason: 'Decode Base64URL-encoded JWT segments' },
 							{ id: 'hash-generator', reason: 'Hash text or files' },
+							{ id: 'escape-tool', reason: 'Escape text in JSON/HTML' },
 						]}
 						aboutText={
 							<>

--- a/src/routes/file-inspector.tsx
+++ b/src/routes/file-inspector.tsx
@@ -456,6 +456,7 @@ function FileInspectorPage() {
 							{ id: 'mime-types', reason: "Look up an extension's MIME" },
 							{ id: 'hash-generator', reason: 'Hash arbitrary text' },
 							{ id: 'x509-decoder', reason: "Decode if it's a cert" },
+							{ id: 'hex-editor', reason: 'View raw bytes' },
 						]}
 						aboutText={
 							<>

--- a/src/routes/ip-converter.tsx
+++ b/src/routes/ip-converter.tsx
@@ -215,6 +215,7 @@ function IpConverterRail({
 				relatedItems={[
 					{ id: 'cidr-calculator', reason: 'Compute subnets and ranges' },
 					{ id: 'dns-lookup', reason: 'Resolve a name to an IP' },
+					{ id: 'mac-lookup', reason: 'Look up MAC vendors' },
 				]}
 				aboutText={
 					<ul className="list-inside list-disc space-y-0.5">


### PR DESCRIPTION
## Summary

- Make three strong one-way related-tool links bidirectional so navigation between paired tools works in both directions

## Changes

### Changed

- `base64-encoder`: add `escape-tool` (escape-tool already links back)
- `file-inspector`: add `hex-editor` (hex-editor already links back)
- `ip-converter`: add `mac-lookup` (mac-lookup already links back)

Each addition keeps the route within the four-item footer cap; reasons match the existing concise style.

## Test Plan

- [x] `bun run check` / `lint` / `test` (156) pass
- [x] All added ids are valid `PAGES` ids
