### PR TITLE
feat(markdown-editor): add a Markdown flavor selector for the Vizel editor

### DIFF
--- a/src/lib/components/markdown/vizel-react.tsx
+++ b/src/lib/components/markdown/vizel-react.tsx
@@ -16,6 +16,7 @@ import {
 	initVizelIconRenderer,
 	type VizelError,
 	type VizelFeatureOptions,
+	type VizelMarkdownFlavor,
 } from '@vizel/core';
 import { VizelBubbleMenu } from './vizel-bubble-menu';
 import { createReactSlashMenuRenderer } from './vizel-slash-menu';
@@ -30,6 +31,13 @@ interface VizelProps {
 	readonly editable?: boolean;
 	readonly autofocus?: boolean | 'start' | 'end' | 'all' | number;
 	readonly features?: VizelFeatureOptions;
+	// Markdown serialization flavor (output syntax). The parser stays tolerant of
+	// all formats; only `getMarkdown` output follows the flavor. Captured at
+	// creation — change it by remounting with a new `key`.
+	readonly markdownFlavor?: VizelMarkdownFlavor;
+	// Seed content for a freshly created editor. Used so a flavor-driven remount
+	// repopulates from the current markdown instead of starting empty.
+	readonly initialMarkdown?: string;
 	readonly className?: string;
 	readonly onCreate?: (args: { readonly editor: VizelEditor }) => void;
 	readonly onUpdate?: (args: { readonly editor: VizelEditor }) => void;
@@ -44,6 +52,8 @@ export function Vizel({
 	editable = true,
 	autofocus = false,
 	features,
+	markdownFlavor,
+	initialMarkdown,
 	className,
 	onCreate,
 	onUpdate,
@@ -89,6 +99,8 @@ export function Vizel({
 			editable,
 			autofocus,
 			...(features !== undefined && { features }),
+			...(markdownFlavor !== undefined && { markdown: { flavor: markdownFlavor } }),
+			...(initialMarkdown !== undefined && { initialMarkdown }),
 			createSlashMenuRenderer: createReactSlashMenuRenderer,
 			onCreate: ({ editor: e }) => callbacksRef.current.onCreate?.({ editor: e }),
 			onError: (error) => callbacksRef.current.onError?.(error),

--- a/src/routes/markdown-editor.tsx
+++ b/src/routes/markdown-editor.tsx
@@ -30,13 +30,21 @@ import {
 import { readText, writeText } from '@tauri-apps/plugin-clipboard-manager';
 import { toast } from 'sonner';
 import { useTheme } from 'next-themes';
-import type { Editor as VizelEditor } from '@vizel/core';
-import { getVizelMarkdown, setVizelMarkdown } from '@vizel/core';
+import type { Editor as VizelEditor, VizelMarkdownFlavor } from '@vizel/core';
+import {
+	getVizelMarkdown,
+	setVizelMarkdown,
+	vizelCommonMarkFlavor,
+	vizelDocusaurusFlavor,
+	vizelGfmFlavor,
+	vizelObsidianFlavor,
+	vizelPandocFlavor,
+} from '@vizel/core';
 import '@vizel/core/styles.css';
 import 'katex/dist/katex.min.css';
 
 import { CodeEditor, type CodeEditorHandle } from '@/lib/components/editor';
-import { FormMode, FormSection } from '@/lib/components/form';
+import { FormMode, FormSection, FormSelect } from '@/lib/components/form';
 import { SplitPane } from '@/lib/components/layout';
 import { MarkdownContextMenuItems, Vizel } from '@/lib/components/markdown';
 import { ToolFooter, ToolShell } from '@/lib/components/shell';
@@ -56,7 +64,7 @@ import {
 import { ListItemButton } from '@/lib/components/ui/list-item-button';
 import { IconTooltip } from '@/lib/components/ui/icon-tooltip';
 import { useDebouncedValue, useDocumentTitle } from '@/lib/hooks';
-import { usePersistedRail } from '@/lib/stores';
+import { createToolOptionsStore, usePersistedRail } from '@/lib/stores';
 import {
 	applyFormat,
 	exportAsHtml,
@@ -76,6 +84,34 @@ import {
 
 type RightPanelMode = 'editor' | 'preview';
 type ActiveEditor = 'monaco' | 'vizel' | null;
+
+// Vizel Markdown flavors. The flavor controls serialization (Vizel -> Markdown);
+// the parser stays tolerant of all formats on input. Selecting a flavor remounts
+// the editor so the new serializers take effect (see the `key` on <Vizel>).
+const FLAVOR_MAP = {
+	gfm: vizelGfmFlavor,
+	commonmark: vizelCommonMarkFlavor,
+	obsidian: vizelObsidianFlavor,
+	docusaurus: vizelDocusaurusFlavor,
+	pandoc: vizelPandocFlavor,
+} satisfies Record<string, VizelMarkdownFlavor>;
+
+type FlavorName = keyof typeof FLAVOR_MAP;
+
+const FLAVOR_OPTIONS: readonly { readonly value: FlavorName; readonly label: string }[] = [
+	{ value: 'gfm', label: 'GitHub Flavored (GFM)' },
+	{ value: 'commonmark', label: 'CommonMark' },
+	{ value: 'obsidian', label: 'Obsidian' },
+	{ value: 'docusaurus', label: 'Docusaurus' },
+	{ value: 'pandoc', label: 'Pandoc' },
+];
+
+const isFlavorName = (value: string): value is FlavorName => value in FLAVOR_MAP;
+
+const useMarkdownEditorPrefs = createToolOptionsStore<{ readonly flavor: FlavorName }>(
+	'markdown-editor',
+	{ flavor: 'gfm' }
+);
 
 // Vizel format command types (subset of Tiptap commands).
 type VizelFormatCommand =
@@ -250,6 +286,8 @@ function MarkdownEditorPage() {
 	const [input, setInput] = useState('');
 	const [rightPanelMode, setRightPanelMode] = useState<RightPanelMode>('editor');
 	const [showOptions, setShowOptions] = usePersistedRail('markdown-editor');
+	const flavor = useMarkdownEditorPrefs((s) => s.value.flavor);
+	const patchPrefs = useMarkdownEditorPrefs((s) => s.patch);
 	const [activeEditor, setActiveEditor] = useState<ActiveEditor>(null);
 	const [htmlOutput, setHtmlOutput] = useState('');
 
@@ -411,6 +449,13 @@ function MarkdownEditorPage() {
 	const handleClear = useCallback(() => setInput(''), []);
 	const handleSample = useCallback(() => setInput(SAMPLE_MARKDOWN), []);
 
+	const handleFlavorChange = useCallback(
+		(value: string) => {
+			if (isFlavorName(value)) patchPrefs({ flavor: value });
+		},
+		[patchPrefs]
+	);
+
 	const handleCopyMarkdown = useCallback(() => {
 		writeText(input)
 			.then(() => toast.success('Markdown copied to clipboard'))
@@ -482,6 +527,18 @@ function MarkdownEditorPage() {
 								{ value: 'preview', label: 'Preview' },
 							]}
 						/>
+					</FormSection>
+
+					<FormSection title="Markdown Flavor">
+						<FormSelect
+							value={flavor}
+							options={FLAVOR_OPTIONS}
+							onValueChange={handleFlavorChange}
+							size="compact"
+						/>
+						<p className="mt-1.5 text-xs text-muted-foreground">
+							Controls how the visual editor serializes Markdown. The parser reads all formats.
+						</p>
 					</FormSection>
 
 					<FormSection title="Export">
@@ -692,6 +749,11 @@ function MarkdownEditorPage() {
 										data-vizel-theme={vizelTheme}
 									>
 										<Vizel
+											// Remount on flavor change so the new serializers take effect;
+											// initialMarkdown re-seeds the fresh editor from the current text.
+											key={`vizel-${flavor}`}
+											markdownFlavor={FLAVOR_MAP[flavor]}
+											initialMarkdown={input}
 											placeholder="Start writing..."
 											editable={true}
 											autofocus={false}


### PR DESCRIPTION
The Vizel editor previously ran on its implicit default flavor (GFM) with no
way to change it. Expose Vizel's five built-in flavors (GFM, CommonMark,
Obsidian, Docusaurus, Pandoc) as a persisted rail selector.

The flavor controls Markdown serialization only; the parser stays tolerant of
all formats on input. Because the flavor is captured at editor construction,
the Vizel component remounts on change (keyed by flavor name) and re-seeds from
the current Markdown via a new `initialMarkdown` prop, so switching flavors
reserializes the document without losing content.

Add `markdownFlavor` and `initialMarkdown` props to the Vizel wrapper and a
`createToolOptionsStore` for the persisted choice (default GFM). Verified
in-app: switching GFM -> Obsidian preserves the document and updates the
Monaco markdown.
