### PR TITLE
perf(string-compressor): format compressed output off the main thread

### DIFF
--- a/src/lib/hooks/use-compression-worker.ts
+++ b/src/lib/hooks/use-compression-worker.ts
@@ -1,0 +1,75 @@
+/**
+ * Bridges `string-compressor.tsx` to the output-formatting worker.
+ *
+ * Exposes a promise-based `formatBytes` so the route's compress flow can
+ * `await` the off-thread hex / base64 / data-URI formatting in place of the
+ * previous synchronous call. Each request carries a monotonic id matched to a
+ * pending promise; the worker is torn down on unmount.
+ */
+import { useCallback, useEffect, useRef } from 'react';
+
+import type {
+	CompressionFormatRequest,
+	CompressionFormatResponse,
+	CompressionOutputFormat,
+} from '@/lib/workers/compression.worker';
+
+export interface UseCompressionWorker {
+	readonly formatBytes: (
+		bytes: Uint8Array,
+		format: CompressionOutputFormat,
+		hexGroup: number,
+		hexSeparator: string
+	) => Promise<string>;
+}
+
+export const useCompressionWorker = (): UseCompressionWorker => {
+	const workerRef = useRef<Worker | null>(null);
+	const idRef = useRef(0);
+	const pendingRef = useRef(new Map<number, (output: string) => void>());
+
+	useEffect(() => {
+		const worker = new Worker(new URL('@/lib/workers/compression.worker.ts', import.meta.url), {
+			type: 'module',
+		});
+		workerRef.current = worker;
+		const pending = pendingRef.current;
+		const handleMessage = (event: MessageEvent<CompressionFormatResponse>) => {
+			const resolve = pending.get(event.data.id);
+			if (!resolve) return;
+			pending.delete(event.data.id);
+			resolve(event.data.output);
+		};
+		worker.addEventListener('message', handleMessage);
+		return () => {
+			worker.removeEventListener('message', handleMessage);
+			worker.terminate();
+			workerRef.current = null;
+			pending.clear();
+		};
+	}, []);
+
+	const formatBytes = useCallback(
+		(bytes: Uint8Array, format: CompressionOutputFormat, hexGroup: number, hexSeparator: string) =>
+			new Promise<string>((resolve, reject) => {
+				const worker = workerRef.current;
+				if (!worker) {
+					reject(new Error('Compression worker is not ready'));
+					return;
+				}
+				const id = idRef.current + 1;
+				idRef.current = id;
+				pendingRef.current.set(id, resolve);
+				worker.postMessage({
+					id,
+					bytes,
+					format,
+					hexGroup,
+					hexSeparator,
+				} satisfies CompressionFormatRequest);
+			}),
+		[]
+	);
+
+	return { formatBytes };
+};

--- a/src/lib/services/compression-bytes.ts
+++ b/src/lib/services/compression-bytes.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure byte <-> string conversions for the compression tool.
+ *
+ * These have no Tauri dependency, so both the main thread and
+ * `compression.worker.ts` can import them. `compression.ts` re-exports them
+ * for existing callers.
+ */
+
+/** Encode bytes as standard base64 (with `=` padding). */
+export const bytesToBase64 = (bytes: Uint8Array): string => {
+	// Avoid String.fromCharCode.apply on large arrays — chunk to stay under
+	// the call-stack limit on Safari/WKWebView.
+	const CHUNK = 0x8000;
+	const parts: string[] = [];
+	for (let i = 0; i < bytes.byteLength; i += CHUNK) {
+		const slice = bytes.subarray(i, Math.min(i + CHUNK, bytes.byteLength));
+		parts.push(String.fromCharCode(...slice));
+	}
+	return btoa(parts.join(''));
+};
+
+/** Decode a standard or URL-safe base64 string to bytes. */
+export const base64ToBytes = (b64: string): Uint8Array => {
+	const trimmed = b64.trim();
+	if (trimmed.length === 0) return new Uint8Array(0);
+
+	// Accept URL-safe alphabet and tolerate missing padding.
+	const normalized = trimmed.replace(/-/g, '+').replace(/_/g, '/').replace(/\s+/g, '');
+	const padLength = (4 - (normalized.length % 4)) % 4;
+	const padded = normalized + '='.repeat(padLength);
+
+	const binary = atob(padded);
+	const out = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i += 1) {
+		out[i] = binary.charCodeAt(i);
+	}
+	return out;
+};
+
+/** Render bytes as a hex string with optional grouping and case. */
+export const bytesToHex = (
+	bytes: Uint8Array,
+	opts?: { readonly upper?: boolean; readonly group?: number; readonly separator?: string }
+): string => {
+	const upper = opts?.upper ?? true;
+	const group = opts?.group ?? 0;
+	const separator = opts?.separator ?? ':';
+
+	const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'));
+	const cased = upper ? hex.map((h) => h.toUpperCase()) : hex;
+
+	if (group <= 0) return cased.join('');
+
+	const groups: string[] = [];
+	for (let i = 0; i < cased.length; i += group) {
+		groups.push(cased.slice(i, i + group).join(''));
+	}
+	return groups.join(separator);
+};
+
+/** Parse a hex string back into bytes; tolerates whitespace and `:` / `-` separators. */
+export const hexToBytes = (hex: string): Uint8Array => {
+	const stripped = hex.replace(/[\s:_-]/g, '');
+	if (stripped.length === 0) return new Uint8Array(0);
+	if (stripped.length % 2 !== 0) {
+		throw new Error('Hex string has an odd character count');
+	}
+	if (!/^[0-9a-fA-F]+$/.test(stripped)) {
+		throw new Error('Hex string contains non-hex characters');
+	}
+	const out = new Uint8Array(stripped.length / 2);
+	for (let i = 0; i < stripped.length; i += 2) {
+		out[i / 2] = Number.parseInt(stripped.slice(i, i + 2), 16);
+	}
+	return out;
+};
+
+/** Render bytes as a `data:` URI with the supplied MIME type. */
+export const bytesToDataUri = (bytes: Uint8Array, mime?: string): string =>
+	`data:${mime ?? 'application/octet-stream'};base64,${bytesToBase64(bytes)}`;

--- a/src/lib/services/compression.ts
+++ b/src/lib/services/compression.ts
@@ -11,6 +11,8 @@
  */
 import { invoke } from '@tauri-apps/api/core';
 
+import { base64ToBytes, bytesToBase64 } from './compression-bytes';
+
 /** Compression algorithm identifier. */
 export type CompressionAlgorithm = 'gzip' | 'brotli';
 
@@ -145,78 +147,15 @@ export const clampLevel = (level: number, algorithm: CompressionAlgorithm): numb
 	return Math.min(max, Math.max(min, Math.round(level)));
 };
 
-/** Encode bytes as standard base64 (with `=` padding). */
-export const bytesToBase64 = (bytes: Uint8Array): string => {
-	// Avoid String.fromCharCode.apply on large arrays — chunk to stay under
-	// the call-stack limit on Safari/WKWebView.
-	const CHUNK = 0x8000;
-	const parts: string[] = [];
-	for (let i = 0; i < bytes.byteLength; i += CHUNK) {
-		const slice = bytes.subarray(i, Math.min(i + CHUNK, bytes.byteLength));
-		parts.push(String.fromCharCode(...slice));
-	}
-	return btoa(parts.join(''));
-};
-
-/** Decode a standard or URL-safe base64 string to bytes. */
-export const base64ToBytes = (b64: string): Uint8Array => {
-	const trimmed = b64.trim();
-	if (trimmed.length === 0) return new Uint8Array(0);
-
-	// Accept URL-safe alphabet and tolerate missing padding.
-	const normalized = trimmed.replace(/-/g, '+').replace(/_/g, '/').replace(/\s+/g, '');
-	const padLength = (4 - (normalized.length % 4)) % 4;
-	const padded = normalized + '='.repeat(padLength);
-
-	const binary = atob(padded);
-	const out = new Uint8Array(binary.length);
-	for (let i = 0; i < binary.length; i += 1) {
-		out[i] = binary.charCodeAt(i);
-	}
-	return out;
-};
-
-/** Render bytes as a hex string with optional grouping and case. */
-export const bytesToHex = (
-	bytes: Uint8Array,
-	opts?: { readonly upper?: boolean; readonly group?: number; readonly separator?: string }
-): string => {
-	const upper = opts?.upper ?? true;
-	const group = opts?.group ?? 0;
-	const separator = opts?.separator ?? ':';
-
-	const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'));
-	const cased = upper ? hex.map((h) => h.toUpperCase()) : hex;
-
-	if (group <= 0) return cased.join('');
-
-	const groups: string[] = [];
-	for (let i = 0; i < cased.length; i += group) {
-		groups.push(cased.slice(i, i + group).join(''));
-	}
-	return groups.join(separator);
-};
-
-/** Parse a hex string back into bytes; tolerates whitespace and `:` / `-` separators. */
-export const hexToBytes = (hex: string): Uint8Array => {
-	const stripped = hex.replace(/[\s:_-]/g, '');
-	if (stripped.length === 0) return new Uint8Array(0);
-	if (stripped.length % 2 !== 0) {
-		throw new Error('Hex string has an odd character count');
-	}
-	if (!/^[0-9a-fA-F]+$/.test(stripped)) {
-		throw new Error('Hex string contains non-hex characters');
-	}
-	const out = new Uint8Array(stripped.length / 2);
-	for (let i = 0; i < stripped.length; i += 2) {
-		out[i / 2] = Number.parseInt(stripped.slice(i, i + 2), 16);
-	}
-	return out;
-};
-
-/** Render bytes as a `data:` URI with the supplied MIME type. */
-export const bytesToDataUri = (bytes: Uint8Array, mime?: string): string =>
-	`data:${mime ?? 'application/octet-stream'};base64,${bytesToBase64(bytes)}`;
+// Pure byte conversions live in compression-bytes.ts (Tauri-free) so the
+// compression worker can import them; re-exported here for existing callers.
+export {
+	base64ToBytes,
+	bytesToBase64,
+	bytesToDataUri,
+	bytesToHex,
+	hexToBytes,
+} from './compression-bytes';
 
 /** Parse a `data:` URI; returns raw bytes when the payload is base64. */
 export const dataUriToBytes = (uri: string): Uint8Array => {

--- a/src/lib/workers/compression.worker.ts
+++ b/src/lib/workers/compression.worker.ts
@@ -1,0 +1,46 @@
+/**
+ * String Compressor output-formatting worker.
+ *
+ * The Tauri command does the actual (de)compression off-thread, but the route
+ * still rendered the compressed bytes on the main thread — `bytesToHex` over a
+ * multi-megabyte buffer for hex output blocked the UI for hundreds of
+ * milliseconds. This worker runs that formatting off the event loop. The
+ * conversion helpers are Tauri-free, so importing them here is safe.
+ *
+ * Decoding the (smaller, already-compressed) decompress input stays on the main
+ * thread; only the larger output formatting is offloaded.
+ *
+ * Message protocol:
+ *
+ * ```
+ * main -> worker: CompressionFormatRequest { id, bytes, format, hexGroup, hexSeparator }
+ * worker -> main: CompressionFormatResponse { id, output }
+ * ```
+ */
+import { bytesToBase64, bytesToDataUri, bytesToHex } from '@/lib/services/compression-bytes';
+
+export type CompressionOutputFormat = 'hex' | 'base64' | 'data-uri';
+
+export interface CompressionFormatRequest {
+	readonly id: number;
+	readonly bytes: Uint8Array;
+	readonly format: CompressionOutputFormat;
+	readonly hexGroup: number;
+	readonly hexSeparator: string;
+}
+
+export interface CompressionFormatResponse {
+	readonly id: number;
+	readonly output: string;
+}
+
+self.addEventListener('message', (event: MessageEvent<CompressionFormatRequest>) => {
+	const req = event.data;
+	const output =
+		req.format === 'hex'
+			? bytesToHex(req.bytes, { upper: true, group: req.hexGroup, separator: req.hexSeparator })
+			: req.format === 'data-uri'
+				? bytesToDataUri(req.bytes, 'application/octet-stream')
+				: bytesToBase64(req.bytes);
+	self.postMessage({ id: req.id, output } satisfies CompressionFormatResponse);
+});

--- a/src/routes/string-compressor.tsx
+++ b/src/routes/string-compressor.tsx
@@ -21,6 +21,7 @@ import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { Textarea } from '@/lib/components/ui/textarea';
 import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
+import { useCompressionWorker } from '@/lib/hooks/use-compression-worker';
 import {
 	type CompressionAlgorithm,
 	type CompressResult,
@@ -29,9 +30,6 @@ import {
 	type OutputFormat,
 	SAMPLE_TEXT,
 	base64ToBytes,
-	bytesToBase64,
-	bytesToDataUri,
-	bytesToHex,
 	clampLevel,
 	compressText,
 	dataUriToBytes,
@@ -89,13 +87,6 @@ const decodeInputForDecompress = (input: string): Uint8Array => {
 	return base64ToBytes(trimmed);
 };
 
-const formatCompressedBytes = (bytes: Uint8Array, format: OutputFormat): string => {
-	if (format === 'hex')
-		return bytesToHex(bytes, { upper: true, group: HEX_GROUP_SIZE, separator: HEX_SEPARATOR });
-	if (format === 'data-uri') return bytesToDataUri(bytes, 'application/octet-stream');
-	return bytesToBase64(bytes);
-};
-
 interface DerivedState {
 	readonly output: string;
 	readonly error: string | null;
@@ -121,12 +112,20 @@ const runCompress = async (
 	text: string,
 	algorithm: CompressionAlgorithm,
 	level: number,
-	outputFormat: OutputFormat
+	outputFormat: OutputFormat,
+	formatOutput: (
+		bytes: Uint8Array,
+		format: OutputFormat,
+		hexGroup: number,
+		hexSeparator: string
+	) => Promise<string>
 ): Promise<DerivedState> => {
 	const result = await compressText(text, { algorithm, level });
 	if (!result.ok) return errorState(result.error);
 	return {
-		output: formatCompressedBytes(result.bytes, outputFormat),
+		// Format the compressed bytes off the main thread (hex of a multi-MB
+		// buffer would otherwise block the UI).
+		output: await formatOutput(result.bytes, outputFormat, HEX_GROUP_SIZE, HEX_SEPARATOR),
 		error: null,
 		result,
 		detectedAlgorithm: null,
@@ -184,6 +183,9 @@ function StringCompressorPage() {
 	const [detectedAlgorithm, setDetectedAlgorithm] = useState<CompressionAlgorithm | null>(null);
 	const [busy, setBusy] = useState(false);
 	const [showRail, setShowRail] = usePersistedRail('string-compressor');
+
+	// Off-thread output formatting (aliased to avoid the byte-size formatBytes).
+	const { formatBytes: formatCompressedOutput } = useCompressionWorker();
 
 	const handleAlgorithmChange = (next: CompressionAlgorithm) => {
 		// Re-clamp level into the new algorithm's range so the slider stays valid.
@@ -251,7 +253,13 @@ function StringCompressorPage() {
 		(async () => {
 			const next =
 				direction === 'compress'
-					? await runCompress(debouncedInput, algorithm, level, outputFormat)
+					? await runCompress(
+							debouncedInput,
+							algorithm,
+							level,
+							outputFormat,
+							formatCompressedOutput
+						)
 					: await runDecompress(debouncedInput, algorithm, autoDetect);
 			if (cancelled) return;
 			apply(next);
@@ -260,7 +268,15 @@ function StringCompressorPage() {
 		return () => {
 			cancelled = true;
 		};
-	}, [debouncedInput, direction, algorithm, level, outputFormat, autoDetect]);
+	}, [
+		debouncedInput,
+		direction,
+		algorithm,
+		level,
+		outputFormat,
+		autoDetect,
+		formatCompressedOutput,
+	]);
 
 	const valid: boolean | null = inputText.trim().length === 0 ? null : error === null;
 


### PR DESCRIPTION
## Summary

- Fix the String Compressor blocking the UI while rendering large compressed output (esp. hex).

## Root cause

The Tauri command compresses off-thread, but the route formatted the compressed bytes on the main thread — `bytesToHex` over a multi-megabyte buffer blocked the UI for hundreds of milliseconds after each (debounced) compress.

## Changes

### Added

- `compression-bytes.ts` — the Tauri-free byte conversions, extracted from `compression.ts` (re-exported there for existing callers) so a worker can import them.
- `compression.worker.ts` + `use-compression-worker.ts` — format the compressed output (hex / base64 / data-URI) off the main thread.

### Changed

- `string-compressor.tsx` awaits the off-thread formatting in the compress flow. Decoding the smaller, already-compressed decompress input stays on the main thread.

## Test Plan

- [x] `bun run check`, `bun run lint`, `bun run test` (156 passed)
- [ ] Manual: compress a large input with hex output, confirm the UI stays responsive; verify base64 / data-URI output and the decompress round-trip
