### PR TITLE
fix(duplicate-finder): run the scan off the main thread

### DIFF
--- a/src-tauri/src/duplicate_finder.rs
+++ b/src-tauri/src/duplicate_finder.rs
@@ -444,7 +444,10 @@ fn collect_full_buckets(
 /// Returns a stringified error when the root path cannot be read,
 /// globs fail to compile, or the file count exceeds
 /// [`MAX_FILES_SCANNED`].
-#[tauri::command]
+// Runs on a worker thread (not the webview's main/event-loop thread) so the
+// blocking directory walk and per-file hashing never freeze the UI. Progress
+// is streamed to the frontend via the `duplicate-scan-progress` event.
+#[tauri::command(async)]
 pub fn duplicate_scan(app: tauri::AppHandle, req: ScanRequest) -> Result<ScanResult, String> {
     let started = Instant::now();
 


### PR DESCRIPTION
## Summary

- Run the duplicate-finder scan off the main thread so it no longer freezes the UI

## Root cause

`duplicate_scan` was a synchronous `#[tauri::command]`, which Tauri executes on the **main thread**. A large directory scan (recursive walk + 3-stage per-file hashing) blocked the webview event loop for the entire scan, freezing the window and preventing even the progress bar from animating.

## Changes

### Fixed

- `duplicate_scan`: annotate with `#[tauri::command(async)]` so Tauri runs the blocking work on a worker thread. The UI stays responsive and the throttled `duplicate-scan-progress` events render in real time. The body is unchanged.

## Test Plan

- [x] `cargo clippy --all-targets -- -W clippy::all` clean (only the pre-existing `block` dep future-incompat warning)
- [x] Verified live (rebuilt dev app): scanning a large folder keeps the UI responsive and animates progress

## Follow-up

Cooperative cancellation (Cancel button + token registry) lands in subsequent PRs; this PR is the minimal freeze fix.
