### PR TITLE
refactor(ui): compact the network-interfaces list to two lines

### DIFF
--- a/src/routes/network-interfaces.tsx
+++ b/src/routes/network-interfaces.tsx
@@ -316,41 +316,43 @@ function NetworkInterfacesPage() {
 													{iface.operState}
 												</span>
 											</div>
-											<div className="flex items-center gap-2">
-												{primaryIpv4 ? (
-													<span className="font-mono text-xs text-muted-foreground">
-														{primaryIpv4}
-													</span>
-												) : (
-													<span className="text-xs text-muted-foreground/50">(no address)</span>
-												)}
-												{iface.ipv6Addresses.length > 0 ? (
-													<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-														IPv6 ×{iface.ipv6Addresses.length}
-													</span>
-												) : null}
-											</div>
-											{iface.macAddress ? (
-												<span className="truncate font-mono text-xs text-muted-foreground/70">
-													{iface.macAddress}
-												</span>
-											) : null}
-											{hasStats(iface) ? (
-												<div className="mt-0.5 flex items-center gap-3 text-xs text-muted-foreground/70">
-													{iface.rxBytes !== null ? (
-														<span className="flex items-center gap-0.5">
-															<ArrowDown className="h-2.5 w-2.5 text-success" />
-															{formatBytes(iface.rxBytes)}
+											<div className="flex items-center gap-2 text-xs">
+												<div className="min-w-0 flex-1 truncate text-muted-foreground">
+													{primaryIpv4 ? (
+														<span className="font-mono">{primaryIpv4}</span>
+													) : (
+														<span className="text-muted-foreground/50">(no address)</span>
+													)}
+													{iface.ipv6Addresses.length > 0 ? (
+														<span className="text-muted-foreground/70">
+															{' '}
+															· IPv6×{iface.ipv6Addresses.length}
 														</span>
 													) : null}
-													{iface.txBytes !== null ? (
-														<span className="flex items-center gap-0.5">
-															<ArrowUp className="h-2.5 w-2.5 text-info" />
-															{formatBytes(iface.txBytes)}
+													{iface.macAddress ? (
+														<span className="font-mono text-muted-foreground/70">
+															{' '}
+															· …{iface.macAddress.split(':').slice(-2).join(':')}
 														</span>
 													) : null}
 												</div>
-											) : null}
+												{hasStats(iface) ? (
+													<div className="flex shrink-0 items-center gap-2 text-muted-foreground/70">
+														{iface.rxBytes !== null ? (
+															<span className="flex items-center gap-0.5">
+																<ArrowDown className="h-2.5 w-2.5 text-success" />
+																{formatBytes(iface.rxBytes)}
+															</span>
+														) : null}
+														{iface.txBytes !== null ? (
+															<span className="flex items-center gap-0.5">
+																<ArrowUp className="h-2.5 w-2.5 text-info" />
+																{formatBytes(iface.txBytes)}
+															</span>
+														) : null}
+													</div>
+												) : null}
+											</div>
 										</div>
 									</ListItemButton>
 								);


### PR DESCRIPTION
## Summary

- Compact the network-interfaces list rows from up to four stacked lines into two, while keeping every field

## Changes

### Changed

- `network-interfaces`: each interface list item now renders two lines — line 1 keeps identity + status (name, status dot, DEFAULT, operState badge on the right); line 2 is a single meta line (primary IPv4 · IPv6 count · MAC tail) on the left with RX/TX throughput pinned to the right
- All information is retained (IPv4, IPv6 count, MAC, RX/TX, operState, DEFAULT); MAC is shortened to its last two octets since the full value is in the detail pane
- Row height roughly halves, so more interfaces are visible and their status/throughput align vertically for at-a-glance comparison

## Test Plan

- [x] `bun run check` / `lint` / `test` (156) pass
- [x] Verified live via HMR: list renders two-line rows; selection, keyboard nav, and the detail pane are unaffected
