### PR TITLE
feat(file-inspector): make inspection cancellable and run file ops off-thread

### DIFF
--- a/src-tauri/src/file_inspect.rs
+++ b/src-tauri/src/file_inspect.rs
@@ -11,12 +11,15 @@
 //! whole file. Beyond that threshold only the first 4096 bytes are
 //! returned, which still supports magic-byte sniffing and previews.
 
-use std::fs;
+use std::fs::{self, File};
+use std::io::Read;
 use std::path::Path;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use base64::Engine as _;
 use serde::Serialize;
+use tokio_util::sync::CancellationToken;
 
 /// Maximum byte count returned in `full_bytes_b64`. Anything larger is
 /// considered too costly to ship through the IPC boundary in one shot.
@@ -116,8 +119,27 @@ fn read_head(path: &Path, size: u64) -> Result<Vec<u8>, String> {
     Ok(bytes.into_iter().take(usize_take).collect())
 }
 
-fn read_full(path: &Path) -> Result<Vec<u8>, String> {
-    fs::read(path).map_err(|e| format!("Failed to read file: {e}"))
+/// Read the whole file in 1 MiB chunks, checking the cancellation token
+/// between chunks. A single `fs::read` of a 500 MB file cannot be
+/// interrupted, so chunking is what lets a cancel actually stop the read.
+fn read_full(path: &Path, size: u64, token: &CancellationToken) -> Result<Vec<u8>, String> {
+    const CHUNK: usize = 1024 * 1024;
+    let mut file = File::open(path).map_err(|e| format!("Failed to open file: {e}"))?;
+    let mut buf = Vec::with_capacity(usize::try_from(size).unwrap_or(0));
+    let mut chunk = vec![0_u8; CHUNK];
+    loop {
+        if token.is_cancelled() {
+            return Err("Operation cancelled".to_string());
+        }
+        let read = file
+            .read(&mut chunk)
+            .map_err(|e| format!("Failed to read file: {e}"))?;
+        if read == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..read]);
+    }
+    Ok(buf)
 }
 
 /// Inspect a file and return its metadata, head bytes, and (when small
@@ -127,8 +149,20 @@ fn read_full(path: &Path) -> Result<Vec<u8>, String> {
 ///
 /// Returns a stringified error when the path cannot be opened, the
 /// file metadata cannot be queried, or reading the bytes fails.
-#[tauri::command]
-pub fn file_inspect(path: String) -> Result<FileInspectResult, String> {
+#[tauri::command(async)]
+pub fn file_inspect(
+    op_id: String,
+    path: String,
+    state: tauri::State<'_, crate::cancellation::OperationRegistry>,
+) -> Result<FileInspectResult, String> {
+    let token = Arc::new(CancellationToken::new());
+    state.register(op_id.clone(), token.clone());
+    let result = run_file_inspect(path, &token);
+    state.remove(&op_id);
+    result
+}
+
+fn run_file_inspect(path: String, token: &CancellationToken) -> Result<FileInspectResult, String> {
     let path_buf = Path::new(&path).to_path_buf();
     let metadata = fs::metadata(&path_buf).map_err(|e| format!("Failed to stat file: {e}"))?;
 
@@ -163,7 +197,7 @@ pub fn file_inspect(path: String) -> Result<FileInspectResult, String> {
     // magic detection and previews; only the full-buffer hashing path
     // degrades.
     let full_bytes = if size_bytes <= MAX_FULL_BYTES {
-        Some(read_full(&path_buf)?)
+        Some(read_full(&path_buf, size_bytes, token)?)
     } else {
         None
     };
@@ -220,5 +254,20 @@ mod tests {
         assert_eq!(format_rwx(0o4_655), "rwSr-xr-x");
         // Sticky bit with exec on other.
         assert_eq!(format_rwx(0o1_777), "rwxrwxrwt");
+    }
+
+    #[test]
+    fn read_full_aborts_when_cancelled() {
+        let dir = std::env::temp_dir().join(format!("kogu-file-inspect-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("data.bin");
+        fs::write(&file, vec![0_u8; 4096]).unwrap();
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let result = read_full(&file, 4096, &token);
+        assert!(result.is_err_and(|e| e.contains("cancelled")));
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/hex_editor.rs
+++ b/src-tauri/src/hex_editor.rs
@@ -89,7 +89,9 @@ pub fn hex_open(path: String) -> Result<HexFileInfo, String> {
 ///
 /// Returns a stringified error when the file cannot be opened, the
 /// requested range is out of bounds, or reading fails.
-#[tauri::command]
+// Runs off the main thread: reading a large window or a slow disk would
+// otherwise block the webview event loop.
+#[tauri::command(async)]
 pub fn hex_read(path: String, offset: u64, length: u64) -> Result<Vec<u8>, String> {
     let path_buf = Path::new(&path).to_path_buf();
     let metadata = fs::metadata(&path_buf).map_err(|e| format!("Failed to stat file: {e}"))?;
@@ -189,7 +191,9 @@ fn apply_op(buffer: Vec<u8>, op: &HexEditOp) -> Result<Vec<u8>, String> {
 ///
 /// Returns a stringified error when reading the file fails, any op is
 /// out of bounds, the backup rename fails, or the final write fails.
-#[tauri::command]
+// Runs off the main thread: rewriting a large file would otherwise block
+// the webview event loop.
+#[tauri::command(async)]
 pub fn hex_save(path: String, ops: Vec<HexEditOp>, backup: bool) -> Result<String, String> {
     let path_buf = Path::new(&path).to_path_buf();
     let original = fs::read(&path_buf).map_err(|e| format!("Failed to read file: {e}"))?;

--- a/src/lib/services/file-inspect.ts
+++ b/src/lib/services/file-inspect.ts
@@ -35,8 +35,12 @@ export interface FileInspectResult {
  * Invoke the Tauri command that reads a file from disk and returns its
  * metadata, head bytes, and (when small enough) full content.
  */
-export const inspectFile = (path: string): Promise<FileInspectResult> =>
-	invoke<FileInspectResult>('file_inspect', { path });
+export const inspectFile = (opId: string, path: string): Promise<FileInspectResult> =>
+	invoke<FileInspectResult>('file_inspect', { opId, path });
+
+/** Cancel an in-flight file_inspect run by its op id. */
+export const cancelFileInspect = (opId: string): Promise<boolean> =>
+	invoke<boolean>('cancel_op', { opId });
 
 export type HashAlgo = 'md5' | 'sha1' | 'sha256' | 'sha512';
 

--- a/src/routes/file-inspector.tsx
+++ b/src/routes/file-inspector.tsx
@@ -11,9 +11,10 @@ import {
 	ScanLine,
 	ShieldAlert,
 	ShieldCheck,
+	Square,
 	Trash2,
 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState, type DragEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type DragEvent } from 'react';
 import { toast } from 'sonner';
 
 import { CopyButton } from '@/lib/components/action';
@@ -35,6 +36,7 @@ import {
 	HASH_ALGO_LABELS,
 	HASH_ALGO_SECURE,
 	type HashAlgo,
+	cancelFileInspect,
 	hashBytes,
 	humanSize,
 	type FileInspectResult,
@@ -83,6 +85,8 @@ function FileInspectorPage() {
 	const [result, setResult] = useState<FileInspectResult | null>(null);
 	const [bytes, setBytes] = useState<Uint8Array | null>(null);
 	const [loading, setLoading] = useState(false);
+	const [cancelling, setCancelling] = useState(false);
+	const inspectOpIdRef = useRef<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [hashes, setHashes] = useState<Partial<Record<HashAlgo, string>>>({});
 	const [hashing, setHashing] = useState<ReadonlySet<HashAlgo>>(new Set());
@@ -125,23 +129,40 @@ function FileInspectorPage() {
 	}, []);
 
 	const loadFromPath = useCallback(async (path: string) => {
+		const opId = crypto.randomUUID();
+		inspectOpIdRef.current = opId;
 		setLoading(true);
+		setCancelling(false);
 		setError(null);
 		setHashes({});
 		setHashing(new Set());
 		setImagePreview(null);
 		setAudioInfo(null);
 		try {
-			const next = await inspectFile(path);
+			const next = await inspectFile(opId, path);
 			setResult(next);
 			setBytes(next.fullBytesB64 ? base64ToBytes(next.fullBytesB64) : null);
 		} catch (e) {
 			const message = e instanceof Error ? e.message : String(e);
-			setError(message);
-			toast.error('Failed to inspect file', { description: message });
+			// Cancellation is a user action, not a failure.
+			if (message.includes('cancelled')) {
+				toast.info('Inspection cancelled');
+			} else {
+				setError(message);
+				toast.error('Failed to inspect file', { description: message });
+			}
 		} finally {
+			inspectOpIdRef.current = null;
 			setLoading(false);
+			setCancelling(false);
 		}
+	}, []);
+
+	const handleCancel = useCallback(() => {
+		const opId = inspectOpIdRef.current;
+		if (!opId) return;
+		setCancelling(true);
+		cancelFileInspect(opId).catch(() => undefined);
 	}, []);
 
 	const handlePickFile = async () => {
@@ -386,6 +407,12 @@ function FileInspectorPage() {
 								<FolderOpen className="h-3.5 w-3.5" />
 								{hasResult ? 'Choose another' : 'Open file…'}
 							</Button>
+							{loading ? (
+								<Button variant="outline" size="sm" onClick={handleCancel} disabled={cancelling}>
+									<Square className="h-3.5 w-3.5" />
+									{cancelling ? 'Cancelling…' : 'Cancel'}
+								</Button>
+							) : null}
 							{hasResult ? (
 								<Button variant="outline" size="sm" onClick={handleClear}>
 									<Trash2 className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary

- Make file inspection cancellable and chunk the full-file read so cancelling a large file actually stops it.
- Run `hex_read` and `hex_save` off the main thread so reading a large window or rewriting a large file never freezes the webview.
- Add a Cancel button to the File Inspector rail.

## Changes

### Added

- `cancelFileInspect(opId)` in the `file-inspect` service.
- A Cancel button in the File Inspector rail, shown while an inspection is in flight.
- `read_full_aborts_when_cancelled` unit test.

### Changed

- `file_inspect` now runs via a `#[tauri::command(async)]` wrapper that registers a `CancellationToken` under a frontend-supplied op id and delegates to a pure `run_file_inspect` helper. `read_full` reads in 1 MiB chunks and checks the token between chunks (a single `fs::read` of a 500 MB file cannot be interrupted).
- `hex_read` and `hex_save` run off the main thread (`#[tauri::command(async)]`).
- `inspectFile` takes an `opId` argument; the route generates one per inspection and cancels it on demand.

## Test Plan

- [x] `bun run check` (tsc + validate-pages + audit-design)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo test --lib` (file_inspect suite passes, incl. new cancellation test)
- [ ] Manual: inspect a large file, hit Cancel mid-read, confirm the backend stops and the UI shows a neutral "Inspection cancelled" notice
