### PR TITLE
fix(markdown-editor): guard Vizel update handler against unready markdown surface

### DIFF
--- a/src/routes/markdown-editor.tsx
+++ b/src/routes/markdown-editor.tsx
@@ -345,6 +345,13 @@ function MarkdownEditorPage() {
 
 	const handleVizelUpdate = useCallback(({ editor }: { editor: VizelEditor }) => {
 		vizelEditorRef.current = editor as unknown as TiptapEditor;
+		// The Markdown surface (editor.getMarkdown) is installed in the markdown
+		// extension's deferred onCreate. An `update` can fire before that runs
+		// (autofocus, the initial content transaction), and getVizelMarkdown only
+		// null-checks the editor — not the method — so reading it too early throws
+		// "getMarkdown is not a function". Skip construction-time updates; the first
+		// update after the surface is ready syncs the content back.
+		if (typeof (editor as { getMarkdown?: unknown }).getMarkdown !== 'function') return;
 		const md = getVizelMarkdown(editor);
 		lastSyncedToVizelRef.current = md;
 		setInput(md);


### PR DESCRIPTION
Loading or reloading the Markdown Editor intermittently crashed with
"e.getMarkdown is not a function". Vizel installs its Markdown surface
(editor.getMarkdown / editor.markdown) in the markdown extension's
deferred onCreate hook, which can resolve after the editor promise. An
`update` fired during construction (autofocus or the initial content
transaction) reaches handleVizelUpdate, and getVizelMarkdown only
null-checks the editor — not the method — so it calls getMarkdown()
before it exists and throws, tripping the route error boundary.

Skip updates until the surface is ready by checking that getMarkdown is
a function (the readiness predicate Vizel uses internally). The first
update after construction syncs the content back, so no edit is lost.
