### PR TITLE
perf(formatters): debounce the format and compare templates

### DIFF
--- a/src/lib/components/template/compare-tab.tsx
+++ b/src/lib/components/template/compare-tab.tsx
@@ -1,7 +1,7 @@
 import { ArrowRightLeft } from 'lucide-react';
 import { useMemo, useState, type ReactNode } from 'react';
 
-import { useReportStats } from '@/lib/hooks';
+import { useDebouncedValue, useReportStats } from '@/lib/hooks';
 import { CodeEditor } from '@/lib/components/editor';
 import { getErrorMessage } from '@/lib/utils';
 import { FormSection } from '@/lib/components/form';
@@ -97,13 +97,18 @@ export function CompareTab({
 		return null;
 	}, [validation1, validation2]);
 
+	// Debounce both inputs feeding the (synchronous, potentially expensive)
+	// compare so two large pastes do not re-parse and re-diff on every keystroke.
+	const debouncedInput = useDebouncedValue(input, 200);
+	const debouncedInput2 = useDebouncedValue(input2, 200);
+
 	// Compare result.
 	const compareResultData = useMemo(() => {
-		if (!input.trim() || !input2.trim()) {
+		if (!debouncedInput.trim() || !debouncedInput2.trim()) {
 			return { diffs: [] as GenericDiffItem[], error: '' };
 		}
 		try {
-			const diffs = compare(input, input2);
+			const diffs = compare(debouncedInput, debouncedInput2);
 			return { diffs, error: '' };
 		} catch (e) {
 			return {
@@ -111,7 +116,7 @@ export function CompareTab({
 				error: getErrorMessage(e, 'Compare failed'),
 			};
 		}
-	}, [input, input2, compare]);
+	}, [debouncedInput, debouncedInput2, compare]);
 
 	const diffResults = compareResultData.diffs;
 	const compareError = compareResultData.error;

--- a/src/lib/components/template/format-tab.tsx
+++ b/src/lib/components/template/format-tab.tsx
@@ -5,7 +5,7 @@ import type { ContextMenuItem, EditorMode } from '@/lib/components/editor';
 import { FormMode, FormSection } from '@/lib/components/form';
 import { InputOutputSplit } from '@/lib/components/layout';
 import { Rail } from '@/lib/components/ui/rail';
-import { useClipboardActions, useReportStats } from '@/lib/hooks';
+import { useClipboardActions, useDebouncedValue, useReportStats } from '@/lib/hooks';
 
 import { FormatterAboutFooter } from './formatter-about';
 
@@ -74,9 +74,13 @@ export function FormatTabTemplate<TOptions>({
 
 	const validity = useMemo<boolean | null>(() => validate(input), [validate, input]);
 
+	// Debounce the input feeding the (synchronous, potentially expensive)
+	// formatter so a large paste does not re-parse and re-serialize on every
+	// keystroke. Validation and the live editor still use the immediate value.
+	const debouncedInput = useDebouncedValue(input, 200);
 	const { output, error } = useMemo<FormatResult>(
-		() => computeOutput(input, formatMode, options),
-		[computeOutput, input, formatMode, options]
+		() => computeOutput(debouncedInput, formatMode, options),
+		[computeOutput, debouncedInput, formatMode, options]
 	);
 
 	useReportStats(onStatsChange, input, validity, error);


### PR DESCRIPTION
## Summary

- Fix the JSON / YAML / XML formatters (Format and Compare tabs) re-parsing and re-serializing on every keystroke for large inputs.

## Root cause

The shared `FormatTabTemplate` and `CompareTabTemplate` ran their per-language `computeOutput` / `compare` functions synchronously inside a `useMemo` keyed on the raw input, with no debounce. A multi-MB paste blocked the editor for 200-500 ms on every character.

## Changes

- `format-tab.tsx` and `compare-tab.tsx` (templates) debounce the input(s) feeding the synchronous derivation by 200 ms. Validation and the live editor keep the immediate value.

## Test Plan

- [x] `bun run check`, `bun run lint`, `bun run test`
- [ ] Manual: paste a large JSON / YAML / XML document, confirm typing stays responsive and the formatted output / diff updates ~200 ms after typing stops; verify the validity badge still reflects the live input
