### PR TITLE
perf(csv-tool): run CSV parse and format in a Web Worker

### DIFF
--- a/src/lib/hooks/use-csv-tool-worker.ts
+++ b/src/lib/hooks/use-csv-tool-worker.ts
@@ -1,0 +1,93 @@
+/**
+ * Bridges `csv-tool.tsx` to the CSV parse / format worker.
+ *
+ * `parse` and `format` are imperative because the parsed table is editable on
+ * the main thread (inline cell edits mutate it, then re-format). Separate
+ * monotonic id counters discard stale parse / format responses independently.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type {
+	ColumnStats,
+	ColumnType,
+	FormatOptions,
+	OutputFormat,
+	ParseHint,
+	ParsedTable,
+} from '@/lib/services/csv-tool';
+import type { CsvWorkerRequest, CsvWorkerResponse } from '@/lib/workers/csv-tool.worker';
+
+export interface CsvParseResult {
+	readonly table: ParsedTable;
+	readonly columnTypes: readonly ColumnType[];
+	readonly columnStats: readonly ColumnStats[];
+}
+
+export interface UseCsvToolWorker {
+	readonly parse: (rawText: string, hint: ParseHint) => void;
+	readonly format: (table: ParsedTable, outputFormat: OutputFormat, options: FormatOptions) => void;
+	readonly parseResult: CsvParseResult | null;
+	readonly output: string;
+}
+
+export const useCsvToolWorker = (): UseCsvToolWorker => {
+	const workerRef = useRef<Worker | null>(null);
+	const parseIdRef = useRef(0);
+	const formatIdRef = useRef(0);
+	const [parseResult, setParseResult] = useState<CsvParseResult | null>(null);
+	const [output, setOutput] = useState('');
+
+	useEffect(() => {
+		const worker = new Worker(new URL('@/lib/workers/csv-tool.worker.ts', import.meta.url), {
+			type: 'module',
+		});
+		workerRef.current = worker;
+		const handleMessage = (event: MessageEvent<CsvWorkerResponse>) => {
+			const response = event.data;
+			if (response.kind === 'parse') {
+				if (response.id !== parseIdRef.current) return;
+				setParseResult({
+					table: response.table,
+					columnTypes: response.columnTypes,
+					columnStats: response.columnStats,
+				});
+			} else {
+				if (response.id !== formatIdRef.current) return;
+				setOutput(response.output);
+			}
+		};
+		worker.addEventListener('message', handleMessage);
+		return () => {
+			worker.removeEventListener('message', handleMessage);
+			worker.terminate();
+			workerRef.current = null;
+		};
+	}, []);
+
+	const parse = useCallback((rawText: string, hint: ParseHint) => {
+		const worker = workerRef.current;
+		if (!worker) return;
+		const id = parseIdRef.current + 1;
+		parseIdRef.current = id;
+		worker.postMessage({ kind: 'parse', id, rawText, hint } satisfies CsvWorkerRequest);
+	}, []);
+
+	const format = useCallback(
+		(table: ParsedTable, outputFormat: OutputFormat, options: FormatOptions) => {
+			const worker = workerRef.current;
+			if (!worker) return;
+			const id = formatIdRef.current + 1;
+			formatIdRef.current = id;
+			worker.postMessage({
+				kind: 'format',
+				id,
+				table,
+				outputFormat,
+				options,
+			} satisfies CsvWorkerRequest);
+		},
+		[]
+	);
+
+	return { parse, format, parseResult, output };
+};

--- a/src/lib/workers/csv-tool.worker.ts
+++ b/src/lib/workers/csv-tool.worker.ts
@@ -1,0 +1,77 @@
+/**
+ * CSV / TSV parse and format worker.
+ *
+ * `parseTable` runs Papa.parse synchronously, and `formatTable` runs
+ * `yaml.stringify` / `JSON.stringify` over every row. On the main thread a
+ * large CSV (tens of MB) froze the UI for seconds — Papa.parse on load and the
+ * YAML output path were the worst. This worker runs both off the event loop.
+ *
+ * Two request kinds:
+ *   'parse'  — text + hint -> { table, columnTypes, columnStats }.
+ *   'format' — table + output format -> { output }.
+ *
+ * Parse and format use separate id counters so a slow format cannot discard a
+ * fresh parse result and vice versa.
+ */
+import {
+	computeColumnStats,
+	detectColumnTypes,
+	formatTable,
+	parseTable,
+	type ColumnStats,
+	type ColumnType,
+	type FormatOptions,
+	type OutputFormat,
+	type ParseHint,
+	type ParsedTable,
+} from '@/lib/services/csv-tool';
+
+export interface CsvParseRequest {
+	readonly kind: 'parse';
+	readonly id: number;
+	readonly rawText: string;
+	readonly hint: ParseHint;
+}
+
+export interface CsvFormatRequest {
+	readonly kind: 'format';
+	readonly id: number;
+	readonly table: ParsedTable;
+	readonly outputFormat: OutputFormat;
+	readonly options: FormatOptions;
+}
+
+export type CsvWorkerRequest = CsvParseRequest | CsvFormatRequest;
+
+export interface CsvParseResponse {
+	readonly kind: 'parse';
+	readonly id: number;
+	readonly table: ParsedTable;
+	readonly columnTypes: readonly ColumnType[];
+	readonly columnStats: readonly ColumnStats[];
+}
+
+export interface CsvFormatResponse {
+	readonly kind: 'format';
+	readonly id: number;
+	readonly output: string;
+}
+
+export type CsvWorkerResponse = CsvParseResponse | CsvFormatResponse;
+
+self.addEventListener('message', (event: MessageEvent<CsvWorkerRequest>) => {
+	const req = event.data;
+	if (req.kind === 'parse') {
+		const table = parseTable(req.rawText, req.hint);
+		self.postMessage({
+			kind: 'parse',
+			id: req.id,
+			table,
+			columnTypes: detectColumnTypes(table),
+			columnStats: computeColumnStats(table),
+		} satisfies CsvParseResponse);
+		return;
+	}
+	const output = formatTable(req.table, req.outputFormat, req.options);
+	self.postMessage({ kind: 'format', id: req.id, output } satisfies CsvFormatResponse);
+});

--- a/src/routes/csv-tool.tsx
+++ b/src/routes/csv-tool.tsx
@@ -18,7 +18,6 @@ import {
 	type ChangeEvent,
 	type DragEvent,
 	type KeyboardEvent,
-	useCallback,
 	useEffect,
 	useMemo,
 	useRef,
@@ -37,20 +36,17 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/ca
 import { Input } from '@/lib/components/ui/input';
 import { Textarea } from '@/lib/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/lib/components/ui/tooltip';
-import { useDocumentTitle } from '@/lib/hooks';
+import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
+import { useCsvToolWorker } from '@/lib/hooks/use-csv-tool-worker';
 import {
 	addColumn,
 	addRow,
 	type ColumnType,
-	computeColumnStats,
 	computeDisplayOrder,
 	type Delimiter,
-	detectColumnTypes,
-	formatTable,
 	getDelimiterLabel,
 	type OutputFormat,
 	type ParsedTable,
-	parseTable,
 	removeColumn,
 	removeRow,
 	renameHeader,
@@ -135,37 +131,33 @@ function CsvToolPage() {
 
 	const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
-	const handleParse = useCallback(
-		(text: string) => {
-			if (text.trim() === '') {
-				setTable(null);
-				return;
-			}
-			const hint =
-				prefs.delimiterOverride === 'auto' ? undefined : { delimiter: prefs.delimiterOverride };
-			const parsed = parseTable(text, { ...hint, hasHeader: prefs.hasHeader });
-			setTable(parsed);
-			setSort(null);
-		},
-		[prefs.delimiterOverride, prefs.hasHeader]
-	);
+	// Parsing and formatting run in a worker so a large CSV never freezes the UI.
+	const { parse, format, parseResult, output: workerOutput } = useCsvToolWorker();
+	const debouncedRawText = useDebouncedValue(rawText, 300);
 
-	// Re-parse whenever the raw text or the user-controlled hints change.
-	// Inline cell edits bypass this effect by mutating `table` directly via
-	// the handlers below.
+	// Re-parse whenever the debounced text or the user-controlled hints change.
+	// Inline cell edits bypass this and mutate `table` directly via the handlers
+	// below; the format effect re-runs on that change.
 	useEffect(() => {
-		if (rawText.trim() === '') {
+		if (debouncedRawText.trim() === '') {
 			setTable(null);
 			return;
 		}
-		handleParse(rawText);
-	}, [rawText, handleParse]);
+		const hint =
+			prefs.delimiterOverride === 'auto'
+				? { hasHeader: prefs.hasHeader }
+				: { delimiter: prefs.delimiterOverride, hasHeader: prefs.hasHeader };
+		parse(debouncedRawText, hint);
+		setSort(null);
+	}, [debouncedRawText, prefs.delimiterOverride, prefs.hasHeader, parse]);
 
-	const columnTypes = useMemo<readonly ColumnType[]>(
-		() => (table ? detectColumnTypes(table) : []),
-		[table]
-	);
-	const columnStats = useMemo(() => (table ? computeColumnStats(table) : []), [table]);
+	// Adopt the worker's parsed table as editable local state.
+	useEffect(() => {
+		if (parseResult) setTable(parseResult.table);
+	}, [parseResult]);
+
+	const columnTypes: readonly ColumnType[] = parseResult?.columnTypes ?? [];
+	const columnStats = parseResult?.columnStats ?? [];
 
 	const displayOrder = useMemo<readonly number[]>(() => {
 		if (!table) return [];
@@ -189,10 +181,13 @@ function CsvToolPage() {
 		return set;
 	}, [table]);
 
-	const output = useMemo(() => {
-		if (!table) return '';
-		return formatTable(table, prefs.outputFormat, { sqlTableName: prefs.sqlTableName });
-	}, [table, prefs.outputFormat, prefs.sqlTableName]);
+	// Re-format off-thread when the table or output options change (covers
+	// inline edits, which mutate `table` directly).
+	useEffect(() => {
+		if (table) format(table, prefs.outputFormat, { sqlTableName: prefs.sqlTableName });
+	}, [table, prefs.outputFormat, prefs.sqlTableName, format]);
+
+	const output = table ? workerOutput : '';
 
 	const errorCount = table?.errors.length ?? 0;
 	const valid = table ? errorCount === 0 : null;


### PR DESCRIPTION
## Summary

- Fix the CSV / TSV Tool freezing for seconds when parsing or formatting a large file.
- Move parsing and output formatting into a Web Worker.

## Root cause

`Papa.parse` and the formatters (`JSON.stringify` / `yaml.stringify` over every row) ran synchronously on the main thread with no debounce. A large CSV (tens of MB) froze the UI on load and on every output-format change; the YAML path was the worst at multiple seconds.

## Changes

### Added

- `src/lib/workers/csv-tool.worker.ts` — `parse` (Papa.parse + column analysis) and `format` (output generation) request kinds, off the main thread.
- `src/lib/hooks/use-csv-tool-worker.ts` — bridges the route; parse and format have independent monotonic ids.

### Changed

- `csv-tool.tsx` debounces the raw text by 300 ms, adopts the worker's parsed table as editable local state, and re-formats off-thread on any table or option change (covering inline cell edits). Running the parse off-thread removes the freeze without a size cap.

## Test Plan

- [x] `bun run check`, `bun run lint`, `bun run test` (156 passed)
- [ ] Manual: load a large CSV, confirm the UI stays responsive on load and when switching output format (esp. YAML); verify sort, filter, inline cell edit, and the column-type/stat badges
