### PR TITLE
feat(folder-tree): make folder scans cancellable

### DIFF
--- a/src-tauri/src/drive_info.rs
+++ b/src-tauri/src/drive_info.rs
@@ -198,7 +198,10 @@ fn collect_children(root: &Path) -> Result<Vec<FolderSizeEntry>, String> {
 /// Returns an error string when `path` cannot be opened or is not a
 /// directory. Per-entry I/O errors during the walk are ignored so a
 /// single unreadable file does not abort the scan.
-#[tauri::command]
+// Runs on a worker thread so the recursive directory walk never blocks the
+// UI event loop. (Not currently wired to a route; off-thread keeps it
+// freeze-safe should a caller be added.)
+#[tauri::command(async)]
 pub fn folder_size_scan(
     path: String,
     app: tauri::AppHandle,

--- a/src-tauri/src/folder_tree.rs
+++ b/src-tauri/src/folder_tree.rs
@@ -8,10 +8,12 @@
 
 use std::collections::BinaryHeap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use globset::{Glob, GlobMatcher};
 use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
 use walkdir::{DirEntry, WalkDir};
 
 /// Hard cap on traversal entries. Protects the IPC channel from
@@ -262,8 +264,20 @@ fn synthesize_root(root_path: &Path, root: &str) -> TreeNode {
 /// Returns a stringified error when the root cannot be opened, when any
 /// supplied glob fails to compile, or when an underlying walk error
 /// occurs that is not silently skippable.
-#[tauri::command]
-pub fn folder_walk(req: WalkRequest) -> Result<TreeNode, String> {
+#[tauri::command(async)]
+pub fn folder_walk(
+    op_id: String,
+    req: WalkRequest,
+    state: tauri::State<'_, crate::cancellation::OperationRegistry>,
+) -> Result<TreeNode, String> {
+    let token = Arc::new(CancellationToken::new());
+    state.register(op_id.clone(), token.clone());
+    let result = run_folder_walk(req, &token);
+    state.remove(&op_id);
+    result
+}
+
+fn run_folder_walk(req: WalkRequest, token: &CancellationToken) -> Result<TreeNode, String> {
     let root_path = Path::new(&req.root);
     let metadata = std::fs::metadata(root_path)
         .map_err(|e| format!("Failed to stat \"{}\": {e}", req.root))?;
@@ -289,6 +303,9 @@ pub fn folder_walk(req: WalkRequest) -> Result<TreeNode, String> {
     let mut truncated_root = false;
 
     for entry in walker {
+        if token.is_cancelled() {
+            return Err("Operation cancelled".to_string());
+        }
         let entry = match entry {
             Ok(e) => e,
             // Skip unreadable directories silently; surface only
@@ -337,12 +354,28 @@ pub fn folder_walk(req: WalkRequest) -> Result<TreeNode, String> {
 ///
 /// Returns a stringified error when the root cannot be opened or when
 /// any supplied glob fails to compile.
-#[tauri::command]
+#[tauri::command(async)]
 pub fn folder_largest_files(
+    op_id: String,
     root: String,
     limit: u32,
     include_globs: Vec<String>,
     exclude_globs: Vec<String>,
+    state: tauri::State<'_, crate::cancellation::OperationRegistry>,
+) -> Result<Vec<LargestFile>, String> {
+    let token = Arc::new(CancellationToken::new());
+    state.register(op_id.clone(), token.clone());
+    let result = run_folder_largest_files(root, limit, include_globs, exclude_globs, &token);
+    state.remove(&op_id);
+    result
+}
+
+fn run_folder_largest_files(
+    root: String,
+    limit: u32,
+    include_globs: Vec<String>,
+    exclude_globs: Vec<String>,
+    token: &CancellationToken,
 ) -> Result<Vec<LargestFile>, String> {
     let root_path = Path::new(&root);
     let metadata =
@@ -372,6 +405,9 @@ pub fn folder_largest_files(
 
     let mut visited = 0_usize;
     for entry in walker.flatten() {
+        if token.is_cancelled() {
+            return Err("Operation cancelled".to_string());
+        }
         visited += 1;
         if visited > MAX_ENTRIES {
             break;
@@ -445,7 +481,7 @@ mod tests {
             max_depth: 5,
             show_hidden: true,
         };
-        let node = folder_walk(req).unwrap();
+        let node = run_folder_walk(req, &CancellationToken::new()).unwrap();
         assert!(node.is_dir);
         assert_eq!(node.size_bytes, 11);
         assert_eq!(node.children.len(), 2);
@@ -465,7 +501,7 @@ mod tests {
             max_depth: 5,
             show_hidden: true,
         };
-        let node = folder_walk(req).unwrap();
+        let node = run_folder_walk(req, &CancellationToken::new()).unwrap();
         assert_eq!(node.size_bytes, 1);
         assert_eq!(node.children.len(), 1);
         assert_eq!(node.children[0].name, "keep.txt");
@@ -484,7 +520,7 @@ mod tests {
             max_depth: 5,
             show_hidden: true,
         };
-        let node = folder_walk(req).unwrap();
+        let node = run_folder_walk(req, &CancellationToken::new()).unwrap();
         let names: Vec<_> = node.children.iter().map(|c| c.name.clone()).collect();
         assert_eq!(names, vec!["a.png"]);
         let _ = fs::remove_dir_all(&dir);
@@ -497,8 +533,14 @@ mod tests {
         write_file(&dir, "big.bin", &vec![0_u8; 1024]);
         write_file(&dir, "mid.bin", &vec![0_u8; 256]);
 
-        let out =
-            folder_largest_files(dir.to_string_lossy().into_owned(), 2, vec![], vec![]).unwrap();
+        let out = run_folder_largest_files(
+            dir.to_string_lossy().into_owned(),
+            2,
+            vec![],
+            vec![],
+            &CancellationToken::new(),
+        )
+        .unwrap();
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].size_bytes, 1024);
         assert_eq!(out[1].size_bytes, 256);
@@ -518,7 +560,7 @@ mod tests {
             max_depth: 1,
             show_hidden: true,
         };
-        assert!(folder_walk(req).is_err());
+        assert!(run_folder_walk(req, &CancellationToken::new()).is_err());
         let _ = fs::remove_dir_all(&dir);
     }
 
@@ -534,9 +576,27 @@ mod tests {
             max_depth: 1,
             show_hidden: false,
         };
-        let node = folder_walk(req).unwrap();
+        let node = run_folder_walk(req, &CancellationToken::new()).unwrap();
         let names: Vec<_> = node.children.iter().map(|c| c.name.clone()).collect();
         assert_eq!(names, vec!["visible.txt"]);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cancelled_token_aborts_walk() {
+        let dir = tempdir("cancel");
+        write_file(&dir, "a.txt", b"x");
+        let req = WalkRequest {
+            root: dir.to_string_lossy().into_owned(),
+            include_globs: vec![],
+            exclude_globs: vec![],
+            max_depth: 5,
+            show_hidden: true,
+        };
+        let token = CancellationToken::new();
+        token.cancel();
+        let result = run_folder_walk(req, &token);
+        assert!(result.is_err_and(|e| e.contains("cancelled")));
         let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/src/lib/services/folder-tree.ts
+++ b/src/lib/services/folder-tree.ts
@@ -32,17 +32,23 @@ export interface LargestFile {
 }
 
 /** Invoke the Tauri command that walks the folder tree. */
-export const walkFolder = (req: WalkRequest): Promise<TreeNode> =>
-	invoke<TreeNode>('folder_walk', { req });
+export const walkFolder = (opId: string, req: WalkRequest): Promise<TreeNode> =>
+	invoke<TreeNode>('folder_walk', { opId, req });
+
+/** Cancel an in-flight folder_walk / folder_largest_files run by its op id. */
+export const cancelFolderScan = (opId: string): Promise<boolean> =>
+	invoke<boolean>('cancel_op', { opId });
 
 /** Invoke the Tauri command that returns the largest individual files. */
 export const findLargestFiles = (
+	opId: string,
 	root: string,
 	limit: number,
 	includeGlobs: readonly string[],
 	excludeGlobs: readonly string[]
 ): Promise<readonly LargestFile[]> =>
 	invoke<readonly LargestFile[]>('folder_largest_files', {
+		opId,
 		root,
 		limit,
 		includeGlobs,

--- a/src/routes/folder-tree-visualizer.tsx
+++ b/src/routes/folder-tree-visualizer.tsx
@@ -12,10 +12,11 @@ import {
 	Image as ImageIcon,
 	Loader2,
 	RefreshCw,
+	Square,
 	Trash2,
 	TrendingUp,
 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import { toast } from 'sonner';
 
 import { CopyButton } from '@/lib/components/action';
@@ -34,6 +35,7 @@ import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
+	cancelFolderScan,
 	countEntries,
 	exportAsJson,
 	exportAsText,
@@ -101,6 +103,11 @@ function FolderTreeVisualizerPage() {
 	const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
 	const [scanTimeMs, setScanTimeMs] = useState<number | null>(null);
 	const [rootPath, setRootPath] = useState<string | null>(null);
+	const [cancelling, setCancelling] = useState(false);
+
+	// The folder walk and the largest-files ranking run concurrently, so each
+	// registers under its own op id. Cancelling must signal both.
+	const scanOpIdsRef = useRef<{ readonly walk: string; readonly largest: string } | null>(null);
 
 	const includes = useMemo(() => splitPatterns(prefs.includeGlobs), [prefs.includeGlobs]);
 	const excludes = useMemo(() => splitPatterns(prefs.excludeGlobs), [prefs.excludeGlobs]);
@@ -122,19 +129,23 @@ function FolderTreeVisualizerPage() {
 
 	const runScan = useCallback(
 		async (path: string) => {
+			const walkOpId = crypto.randomUUID();
+			const largestOpId = crypto.randomUUID();
+			scanOpIdsRef.current = { walk: walkOpId, largest: largestOpId };
 			setLoading(true);
+			setCancelling(false);
 			setError(null);
 			const startedAt = performance.now();
 			try {
 				const [walked, top] = await Promise.all([
-					walkFolder({
+					walkFolder(walkOpId, {
 						root: path,
 						includeGlobs: includes,
 						excludeGlobs: excludes,
 						maxDepth: prefs.maxDepth,
 						showHidden: prefs.showHidden,
 					}),
-					findLargestFiles(path, TOP_N, includes, excludes),
+					findLargestFiles(largestOpId, path, TOP_N, includes, excludes),
 				]);
 				setRoot(walked);
 				setLargest(top);
@@ -144,14 +155,31 @@ function FolderTreeVisualizerPage() {
 				setScanTimeMs(performance.now() - startedAt);
 			} catch (e) {
 				const message = e instanceof Error ? e.message : String(e);
-				setError(message);
-				toast.error('Failed to scan folder', { description: message });
+				// Cancellation is a user action, not a failure: keep the panel clean.
+				if (message.includes('cancelled')) {
+					toast.info('Scan cancelled');
+				} else {
+					setError(message);
+					toast.error('Failed to scan folder', { description: message });
+				}
 			} finally {
+				scanOpIdsRef.current = null;
 				setLoading(false);
+				setCancelling(false);
 			}
 		},
 		[includes, excludes, prefs.maxDepth, prefs.showHidden]
 	);
+
+	const handleCancel = useCallback(() => {
+		const ids = scanOpIdsRef.current;
+		if (!ids) return;
+		setCancelling(true);
+		// Signal both concurrent operations so the Rust backend stops walking
+		// the tree and ranking the largest files at their next check point.
+		cancelFolderScan(ids.walk).catch(() => undefined);
+		cancelFolderScan(ids.largest).catch(() => undefined);
+	}, []);
 
 	const handlePickFolder = useCallback(async () => {
 		try {
@@ -283,6 +311,12 @@ function FolderTreeVisualizerPage() {
 								onPick={handlePickFolder}
 								disabled={loading}
 							/>
+							{loading ? (
+								<Button variant="outline" size="sm" onClick={handleCancel} disabled={cancelling}>
+									<Square className="h-3.5 w-3.5" />
+									{cancelling ? 'Cancelling…' : 'Cancel'}
+								</Button>
+							) : null}
 							{hasRoot ? (
 								<>
 									<Button variant="outline" size="sm" onClick={handleRefresh} disabled={loading}>


### PR DESCRIPTION
## Summary

- Make the Folder Tree scan cancellable, extending the cooperative cancellation pattern from the duplicate scanner to the folder tools.
- Run `folder_walk`, `folder_largest_files`, and `folder_size_scan` off the main thread so a large directory never freezes the webview.
- Add a Cancel button to the Folder Tree rail that stops the backend at its next loop boundary.

## Changes

### Added

- `cancelFolderScan(opId)` in the `folder-tree` service.
- A Cancel button in the Folder Tree rail, shown while a scan is in flight.
- `cancelled_token_aborts_walk` unit test proving a pre-cancelled token short-circuits the walk.

### Changed

- `folder_walk` / `folder_largest_files` now run via `#[tauri::command(async)]` wrappers that register a `CancellationToken` under a frontend-supplied op id and delegate to pure `run_*` helpers. Both helpers check the token at their loop boundaries and return `Err("Operation cancelled")`.
- `folder_size_scan` runs off the main thread (`#[tauri::command(async)]`).
- `walkFolder` / `findLargestFiles` take an `opId` argument. Because they run concurrently via `Promise.all`, the page registers each under its own op id and cancels both.

## Test Plan

- [x] `bun run check` (tsc + validate-pages + audit-design)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo test --lib` (242 passed, incl. new cancellation test)
- [ ] Manual: scan a large folder, hit Cancel mid-scan, confirm the backend stops and the UI returns to idle with a neutral "Scan cancelled" notice
