### PR TITLE
fix(rest-client): stack tab content below the tab list

### DIFF
--- a/src/routes/rest-client.tsx
+++ b/src/routes/rest-client.tsx
@@ -512,7 +512,7 @@ function RequestPanel({
 	return (
 		<Card density="compact">
 			<CardContent className="space-y-3">
-				<Tabs value={activeTab} onValueChange={handleValueChange}>
+				<Tabs value={activeTab} onValueChange={handleValueChange} className="contents">
 					<TabsList className="grid w-full grid-cols-3">
 						<TabsTrigger value="params" className="gap-2">
 							<Link2 className="h-3.5 w-3.5" />
@@ -800,7 +800,7 @@ function ResponseTabs({ response, activeTab, onTabChange }: ResponseTabsProps) {
 	};
 
 	return (
-		<Tabs value={activeTab} onValueChange={handleValueChange}>
+		<Tabs value={activeTab} onValueChange={handleValueChange} className="contents">
 			<TabsList className="grid w-full grid-cols-2">
 				<TabsTrigger value="body" className="gap-2">
 					<FileText className="h-3.5 w-3.5" />


### PR DESCRIPTION
The shared Tabs root is `display: flex` (row) for horizontal orientation, so a
bare `<Tabs>` placed its panel beside the full-width tab list, squeezing the
request rows into a sliver at the right edge. Add `className="contents"` to both
the request and response Tabs — the pattern ToolShell already uses — so the list
and panel fall back into the card's normal block flow and render full width
below the tabs.
