### PR TITLE
refactor: use ErrorDisplay for jwt-decoder, rest-client, image-converter errors

### DIFF
--- a/src/routes/image-converter.tsx
+++ b/src/routes/image-converter.tsx
@@ -7,14 +7,13 @@ import { ActionButton } from '@/lib/components/action';
 import {
 	FormCheckbox,
 	FormCheckboxGroup,
-	FormError,
 	FormInfo,
 	FormInput,
 	FormSection,
 	FormSlider,
 } from '@/lib/components/form';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
-import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { EmbeddedEmptyState, ErrorDisplay, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
@@ -524,13 +523,7 @@ function ImageConverterPage() {
 					</section>
 				) : (
 					<div className="flex flex-col gap-4 overflow-auto">
-						{error ? (
-							<Card density="compact">
-								<CardContent>
-									<FormError message={error} className="text-sm" />
-								</CardContent>
-							</Card>
-						) : null}
+						{error ? <ErrorDisplay variant="banner" message={error} /> : null}
 						<div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
 							<Card density="compact">
 								<CardHeader>

--- a/src/routes/jwt-decoder.tsx
+++ b/src/routes/jwt-decoder.tsx
@@ -100,7 +100,6 @@ function JwtDecoderPage() {
 	return (
 		<ToolShell
 			valid={valid}
-			error={error || undefined}
 			showRail={showOptions}
 			onShowRailChange={setShowOptions}
 			statusContent={
@@ -321,12 +320,7 @@ function JwtDecoderPage() {
 						) : (
 							<div className="flex-1">
 								{error ? (
-									<div className="flex h-full items-center justify-center text-muted-foreground">
-										<div className="text-center">
-											<AlertTriangle className="mx-auto mb-2 h-8 w-8 text-destructive" />
-											<p className="text-sm">{error}</p>
-										</div>
-									</div>
+									<ErrorDisplay variant="centered" message={error} />
 								) : (
 									<EmptyState icon={KeyRound} title="Enter a JWT token to decode" />
 								)}

--- a/src/routes/rest-client.tsx
+++ b/src/routes/rest-client.tsx
@@ -16,14 +16,13 @@ import { toast } from 'sonner';
 import { CopyButton } from '@/lib/components/action';
 import {
 	FormCheckbox,
-	FormError,
 	FormInput,
 	FormSection,
 	FormSelect,
 	FormSlider,
 } from '@/lib/components/form';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
-import { EmbeddedEmptyState, StatItem } from '@/lib/components/status';
+import { EmbeddedEmptyState, ErrorDisplay, StatItem } from '@/lib/components/status';
 import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
@@ -211,7 +210,6 @@ function RestClientPage() {
 	return (
 		<ToolShell
 			valid={error ? false : response ? true : null}
-			error={error ?? undefined}
 			primaryAction={{ run: () => handleSend().catch(() => undefined), canRun: canSend }}
 			rail={rail}
 			statusContent={statusContent}
@@ -241,7 +239,7 @@ function RestClientPage() {
 							onBodyChange={(e) => patch({ body: e.target.value })}
 						/>
 
-						{error ? <ErrorCard message={error} /> : null}
+						{error ? <ErrorDisplay variant="banner" message={error} /> : null}
 
 						<ResponseCard
 							response={response}
@@ -587,23 +585,6 @@ function HeaderRow({ entry, onChange, onRemove }: HeaderRowProps) {
 				<Trash2 className="h-3.5 w-3.5" />
 			</Button>
 		</div>
-	);
-}
-
-interface ErrorCardProps {
-	readonly message: string;
-}
-
-function ErrorCard({ message }: ErrorCardProps) {
-	return (
-		<Card density="compact" variant="destructive">
-			<CardHeader className="pb-3">
-				<CardTitle className="text-sm font-medium text-destructive">Request failed</CardTitle>
-			</CardHeader>
-			<CardContent>
-				<FormError message={message} />
-			</CardContent>
-		</Card>
 	);
 }
 


### PR DESCRIPTION
jwt-decoder: replace the hand-rolled centered error block with ErrorDisplay variant=centered and drop the duplicate ToolShell error prop, leaving the body as the single error channel (valid still drives the status dot). rest-client: replace the bespoke ErrorCard (destructive Card + FormError) with ErrorDisplay variant=banner, delete the ErrorCard component, and drop the duplicate ToolShell error prop. image-converter: replace the Card + FormError error block with ErrorDisplay variant=banner. Prune the now-unused FormError imports.
