### PR TITLE
refactor(ui): forward title on ToneBadge; adopt in archive-inspector

### DIFF
--- a/src/lib/components/ui/tone-badge.tsx
+++ b/src/lib/components/ui/tone-badge.tsx
@@ -14,6 +14,7 @@ interface ToneBadgeProps {
 	// "Weak"). Renders at 12px on the left of the label.
 	readonly icon?: LucideIcon;
 	readonly className?: string;
+	readonly title?: string;
 	readonly children: ReactNode;
 }
 
@@ -29,9 +30,9 @@ const TONE_CLASS: Record<Tone, string> = {
 // `<Badge variant="outline" className="gap-1 bg-success/10 text-success">…`
 // that appeared verbatim across the hash / ssh / gpg result panes — a single
 // place to evolve tone treatment going forward.
-export function ToneBadge({ tone, icon: Icon, className, children }: ToneBadgeProps) {
+export function ToneBadge({ tone, icon: Icon, title, className, children }: ToneBadgeProps) {
 	return (
-		<Badge variant="outline" className={cn('gap-1', TONE_CLASS[tone], className)}>
+		<Badge variant="outline" title={title} className={cn('gap-1', TONE_CLASS[tone], className)}>
 			{Icon ? <Icon className="h-3 w-3" /> : null}
 			{children}
 		</Badge>

--- a/src/routes/archive-inspector.tsx
+++ b/src/routes/archive-inspector.tsx
@@ -27,6 +27,7 @@ import { DefinitionList, SectionLabel } from '@/lib/components/layout';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
+import { ToneBadge } from '@/lib/components/ui/tone-badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { Checkbox } from '@/lib/components/ui/checkbox';
@@ -723,13 +724,9 @@ function ArchiveBanner({ archive, filename, filteredCount }: ArchiveBannerProps)
 					<Badge variant="outline" className="text-2xs uppercase">
 						{archive.format}
 					</Badge>
-					<Badge
-						variant="outline"
-						className="border-info/40 bg-info/10 text-info text-2xs"
-						title="Overall compression ratio"
-					>
+					<ToneBadge tone="info" title="Overall compression ratio" className="text-2xs">
 						{ratio} saved
-					</Badge>
+					</ToneBadge>
 				</CardTitle>
 			</CardHeader>
 			<CardContent>


### PR DESCRIPTION
## Summary

Add an optional `title` prop to the `ToneBadge` primitive (forwarded to the underlying `Badge`) and adopt `ToneBadge` for the archive-inspector compression-ratio pill, preserving its tooltip.

## Changes

### Changed

- `src/lib/components/ui/tone-badge.tsx` — add optional `title` prop, forward to `Badge`.
- `src/routes/archive-inspector.tsx` — compression-ratio info pill → `ToneBadge` with `title`.

The `title` addition is backward-compatible (existing callers pass no `title`). The ratio pill keeps its "Overall compression ratio" tooltip and drops its redundant tinted border for `ToneBadge`'s neutral outline.

## Test Plan

- [x] `bun run check` passes
- [x] `bun run lint` clean (26 pre-existing warnings)
- [x] `bunx prettier --check` clean
- [ ] CI: Test Frontend + Test Backend
