### PR TITLE
perf(markdown-editor): debounce the stats and table-of-contents derivations

### DIFF
--- a/src/routes/markdown-editor.tsx
+++ b/src/routes/markdown-editor.tsx
@@ -268,14 +268,15 @@ function MarkdownEditorPage() {
 
 	useDocumentTitle('Markdown Editor');
 
-	const stats = useMemo(() => getMarkdownStats(input), [input]);
-	const toc = useMemo(() => generateToc(input), [input]);
-	const valid: boolean | null = input.trim() ? true : null;
-
 	// Debounce the input feeding the preview pipeline so Mermaid / KaTeX /
-	// Lowlight do not recompile on every keystroke. 200ms is short enough to
-	// feel live and long enough to collapse rapid typing into one render.
+	// Lowlight do not recompile on every keystroke, and so the stats / TOC
+	// derivations (multiple full-string regex passes plus an O(N×M) heading
+	// line lookup) do not run on every raw keystroke. 200ms feels live.
 	const debouncedInput = useDebouncedValue(input, 200);
+
+	const stats = useMemo(() => getMarkdownStats(debouncedInput), [debouncedInput]);
+	const toc = useMemo(() => generateToc(debouncedInput), [debouncedInput]);
+	const valid: boolean | null = input.trim() ? true : null;
 
 	// Render HTML preview asynchronously to support TeX and diagrams. The
 	// cancellation flag lives in a const ref so the cleanup closure can flip


### PR DESCRIPTION
## Summary

- Fix cumulative typing lag in the Markdown Editor on large documents.

## Root cause

`getMarkdownStats` and `generateToc` ran on the raw input on every keystroke (multiple full-string regex passes plus an O(N×M) per-heading line lookup). The HTML preview pipeline was already debounced, but the stats and TOC were not.

## Changes

- `markdown-editor.tsx` points the stats and TOC `useMemo`s at the existing 200 ms `debouncedInput` instead of the raw input.

## Test Plan

- [x] `bun run check`, `bun run lint`, `bun run format`
- [ ] Manual: type in a large markdown document, confirm typing is smooth and the stats / TOC update ~200 ms after typing stops
