### PR TITLE
feat(rest-client): add a query parameters tab synced with the URL

### DIFF
--- a/src/lib/services/rest-client.test.ts
+++ b/src/lib/services/rest-client.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildUrlWithParams, parseQueryParams, type QueryParam } from './rest-client';
+
+const param = (key: string, value: string, enabled = true): QueryParam => ({
+	id: `${key}-${value}`,
+	key,
+	value,
+	enabled,
+});
+
+describe('parseQueryParams', () => {
+	it('returns an empty array when the URL has no query string', () => {
+		expect(parseQueryParams('https://example.com/api')).toEqual([]);
+		expect(parseQueryParams('')).toEqual([]);
+	});
+
+	it('parses key/value pairs', () => {
+		const params = parseQueryParams('https://example.com?a=1&b=2');
+		expect(params.map((p) => [p.key, p.value])).toEqual([
+			['a', '1'],
+			['b', '2'],
+		]);
+		expect(params.every((p) => p.enabled)).toBe(true);
+	});
+
+	it('decodes percent-encoding and `+` as space', () => {
+		const params = parseQueryParams('https://example.com?q=hello+world&tag=a%26b');
+		expect(params).toMatchObject([
+			{ key: 'q', value: 'hello world' },
+			{ key: 'tag', value: 'a&b' },
+		]);
+	});
+
+	it('handles keys without a value', () => {
+		expect(parseQueryParams('https://example.com?flag&x=1')).toMatchObject([
+			{ key: 'flag', value: '' },
+			{ key: 'x', value: '1' },
+		]);
+	});
+
+	it('ignores the fragment', () => {
+		expect(parseQueryParams('https://example.com?a=1#section')).toMatchObject([
+			{ key: 'a', value: '1' },
+		]);
+	});
+});
+
+describe('buildUrlWithParams', () => {
+	it('appends an encoded query string', () => {
+		expect(buildUrlWithParams('https://example.com/api', [param('q', 'hello world')])).toBe(
+			'https://example.com/api?q=hello%20world'
+		);
+	});
+
+	it('drops disabled and empty-key rows', () => {
+		const url = buildUrlWithParams('https://example.com', [
+			param('a', '1'),
+			param('b', '2', false),
+			param('', 'orphan'),
+		]);
+		expect(url).toBe('https://example.com?a=1');
+	});
+
+	it('removes the query string entirely when no rows remain', () => {
+		expect(buildUrlWithParams('https://example.com?a=1', [])).toBe('https://example.com');
+	});
+
+	it('preserves the fragment', () => {
+		expect(buildUrlWithParams('https://example.com#top', [param('a', '1')])).toBe(
+			'https://example.com?a=1#top'
+		);
+	});
+
+	it('round-trips parsed params', () => {
+		const url = 'https://example.com/api?a=1&b=two';
+		expect(buildUrlWithParams(url, [...parseQueryParams(url)])).toBe(url);
+	});
+});

--- a/src/lib/services/rest-client.ts
+++ b/src/lib/services/rest-client.ts
@@ -31,6 +31,72 @@ export interface HeaderEntry {
 /** Tuple form transmitted over IPC. */
 export type HeaderTuple = readonly [string, string];
 
+/**
+ * Single query-parameter row derived from the URL. Rows are parsed from the
+ * URL's query string on render and written back on edit, so the URL field stays
+ * the single source of truth (no separate persisted parameter state).
+ */
+export interface QueryParam {
+	readonly id: string;
+	readonly key: string;
+	readonly value: string;
+	readonly enabled: boolean;
+}
+
+/** Split a URL into its base (scheme + path), query string, and `#fragment`. */
+const splitUrl = (url: string): { base: string; query: string; fragment: string } => {
+	const hashIndex = url.indexOf('#');
+	const fragment = hashIndex === -1 ? '' : url.slice(hashIndex);
+	const withoutFragment = hashIndex === -1 ? url : url.slice(0, hashIndex);
+	const queryIndex = withoutFragment.indexOf('?');
+	const base = queryIndex === -1 ? withoutFragment : withoutFragment.slice(0, queryIndex);
+	const query = queryIndex === -1 ? '' : withoutFragment.slice(queryIndex + 1);
+	return { base, query, fragment };
+};
+
+const decodeComponent = (value: string): string => {
+	try {
+		return decodeURIComponent(value.replace(/\+/g, ' '));
+	} catch {
+		return value;
+	}
+};
+
+/**
+ * Parse the query string of `url` into editable rows. Disabled rows are never
+ * represented in a URL, so every parsed row is enabled. Returns an empty array
+ * when the URL carries no query string.
+ */
+export const parseQueryParams = (url: string): readonly QueryParam[] => {
+	const { query } = splitUrl(url);
+	if (query.length === 0) return [];
+	return query.split('&').map((pair, index) => {
+		const eq = pair.indexOf('=');
+		const rawKey = eq === -1 ? pair : pair.slice(0, eq);
+		const rawValue = eq === -1 ? '' : pair.slice(eq + 1);
+		return {
+			id: `qp_${index}`,
+			key: decodeComponent(rawKey),
+			value: decodeComponent(rawValue),
+			enabled: true,
+		};
+	});
+};
+
+/**
+ * Rebuild a URL from its base and the supplied parameter rows. Enabled rows
+ * with a non-empty key are encoded into the query string; the original
+ * `#fragment` is preserved.
+ */
+export const buildUrlWithParams = (url: string, params: readonly QueryParam[]): string => {
+	const { base, fragment } = splitUrl(url);
+	const query = params
+		.filter((p) => p.enabled && p.key.trim().length > 0)
+		.map((p) => `${encodeURIComponent(p.key.trim())}=${encodeURIComponent(p.value)}`)
+		.join('&');
+	return `${base}${query.length > 0 ? `?${query}` : ''}${fragment}`;
+};
+
 export interface RestRequest {
 	readonly method: HttpMethod | string;
 	readonly url: string;

--- a/src/routes/rest-client.tsx
+++ b/src/routes/rest-client.tsx
@@ -1,10 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useMemo, useState, type ChangeEvent, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ChangeEvent, type ReactNode } from 'react';
 import {
 	Code2,
 	FileText,
 	FlaskConical,
 	Globe,
+	Link2,
 	Loader2,
 	Plus,
 	Send,
@@ -33,6 +34,7 @@ import { Textarea } from '@/lib/components/ui/textarea';
 import { ToneBadge } from '@/lib/components/ui/tone-badge';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
+	buildUrlWithParams,
 	createEmptyHeader,
 	createHeaderId,
 	exportAsCurl,
@@ -44,6 +46,8 @@ import {
 	headerValue,
 	headersToTuples,
 	isHttpMethod,
+	parseQueryParams,
+	type QueryParam,
 	type RestResponse,
 	SAMPLE_GET_URL,
 	SAMPLE_POST_BODY,
@@ -88,7 +92,7 @@ export const Route = createFileRoute('/rest-client')({
 	component: RestClientPage,
 });
 
-type RequestTab = 'headers' | 'body';
+type RequestTab = 'params' | 'headers' | 'body';
 type ResponseTab = 'body' | 'headers';
 
 function RestClientPage() {
@@ -98,8 +102,29 @@ function RestClientPage() {
 	const [response, setResponse] = useState<RestResponse | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [sending, setSending] = useState(false);
-	const [requestTab, setRequestTab] = useState<RequestTab>('headers');
+	const [requestTab, setRequestTab] = useState<RequestTab>('params');
 	const [responseTab, setResponseTab] = useState<ResponseTab>('body');
+
+	// Query parameters are an editable view of the URL's query string. Keeping a
+	// local model (instead of re-parsing on every render) preserves input focus
+	// while typing. The effect re-syncs only when the URL changes from outside
+	// the table (paste, sample, history), guarded so table edits don't loop.
+	const [paramRows, setParamRows] = useState<readonly QueryParam[]>(() => parseQueryParams(url));
+	const paramsFromTableRef = useRef(false);
+
+	useEffect(() => {
+		if (paramsFromTableRef.current) {
+			paramsFromTableRef.current = false;
+			return;
+		}
+		setParamRows(parseQueryParams(url));
+	}, [url]);
+
+	const commitParams = (next: readonly QueryParam[]) => {
+		setParamRows(next);
+		paramsFromTableRef.current = true;
+		patch({ url: buildUrlWithParams(url, next) });
+	};
 
 	useDocumentTitle('HTTP REST Client');
 
@@ -109,6 +134,25 @@ function RestClientPage() {
 		() => headers.filter((h) => h.enabled && h.key.trim().length > 0).length,
 		[headers]
 	);
+
+	const enabledParamCount = useMemo(
+		() => paramRows.filter((p) => p.enabled && p.key.trim().length > 0).length,
+		[paramRows]
+	);
+
+	const handleParamChange = (id: string, delta: Partial<QueryParam>) => {
+		commitParams(paramRows.map((p) => (p.id === id ? { ...p, ...delta } : p)));
+	};
+
+	const handleParamRemove = (id: string) => {
+		commitParams(paramRows.filter((p) => p.id !== id));
+	};
+
+	const handleParamAdd = () => {
+		// New rows live in the local model until they gain a key; an empty key is
+		// filtered out of the rebuilt URL by buildUrlWithParams.
+		setParamRows([...paramRows, { id: createHeaderId(), key: '', value: '', enabled: true }]);
+	};
 
 	const handleMethodChange = (value: string) => {
 		if (isHttpMethod(value)) patch({ method: value });
@@ -230,9 +274,14 @@ function RestClientPage() {
 						<RequestPanel
 							activeTab={requestTab}
 							onTabChange={setRequestTab}
+							params={paramRows}
+							enabledParamCount={enabledParamCount}
 							headers={headers}
 							enabledHeaderCount={enabledHeaderCount}
 							body={body}
+							onParamChange={handleParamChange}
+							onParamRemove={handleParamRemove}
+							onParamAdd={handleParamAdd}
 							onHeaderChange={handleHeaderChange}
 							onHeaderRemove={handleHeaderRemove}
 							onHeaderAdd={() => patch({ headers: [...headers, createEmptyHeader()] })}
@@ -426,9 +475,14 @@ function RequestBar({
 interface RequestPanelProps {
 	readonly activeTab: RequestTab;
 	readonly onTabChange: (tab: RequestTab) => void;
+	readonly params: readonly QueryParam[];
+	readonly enabledParamCount: number;
 	readonly headers: readonly HeaderEntry[];
 	readonly enabledHeaderCount: number;
 	readonly body: string;
+	readonly onParamChange: (id: string, delta: Partial<QueryParam>) => void;
+	readonly onParamRemove: (id: string) => void;
+	readonly onParamAdd: () => void;
 	readonly onHeaderChange: (id: string, delta: Partial<HeaderEntry>) => void;
 	readonly onHeaderRemove: (id: string) => void;
 	readonly onHeaderAdd: () => void;
@@ -438,23 +492,37 @@ interface RequestPanelProps {
 function RequestPanel({
 	activeTab,
 	onTabChange,
+	params,
+	enabledParamCount,
 	headers,
 	enabledHeaderCount,
 	body,
+	onParamChange,
+	onParamRemove,
+	onParamAdd,
 	onHeaderChange,
 	onHeaderRemove,
 	onHeaderAdd,
 	onBodyChange,
 }: RequestPanelProps) {
 	const handleValueChange = (v: string) => {
-		if (v === 'headers' || v === 'body') onTabChange(v);
+		if (v === 'params' || v === 'headers' || v === 'body') onTabChange(v);
 	};
 
 	return (
 		<Card density="compact">
 			<CardContent className="space-y-3">
 				<Tabs value={activeTab} onValueChange={handleValueChange}>
-					<TabsList className="grid w-full grid-cols-2">
+					<TabsList className="grid w-full grid-cols-3">
+						<TabsTrigger value="params" className="gap-2">
+							<Link2 className="h-3.5 w-3.5" />
+							Params
+							{enabledParamCount > 0 ? (
+								<Badge variant="secondary" className="ml-1 h-4 px-1.5 text-2xs">
+									{enabledParamCount}
+								</Badge>
+							) : null}
+						</TabsTrigger>
 						<TabsTrigger value="headers" className="gap-2">
 							<Settings2 className="h-3.5 w-3.5" />
 							Headers
@@ -474,6 +542,15 @@ function RequestPanel({
 							) : null}
 						</TabsTrigger>
 					</TabsList>
+
+					<TabsContent value="params" className="space-y-2 pt-3">
+						<ParamsEditor
+							params={params}
+							onParamChange={onParamChange}
+							onParamRemove={onParamRemove}
+							onParamAdd={onParamAdd}
+						/>
+					</TabsContent>
 
 					<TabsContent value="headers" className="space-y-2 pt-3">
 						<HeadersEditor
@@ -581,6 +658,86 @@ function HeaderRow({ entry, onChange, onRemove }: HeaderRowProps) {
 				className="h-8 w-8 text-muted-foreground hover:text-destructive"
 				onClick={onRemove}
 				aria-label="Remove header"
+			>
+				<Trash2 className="h-3.5 w-3.5" />
+			</Button>
+		</div>
+	);
+}
+
+interface ParamsEditorProps {
+	readonly params: readonly QueryParam[];
+	readonly onParamChange: (id: string, delta: Partial<QueryParam>) => void;
+	readonly onParamRemove: (id: string) => void;
+	readonly onParamAdd: () => void;
+}
+
+function ParamsEditor({ params, onParamChange, onParamRemove, onParamAdd }: ParamsEditorProps) {
+	return (
+		<>
+			{params.length === 0 ? (
+				<EmbeddedEmptyState
+					icon={Link2}
+					title="No query parameters"
+					description="Add parameters or type them after ? in the URL."
+				/>
+			) : (
+				<div className="space-y-1.5">
+					{params.map((entry) => (
+						<ParamRow
+							key={entry.id}
+							entry={entry}
+							onChange={(delta) => onParamChange(entry.id, delta)}
+							onRemove={() => onParamRemove(entry.id)}
+						/>
+					))}
+				</div>
+			)}
+			<Button variant="outline" size="sm" onClick={onParamAdd}>
+				<Plus className="h-3.5 w-3.5" />
+				Add parameter
+			</Button>
+		</>
+	);
+}
+
+interface ParamRowProps {
+	readonly entry: QueryParam;
+	readonly onChange: (delta: Partial<QueryParam>) => void;
+	readonly onRemove: () => void;
+}
+
+function ParamRow({ entry, onChange, onRemove }: ParamRowProps) {
+	return (
+		<div
+			className={cn(
+				'grid grid-cols-[auto_minmax(0,1fr)_minmax(0,2fr)_auto] items-center gap-2',
+				!entry.enabled && 'opacity-50'
+			)}
+		>
+			<Checkbox
+				checked={entry.enabled}
+				onCheckedChange={(v) => onChange({ enabled: Boolean(v) })}
+				aria-label="Include parameter"
+			/>
+			<Input
+				value={entry.key}
+				placeholder="Key"
+				className="h-8 font-mono text-xs"
+				onChange={(e) => onChange({ key: e.target.value })}
+			/>
+			<Input
+				value={entry.value}
+				placeholder="Value"
+				className="h-8 font-mono text-xs"
+				onChange={(e) => onChange({ value: e.target.value })}
+			/>
+			<Button
+				variant="ghost"
+				size="icon-sm"
+				className="h-8 w-8 text-muted-foreground hover:text-destructive"
+				onClick={onRemove}
+				aria-label="Remove parameter"
 			>
 				<Trash2 className="h-3.5 w-3.5" />
 			</Button>


### PR DESCRIPTION
Add a Params tab to the request panel that parses the URL's query string into
an editable key/value/enable table. Editing a row re-encodes the query and
writes it back, keeping the URL the single source of truth; a guarded effect
re-syncs the table when the URL changes from outside (paste, sample). Adds
parseQueryParams / buildUrlWithParams pure helpers (fragment-aware,
percent-decoding) with unit tests, and an enabled-parameter count badge.
