### PR TITLE
refactor: adopt ToneBadge in semver-tools and date-timestamp-converter

### DIFF
--- a/src/routes/date-timestamp-converter.tsx
+++ b/src/routes/date-timestamp-converter.tsx
@@ -501,10 +501,9 @@ function TimezonesSection({ timezones, activeMs, nowMs }: TimezonesSectionProps)
 										{render.relative}
 									</Badge>
 									{render.isDstBoundary ? (
-										<Badge className="bg-warning/10 text-warning border-warning/30 gap-1">
-											<AlertTriangle className="h-3 w-3" />
+										<ToneBadge tone="warning" icon={AlertTriangle}>
 											DST boundary
-										</Badge>
+										</ToneBadge>
 									) : null}
 								</div>
 							</CardContent>
@@ -575,9 +574,9 @@ function CronSection({
 											<span className="w-6 text-xs tabular-nums text-muted-foreground">
 												{idx + 1}.
 											</span>
-											<Badge className="bg-info/10 text-info border-info/30 text-2xs font-mono">
+											<ToneBadge tone="info" className="text-2xs font-mono">
 												{clock.day}
-											</Badge>
+											</ToneBadge>
 											<span className="font-mono text-sm tabular-nums">{clock.date}</span>
 											<span className="font-mono text-sm tabular-nums text-muted-foreground">
 												{clock.time}

--- a/src/routes/semver-tools.tsx
+++ b/src/routes/semver-tools.tsx
@@ -517,9 +517,9 @@ function SemverToolsPage() {
 									<div className="flex flex-wrap items-center justify-center gap-2">
 										<BumpBadge bump={compareResult.bump} className="text-xs" />
 										{compareResult.metadataOnly ? (
-											<Badge className="bg-info/10 text-info border-info/30 text-xs">
+											<ToneBadge tone="info" className="text-xs">
 												metadata-only
-											</Badge>
+											</ToneBadge>
 										) : null}
 									</div>
 									<p className="text-center text-xs text-muted-foreground">
@@ -683,21 +683,13 @@ function SemverToolsPage() {
 						<>
 							<Card density="compact">
 								<CardContent className="flex flex-col items-center gap-3 py-6">
-									<Badge
-										className={cn(
-											'px-4 py-1 text-base font-medium',
-											rangeResult.satisfies
-												? 'bg-success/10 text-success border-success/30'
-												: 'bg-destructive/10 text-destructive border-destructive/30'
-										)}
+									<ToneBadge
+										tone={rangeResult.satisfies ? 'success' : 'destructive'}
+										icon={rangeResult.satisfies ? Check : X}
+										className="px-4 py-1 text-base font-medium"
 									>
-										{rangeResult.satisfies ? (
-											<Check className="mr-1 h-4 w-4" />
-										) : (
-											<X className="mr-1 h-4 w-4" />
-										)}
 										{rangeResult.satisfies ? 'Satisfies' : 'Does not satisfy'}
-									</Badge>
+									</ToneBadge>
 									<p className="text-center text-xs text-muted-foreground">
 										<code className="font-mono">{rangeResult.version}</code>{' '}
 										{rangeResult.satisfies ? 'matches' : 'does not match'}{' '}


### PR DESCRIPTION
## Summary

Adopt the canonical `ToneBadge` primitive for four tone pills in semver-tools and date-timestamp-converter.

## Changes

### Changed

- `src/routes/semver-tools.tsx` — metadata-only pill (`info`) and the Satisfies / Does-not-satisfy pill (`success` / `destructive`, `Check` / `X` moved to the `icon` prop).
- `src/routes/date-timestamp-converter.tsx` — DST-boundary pill (`warning`, `AlertTriangle` moved to the `icon` prop) and the next-fires clock.day pill (`info`).

Each drops its redundant tinted border for `ToneBadge`'s neutral outline plus the `bg-{tone}/10 text-{tone}` surface. The operator color map and muted / neutral badges are left untouched (categorical, not tone-semantic).

## Test Plan

- [x] `bun run check` passes
- [x] `bun run lint` clean (26 pre-existing warnings)
- [x] `bunx prettier --check` clean
- [ ] CI: Test Frontend + Test Backend
