### PR TITLE
perf(diff-viewer): compute the diff in a Web Worker

### DIFF
--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -5,6 +5,8 @@ export { useRegexWorker } from './use-regex-worker';
 export type { UseRegexWorkerInput, UseRegexWorkerOutput } from './use-regex-worker';
 export { useFileInspectWorker } from './use-file-inspect-worker';
 export type { FileHashOutput, UseFileInspectWorker } from './use-file-inspect-worker';
+export { useDiffWorker } from './use-diff-worker';
+export type { UseDiffWorkerInput, UseDiffWorkerOutput } from './use-diff-worker';
 export {
 	useFormatterPage,
 	FORMATTER_TABS,

--- a/src/lib/hooks/use-diff-worker.ts
+++ b/src/lib/hooks/use-diff-worker.ts
@@ -1,0 +1,84 @@
+/**
+ * Bridges `diff-viewer.tsx` to the text-diff computation worker.
+ *
+ * The typed inputs are debounced before dispatch so a fast typist does not
+ * queue a worker request per keystroke, and a monotonic request id discards
+ * stale responses so an out-of-order return cannot tear the UI. The previous
+ * result stays visible while a new one computes.
+ */
+import { useEffect, useRef, useState } from 'react';
+
+import type { DiffOptions, EnhancedDiffResult } from '@/lib/services/text-diff';
+import type { DiffRequest, DiffResponse } from '@/lib/workers/diff.worker';
+
+import { useDebouncedValue } from './use-debounced-value';
+
+export interface UseDiffWorkerInput {
+	readonly leftText: string;
+	readonly rightText: string;
+	/** Pass a stable (memoized) reference so the effect only fires on real changes. */
+	readonly options: Partial<DiffOptions>;
+	readonly contextLines: number;
+}
+
+export interface UseDiffWorkerOutput {
+	readonly enhancedDiff: EnhancedDiffResult | null;
+	readonly isIdentical: boolean | null;
+	readonly isPending: boolean;
+}
+
+const EMPTY_OUTPUT: UseDiffWorkerOutput = {
+	enhancedDiff: null,
+	isIdentical: null,
+	isPending: false,
+};
+
+export const useDiffWorker = (input: UseDiffWorkerInput): UseDiffWorkerOutput => {
+	const workerRef = useRef<Worker | null>(null);
+	const latestIdRef = useRef(0);
+	const [output, setOutput] = useState<UseDiffWorkerOutput>(EMPTY_OUTPUT);
+
+	const debouncedLeft = useDebouncedValue(input.leftText, 180);
+	const debouncedRight = useDebouncedValue(input.rightText, 180);
+
+	// Lazy single worker instance for the lifetime of the route.
+	useEffect(() => {
+		const worker = new Worker(new URL('@/lib/workers/diff.worker.ts', import.meta.url), {
+			type: 'module',
+		});
+		workerRef.current = worker;
+		const handleMessage = (event: MessageEvent<DiffResponse>) => {
+			// Discard stale responses; only the most recently requested id wins.
+			if (event.data.id !== latestIdRef.current) return;
+			setOutput({
+				enhancedDiff: event.data.enhancedDiff,
+				isIdentical: event.data.isIdentical,
+				isPending: false,
+			});
+		};
+		worker.addEventListener('message', handleMessage);
+		return () => {
+			worker.removeEventListener('message', handleMessage);
+			worker.terminate();
+			workerRef.current = null;
+		};
+	}, []);
+
+	useEffect(() => {
+		const worker = workerRef.current;
+		if (!worker) return;
+		const id = latestIdRef.current + 1;
+		latestIdRef.current = id;
+		setOutput((prev) => ({ ...prev, isPending: true }));
+		const request: DiffRequest = {
+			id,
+			leftText: debouncedLeft,
+			rightText: debouncedRight,
+			options: input.options,
+			contextLines: input.contextLines,
+		};
+		worker.postMessage(request);
+	}, [debouncedLeft, debouncedRight, input.options, input.contextLines]);
+
+	return output;
+};

--- a/src/lib/workers/diff.worker.ts
+++ b/src/lib/workers/diff.worker.ts
@@ -1,0 +1,62 @@
+/**
+ * Text-diff computation worker.
+ *
+ * The Longest Common Subsequence (LCS) line diff is O(m×n) in the two
+ * documents and the inline character diff adds O(chars²) per modified line
+ * pair. Run on the main thread for two large pastes this blocks the webview
+ * for seconds on every keystroke. This worker moves both off the event loop.
+ *
+ * Message protocol:
+ *
+ * ```
+ * main -> worker: DiffRequest { id, leftText, rightText, options, contextLines }
+ * worker -> main: DiffResponse { id, enhancedDiff, isIdentical, error }
+ * ```
+ *
+ * `id` is monotonically increasing per request; the bridging hook keeps the
+ * latest id and discards any response carrying a smaller one, so a slow diff
+ * followed by a quick one cannot tear the UI.
+ */
+import {
+	areTextsIdentical,
+	computeEnhancedDiff,
+	type DiffOptions,
+	type EnhancedDiffResult,
+} from '@/lib/services/text-diff';
+
+export interface DiffRequest {
+	readonly id: number;
+	readonly leftText: string;
+	readonly rightText: string;
+	readonly options: Partial<DiffOptions>;
+	readonly contextLines: number;
+}
+
+export interface DiffResponse {
+	readonly id: number;
+	readonly enhancedDiff: EnhancedDiffResult | null;
+	readonly isIdentical: boolean | null;
+	readonly error: string | null;
+}
+
+self.addEventListener('message', (event: MessageEvent<DiffRequest>) => {
+	const { id, leftText, rightText, options, contextLines } = event.data;
+	// Empty on both sides mirrors the route's "nothing to diff" state.
+	if (!leftText && !rightText) {
+		self.postMessage({
+			id,
+			enhancedDiff: null,
+			isIdentical: null,
+			error: null,
+		} satisfies DiffResponse);
+		return;
+	}
+	try {
+		const enhancedDiff = computeEnhancedDiff(leftText, rightText, options, contextLines);
+		const isIdentical = areTextsIdentical(leftText, rightText, options);
+		self.postMessage({ id, enhancedDiff, isIdentical, error: null } satisfies DiffResponse);
+	} catch (err) {
+		const error = err instanceof Error ? err.message : 'diff worker failed';
+		self.postMessage({ id, enhancedDiff: null, isIdentical: null, error } satisfies DiffResponse);
+	}
+});

--- a/src/routes/diff-viewer.tsx
+++ b/src/routes/diff-viewer.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Equal, GitCompare, Layers, Minus, Plus, SplitSquareHorizontal } from 'lucide-react';
 import { readText } from '@tauri-apps/plugin-clipboard-manager';
 
@@ -14,11 +14,9 @@ import {
 } from '@/lib/components/form';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, EmptyState } from '@/lib/components/status';
-import { useDocumentTitle } from '@/lib/hooks';
+import { useDiffWorker, useDocumentTitle } from '@/lib/hooks';
 import { usePersistedRail } from '@/lib/stores';
 import {
-	areTextsIdentical,
-	computeEnhancedDiff,
 	type DiffOptions,
 	type DiffSegment,
 	defaultDiffOptions,
@@ -65,22 +63,23 @@ function DiffViewerPage() {
 
 	useDocumentTitle('Diff Viewer');
 
-	const diffOptions: Partial<DiffOptions> = { ignoreWhitespace, ignoreCase, trimLines };
+	const diffOptions = useMemo<Partial<DiffOptions>>(
+		() => ({ ignoreWhitespace, ignoreCase, trimLines }),
+		[ignoreWhitespace, ignoreCase, trimLines]
+	);
 
-	const enhancedDiff =
-		!leftInput && !rightInput
-			? null
-			: computeEnhancedDiff(leftInput, rightInput, diffOptions, contextLines);
-
-	const isIdentical = (() => {
-		if (!leftInput && !rightInput) return null;
-		return areTextsIdentical(leftInput, rightInput, diffOptions);
-	})();
+	// Diffing runs in a worker so two large pastes never freeze the editor.
+	const { enhancedDiff, isIdentical } = useDiffWorker({
+		leftText: leftInput,
+		rightText: rightInput,
+		options: diffOptions,
+		contextLines,
+	});
 
 	const stats = enhancedDiff?.stats ?? null;
 	const valid: boolean | null = !leftInput && !rightInput ? null : isIdentical === true;
 
-	const unifiedWithSegments: readonly UnifiedLineWithSegments[] = (() => {
+	const unifiedWithSegments = useMemo<readonly UnifiedLineWithSegments[]>(() => {
 		if (!enhancedDiff) return [];
 		const lines: UnifiedLineWithSegments[] = [];
 
@@ -163,7 +162,7 @@ function DiffViewerPage() {
 		});
 
 		return lines;
-	})();
+	}, [enhancedDiff]);
 
 	const handleLeftPaste = async () => {
 		try {


### PR DESCRIPTION
## Summary

- Fix the Diff Viewer freezing while typing or pasting large documents.
- Move the LCS diff computation into a Web Worker and debounce the inputs.

## Root cause

`computeEnhancedDiff` (O(m×n) LCS line diff + O(chars²) inline character diff) ran synchronously on the main thread on **every keystroke**, with no debounce and a `diffOptions` object rebuilt every render. Two large pastes blocked the editor: ~700 ms for two 4000-line documents (measured live), seconds for larger inputs.

## Changes

### Added

- `src/lib/workers/diff.worker.ts` — runs `computeEnhancedDiff` + `areTextsIdentical` off the main thread.
- `src/lib/hooks/use-diff-worker.ts` — bridges the route with a monotonic request id (discards stale responses) and a 180 ms input debounce.

### Changed

- `diff-viewer.tsx` consumes the worker hook. `diffOptions` and the unified-view transform are now memoized so unrelated re-renders no longer recompute.

## Test Plan

- [x] `bun run check`, `bun run lint`, `bun run test` (156 passed)
- [x] Live (running app, two 4000-line docs): main-thread max stall **11 ms** (was ~700 ms); worker hunks match the synchronous result exactly (364 = 364)
- [ ] Manual: paste two large texts, confirm typing stays responsive and the diff updates ~180 ms after typing stops; toggle options and view modes
