### PR TITLE
fix(markdown-editor): take the Vizel bubble menu out of the editor flow

### DIFF
--- a/src/lib/components/markdown/vizel-bubble-menu.tsx
+++ b/src/lib/components/markdown/vizel-bubble-menu.tsx
@@ -75,14 +75,17 @@ export function VizelBubbleMenu({ editor }: VizelBubbleMenuProps) {
 	}, [editor]);
 
 	return (
-		// The plugin toggles visibility and positions this element; start hidden so
-		// it does not flash at the document origin before the first update.
+		// `absolute` keeps the toolbar out of the editor's flow — without it the
+		// hidden element reserves vertical space at the top of the scroll
+		// container, shifting the content down and throwing the drag handle off the
+		// cursor. The plugin toggles visibility and positions it via top/left;
+		// start hidden so it does not flash at the origin before the first update.
 		<div
 			ref={elementRef}
 			role="toolbar"
 			aria-label="Text formatting"
 			style={{ visibility: 'hidden' }}
-			className="flex items-center gap-0.5 rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
+			className="absolute flex items-center gap-0.5 rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
 		>
 			{actionGroups.map((group, groupIndex) => (
 				<div key={group[0]?.id ?? groupIndex} className="flex items-center gap-0.5">


### PR DESCRIPTION
The bubble menu element was rendered with the default static position, so
even while hidden it reserved its full height (~38px) at the top of the
editor's scroll container. That pushed the editor content down and shifted
the drag handle's coordinate origin, so the handle rendered a line below the
cursor and could not be grabbed. Static positioning also left Tiptap's
floating-ui top/left placement ineffective.

Add `absolute` so the toolbar leaves the flow: the content sits at its
intended padding offset, the drag handle aligns with the cursor again, and
the plugin's top/left positioning takes effect on show.
