### PR TITLE
perf(hex-editor): run byte search in a Web Worker and debounce input

### DIFF
--- a/src/lib/hooks/use-hex-search-worker.ts
+++ b/src/lib/hooks/use-hex-search-worker.ts
@@ -1,0 +1,67 @@
+/**
+ * Bridges `hex-editor.tsx` to the byte-search worker.
+ *
+ * Runs `findAllMatches` off the main thread and keeps the previous match list
+ * visible while a new search runs. A monotonic request id discards stale
+ * responses (a superseded buffer edit or pattern change). The caller is
+ * expected to debounce the search input upstream.
+ */
+import { useEffect, useRef, useState } from 'react';
+
+import type { HexSearchRequest, HexSearchResponse } from '@/lib/workers/hex-search.worker';
+
+export interface UseHexSearchInput {
+	readonly buffer: Uint8Array | null;
+	readonly pattern: Uint8Array | null;
+}
+
+export interface UseHexSearchOutput {
+	readonly matches: readonly number[];
+	readonly isPending: boolean;
+}
+
+const EMPTY_OUTPUT: UseHexSearchOutput = { matches: [], isPending: false };
+
+export const useHexSearchWorker = (input: UseHexSearchInput): UseHexSearchOutput => {
+	const workerRef = useRef<Worker | null>(null);
+	const latestIdRef = useRef(0);
+	const [output, setOutput] = useState<UseHexSearchOutput>(EMPTY_OUTPUT);
+
+	useEffect(() => {
+		const worker = new Worker(new URL('@/lib/workers/hex-search.worker.ts', import.meta.url), {
+			type: 'module',
+		});
+		workerRef.current = worker;
+		const handleMessage = (event: MessageEvent<HexSearchResponse>) => {
+			if (event.data.id !== latestIdRef.current) return;
+			setOutput({ matches: event.data.matches, isPending: false });
+		};
+		worker.addEventListener('message', handleMessage);
+		return () => {
+			worker.removeEventListener('message', handleMessage);
+			worker.terminate();
+			workerRef.current = null;
+		};
+	}, []);
+
+	const { buffer, pattern } = input;
+
+	useEffect(() => {
+		const worker = workerRef.current;
+		if (!worker) return;
+		if (!buffer || !pattern || pattern.length === 0) {
+			latestIdRef.current += 1;
+			setOutput(EMPTY_OUTPUT);
+			return;
+		}
+		const id = latestIdRef.current + 1;
+		latestIdRef.current = id;
+		setOutput((prev) => ({ ...prev, isPending: true }));
+		// Structure-clone the buffer to the worker; the route keeps its own copy
+		// for rendering and editing.
+		const request: HexSearchRequest = { id, buffer, pattern };
+		worker.postMessage(request);
+	}, [buffer, pattern]);
+
+	return output;
+};

--- a/src/lib/workers/hex-search.worker.ts
+++ b/src/lib/workers/hex-search.worker.ts
@@ -1,0 +1,36 @@
+/**
+ * Hex Editor byte-search worker.
+ *
+ * `findAllMatches` is a naive O(n×m) scan over the whole buffer. On the main
+ * thread it ran on every search keystroke with no debounce, freezing the UI
+ * for up to a couple of seconds on a large binary. This worker runs the scan
+ * off the event loop.
+ *
+ * Message protocol:
+ *
+ * ```
+ * main -> worker: HexSearchRequest { id, buffer, pattern }
+ * worker -> main: HexSearchResponse { id, matches }
+ * ```
+ *
+ * `id` is monotonic; the bridging hook keeps the latest id and discards stale
+ * responses so a superseded buffer or pattern cannot tear the UI.
+ */
+import { findAllMatches } from '@/lib/services/hex-editor';
+
+export interface HexSearchRequest {
+	readonly id: number;
+	readonly buffer: Uint8Array;
+	readonly pattern: Uint8Array;
+}
+
+export interface HexSearchResponse {
+	readonly id: number;
+	readonly matches: readonly number[];
+}
+
+self.addEventListener('message', (event: MessageEvent<HexSearchRequest>) => {
+	const { id, buffer, pattern } = event.data;
+	const matches = pattern.length === 0 ? [] : findAllMatches(buffer, pattern);
+	self.postMessage({ id, matches } satisfies HexSearchResponse);
+});

--- a/src/routes/hex-editor.tsx
+++ b/src/routes/hex-editor.tsx
@@ -32,11 +32,11 @@ import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
-import { useDocumentTitle } from '@/lib/hooks';
+import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
+import { useHexSearchWorker } from '@/lib/hooks/use-hex-search-worker';
 import { detectMimeFromMagic } from '@/lib/services/file-inspect';
 import {
 	bytesToAscii,
-	findAllMatches,
 	formatHexByte,
 	formatOffset,
 	hexOpen,
@@ -204,16 +204,15 @@ function HexEditorPage() {
 	}, [buffer, file]);
 	const detectedMime = mimeInfo?.mime ?? mimeInfo?.expectedFromExtension ?? null;
 
+	const debouncedSearch = useDebouncedValue(searchInput, 250);
 	const searchPattern = useMemo<Uint8Array | null>(() => {
-		if (searchInput.length === 0) return null;
-		if (searchMode === 'hex') return parseHexPattern(searchInput);
-		return textToBytes(searchInput);
-	}, [searchInput, searchMode]);
+		if (debouncedSearch.length === 0) return null;
+		if (searchMode === 'hex') return parseHexPattern(debouncedSearch);
+		return textToBytes(debouncedSearch);
+	}, [debouncedSearch, searchMode]);
 
-	const matches = useMemo(() => {
-		if (!buffer || !searchPattern) return [] as readonly number[];
-		return findAllMatches(buffer, searchPattern);
-	}, [buffer, searchPattern]);
+	// Byte search runs in a worker so scanning a large binary never freezes typing.
+	const { matches } = useHexSearchWorker({ buffer, pattern: searchPattern });
 
 	useEffect(() => {
 		if (matches.length === 0) {


### PR DESCRIPTION
## Summary

- Fix the Hex Editor freezing while typing in the search box on a large binary.
- Move the byte search into a Web Worker and debounce the search input.

## Root cause

`findAllMatches` is a naive O(n×m) scan over the whole buffer. It ran inside a `useMemo` on every search keystroke with **no debounce**, blocking the UI for up to a couple of seconds per character on a large file.

## Changes

### Added

- `src/lib/workers/hex-search.worker.ts` — runs `findAllMatches` off the main thread.
- `src/lib/hooks/use-hex-search-worker.ts` — bridges the route with the monotonic-id discard-stale pattern.

### Changed

- `hex-editor.tsx` derives the search pattern from a 250 ms-debounced input and consumes the worker's match list. The match-offset set used for highlighting is still built on the main thread from the worker result (cheap for normal multi-byte patterns).

## Test Plan

- [x] `bun run check`, `bun run lint`, `bun run test`
- [ ] Manual: open a large binary, type a hex / text pattern, confirm typing stays responsive and matches/highlights appear ~250 ms after typing stops; verify find-next / find-prev and the match counter
