### PR TITLE
feat(duplicate-finder): make the scan cancellable

### DIFF
--- a/src-tauri/src/cancellation.rs
+++ b/src-tauri/src/cancellation.rs
@@ -1,0 +1,95 @@
+//! Shared cooperative-cancellation registry for long-running commands.
+//!
+//! A heavy async command registers an [`Arc<CancellationToken>`] under a
+//! frontend-supplied operation id, then checks `token.is_cancelled()` at its
+//! hot-loop boundaries and bails out promptly. The frontend signals
+//! cancellation through the generic `cancel_op` command, which removes the
+//! token from the registry and cancels it.
+//!
+//! This mirrors the proven `network::NetworkScannerState` registry so the two
+//! can be unified later. Cancellation is cooperative: Rust threads cannot be
+//! force-killed, so a cancelled operation stops at its next check point rather
+//! than instantly.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use tokio_util::sync::CancellationToken;
+
+/// Registry of in-flight cancellable operations, keyed by operation id.
+#[derive(Default)]
+pub struct OperationRegistry {
+    tokens: Mutex<HashMap<String, Arc<CancellationToken>>>,
+}
+
+impl OperationRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a cancellation token for an operation id.
+    pub fn register(&self, operation_id: String, token: Arc<CancellationToken>) {
+        self.tokens
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(operation_id, token);
+    }
+
+    /// Cancel an active operation by signalling and removing its token.
+    ///
+    /// Returns `true` if a matching operation was found.
+    pub fn cancel(&self, operation_id: &str) -> bool {
+        let removed = self
+            .tokens
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(operation_id);
+        if let Some(token) = &removed {
+            token.cancel();
+        }
+        removed.is_some()
+    }
+
+    /// Remove a completed operation without cancelling it.
+    pub fn remove(&self, operation_id: &str) {
+        self.tokens
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(operation_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cancel_signals_the_registered_token() {
+        let registry = OperationRegistry::new();
+        let token = Arc::new(CancellationToken::new());
+        registry.register("op-1".to_string(), token.clone());
+
+        assert!(!token.is_cancelled());
+        assert!(registry.cancel("op-1"));
+        assert!(token.is_cancelled());
+    }
+
+    #[test]
+    fn cancel_unknown_operation_returns_false() {
+        let registry = OperationRegistry::new();
+        assert!(!registry.cancel("missing"));
+    }
+
+    #[test]
+    fn remove_drops_the_token_without_cancelling() {
+        let registry = OperationRegistry::new();
+        let token = Arc::new(CancellationToken::new());
+        registry.register("op-2".to_string(), token.clone());
+
+        registry.remove("op-2");
+        assert!(!token.is_cancelled());
+        // The token is gone, so a later cancel finds nothing.
+        assert!(!registry.cancel("op-2"));
+    }
+}

--- a/src-tauri/src/duplicate_finder.rs
+++ b/src-tauri/src/duplicate_finder.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use blake3::Hasher as Blake3Hasher;
@@ -27,6 +28,7 @@ use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tauri::Emitter;
+use tokio_util::sync::CancellationToken;
 use walkdir::WalkDir;
 
 /// Bytes hashed from the head of a file during the partial-hash phase.
@@ -263,8 +265,8 @@ fn emit_progress(app: &tauri::AppHandle, payload: &ScanProgress) {
 /// total number of files inspected post-filter.
 fn collect_size_buckets(
     app: &tauri::AppHandle,
+    token: &CancellationToken,
     root: &Path,
-    root_label: &str,
     includes: &GlobSet,
     excludes: &GlobSet,
     min_size: u64,
@@ -278,13 +280,16 @@ fn collect_size_buckets(
         app,
         &ScanProgress {
             phase: "scanning".to_string(),
-            current: root_label.to_string(),
+            current: root.display().to_string(),
             done: 0,
             total: 0,
         },
     );
 
     for entry in WalkDir::new(root).follow_links(false) {
+        if token.is_cancelled() {
+            return Err("Operation cancelled".to_string());
+        }
         let Ok(entry) = entry else { continue };
 
         let path = entry.path();
@@ -343,15 +348,19 @@ fn collect_size_buckets(
 /// `(size, partial-hash)`.
 fn collect_partial_buckets(
     app: &tauri::AppHandle,
+    token: &CancellationToken,
     candidates: Vec<SizeBucket>,
     algorithm: &str,
-) -> Vec<PartialBucket> {
+) -> Result<Vec<PartialBucket>, String> {
     let mut partial: HashMap<(u64, String), Vec<Candidate>> = HashMap::new();
     let partial_total: u64 = candidates.iter().map(|(_, v)| v.len() as u64).sum();
     let mut partial_done: u64 = 0;
 
     for (size, files) in candidates {
         for (path, modified_ms) in files {
+            if token.is_cancelled() {
+                return Err("Operation cancelled".to_string());
+            }
             partial_done += 1;
             if partial_done.is_multiple_of(PARTIAL_PROGRESS_INTERVAL)
                 || partial_done == partial_total
@@ -375,10 +384,10 @@ fn collect_partial_buckets(
         }
     }
 
-    partial
+    Ok(partial
         .into_iter()
         .filter(|(_, files)| files.len() > 1)
-        .collect()
+        .collect())
 }
 
 /// Phase 3: full-hash every survivor of phase 2 and bucket by
@@ -387,9 +396,10 @@ fn collect_partial_buckets(
 /// already covers the entire content.
 fn collect_full_buckets(
     app: &tauri::AppHandle,
+    token: &CancellationToken,
     candidates: Vec<PartialBucket>,
     algorithm: &str,
-) -> HashMap<(u64, String), Vec<DuplicateEntry>> {
+) -> Result<HashMap<(u64, String), Vec<DuplicateEntry>>, String> {
     let mut groups_map: HashMap<(u64, String), Vec<DuplicateEntry>> = HashMap::new();
     let full_total: u64 = candidates.iter().map(|(_, v)| v.len() as u64).sum();
     let mut full_done: u64 = 0;
@@ -409,6 +419,9 @@ fn collect_full_buckets(
         }
 
         for (path, modified_ms) in files {
+            if token.is_cancelled() {
+                return Err("Operation cancelled".to_string());
+            }
             full_done += 1;
             if full_done.is_multiple_of(FULL_PROGRESS_INTERVAL) || full_done == full_total {
                 emit_progress(
@@ -434,7 +447,7 @@ fn collect_full_buckets(
         }
     }
 
-    groups_map
+    Ok(groups_map)
 }
 
 /// Scan `req.root` for duplicate files.
@@ -448,7 +461,29 @@ fn collect_full_buckets(
 // blocking directory walk and per-file hashing never freeze the UI. Progress
 // is streamed to the frontend via the `duplicate-scan-progress` event.
 #[tauri::command(async)]
-pub fn duplicate_scan(app: tauri::AppHandle, req: ScanRequest) -> Result<ScanResult, String> {
+pub fn duplicate_scan(
+    app: tauri::AppHandle,
+    op_id: String,
+    req: ScanRequest,
+    state: tauri::State<'_, crate::cancellation::OperationRegistry>,
+) -> Result<ScanResult, String> {
+    let token = Arc::new(CancellationToken::new());
+    state.register(op_id.clone(), token.clone());
+
+    // Always unregister afterwards so the registry never leaks tokens, whether
+    // the scan finishes, errors, or is cancelled.
+    let result = run_duplicate_scan(app, &token, &req);
+    state.remove(&op_id);
+    result
+}
+
+/// Run the three-phase scan, checking `token` at loop boundaries so the work
+/// can be cancelled cooperatively (the scan stops at its next check point).
+fn run_duplicate_scan(
+    app: tauri::AppHandle,
+    token: &CancellationToken,
+    req: &ScanRequest,
+) -> Result<ScanResult, String> {
     let started = Instant::now();
 
     let root = PathBuf::from(&req.root);
@@ -468,16 +503,16 @@ pub fn duplicate_scan(app: tauri::AppHandle, req: ScanRequest) -> Result<ScanRes
 
     let (size_buckets, total_files) = collect_size_buckets(
         &app,
+        token,
         &root,
-        &req.root,
         &includes,
         &excludes,
         req.min_size,
         req.max_size,
     )?;
 
-    let partial_buckets = collect_partial_buckets(&app, size_buckets, algorithm);
-    let groups_map = collect_full_buckets(&app, partial_buckets, algorithm);
+    let partial_buckets = collect_partial_buckets(&app, token, size_buckets, algorithm)?;
+    let groups_map = collect_full_buckets(&app, token, partial_buckets, algorithm)?;
 
     let mut groups: Vec<DuplicateGroup> = groups_map
         .into_iter()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,6 +48,7 @@
 
 mod archive_inspect;
 mod ast;
+mod cancellation;
 mod dns_lookup;
 mod drive_info;
 mod duplicate_finder;
@@ -283,6 +284,13 @@ fn cancel_network_scan(scan_id: String, state: tauri::State<'_, NetworkScannerSt
     state.cancel(&scan_id)
 }
 
+/// Cancel any cancellable operation registered in the shared
+/// [`cancellation::OperationRegistry`] by its operation id.
+#[tauri::command]
+fn cancel_op(op_id: String, state: tauri::State<'_, cancellation::OperationRegistry>) -> bool {
+    state.cancel(&op_id)
+}
+
 /// Get comprehensive network interface information.
 #[tauri::command]
 fn get_detailed_network_interfaces() -> Vec<serde_json::Value> {
@@ -466,6 +474,7 @@ pub fn run() {
         .manage(websocket::WebSocketState::new())
         .manage(webhook::WebhookState::new())
         .manage(file_watch::FileWatchState::new())
+        .manage(cancellation::OperationRegistry::new())
         .setup(setup_app)
         .invoke_handler(tauri::generate_handler![
             greet,
@@ -479,6 +488,7 @@ pub fn run() {
             check_cli_availability,
             start_network_scan,
             cancel_network_scan,
+            cancel_op,
             get_detailed_network_interfaces,
             get_local_network_interfaces,
             discover_mdns_services,

--- a/src/lib/services/duplicate-finder.ts
+++ b/src/lib/services/duplicate-finder.ts
@@ -54,8 +54,16 @@ export interface ScanProgress {
  * already lines up with our TypeScript interfaces, so we hand the
  * payload straight through.
  */
-export const scanForDuplicates = (req: ScanRequest): Promise<ScanResult> =>
-	invoke<ScanResult>('duplicate_scan', { req });
+export const scanForDuplicates = (opId: string, req: ScanRequest): Promise<ScanResult> =>
+	invoke<ScanResult>('duplicate_scan', { opId, req });
+
+/**
+ * Request cancellation of an in-flight scan by its operation id. Returns true
+ * when a matching operation was found and signalled. Cancellation is
+ * cooperative: the scan stops at its next check point rather than instantly.
+ */
+export const cancelScan = (opId: string): Promise<boolean> =>
+	invoke<boolean>('cancel_op', { opId });
 
 /**
  * Delete the given files. Returns the total number of bytes freed.

--- a/src/routes/duplicate-finder.tsx
+++ b/src/routes/duplicate-finder.tsx
@@ -26,6 +26,7 @@ import {
 	onScanProgress,
 	pickKeeper,
 	replaceWithLink,
+	cancelScan,
 	scanForDuplicates,
 	selectDeletablePaths,
 	type DuplicateEntry,
@@ -175,6 +176,7 @@ function DuplicateFinderPage() {
 	const [root, setRoot] = useState<string | null>(null);
 	const [result, setResult] = useState<ScanResult | null>(null);
 	const [scanning, setScanning] = useState(false);
+	const [cancelling, setCancelling] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [progress, setProgress] = useState<ScanProgress | null>(null);
 	const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
@@ -198,6 +200,7 @@ function DuplicateFinderPage() {
 	// unlisten function is captured in a ref so it remains stable across
 	// renders.
 	const unlistenRef = useRef<(() => void) | null>(null);
+	const scanOpIdRef = useRef<string | null>(null);
 	useEffect(() => {
 		let cancelled = false;
 		onScanProgress((p) => {
@@ -237,13 +240,16 @@ function DuplicateFinderPage() {
 			toast.error('Pick a folder first');
 			return;
 		}
+		const opId = crypto.randomUUID();
+		scanOpIdRef.current = opId;
 		setScanning(true);
+		setCancelling(false);
 		setError(null);
 		setResult(null);
 		setSelected(new Set());
 		setProgress({ phase: 'scanning', current: root, done: 0, total: 0 });
 		try {
-			const next = await scanForDuplicates({
+			const next = await scanForDuplicates(opId, {
 				root,
 				includeGlobs: splitPatterns(prefs.includeGlob),
 				excludeGlobs: splitPatterns(prefs.excludeGlob),
@@ -266,13 +272,26 @@ function DuplicateFinderPage() {
 			}
 		} catch (e) {
 			const message = e instanceof Error ? e.message : String(e);
-			setError(message);
-			toast.error('Scan failed', { description: message });
+			if (message.includes('cancelled')) {
+				toast.info('Scan cancelled');
+			} else {
+				setError(message);
+				toast.error('Scan failed', { description: message });
+			}
 		} finally {
+			scanOpIdRef.current = null;
 			setScanning(false);
+			setCancelling(false);
 			setProgress(null);
 		}
 	}, [root, prefs.includeGlob, prefs.excludeGlob, prefs.algorithm, minSize, maxSize]);
+
+	const handleCancel = useCallback(() => {
+		const opId = scanOpIdRef.current;
+		if (!opId) return;
+		setCancelling(true);
+		cancelScan(opId).catch(() => undefined);
+	}, []);
 
 	const togglePath = useCallback((path: string) => {
 		setSelected((prev) => {
@@ -431,6 +450,12 @@ function DuplicateFinderPage() {
 								)}
 								{scanning ? 'Scanning…' : 'Scan'}
 							</Button>
+							{scanning ? (
+								<Button variant="outline" size="sm" onClick={handleCancel} disabled={cancelling}>
+									<Square className="h-3.5 w-3.5" />
+									{cancelling ? 'Cancelling…' : 'Cancel'}
+								</Button>
+							) : null}
 							{result ? (
 								<Button variant="outline" size="sm" onClick={handleClear} disabled={scanning}>
 									<Square className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary

- Add a shared cooperative-cancellation system and make the duplicate-finder scan cancellable with a Cancel button

## Changes

### Added

- `src-tauri/src/cancellation.rs`: `OperationRegistry` — a registry of `Arc<CancellationToken>` keyed by an operation id (`register` / `cancel` / `remove`), mirroring the proven `NetworkScannerState` pattern. Unit-tested.
- `cancel_op(opId)` command in `lib.rs`, wired via `Builder.manage(OperationRegistry::new())`. Generic, reusable by every future cancellable op.

### Changed

- `duplicate_scan`: takes an `opId`, registers a token, and checks it at each phase's loop boundary (size walk, partial hash, full hash), returning promptly when cancelled. The registry entry is always removed afterwards (success, error, or cancel) so tokens never leak. The scan body was extracted into `run_duplicate_scan` so the wrapper owns register/remove.
- Frontend (`duplicate-finder` service + route): generate an `opId` (`crypto.randomUUID()`) per scan, pass it through, and show a **Cancel** button while scanning that calls `cancel_op`. A cancelled scan surfaces a neutral "Scan cancelled" toast rather than an error.

## Notes

Cancellation is **cooperative** — Rust threads cannot be force-killed, so the scan stops at its next loop-boundary check (sub-second for the directory walk; between files during hashing). This is the same registry/token pattern used by the wifi and network scanners, and is the foundation the remaining heavy ops will adopt.

## Test Plan

- [x] `cargo clippy --all-targets -- -W clippy::all` clean
- [x] `cargo test --lib` — 241 passed (incl. 3 new `cancellation` tests)
- [x] `bun run check` / `lint` / `test` (156) pass
- [ ] Manual: scan a large folder, click Cancel mid-scan, confirm it stops and returns control (verify after restart)
