### PR TITLE
perf(encoding-converter): run the conversion pipeline in a Web Worker

### DIFF
--- a/src/lib/hooks/use-encoding-converter-worker.ts
+++ b/src/lib/hooks/use-encoding-converter-worker.ts
@@ -1,0 +1,108 @@
+/**
+ * Bridges `encoding-converter.tsx` to the encoding-conversion worker.
+ *
+ * Runs the whole detect → decode → encode → base64 pipeline off the main
+ * thread. A monotonic request id discards stale responses (a superseded file
+ * or option toggle), and the previous result stays visible while a new one
+ * computes. `sourceBytes` is structure-cloned to the worker, so the route
+ * keeps its own copy for the hex-dump preview.
+ */
+import { useEffect, useRef, useState } from 'react';
+
+import type {
+	BomAction,
+	DetectedEncoding,
+	Encoding,
+	LineEnding,
+} from '@/lib/services/encoding-converter';
+import type {
+	EncodingConvertRequest,
+	EncodingConvertResponse,
+} from '@/lib/workers/encoding-converter.worker';
+
+export interface UseEncodingConverterInput {
+	readonly sourceBytes: Uint8Array | null;
+	readonly overrideEncoding: Encoding | null;
+	readonly targetEncoding: Encoding;
+	readonly lineEnding: LineEnding;
+	readonly bomAction: BomAction;
+}
+
+export interface EncodingConverterResult {
+	readonly detected: DetectedEncoding | null;
+	readonly decodedText: string | null;
+	readonly targetBytes: Uint8Array | null;
+	readonly targetText: string | null;
+	readonly base64: string;
+	readonly isPending: boolean;
+}
+
+const EMPTY_RESULT: EncodingConverterResult = {
+	detected: null,
+	decodedText: null,
+	targetBytes: null,
+	targetText: null,
+	base64: '',
+	isPending: false,
+};
+
+export const useEncodingConverterWorker = (
+	input: UseEncodingConverterInput
+): EncodingConverterResult => {
+	const workerRef = useRef<Worker | null>(null);
+	const latestIdRef = useRef(0);
+	const [output, setOutput] = useState<EncodingConverterResult>(EMPTY_RESULT);
+
+	useEffect(() => {
+		const worker = new Worker(
+			new URL('@/lib/workers/encoding-converter.worker.ts', import.meta.url),
+			{ type: 'module' }
+		);
+		workerRef.current = worker;
+		const handleMessage = (event: MessageEvent<EncodingConvertResponse>) => {
+			const response = event.data;
+			if (response.id !== latestIdRef.current) return;
+			setOutput({
+				detected: response.detected,
+				decodedText: response.decodedText,
+				targetBytes: response.targetBytes,
+				targetText: response.targetText,
+				base64: response.base64,
+				isPending: false,
+			});
+		};
+		worker.addEventListener('message', handleMessage);
+		return () => {
+			worker.removeEventListener('message', handleMessage);
+			worker.terminate();
+			workerRef.current = null;
+		};
+	}, []);
+
+	const { sourceBytes, overrideEncoding, targetEncoding, lineEnding, bomAction } = input;
+
+	useEffect(() => {
+		const worker = workerRef.current;
+		if (!worker) return;
+		if (!sourceBytes) {
+			latestIdRef.current += 1;
+			setOutput(EMPTY_RESULT);
+			return;
+		}
+		const id = latestIdRef.current + 1;
+		latestIdRef.current = id;
+		setOutput((prev) => ({ ...prev, isPending: true }));
+		const request: EncodingConvertRequest = {
+			id,
+			sourceBytes,
+			overrideEncoding,
+			targetEncoding,
+			lineEnding,
+			bomAction,
+		};
+		// No transfer: the route keeps `sourceBytes` for its own hex-dump preview.
+		worker.postMessage(request);
+	}, [sourceBytes, overrideEncoding, targetEncoding, lineEnding, bomAction]);
+
+	return output;
+};

--- a/src/lib/workers/encoding-converter.worker.ts
+++ b/src/lib/workers/encoding-converter.worker.ts
@@ -1,0 +1,86 @@
+/**
+ * Encoding-conversion worker.
+ *
+ * Encoding detection runs jschardet plus a Latin-1 build loop that is O(N²)
+ * in V8 (rope-string pressure), and the single-byte / UTF-16 encoders walk
+ * every code unit. On the main thread an 8–10 MB legacy-encoded file blocks
+ * the webview for hundreds of milliseconds on load and on every option change.
+ * This worker runs the whole detect → decode → encode → base64 pipeline off
+ * the event loop.
+ *
+ * Message protocol:
+ *
+ * ```
+ * main -> worker: EncodingConvertRequest { id, sourceBytes, overrideEncoding, target… }
+ * worker -> main: EncodingConvertResponse { id, detected, decodedText, targetBytes, … }
+ * ```
+ *
+ * `id` is monotonic; the bridging hook keeps the latest id and discards stale
+ * responses so a superseded file or option toggle cannot tear the UI.
+ */
+import {
+	applyBomAction,
+	bytesToBase64,
+	decodeBytes,
+	detectEncoding,
+	encodeText,
+	type BomAction,
+	type DetectedEncoding,
+	type Encoding,
+	type LineEnding,
+} from '@/lib/services/encoding-converter';
+
+export interface EncodingConvertRequest {
+	readonly id: number;
+	readonly sourceBytes: Uint8Array;
+	readonly overrideEncoding: Encoding | null;
+	readonly targetEncoding: Encoding;
+	readonly lineEnding: LineEnding;
+	readonly bomAction: BomAction;
+}
+
+export interface EncodingConvertResponse {
+	readonly id: number;
+	readonly detected: DetectedEncoding | null;
+	readonly decodedText: string;
+	readonly targetBytes: Uint8Array;
+	readonly targetText: string;
+	readonly base64: string;
+	readonly error: string | null;
+}
+
+self.addEventListener('message', (event: MessageEvent<EncodingConvertRequest>) => {
+	const req = event.data;
+	try {
+		const detected = detectEncoding(req.sourceBytes);
+		const effectiveSource = req.overrideEncoding ?? detected.encoding;
+		const decodedText = decodeBytes(req.sourceBytes, effectiveSource);
+		const encoded = encodeText(decodedText, req.targetEncoding, req.lineEnding);
+		const targetBytes = applyBomAction(encoded, req.targetEncoding, req.bomAction);
+		const targetText = decodeBytes(targetBytes, req.targetEncoding);
+		const base64 = bytesToBase64(targetBytes);
+		self.postMessage(
+			{
+				id: req.id,
+				detected,
+				decodedText,
+				targetBytes,
+				targetText,
+				base64,
+				error: null,
+			} satisfies EncodingConvertResponse,
+			[targetBytes.buffer as ArrayBuffer]
+		);
+	} catch (err) {
+		const error = err instanceof Error ? err.message : 'encoding worker failed';
+		self.postMessage({
+			id: req.id,
+			detected: null,
+			decodedText: '',
+			targetBytes: new Uint8Array(0),
+			targetText: '',
+			base64: '',
+			error,
+		} satisfies EncodingConvertResponse);
+	}
+});

--- a/src/routes/encoding-converter.tsx
+++ b/src/routes/encoding-converter.tsx
@@ -21,12 +21,8 @@ import { SplitPane } from '@/lib/components/layout';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { useDocumentTitle } from '@/lib/hooks';
+import { useEncodingConverterWorker } from '@/lib/hooks/use-encoding-converter-worker';
 import {
-	applyBomAction,
-	bytesToBase64,
-	decodeBytes,
-	detectEncoding,
-	encodeText,
 	ENCODING_META,
 	formatHexDump,
 	getEncodingMeta,
@@ -100,28 +96,17 @@ function EncodingConverterPage() {
 	const [isDragOver, setIsDragOver] = useState(false);
 	const [showRail, setShowRail] = usePersistedRail('encoding-converter');
 
-	const detected = useMemo<DetectedEncoding | null>(() => {
-		if (!sourceBytes) return null;
-		return detectEncoding(sourceBytes);
-	}, [sourceBytes]);
+	// The detect → decode → encode → base64 pipeline runs in a worker so a
+	// large legacy-encoded file never freezes the UI on load or option change.
+	const { detected, decodedText, targetBytes, targetText, base64 } = useEncodingConverterWorker({
+		sourceBytes,
+		overrideEncoding,
+		targetEncoding: prefs.targetEncoding,
+		lineEnding: prefs.lineEnding,
+		bomAction: prefs.bomAction,
+	});
 
 	const effectiveSourceEncoding = overrideEncoding ?? detected?.encoding ?? 'utf-8';
-
-	const decodedText = useMemo<string | null>(() => {
-		if (!sourceBytes) return null;
-		return decodeBytes(sourceBytes, effectiveSourceEncoding);
-	}, [sourceBytes, effectiveSourceEncoding]);
-
-	const targetBytes = useMemo<Uint8Array | null>(() => {
-		if (decodedText === null) return null;
-		const encoded = encodeText(decodedText, prefs.targetEncoding, prefs.lineEnding);
-		return applyBomAction(encoded, prefs.targetEncoding, prefs.bomAction);
-	}, [decodedText, prefs.targetEncoding, prefs.lineEnding, prefs.bomAction]);
-
-	const targetText = useMemo<string | null>(() => {
-		if (!targetBytes) return null;
-		return decodeBytes(targetBytes, prefs.targetEncoding);
-	}, [targetBytes, prefs.targetEncoding]);
 
 	const hasContent = sourceBytes !== null;
 	const targetWritable = isWritableEncoding(prefs.targetEncoding);
@@ -347,7 +332,7 @@ function EncodingConverterPage() {
 								Save bytes…
 							</Button>
 							<CopyButton
-								text={targetBytes ? bytesToBase64(targetBytes) : ''}
+								text={base64}
 								label="Copy as base64"
 								toastLabel="Base64"
 								className="w-full justify-center"
@@ -381,6 +366,10 @@ function EncodingConverterPage() {
 					sourceEncodingLabel={overrideLabel ? `${overrideLabel} (overridden)` : detectedLabel}
 					targetEncodingLabel={targetLabel}
 				/>
+			) : hasContent ? (
+				<div className="flex h-full items-center justify-center">
+					<Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+				</div>
 			) : (
 				<DropZone
 					loading={loading}


### PR DESCRIPTION
## Summary

- Fix the Encoding Converter freezing for ~400-900 ms when a large legacy-encoded file is loaded or a target option changes.
- Move the detect → decode → encode → base64 pipeline into a Web Worker.

## Root cause

`detectEncoding` runs jschardet plus an O(N²) Latin-1 build loop (rope-string pressure in V8), and the single-byte / UTF-16 encoders walk every code unit — all synchronous on the main thread, with no debounce. The `bytesToBase64` copy ran inline on every render while a file was loaded. An 8-10 MB legacy-encoded file (the tool's core use case) blocked the webview on load and on every option change.

## Changes

### Added

- `src/lib/workers/encoding-converter.worker.ts` — runs detect → decode → encode → apply-BOM → base64 off the main thread, transferring the encoded `ArrayBuffer` back.
- `src/lib/hooks/use-encoding-converter-worker.ts` — bridges the route with the monotonic-id discard-stale pattern.

### Changed

- `encoding-converter.tsx` consumes the bundled worker result (replacing four `useMemo` chains + the inline base64) and shows a spinner while the worker computes. The 256-byte hex-dump preview stays on the main thread (already bounded).

## Test Plan

- [x] `bun run check`, `bun run lint`, `bun run test` (156 passed)
- [ ] Manual: open a large Shift-JIS / legacy file, confirm the UI stays responsive on load and when changing target encoding / line ending / BOM; verify detected encoding, both panes, and "Copy as base64"
