### PR TITLE
chore: ignore .claude/worktrees to fix Biome nested-config lint error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ vite.config.ts.timestamp-*
 # Claude Code
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+.claude/worktrees/
 .mcp.json
 CLAUDE.local.md
 


### PR DESCRIPTION
## Summary

- `.claude/worktrees/` holds ephemeral git worktrees that Claude Code creates for isolated feature work. Each is a full repo checkout, including a nested `biome.json`.
- Biome 2.x rejects nested root configurations during config discovery, so `bun run lint` in the primary checkout fails the moment such a worktree exists.
- Ignoring the directory lets the already-enabled `vcs.useIgnoreFile` skip it and stops the ephemeral worktrees from being accidentally staged.

## Changes

### Changed

- `.gitignore`: add `.claude/worktrees/` under the existing "Claude Code" section.

## Test Plan

- [x] `bun run lint` reports a nested-root-configuration error before the change when a worktree exists under `.claude/worktrees/`
- [x] `bun run lint` passes after the change (26 pre-existing warnings, exit 0)
- [x] `bun run check` still passes
