### PR TITLE
refactor(network-scanner): use SubsectionLabel for the Scan Settings heading

### DIFF
--- a/src/routes/network-scanner.tsx
+++ b/src/routes/network-scanner.tsx
@@ -28,6 +28,7 @@ import {
 	FormSection,
 	FormSlider,
 } from '@/lib/components/form';
+import { SubsectionLabel } from '@/lib/components/layout';
 import { UnifiedHostDetailPanel, UnifiedHostListItem } from '@/lib/components/network-scanner';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
 import { EmptyState, ErrorDisplay, LiveStatusRegion, StatItem } from '@/lib/components/status';
@@ -595,9 +596,7 @@ function PortScanSection({
 			) : null}
 
 			<div className="mt-3 border-t border-border/30 pt-3">
-				<p className="mb-2 text-xs font-semibold uppercase tracking-wide text-foreground/70">
-					Scan Settings
-				</p>
+				<SubsectionLabel className="mb-2">Scan Settings</SubsectionLabel>
 				<FormSlider
 					label="Concurrency"
 					value={concurrency}


### PR DESCRIPTION
Replace the hand-rolled <p> subsection heading with the canonical SubsectionLabel primitive, matching cron-expression-builder, webhook-receiver, and http-status-codes; the text-foreground/70 color normalizes to text-muted-foreground and the element becomes a semantic heading. The panel's IconTooltip-wrapped copy buttons are left as-is: they share a cohesive IconTooltip pattern with the panel's non-copy icon actions, which CopyButton's icon variant cannot reproduce.
