### PR TITLE
refactor: adopt ToneBadge for single-tone status pills

### DIFF
--- a/src/routes/drive-info.tsx
+++ b/src/routes/drive-info.tsx
@@ -315,13 +315,9 @@ function DriveCard({ drive }: { readonly drive: DriveInfo }) {
 							</Badge>
 						) : null}
 						{drive.isReadOnly ? (
-							<Badge
-								variant="outline"
-								className="gap-1 border-warning/40 bg-warning/10 font-mono text-2xs text-warning"
-							>
-								<Lock className="h-3 w-3" />
+							<ToneBadge tone="warning" icon={Lock} className="font-mono text-2xs">
 								Read only
-							</Badge>
+							</ToneBadge>
 						) : null}
 					</div>
 				</CardTitle>

--- a/src/routes/duplicate-finder.tsx
+++ b/src/routes/duplicate-finder.tsx
@@ -14,6 +14,7 @@ import {
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
+import { ToneBadge } from '@/lib/components/ui/tone-badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { Checkbox } from '@/lib/components/ui/checkbox';
@@ -728,9 +729,9 @@ function GroupRow({ entry, isKeeper, isSelected, onToggle }: GroupRowProps) {
 						{entry.path}
 					</span>
 					{isKeeper ? (
-						<Badge variant="outline" className="shrink-0 font-mono text-2xs text-success">
+						<ToneBadge tone="success" className="shrink-0 font-mono text-2xs">
 							Keeper
-						</Badge>
+						</ToneBadge>
 					) : null}
 				</div>
 				<div className="text-2xs text-muted-foreground">

--- a/src/routes/hex-editor.tsx
+++ b/src/routes/hex-editor.tsx
@@ -30,6 +30,7 @@ import { DefinitionList } from '@/lib/components/layout';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
+import { ToneBadge } from '@/lib/components/ui/tone-badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
@@ -917,9 +918,9 @@ function FileBanner({ file, detectedMime, magicHex, dirty, pendingCount }: FileB
 				<CardTitle className="flex items-center gap-2 text-sm">
 					<span className="truncate font-mono">{filename}</span>
 					{dirty ? (
-						<Badge variant="outline" className="border-warning/50 bg-warning/10 text-warning">
+						<ToneBadge tone="warning">
 							{pendingCount} pending edit{pendingCount > 1 ? 's' : ''}
-						</Badge>
+						</ToneBadge>
 					) : null}
 				</CardTitle>
 			</CardHeader>


### PR DESCRIPTION
## Summary

Adopt the canonical `ToneBadge` primitive for three lone single-tone status pills that were hand-rolled with raw `Badge` + tone classes.

## Changes

### Changed

- `src/routes/hex-editor.tsx` — pending-edits pill → `ToneBadge tone="warning"`.
- `src/routes/duplicate-finder.tsx` — Keeper pill → `ToneBadge tone="success"`.
- `src/routes/drive-info.tsx` — read-only pill → `ToneBadge tone="warning"` (the `Lock` icon moves to the `icon` prop).

Each drops its redundant tinted border for `ToneBadge`'s neutral outline plus the `bg-{tone}/10 text-{tone}` surface. The neutral count / format `Badge`s in each file are unaffected.

## Test Plan

- [x] `bun run check` passes
- [x] `bun run lint` clean (26 pre-existing warnings)
- [x] `bunx prettier --check` clean
- [ ] CI: Test Frontend + Test Backend
