### PR TITLE
perf(tauri): run remaining heavy commands off the main thread

### DIFF
--- a/src-tauri/src/archive_inspect.rs
+++ b/src-tauri/src/archive_inspect.rs
@@ -432,7 +432,10 @@ fn resolve_destination(target: PathBuf, conflict: &str) -> Result<Option<PathBuf
 /// Extract a single named entry to a specified destination file path.
 /// Returns the number of bytes written. Directory entries are created
 /// without contents.
-#[tauri::command]
+///
+/// Runs off the main thread: a single entry can be large, and copying it
+/// to disk would otherwise block the webview event loop.
+#[tauri::command(async)]
 pub fn archive_extract_entry(
     archive_path: String,
     entry_path: String,

--- a/src-tauri/src/duplicate_finder.rs
+++ b/src-tauri/src/duplicate_finder.rs
@@ -564,7 +564,9 @@ fn run_duplicate_scan(
 /// Returns a stringified error listing every path that could not be
 /// removed; the operation continues past per-file failures so successful
 /// deletes are not lost.
-#[tauri::command]
+// Runs off the main thread: deleting a large selection of files would
+// otherwise block the webview event loop.
+#[tauri::command(async)]
 pub fn duplicate_delete(paths: Vec<String>) -> Result<u64, String> {
     let mut freed: u64 = 0;
     let mut errors: Vec<String> = Vec::new();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -375,11 +375,14 @@ fn check_discovery_privilege(method: DiscoveryMethod) -> bool {
 ///
 /// # Returns
 /// `AstParseResult` containing the AST and any errors
-#[tauri::command]
-fn parse_to_ast(text: &str, language: &str) -> Result<AstParseResult, String> {
+// Runs off the main thread: parsing a large document into an AST is
+// CPU-bound and would otherwise block the webview event loop. Async
+// Tauri commands require owned arguments, hence `String` over `&str`.
+#[tauri::command(async)]
+fn parse_to_ast(text: String, language: String) -> Result<AstParseResult, String> {
     let lang: AstLanguage = language.parse().map_err(|e: ast::AstError| e.to_string())?;
 
-    Ok(ast::parse_to_ast(text, lang))
+    Ok(ast::parse_to_ast(&text, lang))
 }
 
 /// Bootstrap routine executed inside the Tauri builder's `setup`


### PR DESCRIPTION
## Summary

- Run the remaining heavy synchronous Tauri commands off the main thread so they never freeze the webview.
- Completes the audit: every command that does CPU-bound or unbounded I/O work now runs on a worker thread.

## Changes

### Changed

- `parse_to_ast` runs off the main thread (`#[tauri::command(async)]`). Parsing a large document into an AST is CPU-bound. Async commands require owned arguments, so the parameters change from `&str` to `String`.
- `duplicate_delete` runs off the main thread. Deleting a large duplicate selection iterates the whole list.
- `archive_extract_entry` runs off the main thread. A single archive entry can be large.

## Notes

These three are off-thread only (no cancellation): `parse_to_ast` is a single CPU-bound pass, and the two file operations are short or irreversible, so off-threading is the appropriate fix. The remaining commands surveyed during the audit are already `async fn` (run on the tokio runtime) and never block the main thread.

## Test Plan

- [x] `cargo clippy --all-targets` clean
- [x] `cargo test --lib` (242 passed)
- [x] No frontend changes (IPC argument names unchanged)
