### PR TITLE
feat(markdown-editor): add React slash and bubble menus to the Vizel editor

### DIFF
--- a/src/lib/components/markdown/vizel-bubble-menu.tsx
+++ b/src/lib/components/markdown/vizel-bubble-menu.tsx
@@ -1,0 +1,120 @@
+/**
+ * Selection bubble menu for the Vizel editor.
+ *
+ * Vizel ships no React binding and the editor factory has no bubble-menu hook,
+ * so this component registers Tiptap's `BubbleMenuPlugin` (re-exported by
+ * `@vizel/core`) after the editor exists and renders a formatting toolbar from
+ * Vizel's bubble-menu action helpers. The plugin owns positioning and
+ * show/hide; this component owns the toolbar DOM and per-action wiring.
+ */
+import { useEffect, useMemo, useReducer, useRef } from 'react';
+import {
+	BubbleMenuPlugin,
+	createVizelBubbleMenuActions,
+	createVizelBubbleMenuEscapeController,
+	type Editor as VizelEditor,
+	filterVizelBubbleMenuActions,
+	formatVizelTooltip,
+	groupVizelBubbleMenuActions,
+} from '@vizel/core';
+import { cn } from '@/lib/utils';
+import { VizelMenuIcon } from './vizel-icon';
+
+const BUBBLE_MENU_PLUGIN_KEY = 'vizelBubbleMenu';
+
+interface VizelBubbleMenuProps {
+	readonly editor: VizelEditor;
+}
+
+export function VizelBubbleMenu({ editor }: VizelBubbleMenuProps) {
+	const elementRef = useRef<HTMLDivElement>(null);
+	// Active-state flags are read from the editor at render time; bump a counter
+	// on every transaction so the toolbar reflects the current selection.
+	const [, forceRender] = useReducer((count: number) => count + 1, 0);
+
+	// Filtering drops actions whose required extension is not registered; the set
+	// is stable for an editor instance, so memoize on the editor.
+	const actionGroups = useMemo(
+		() =>
+			groupVizelBubbleMenuActions(
+				filterVizelBubbleMenuActions(createVizelBubbleMenuActions(), editor)
+			),
+		[editor]
+	);
+
+	useEffect(() => {
+		const element = elementRef.current;
+		if (!element) return;
+		editor.registerPlugin(
+			BubbleMenuPlugin({
+				pluginKey: BUBBLE_MENU_PLUGIN_KEY,
+				editor,
+				element,
+				updateDelay: 100,
+				options: { placement: 'top' },
+			})
+		);
+		return () => {
+			editor.unregisterPlugin(BUBBLE_MENU_PLUGIN_KEY);
+		};
+	}, [editor]);
+
+	useEffect(() => {
+		const controller = createVizelBubbleMenuEscapeController({ getEditor: () => editor });
+		controller.mount();
+		return () => controller.unmount();
+	}, [editor]);
+
+	useEffect(() => {
+		editor.on('transaction', forceRender);
+		editor.on('selectionUpdate', forceRender);
+		return () => {
+			editor.off('transaction', forceRender);
+			editor.off('selectionUpdate', forceRender);
+		};
+	}, [editor]);
+
+	return (
+		// The plugin toggles visibility and positions this element; start hidden so
+		// it does not flash at the document origin before the first update.
+		<div
+			ref={elementRef}
+			role="toolbar"
+			aria-label="Text formatting"
+			style={{ visibility: 'hidden' }}
+			className="flex items-center gap-0.5 rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
+		>
+			{actionGroups.map((group, groupIndex) => (
+				<div key={group[0]?.id ?? groupIndex} className="flex items-center gap-0.5">
+					{groupIndex > 0 ? <div className="mx-0.5 h-5 w-px bg-border" /> : null}
+					{group.map((action) => {
+						const active = action.isActive(editor);
+						return (
+							<button
+								key={action.id}
+								type="button"
+								aria-pressed={active}
+								title={formatVizelTooltip(action.label, action.shortcut)}
+								className={cn(
+									'flex h-7 w-7 items-center justify-center rounded-sm',
+									active
+										? 'bg-accent text-accent-foreground'
+										: 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+								)}
+								onMouseDown={(event) => {
+									// Keep the editor selection while running the command.
+									event.preventDefault();
+									action.run(editor);
+									forceRender();
+								}}
+							>
+								<VizelMenuIcon name={action.icon} className="h-4 w-4" />
+								<span className="sr-only">{action.label}</span>
+							</button>
+						);
+					})}
+				</div>
+			))}
+		</div>
+	);
+}

--- a/src/lib/components/markdown/vizel-icon.tsx
+++ b/src/lib/components/markdown/vizel-icon.tsx
@@ -1,0 +1,149 @@
+/**
+ * Renders a Vizel icon name with a Lucide React component.
+ *
+ * Vizel commands and menu actions carry a semantic `VizelIconName`
+ * (`bold`, `heading1`, …). `getVizelIconId` resolves each to an Iconify id,
+ * and every default icon in the catalogue is a `lucide:*` id. Rather than pull
+ * the whole Iconify runtime, map the `lucide:*` ids to the `lucide-react`
+ * components Kogu already depends on. The map is explicit so Vite tree-shakes
+ * to only the icons the slash / bubble menus actually use.
+ */
+import type { ComponentType } from 'react';
+import {
+	AlignCenter,
+	AlignLeft,
+	AlignRight,
+	ArrowDown,
+	ArrowLeft,
+	ArrowRight,
+	ArrowRightLeft,
+	ArrowUp,
+	AtSign,
+	Baseline,
+	Bold,
+	Check,
+	ChevronDown,
+	ChevronRight,
+	Circle,
+	Clipboard,
+	Code,
+	Copy,
+	CopyPlus,
+	Ellipsis,
+	ExternalLink,
+	GitGraph,
+	GripHorizontal,
+	GripVertical,
+	Heading1,
+	Heading2,
+	Heading3,
+	Heading4,
+	Heading5,
+	Heading6,
+	Highlighter,
+	Image,
+	ImageUp,
+	Italic,
+	Link,
+	List,
+	ListChecks,
+	ListOrdered,
+	ListTree,
+	Loader2,
+	MessageSquareWarning,
+	Minus,
+	Pilcrow,
+	Plus,
+	Quote,
+	Redo2,
+	Scissors,
+	Sigma,
+	Strikethrough,
+	Subscript,
+	Superscript,
+	Table,
+	Trash2,
+	TriangleAlert,
+	Underline,
+	Undo2,
+	Workflow,
+	X,
+} from 'lucide-react';
+import { getVizelIconId, type VizelIconName } from '@vizel/core';
+
+type IconComponent = ComponentType<{ className?: string }>;
+
+// Keyed by the Lucide id Vizel resolves to (the `lucide:` prefix stripped).
+const LUCIDE_BY_ID: Record<string, IconComponent> = {
+	'align-center': AlignCenter,
+	'align-left': AlignLeft,
+	'align-right': AlignRight,
+	'arrow-down': ArrowDown,
+	'arrow-left': ArrowLeft,
+	'arrow-right': ArrowRight,
+	'arrow-right-left': ArrowRightLeft,
+	'arrow-up': ArrowUp,
+	'at-sign': AtSign,
+	baseline: Baseline,
+	bold: Bold,
+	check: Check,
+	'chevron-down': ChevronDown,
+	'chevron-right': ChevronRight,
+	circle: Circle,
+	clipboard: Clipboard,
+	code: Code,
+	copy: Copy,
+	'copy-plus': CopyPlus,
+	ellipsis: Ellipsis,
+	'external-link': ExternalLink,
+	'git-graph': GitGraph,
+	'grip-horizontal': GripHorizontal,
+	'grip-vertical': GripVertical,
+	'heading-1': Heading1,
+	'heading-2': Heading2,
+	'heading-3': Heading3,
+	'heading-4': Heading4,
+	'heading-5': Heading5,
+	'heading-6': Heading6,
+	highlighter: Highlighter,
+	image: Image,
+	'image-up': ImageUp,
+	italic: Italic,
+	link: Link,
+	list: List,
+	'list-checks': ListChecks,
+	'list-ordered': ListOrdered,
+	'list-tree': ListTree,
+	'loader-2': Loader2,
+	'message-square-warning': MessageSquareWarning,
+	minus: Minus,
+	pilcrow: Pilcrow,
+	plus: Plus,
+	quote: Quote,
+	'redo-2': Redo2,
+	scissors: Scissors,
+	sigma: Sigma,
+	strikethrough: Strikethrough,
+	subscript: Subscript,
+	superscript: Superscript,
+	table: Table,
+	'trash-2': Trash2,
+	'alert-triangle': TriangleAlert,
+	underline: Underline,
+	'undo-2': Undo2,
+	workflow: Workflow,
+	x: X,
+};
+
+interface VizelMenuIconProps {
+	readonly name?: VizelIconName;
+	readonly className?: string;
+}
+
+export function VizelMenuIcon({ name, className = 'h-4 w-4' }: VizelMenuIconProps) {
+	// Unknown / unmapped icons fall back to a neutral dot so the row keeps its
+	// leading-icon column alignment instead of collapsing.
+	const id = name ? getVizelIconId(name).replace(/^lucide:/, '') : '';
+	const Icon = LUCIDE_BY_ID[id] ?? Circle;
+	return <Icon className={className} />;
+}

--- a/src/lib/components/markdown/vizel-react.tsx
+++ b/src/lib/components/markdown/vizel-react.tsx
@@ -3,10 +3,10 @@
  *
  * Vizel ships no React binding, so this component drives a Tiptap editor via
  * `createVizelEditorInstance` and mounts it through `EditorContent` from
- * `@tiptap/react`. Vizel's built-in bubble menu and slash menu are not
- * reusable here and the wrapper deliberately omits them — formatting
- * commands stay reachable through the page-level toolbar and the
- * right-click context menu.
+ * `@tiptap/react`. The slash command menu (`/`) is supplied through the
+ * factory's `createSlashMenuRenderer` hook, and the selection bubble menu is
+ * registered after creation — both implemented in React (see
+ * `vizel-slash-menu.tsx` / `vizel-bubble-menu.tsx`).
  */
 import { useEffect, useRef, useState } from 'react';
 import { EditorContent } from '@tiptap/react';
@@ -17,23 +17,13 @@ import {
 	type VizelError,
 	type VizelFeatureOptions,
 } from '@vizel/core';
+import { VizelBubbleMenu } from './vizel-bubble-menu';
+import { createReactSlashMenuRenderer } from './vizel-slash-menu';
 
 // Wire Vizel's default icon renderer at module load. Without this call,
 // Vizel internals warn "Icon renderer not set" and emit empty placeholders
 // for menu / drag-handle / list-item icons.
 initVizelIconRenderer();
-
-// A no-op slash menu renderer satisfies the required factory parameter.
-// We rely on the toolbar / context menu for command discovery instead of
-// replicating Vizel's slash popup in React.
-const createNoopSlashMenuRenderer = () => ({
-	render: () => ({
-		onStart: () => {},
-		onUpdate: () => {},
-		onKeyDown: () => false,
-		onExit: () => {},
-	}),
-});
 
 interface VizelProps {
 	readonly placeholder?: string;
@@ -99,7 +89,7 @@ export function Vizel({
 			editable,
 			autofocus,
 			...(features !== undefined && { features }),
-			createSlashMenuRenderer: createNoopSlashMenuRenderer,
+			createSlashMenuRenderer: createReactSlashMenuRenderer,
 			onCreate: ({ editor: e }) => callbacksRef.current.onCreate?.({ editor: e }),
 			onError: (error) => callbacksRef.current.onError?.(error),
 		})
@@ -147,5 +137,10 @@ export function Vizel({
 		editor?.setEditable(editable);
 	}, [editor, editable]);
 
-	return <EditorContent editor={editor} className={className} />;
+	return (
+		<>
+			{editor ? <VizelBubbleMenu editor={editor} /> : null}
+			<EditorContent editor={editor} className={className} />
+		</>
+	);
 }

--- a/src/lib/components/markdown/vizel-slash-menu.tsx
+++ b/src/lib/components/markdown/vizel-slash-menu.tsx
@@ -1,0 +1,222 @@
+/**
+ * Slash command menu for the Vizel editor.
+ *
+ * Vizel ships no React binding, so this module supplies the
+ * `createSlashMenuRenderer` factory the editor instance expects. The factory
+ * returns a Tiptap suggestion `render()` that mounts a React popup with its own
+ * root, driven by `buildVizelSlashMenuSpecFromCommands`. The `VizelSlashCommand`
+ * extension owns `items` / `command` / `char`; this renderer only owns the popup
+ * lifecycle and keyboard navigation.
+ */
+import { createRoot, type Root } from 'react-dom/client';
+import type {
+	SuggestionKeyDownProps,
+	SuggestionOptions,
+	SuggestionProps,
+} from '@tiptap/suggestion';
+import {
+	buildVizelSlashMenuSpecFromCommands,
+	createVizelSuggestionContainer,
+	formatVizelShortcut,
+	getNextVizelSlashMenuGroupIndex,
+	getVizelSlashCommandLocale,
+	handleVizelSuggestionEscape,
+	type Editor as VizelEditor,
+	type VizelCommand,
+	type VizelCommandSpec,
+	type VizelMenuItemSpec,
+	type VizelMenuSpec,
+	type VizelSuggestionContainer,
+} from '@vizel/core';
+import { cn } from '@/lib/utils';
+import { VizelMenuIcon } from './vizel-icon';
+
+type CommandMenuSpec = VizelMenuSpec<VizelCommandSpec>;
+
+const flattenItems = (spec: CommandMenuSpec): readonly VizelMenuItemSpec<VizelCommandSpec>[] =>
+	spec.sections.flatMap((section) => section.items);
+
+interface SlashMenuProps {
+	readonly spec: CommandMenuSpec;
+	readonly selectedIndex: number;
+	readonly onSelect: (flatIndex: number) => void;
+}
+
+function SlashMenu({ spec, selectedIndex, onSelect }: SlashMenuProps) {
+	if (spec.sections.length === 0) {
+		return (
+			<div className="min-w-[16rem] rounded-md border bg-popover p-3 text-sm text-muted-foreground shadow-md">
+				No matching commands
+			</div>
+		);
+	}
+	// Running counter assigns each item its flat position across all sections so
+	// the keyboard selection (a single flat index) maps to the right row.
+	const flatCounter = { value: -1 };
+	return (
+		<div className="max-h-80 min-w-[16rem] max-w-[20rem] overflow-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md">
+			{spec.sections.map((section) => (
+				<div key={section.key}>
+					{section.header ? (
+						<div className="px-2 pb-1 pt-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+							{section.header.label}
+						</div>
+					) : null}
+					{section.items.map((item) => {
+						flatCounter.value += 1;
+						const flatIndex = flatCounter.value;
+						const selected = flatIndex === selectedIndex;
+						const { data } = item;
+						return (
+							<button
+								key={item.key}
+								type="button"
+								// Mouse hover does not drive selection here; click activates
+								// directly via the flat index to keep keyboard state simple.
+								className={cn(
+									'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm',
+									selected ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50'
+								)}
+								onMouseDown={(event) => {
+									// Prevent the editor from losing the selection before the
+									// command runs.
+									event.preventDefault();
+									onSelect(flatIndex);
+								}}
+							>
+								<VizelMenuIcon
+									name={data.icon}
+									className="h-4 w-4 shrink-0 text-muted-foreground"
+								/>
+								<span className="flex-1 truncate">{data.label}</span>
+								{data.shortcut ? (
+									<span className="shrink-0 text-xs text-muted-foreground">
+										{formatVizelShortcut(data.shortcut)}
+									</span>
+								) : null}
+							</button>
+						);
+					})}
+				</div>
+			))}
+		</div>
+	);
+}
+
+/**
+ * Build the Tiptap suggestion renderer for the slash menu. Returns only
+ * `{ render }`; the extension supplies `items` / `command` / `char`.
+ */
+export const createReactSlashMenuRenderer = (): Partial<SuggestionOptions<VizelCommand>> => ({
+	render: () => {
+		// Mutable closure state for one open/close cycle.
+		const state: {
+			root: Root | null;
+			suggestion: VizelSuggestionContainer | null;
+			items: readonly VizelCommand[];
+			command: ((item: VizelCommand) => void) | null;
+			editor: VizelEditor | null;
+			query: string;
+			selectedIndex: number;
+		} = {
+			root: null,
+			suggestion: null,
+			items: [],
+			command: null,
+			editor: null,
+			query: '',
+			selectedIndex: 0,
+		};
+
+		const buildSpec = (): CommandMenuSpec => {
+			if (!state.editor) return { root: {}, sections: [] };
+			return buildVizelSlashMenuSpecFromCommands(state.items, {
+				editor: state.editor,
+				locale: getVizelSlashCommandLocale(state.editor),
+				query: state.query,
+				selectedIndex: state.selectedIndex,
+				showGroups: true,
+			});
+		};
+
+		const selectByFlatIndex = (flatIndex: number) => {
+			const target = flattenItems(buildSpec())[flatIndex];
+			if (!target || !state.command) return;
+			const command = state.items[target.index];
+			if (command) state.command(command);
+		};
+
+		const renderMenu = () => {
+			if (!state.root) return;
+			const spec = buildSpec();
+			const flat = flattenItems(spec);
+			if (state.selectedIndex >= flat.length) {
+				state.selectedIndex = Math.max(0, flat.length - 1);
+			}
+			state.root.render(
+				<SlashMenu spec={spec} selectedIndex={state.selectedIndex} onSelect={selectByFlatIndex} />
+			);
+		};
+
+		const move = (delta: number) => {
+			const total = flattenItems(buildSpec()).length;
+			if (total === 0) return;
+			state.selectedIndex = (state.selectedIndex + delta + total) % total;
+			renderMenu();
+		};
+
+		return {
+			onStart: (props: SuggestionProps<VizelCommand>) => {
+				state.items = props.items;
+				state.command = props.command;
+				state.editor = props.editor as unknown as VizelEditor;
+				state.query = props.query;
+				state.selectedIndex = 0;
+				state.suggestion = createVizelSuggestionContainer();
+				state.root = createRoot(state.suggestion.menuContainer);
+				renderMenu();
+				state.suggestion.updatePosition(props.clientRect);
+			},
+			onUpdate: (props: SuggestionProps<VizelCommand>) => {
+				state.items = props.items;
+				state.command = props.command;
+				state.editor = props.editor as unknown as VizelEditor;
+				state.query = props.query;
+				renderMenu();
+				state.suggestion?.updatePosition(props.clientRect);
+			},
+			onKeyDown: (props: SuggestionKeyDownProps): boolean => {
+				if (handleVizelSuggestionEscape(props.event)) {
+					return true;
+				}
+				const { key } = props.event;
+				if (key === 'ArrowDown') {
+					move(1);
+					return true;
+				}
+				if (key === 'ArrowUp') {
+					move(-1);
+					return true;
+				}
+				if (key === 'Enter') {
+					selectByFlatIndex(state.selectedIndex);
+					return true;
+				}
+				if (key === 'Tab') {
+					state.selectedIndex = getNextVizelSlashMenuGroupIndex(buildSpec(), state.selectedIndex);
+					renderMenu();
+					return true;
+				}
+				return false;
+			},
+			onExit: () => {
+				state.root?.unmount();
+				state.suggestion?.destroy();
+				state.root = null;
+				state.suggestion = null;
+				state.command = null;
+				state.editor = null;
+			},
+		};
+	},
+});

--- a/src/routes/markdown-editor.tsx
+++ b/src/routes/markdown-editor.tsx
@@ -549,6 +549,7 @@ function MarkdownEditorPage() {
 								<li>Vizel visual editor with rich block content</li>
 								<li>Real-time bidirectional sync</li>
 								<li>Formatting toolbar &amp; context menu</li>
+								<li>Slash commands (/) &amp; selection bubble menu</li>
 								<li>Table of Contents generation</li>
 								<li>Export to HTML</li>
 							</ul>


### PR DESCRIPTION
The hand-rolled Vizel wrapper stubbed the slash-menu renderer with a no-op
and omitted the bubble menu, so the visual editor lacked its core inline
interactions even though editing and bidirectional sync already worked.

Implement both in React against the v2 API:
- vizel-slash-menu.tsx supplies createSlashMenuRenderer — a Tiptap suggestion
  render() that mounts a React popup with its own root, builds the command
  list via buildVizelSlashMenuSpecFromCommands, and wires query filtering,
  keyboard navigation, and command execution.
- vizel-bubble-menu.tsx registers Tiptap's BubbleMenuPlugin after creation
  and renders a selection toolbar from the Vizel bubble-menu action helpers,
  re-deriving active state on each editor transaction.
- vizel-icon.tsx maps VizelIconName -> lucide-react components (every default
  icon resolves to a lucide id), keeping the bundle tree-shakeable with no new
  dependency.

Popups use Kogu's own popover tokens so they follow the app theme. Verified
in-app: slash menu lists all commands with icons/shortcuts and executes;
bubble menu appears on selection, toggles marks, and reflects active state;
both sync through to the Monaco markdown.
