### PR TITLE
fix(file-inspector): decode and hash large files off the main thread

### DIFF
--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -3,6 +3,8 @@ export { useDebouncedCallback, useDebouncedValue } from './use-debounced-value';
 export { useDocumentTitle } from './use-document-title';
 export { useRegexWorker } from './use-regex-worker';
 export type { UseRegexWorkerInput, UseRegexWorkerOutput } from './use-regex-worker';
+export { useFileInspectWorker } from './use-file-inspect-worker';
+export type { FileHashOutput, UseFileInspectWorker } from './use-file-inspect-worker';
 export {
 	useFormatterPage,
 	FORMATTER_TABS,

--- a/src/lib/hooks/use-file-inspect-worker.ts
+++ b/src/lib/hooks/use-file-inspect-worker.ts
@@ -1,0 +1,111 @@
+/**
+ * Bridges `file-inspector.tsx` to the file-inspect decoding / hashing worker.
+ *
+ * The worker decodes the full file bytes and computes every hash off the main
+ * thread, so selecting a large file no longer freezes the webview. A monotonic
+ * request id discards responses from a superseded file, and the decoded buffer
+ * is handed back through an `onBuffer` callback so the route can build the
+ * image / audio preview and drive hashing without decoding anything itself.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { HashAlgo } from '@/lib/services/file-inspect';
+import type {
+	FileInspectWorkerRequest,
+	FileInspectWorkerResponse,
+} from '@/lib/workers/file-inspect.worker';
+
+export interface FileHashOutput {
+	readonly hashes: Partial<Record<HashAlgo, string>>;
+	readonly hashing: ReadonlySet<HashAlgo>;
+}
+
+export interface UseFileInspectWorker {
+	readonly output: FileHashOutput;
+	/** Decode a base64 payload off-thread; `onBuffer` receives the decoded bytes. */
+	readonly decode: (base64: string, onBuffer: (buffer: ArrayBuffer) => void) => void;
+	/** Hash a buffer (passed as a transferable copy) for the given algorithm set. */
+	readonly hash: (buffer: ArrayBuffer, algorithms: readonly HashAlgo[]) => void;
+	/** Discard any in-flight response and clear the hash state. */
+	readonly reset: () => void;
+}
+
+const EMPTY_OUTPUT: FileHashOutput = { hashes: {}, hashing: new Set() };
+
+export const useFileInspectWorker = (): UseFileInspectWorker => {
+	const workerRef = useRef<Worker | null>(null);
+	const latestIdRef = useRef(0);
+	const onBufferRef = useRef<((buffer: ArrayBuffer) => void) | null>(null);
+	// Mirror of the current hashes so `hash` can keep already-computed digests
+	// visible (only genuinely new algorithms show the spinner).
+	const hashesRef = useRef<Partial<Record<HashAlgo, string>>>({});
+	const [output, setOutput] = useState<FileHashOutput>(EMPTY_OUTPUT);
+
+	// Single worker instance for the lifetime of the route.
+	useEffect(() => {
+		const worker = new Worker(new URL('@/lib/workers/file-inspect.worker.ts', import.meta.url), {
+			type: 'module',
+		});
+		workerRef.current = worker;
+		const handleMessage = (event: MessageEvent<FileInspectWorkerResponse>) => {
+			const response = event.data;
+			// Discard stale responses; only the most recently requested id wins.
+			if (response.id !== latestIdRef.current) return;
+			if (response.buffer !== undefined) {
+				// Decode response: hand the bytes to the route, leave hashes alone.
+				if (onBufferRef.current) {
+					onBufferRef.current(response.buffer);
+					onBufferRef.current = null;
+				}
+				return;
+			}
+			// Hash response: merge results and clear the pending spinners.
+			const merged = { ...hashesRef.current, ...response.hashes };
+			hashesRef.current = merged;
+			setOutput({ hashes: merged, hashing: new Set() });
+		};
+		worker.addEventListener('message', handleMessage);
+		return () => {
+			worker.removeEventListener('message', handleMessage);
+			worker.terminate();
+			workerRef.current = null;
+		};
+	}, []);
+
+	const decode = useCallback((base64: string, onBuffer: (buffer: ArrayBuffer) => void) => {
+		const worker = workerRef.current;
+		if (!worker) return;
+		const id = latestIdRef.current + 1;
+		latestIdRef.current = id;
+		onBufferRef.current = onBuffer;
+		// A decode starts a new file: clear the previous file's hashes.
+		hashesRef.current = {};
+		setOutput(EMPTY_OUTPUT);
+		const request: FileInspectWorkerRequest = { kind: 'decode', id, base64 };
+		worker.postMessage(request);
+	}, []);
+
+	const hash = useCallback((buffer: ArrayBuffer, algorithms: readonly HashAlgo[]) => {
+		const worker = workerRef.current;
+		if (!worker) return;
+		const id = latestIdRef.current + 1;
+		latestIdRef.current = id;
+		onBufferRef.current = null;
+		// Keep already-computed digests visible; spin only on genuinely new ones.
+		const pending = new Set(algorithms.filter((algo) => hashesRef.current[algo] === undefined));
+		setOutput({ hashes: hashesRef.current, hashing: pending });
+		const request: FileInspectWorkerRequest = { kind: 'hash', id, buffer, algorithms };
+		// Transfer the buffer copy so the worker receives the bytes without a synchronous copy.
+		worker.postMessage(request, [buffer]);
+	}, []);
+
+	const reset = useCallback(() => {
+		// Bump the id so any in-flight response is ignored, then clear state.
+		latestIdRef.current += 1;
+		onBufferRef.current = null;
+		hashesRef.current = {};
+		setOutput(EMPTY_OUTPUT);
+	}, []);
+
+	return { output, decode, hash, reset };
+};

--- a/src/lib/services/file-inspect.ts
+++ b/src/lib/services/file-inspect.ts
@@ -2,17 +2,15 @@
  * File Inspector service.
  *
  * Wraps the `file_inspect` Tauri command and provides browser-side
- * helpers for the inspector tool: byte conversion, hash computation
- * (MD5 / SHA-1 / SHA-256 / SHA-512), human-readable size formatting,
- * hex previews, and magic-byte MIME detection against the existing
- * MIME Type Explorer catalog.
+ * helpers for the inspector tool: byte conversion, the hash-algorithm
+ * catalog, human-readable size formatting, hex previews, and magic-byte
+ * MIME detection against the existing MIME Type Explorer catalog.
  *
- * Hashing routes SHA-1 / 256 / 512 through `crypto.subtle` (native,
- * streaming-friendly) and MD5 through `js-md5`. BLAKE3 is left as a
- * follow-up; the [`HashAlgo`] enum has a placeholder.
+ * Hashing itself runs in `file-inspect.worker.ts` (off the main thread)
+ * so decoding and digesting a large file never freezes the webview. This
+ * module only describes the supported algorithms via [`HashAlgo`].
  */
 import { invoke } from '@tauri-apps/api/core';
-import { md5 } from 'js-md5';
 
 import { MIME_ENTRIES, type MimeEntry } from './mime';
 
@@ -30,6 +28,13 @@ export interface FileInspectResult {
 	readonly headBytesB64: string;
 	readonly fullBytesB64: string | null;
 }
+
+/**
+ * Maximum file size for which the backend returns the full content as base64.
+ * Files larger than this return only the head bytes, so hashing the whole file
+ * is unavailable. Mirrors `MAX_FULL_BYTES` in `src-tauri/src/file_inspect.rs`.
+ */
+export const MAX_FULL_BYTES = 500 * 1024 * 1024;
 
 /**
  * Invoke the Tauri command that reads a file from disk and returns its
@@ -71,31 +76,6 @@ export const base64ToBytes = (b64: string): Uint8Array => {
 		bytes[i] = binary.charCodeAt(i);
 	}
 	return bytes;
-};
-
-const bytesToHex = (bytes: Uint8Array): string =>
-	Array.from(bytes)
-		.map((b) => b.toString(16).padStart(2, '0'))
-		.join('');
-
-/**
- * Hash an arbitrary byte buffer with one of the supported algorithms.
- *
- * SHA-1 / 256 / 512 go through `crypto.subtle` — universally
- * available in the Tauri WebView (Chromium / WebKit both ship the
- * Web Crypto API). MD5 uses `js-md5` since `crypto.subtle` does not
- * implement it.
- */
-export const hashBytes = async (bytes: Uint8Array, algo: HashAlgo): Promise<string> => {
-	if (algo === 'md5') return md5(bytes);
-
-	const algoName: Readonly<Record<Exclude<HashAlgo, 'md5'>, string>> = {
-		sha1: 'SHA-1',
-		sha256: 'SHA-256',
-		sha512: 'SHA-512',
-	};
-	const digest = await globalThis.crypto.subtle.digest(algoName[algo], bytes as BufferSource);
-	return bytesToHex(new Uint8Array(digest));
 };
 
 /**

--- a/src/lib/workers/file-inspect.worker.ts
+++ b/src/lib/workers/file-inspect.worker.ts
@@ -1,0 +1,126 @@
+/**
+ * Off-thread decoding and hashing worker for the File Inspector tool.
+ *
+ * Decoding an 8 MB base64 payload (`atob` + a per-byte copy loop) and the
+ * `js-md5` digest are both synchronous and CPU-bound. Run on the main thread
+ * they freeze the webview for hundreds of milliseconds; this worker moves them
+ * off the event loop. The Web Crypto digests already run off-thread, but they
+ * live here too so the route never touches raw bytes on the main thread.
+ *
+ * Message protocol:
+ *
+ * ```
+ * main -> worker: FileInspectWorkerRequest (union discriminated by `kind`)
+ * worker -> main: FileInspectWorkerResponse
+ * ```
+ *
+ * `'decode'` decodes the base64 string and transfers the decoded `ArrayBuffer`
+ * back (zero-copy) so the main thread can build the image / audio preview and
+ * drive hashing without decoding anything itself.
+ *
+ * `'hash'` receives a buffer (a transferred copy from the main thread) and
+ * computes the requested digests, leaving the main thread's own copy untouched.
+ *
+ * Decode responses carry `buffer`; hash responses carry `hashes`. `id` is the
+ * monotonic request id supplied by the caller — the hook keeps the latest id
+ * and discards responses carrying a smaller one so a superseded file cannot
+ * tear the UI.
+ */
+import { md5 } from 'js-md5';
+
+import type { HashAlgo } from '@/lib/services/file-inspect';
+
+export interface DecodeRequest {
+	readonly kind: 'decode';
+	readonly id: number;
+	readonly base64: string;
+}
+
+export interface HashRequest {
+	readonly kind: 'hash';
+	readonly id: number;
+	readonly buffer: ArrayBuffer;
+	readonly algorithms: readonly HashAlgo[];
+}
+
+export type FileInspectWorkerRequest = DecodeRequest | HashRequest;
+
+export interface FileInspectWorkerResponse {
+	readonly id: number;
+	/** Computed digests. Present only on `'hash'` responses. */
+	readonly hashes: Partial<Record<HashAlgo, string>> | undefined;
+	/** Decoded byte buffer, transferred back only on `'decode'` responses. */
+	readonly buffer: ArrayBuffer | undefined;
+	readonly error: string | null;
+}
+
+/** Decode a standard base64 string into an `ArrayBuffer` off the main thread. */
+const decodeBase64 = (b64: string): ArrayBuffer => {
+	if (b64.length === 0) return new ArrayBuffer(0);
+	const binary = atob(b64);
+	const out = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i += 1) {
+		out[i] = binary.charCodeAt(i);
+	}
+	return out.buffer;
+};
+
+const bytesToHex = (bytes: Uint8Array): string =>
+	Array.from(bytes)
+		.map((b) => b.toString(16).padStart(2, '0'))
+		.join('');
+
+const SUBTLE_NAME: Readonly<Record<Exclude<HashAlgo, 'md5'>, string>> = {
+	sha1: 'SHA-1',
+	sha256: 'SHA-256',
+	sha512: 'SHA-512',
+};
+
+/** Compute every requested digest for a buffer, all inside the worker. */
+const computeHashes = async (
+	buffer: ArrayBuffer,
+	algorithms: readonly HashAlgo[]
+): Promise<Partial<Record<HashAlgo, string>>> => {
+	const entries = await Promise.all(
+		algorithms.map(async (algo): Promise<readonly [HashAlgo, string]> => {
+			if (algo === 'md5') return [algo, md5(new Uint8Array(buffer))];
+			const digest = await crypto.subtle.digest(SUBTLE_NAME[algo], buffer);
+			return [algo, bytesToHex(new Uint8Array(digest))];
+		})
+	);
+	return Object.fromEntries(entries) as Partial<Record<HashAlgo, string>>;
+};
+
+self.addEventListener('message', async (event: MessageEvent<FileInspectWorkerRequest>) => {
+	const request = event.data;
+	try {
+		if (request.kind === 'decode') {
+			const buffer = decodeBase64(request.base64);
+			self.postMessage(
+				{
+					id: request.id,
+					hashes: undefined,
+					buffer,
+					error: null,
+				} satisfies FileInspectWorkerResponse,
+				[buffer]
+			);
+			return;
+		}
+		const hashes = await computeHashes(request.buffer, request.algorithms);
+		self.postMessage({
+			id: request.id,
+			hashes,
+			buffer: undefined,
+			error: null,
+		} satisfies FileInspectWorkerResponse);
+	} catch (err) {
+		const error = err instanceof Error ? err.message : 'file-inspect worker failed';
+		self.postMessage({
+			id: request.id,
+			hashes: undefined,
+			buffer: undefined,
+			error,
+		} satisfies FileInspectWorkerResponse);
+	}
+});

--- a/src/routes/file-inspector.tsx
+++ b/src/routes/file-inspector.tsx
@@ -25,7 +25,7 @@ import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
-import { useDocumentTitle } from '@/lib/hooks';
+import { useDocumentTitle, useFileInspectWorker } from '@/lib/hooks';
 import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import {
 	base64ToBytes,
@@ -35,9 +35,9 @@ import {
 	formatTimestamp,
 	HASH_ALGO_LABELS,
 	HASH_ALGO_SECURE,
+	MAX_FULL_BYTES,
 	type HashAlgo,
 	cancelFileInspect,
-	hashBytes,
 	humanSize,
 	type FileInspectResult,
 	inspectFile,
@@ -88,8 +88,13 @@ function FileInspectorPage() {
 	const [cancelling, setCancelling] = useState(false);
 	const inspectOpIdRef = useRef<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
-	const [hashes, setHashes] = useState<Partial<Record<HashAlgo, string>>>({});
-	const [hashing, setHashing] = useState<ReadonlySet<HashAlgo>>(new Set());
+	// Decoding and hashing run in a worker so a large file never freezes the UI.
+	const {
+		output: { hashes, hashing },
+		decode: decodeFile,
+		hash: hashBuffer,
+		reset: resetHashWorker,
+	} = useFileInspectWorker();
 	const [imagePreview, setImagePreview] = useState<ImagePreview | null>(null);
 	const [audioInfo, setAudioInfo] = useState<{
 		readonly duration: number;
@@ -119,44 +124,55 @@ function FileInspectorPage() {
 	}, [mimeInfo]);
 
 	const handleClear = useCallback(() => {
+		// Discard any in-flight worker response for the previous file.
+		resetHashWorker();
 		setResult(null);
 		setBytes(null);
 		setError(null);
-		setHashes({});
-		setHashing(new Set());
 		setImagePreview(null);
 		setAudioInfo(null);
-	}, []);
+	}, [resetHashWorker]);
 
-	const loadFromPath = useCallback(async (path: string) => {
-		const opId = crypto.randomUUID();
-		inspectOpIdRef.current = opId;
-		setLoading(true);
-		setCancelling(false);
-		setError(null);
-		setHashes({});
-		setHashing(new Set());
-		setImagePreview(null);
-		setAudioInfo(null);
-		try {
-			const next = await inspectFile(opId, path);
-			setResult(next);
-			setBytes(next.fullBytesB64 ? base64ToBytes(next.fullBytesB64) : null);
-		} catch (e) {
-			const message = e instanceof Error ? e.message : String(e);
-			// Cancellation is a user action, not a failure.
-			if (message.includes('cancelled')) {
-				toast.info('Inspection cancelled');
-			} else {
-				setError(message);
-				toast.error('Failed to inspect file', { description: message });
-			}
-		} finally {
-			inspectOpIdRef.current = null;
-			setLoading(false);
+	const loadFromPath = useCallback(
+		async (path: string) => {
+			const opId = crypto.randomUUID();
+			inspectOpIdRef.current = opId;
+			// Drop any in-flight worker response so the previous file's decoded
+			// bytes cannot be applied once this file's request resolves.
+			resetHashWorker();
+			setBytes(null);
+			setLoading(true);
 			setCancelling(false);
-		}
-	}, []);
+			setError(null);
+			setImagePreview(null);
+			setAudioInfo(null);
+			try {
+				const next = await inspectFile(opId, path);
+				setResult(next);
+				if (next.fullBytesB64) {
+					// Decode off-thread; onBuffer hands the decoded bytes back for the
+					// image / audio preview. Hashing is driven by the effect below.
+					decodeFile(next.fullBytesB64, (buffer) => {
+						setBytes(new Uint8Array(buffer));
+					});
+				}
+			} catch (e) {
+				const message = e instanceof Error ? e.message : String(e);
+				// Cancellation is a user action, not a failure.
+				if (message.includes('cancelled')) {
+					toast.info('Inspection cancelled');
+				} else {
+					setError(message);
+					toast.error('Failed to inspect file', { description: message });
+				}
+			} finally {
+				inspectOpIdRef.current = null;
+				setLoading(false);
+				setCancelling(false);
+			}
+		},
+		[decodeFile, resetHashWorker]
+	);
 
 	const handleCancel = useCallback(() => {
 		const opId = inspectOpIdRef.current;
@@ -205,48 +221,15 @@ function FileInspectorPage() {
 		setIsDragOver(false);
 	};
 
-	// Compute hashes whenever the file bytes or the enabled-hashes
-	// preference changes. Each algorithm runs as an independent async
-	// task so SHA-256 does not have to wait for SHA-512 to finish.
+	// Hash the decoded bytes off-thread — on initial decode and whenever the
+	// user toggles algorithms. A copy of the buffer goes to the worker as a
+	// transferable so hashing never blocks the main thread and the preview's
+	// own `bytes` copy is untouched. Keyed on bytes + enabledHashes only (never
+	// on the hash results), which is what avoids the old render-churn loop.
 	useEffect(() => {
 		if (!bytes) return;
-		const enabled = new Set(prefs.enabledHashes);
-		// Track which algorithms are still pending; algorithms already
-		// computed for the current buffer are skipped.
-		setHashing((prev) => {
-			const next = new Set(prev);
-			for (const algo of enabled) {
-				if (hashes[algo] === undefined) next.add(algo);
-			}
-			return next;
-		});
-
-		let cancelled = false;
-		for (const algo of enabled) {
-			if (hashes[algo] !== undefined) continue;
-			hashBytes(bytes, algo)
-				.then((hex) => {
-					if (cancelled) return;
-					setHashes((prev) => ({ ...prev, [algo]: hex }));
-					setHashing((prev) => {
-						const next = new Set(prev);
-						next.delete(algo);
-						return next;
-					});
-				})
-				.catch(() => {
-					if (cancelled) return;
-					setHashing((prev) => {
-						const next = new Set(prev);
-						next.delete(algo);
-						return next;
-					});
-				});
-		}
-		return () => {
-			cancelled = true;
-		};
-	}, [bytes, prefs.enabledHashes, hashes]);
+		hashBuffer(bytes.buffer.slice(0) as ArrayBuffer, prefs.enabledHashes);
+	}, [bytes, prefs.enabledHashes, hashBuffer]);
 
 	// Image-format extraction: dimensions, EXIF. Audio-format
 	// extraction: duration, sample rate, channel count.
@@ -498,7 +481,6 @@ function FileInspectorPage() {
 			{hasResult ? (
 				<ResultView
 					result={result}
-					bytes={bytes}
 					headBytes={headBytes}
 					detectedMime={detectedMime}
 					mimeInfo={mimeInfo}
@@ -574,7 +556,6 @@ function DropZone({ loading, isDragOver, onDrop, onDragOver, onDragLeave, onPick
 
 interface ResultViewProps {
 	readonly result: FileInspectResult;
-	readonly bytes: Uint8Array | null;
 	readonly headBytes: Uint8Array | null;
 	readonly detectedMime: string | null;
 	readonly mimeInfo: {
@@ -603,7 +584,6 @@ interface ResultViewProps {
 
 function ResultView({
 	result,
-	bytes,
 	headBytes,
 	detectedMime,
 	mimeInfo,
@@ -618,7 +598,7 @@ function ResultView({
 	onCopyJson,
 	onReveal,
 }: ResultViewProps) {
-	const isLargeFile = bytes === null && result.sizeBytes > 0;
+	const isLargeFile = result.sizeBytes > MAX_FULL_BYTES;
 
 	return (
 		<div className="flex h-full flex-col overflow-hidden">


### PR DESCRIPTION
## Summary

- Fix the File Inspector freezing for ~600 ms when a large file (e.g. an 8 MB JPEG) is selected.
- Move base64 decoding and hashing into a Web Worker so the main thread is never blocked.
- Remove a `useEffect` anti-pattern that re-issued redundant whole-buffer digests.

## Root cause

`PR #415` moved the Rust `file_inspect` read off-thread, but the freeze was in the **frontend** post-processing, which it never touched. On selecting an 8 MB file the main thread ran, synchronously:

- `base64ToBytes` (atob + an 8 M-iteration copy loop): ~306 ms — measured live.
- `md5(bytes)` via `js-md5`: ~298 ms — measured live (`crypto.subtle` SHA digests already run off-thread).

The hashing `useEffect` also listed its own `hashes` output in its dependency array while calling `setHashes`, so it re-ran on every completion and re-issued redundant 8 MB `crypto.subtle.digest` calls (violating the project's own rule against reacting to state in effects).

## Changes

### Added

- `src/lib/workers/file-inspect.worker.ts` — decodes the base64 payload and computes every digest off the main thread. A `decode` request transfers the `ArrayBuffer` back; a `hash` request digests a transferred copy.
- `src/lib/hooks/use-file-inspect-worker.ts` — bridges the route to the worker with a monotonic request id that discards superseded responses (mirrors `use-regex-worker`).
- `MAX_FULL_BYTES` constant in the service (mirrors the Rust threshold).

### Changed

- `file-inspector.tsx` drives decoding / hashing through the worker. A single effect keyed on the decoded bytes and the enabled-hash set replaces the self-referential hashing effect. The "head-only" banner now keys on `result.sizeBytes > MAX_FULL_BYTES` instead of a transiently-null `bytes` buffer.

### Removed

- `hashBytes` from the service (hashing now lives in the worker).

## Test Plan

- [x] `bun run check`, `bun run lint`, `bun run test` (156 passed)
- [x] Live (running app, 8 MB buffer): main-thread max stall **22 ms** (was ~604 ms) across decode + hash
- [x] Live: worker MD5 / SHA-1 / SHA-256 / SHA-512 match Web Crypto and js-md5 references byte for byte
- [ ] Manual: open an 8 MB JPEG; confirm the UI stays responsive, the image + EXIF render, and all four hashes appear; toggle an algorithm and confirm only the new one recomputes
