### PR TITLE
perf(base64-encoder): run encode/decode in a Web Worker

### DIFF
--- a/src/lib/hooks/use-base64-worker.ts
+++ b/src/lib/hooks/use-base64-worker.ts
@@ -1,0 +1,64 @@
+/**
+ * Bridges `base64-encoder.tsx` to the Base64 encode / decode worker.
+ *
+ * Runs the transform off the main thread and keeps the previous output visible
+ * while a new one computes. A monotonic request id discards stale responses.
+ * The caller is expected to pass an already-debounced input.
+ */
+import { useEffect, useRef, useState } from 'react';
+
+import type { Base64DecodeOptions, Base64EncodeOptions } from '@/lib/services/encoders/base64';
+import type { Base64Mode, Base64Request, Base64Response } from '@/lib/workers/base64.worker';
+
+export interface UseBase64WorkerInput {
+	readonly mode: Base64Mode;
+	readonly input: string;
+	/** Pass stable (memoized) references so the effect only fires on real changes. */
+	readonly encodeOptions: Partial<Base64EncodeOptions>;
+	readonly decodeOptions: Partial<Base64DecodeOptions>;
+}
+
+export interface UseBase64WorkerOutput {
+	readonly output: string;
+	readonly error: string;
+	readonly isPending: boolean;
+}
+
+const EMPTY_OUTPUT: UseBase64WorkerOutput = { output: '', error: '', isPending: false };
+
+export const useBase64Worker = (input: UseBase64WorkerInput): UseBase64WorkerOutput => {
+	const workerRef = useRef<Worker | null>(null);
+	const latestIdRef = useRef(0);
+	const [output, setOutput] = useState<UseBase64WorkerOutput>(EMPTY_OUTPUT);
+
+	useEffect(() => {
+		const worker = new Worker(new URL('@/lib/workers/base64.worker.ts', import.meta.url), {
+			type: 'module',
+		});
+		workerRef.current = worker;
+		const handleMessage = (event: MessageEvent<Base64Response>) => {
+			if (event.data.id !== latestIdRef.current) return;
+			setOutput({ output: event.data.output, error: event.data.error, isPending: false });
+		};
+		worker.addEventListener('message', handleMessage);
+		return () => {
+			worker.removeEventListener('message', handleMessage);
+			worker.terminate();
+			workerRef.current = null;
+		};
+	}, []);
+
+	const { mode, input: text, encodeOptions, decodeOptions } = input;
+
+	useEffect(() => {
+		const worker = workerRef.current;
+		if (!worker) return;
+		const id = latestIdRef.current + 1;
+		latestIdRef.current = id;
+		setOutput((prev) => ({ ...prev, isPending: true }));
+		const request: Base64Request = { id, mode, input: text, encodeOptions, decodeOptions };
+		worker.postMessage(request);
+	}, [mode, text, encodeOptions, decodeOptions]);
+
+	return output;
+};

--- a/src/lib/workers/base64.worker.ts
+++ b/src/lib/workers/base64.worker.ts
@@ -1,0 +1,58 @@
+/**
+ * Base64 encode / decode worker.
+ *
+ * `encodeToBase64` / `decodeFromBase64` walk the whole payload (atob/btoa plus
+ * per-character loops). Decoding an 8 MB Data URL (image / PDF / octet-stream —
+ * an intended use case) blocked the main thread for ~300 ms. This worker runs
+ * the transform off the event loop.
+ *
+ * Message protocol:
+ *
+ * ```
+ * main -> worker: Base64Request { id, mode, input, encodeOptions, decodeOptions }
+ * worker -> main: Base64Response { id, output, error }
+ * ```
+ *
+ * `id` is monotonic; the bridging hook keeps the latest id and discards stale
+ * responses so a superseded input cannot tear the UI.
+ */
+import {
+	decodeFromBase64,
+	encodeToBase64,
+	type Base64DecodeOptions,
+	type Base64EncodeOptions,
+} from '@/lib/services/encoders/base64';
+
+export type Base64Mode = 'encode' | 'decode';
+
+export interface Base64Request {
+	readonly id: number;
+	readonly mode: Base64Mode;
+	readonly input: string;
+	readonly encodeOptions: Partial<Base64EncodeOptions>;
+	readonly decodeOptions: Partial<Base64DecodeOptions>;
+}
+
+export interface Base64Response {
+	readonly id: number;
+	readonly output: string;
+	readonly error: string;
+}
+
+self.addEventListener('message', (event: MessageEvent<Base64Request>) => {
+	const { id, mode, input, encodeOptions, decodeOptions } = event.data;
+	if (!input.trim()) {
+		self.postMessage({ id, output: '', error: '' } satisfies Base64Response);
+		return;
+	}
+	try {
+		const output =
+			mode === 'encode'
+				? encodeToBase64(input, encodeOptions)
+				: decodeFromBase64(input, decodeOptions);
+		self.postMessage({ id, output, error: '' } satisfies Base64Response);
+	} catch (e) {
+		const error = e instanceof Error ? e.message : 'Invalid input';
+		self.postMessage({ id, output: '', error } satisfies Base64Response);
+	}
+});

--- a/src/routes/base64-encoder.tsx
+++ b/src/routes/base64-encoder.tsx
@@ -1,10 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Code2 } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { CodeEditor } from '@/lib/components/editor';
-import { getErrorMessage } from '@/lib/utils';
 import {
 	FormCheckbox,
 	FormCheckboxGroup,
@@ -16,6 +15,7 @@ import { SplitPane } from '@/lib/components/layout';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { DetectedInfo, EmptyOutputPane, StatItem } from '@/lib/components/status';
 import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
+import { useBase64Worker } from '@/lib/hooks/use-base64-worker';
 import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import {
 	BASE64_MIME_TYPES,
@@ -24,11 +24,9 @@ import {
 	type Base64LineBreak,
 	type Base64Variant,
 	calculateBase64Stats,
-	decodeFromBase64,
 	defaultBase64DecodeOptions,
 	defaultBase64EncodeOptions,
 	detectBase64Variant,
-	encodeToBase64,
 	extractMimeType,
 	isDataUrl,
 	SAMPLE_TEXT_FOR_BASE64,
@@ -83,19 +81,15 @@ function Base64EncoderPage() {
 
 	useDocumentTitle('Base64 Encoder');
 
-	const encodeOptions: Partial<Base64EncodeOptions> = {
-		variant,
-		padding,
-		lineBreak,
-		dataUrl,
-		mimeType,
-	};
+	const encodeOptions = useMemo<Partial<Base64EncodeOptions>>(
+		() => ({ variant, padding, lineBreak, dataUrl, mimeType }),
+		[variant, padding, lineBreak, dataUrl, mimeType]
+	);
 
-	const decodeOptions: Partial<Base64DecodeOptions> = {
-		ignoreWhitespace,
-		ignoreInvalidChars,
-		autoDetectVariant,
-	};
+	const decodeOptions = useMemo<Partial<Base64DecodeOptions>>(
+		() => ({ ignoreWhitespace, ignoreInvalidChars, autoDetectVariant }),
+		[ignoreWhitespace, ignoreInvalidChars, autoDetectVariant]
+	);
 
 	// Debounce the input feeding the encode / decode pipeline so typing
 	// large payloads (data URLs, base64 blobs) does not retrigger the
@@ -109,18 +103,13 @@ function Base64EncoderPage() {
 		mode === 'decode' && debouncedInput.trim() ? isDataUrl(debouncedInput) : false;
 	const detectedMimeType = detectedDataUrl ? extractMimeType(debouncedInput) : null;
 
-	const { output, error } = ((): { output: string; error: string } => {
-		if (!debouncedInput.trim()) return { output: '', error: '' };
-		try {
-			const result =
-				mode === 'encode'
-					? encodeToBase64(debouncedInput, encodeOptions)
-					: decodeFromBase64(debouncedInput, decodeOptions);
-			return { output: result, error: '' };
-		} catch (e) {
-			return { output: '', error: getErrorMessage(e, 'Invalid input') };
-		}
-	})();
+	// Encoding / decoding runs in a worker so a large Data URL never freezes typing.
+	const { output, error } = useBase64Worker({
+		mode,
+		input: debouncedInput,
+		encodeOptions,
+		decodeOptions,
+	});
 
 	const stats =
 		input.trim() && output


### PR DESCRIPTION
## Summary

- Fix the Base64 Encoder freezing when encoding/decoding a large payload (e.g. an 8 MB Data URL).
- Move the encode/decode transform into a Web Worker.

## Root cause

`encodeToBase64` / `decodeFromBase64` walk the whole payload (atob/btoa plus per-character loops). Decoding an 8 MB Data URL (image / PDF / octet-stream — an intended use case, listed in `BASE64_MIME_TYPES`) blocked the main thread for ~300 ms. The existing 100 ms input debounce collapsed keystrokes but not the block itself.

## Changes

### Added

- `src/lib/workers/base64.worker.ts` — runs the encode/decode transform off the main thread.
- `src/lib/hooks/use-base64-worker.ts` — bridges the route with the monotonic-id discard-stale pattern.

### Changed

- `base64-encoder.tsx` consumes the worker hook (replacing the inline transform) and memoizes the encode/decode option objects so the worker effect only fires on real changes.

## Test Plan

- [x] `bun run check`, `bun run lint`, `bun run test` (156 passed)
- [ ] Manual: paste a large Data URL / base64 blob, confirm typing stays responsive and the output, stats, and variant detection update; toggle encode/decode and the options
