### PR TITLE
perf(folder-tree-visualizer): memoize the export strings

### DIFF
--- a/src/routes/folder-tree-visualizer.tsx
+++ b/src/routes/folder-tree-visualizer.tsx
@@ -122,6 +122,12 @@ function FolderTreeVisualizerPage() {
 		[sortedRoot, expanded]
 	);
 
+	// Memoize the export strings so the CopyButton text props do not rebuild a
+	// multi-MB string on every render (scroll, hover, expand) — only when the
+	// sorted tree itself changes.
+	const exportText = useMemo(() => (sortedRoot ? exportAsText(sortedRoot) : ''), [sortedRoot]);
+	const exportJson = useMemo(() => (sortedRoot ? exportAsJson(sortedRoot) : ''), [sortedRoot]);
+
 	const totals = useMemo(
 		() => (sortedRoot ? countEntries(sortedRoot) : { files: 0, dirs: 0 }),
 		[sortedRoot]
@@ -383,14 +389,14 @@ function FolderTreeVisualizerPage() {
 					<FormSection title="Export">
 						<div className="flex flex-col gap-2">
 							<CopyButton
-								text={sortedRoot ? exportAsText(sortedRoot) : ''}
+								text={exportText}
 								label="Copy as text"
 								toastLabel="tree as text"
 								className="w-full justify-center"
 								disabled={!hasRoot}
 							/>
 							<CopyButton
-								text={sortedRoot ? exportAsJson(sortedRoot) : ''}
+								text={exportJson}
 								label="Copy as JSON"
 								toastLabel="tree as JSON"
 								className="w-full justify-center"


### PR DESCRIPTION
## Summary

- Stop the Folder Tree rebuilding the export strings on every render.

## Root cause

`exportAsText` / `exportAsJson` were evaluated inline in the CopyButton `text` props, rebuilding a multi-MB string on every render (scroll, hover, expand) for a large tree (up to the 50k-node cap).

## Changes

- Memoize both export strings on the sorted tree so they only rebuild when the tree changes.

## Test Plan

- [x] `bun run check`, `bun run lint`, `bun run format`
- [ ] Manual: scan a large folder, scroll/expand, confirm no lag; verify Copy as text / Copy as JSON still work