### PR TITLE
refactor: use ActionButton for mac-lookup and tls-inspector rail buttons

### DIFF
--- a/src/routes/mac-lookup.tsx
+++ b/src/routes/mac-lookup.tsx
@@ -270,10 +270,7 @@ function MacLookupRail({
 					size="compact"
 					onValueChange={(v) => onPatch({ randomVendorOui: v })}
 				/>
-				<Button variant="default" size="sm" className="w-full" onClick={onGenerateRandom}>
-					<Dice5 className="mr-1.5 h-3.5 w-3.5" />
-					Generate random
-				</Button>
+				<ActionButton label="Generate random" icon={Dice5} size="sm" onClick={onGenerateRandom} />
 			</FormSection>
 
 			{dbInfo ? (

--- a/src/routes/tls-inspector.tsx
+++ b/src/routes/tls-inspector.tsx
@@ -11,7 +11,7 @@ import {
 import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
-import { CopyButton } from '@/lib/components/action';
+import { ActionButton, CopyButton } from '@/lib/components/action';
 import { FormError, FormInput, FormSection, FormSlider } from '@/lib/components/form';
 import { DefinitionList, SectionLabel } from '@/lib/components/layout';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
@@ -180,14 +180,15 @@ function TlsInspectorPage() {
 			rail={
 				<>
 					<FormSection title="Run">
-						<Button onClick={handleRun} disabled={!canRun} className="w-full">
-							{running ? (
-								<Loader2 className="h-4 w-4 animate-spin" />
-							) : (
-								<ShieldCheck className="h-4 w-4" />
-							)}
-							{running ? 'Inspecting…' : 'Inspect'}
-						</Button>
+						<ActionButton
+							label="Inspect"
+							icon={ShieldCheck}
+							loading={running}
+							loadingLabel="Inspecting…"
+							disabled={!canRun}
+							shortcutHint
+							onClick={handleRun}
+						/>
 					</FormSection>
 
 					<FormSection title="SNI override">


### PR DESCRIPTION
## Summary

- `mac-lookup`: replace the hand-rolled full-width "Generate random" `Button` with the canonical `ActionButton`.
- `tls-inspector`: replace the rail "Inspect" run `Button` (manual `Loader2` spinner + Inspecting/Inspect label swap) with `ActionButton` using `shortcutHint`.

## Changes

### Changed

- `src/routes/mac-lookup.tsx`
- `src/routes/tls-inspector.tsx`

`tls-inspector` uses `shortcutHint` (visual ⏎ badge, no listener) because `ToolShell.primaryAction` already binds Cmd+Enter centrally, which avoids a duplicate keydown listener. `ActionButton` owns the spinner and label swap, so the inline `Loader2` ternary is dropped (the `Loader2` import stays — still used by the host/port input bar).

## Test Plan

- [x] `bun run check` passes
- [x] `bun run lint` clean (26 pre-existing warnings)
- [x] `bunx prettier --check` clean
- [ ] CI: Test Frontend + Test Backend
