### PR TITLE
feat(rest-client): add an authentication tab

### DIFF
--- a/src/lib/services/rest-client.test.ts
+++ b/src/lib/services/rest-client.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildUrlWithParams, parseQueryParams, type QueryParam } from './rest-client';
+import {
+	applyAuth,
+	type AuthConfig,
+	buildUrlWithParams,
+	DEFAULT_AUTH,
+	parseQueryParams,
+	type QueryParam,
+} from './rest-client';
+
+const auth = (overrides: Partial<AuthConfig>): AuthConfig => ({ ...DEFAULT_AUTH, ...overrides });
 
 const param = (key: string, value: string, enabled = true): QueryParam => ({
 	id: `${key}-${value}`,
@@ -75,5 +84,71 @@ describe('buildUrlWithParams', () => {
 	it('round-trips parsed params', () => {
 		const url = 'https://example.com/api?a=1&b=two';
 		expect(buildUrlWithParams(url, [...parseQueryParams(url)])).toBe(url);
+	});
+});
+
+describe('applyAuth', () => {
+	const base: readonly (readonly [string, string])[] = [['Accept', '*/*']];
+	const url = 'https://example.com/api';
+
+	it('is a no-op for type none', () => {
+		expect(applyAuth(base, url, DEFAULT_AUTH)).toEqual({ headers: base, url });
+	});
+
+	it('adds a Bearer Authorization header', () => {
+		const result = applyAuth(base, url, auth({ type: 'bearer', token: ' abc ' }));
+		expect(result.headers).toContainEqual(['Authorization', 'Bearer abc']);
+	});
+
+	it('skips Bearer when the token is empty', () => {
+		expect(applyAuth(base, url, auth({ type: 'bearer' }))).toEqual({ headers: base, url });
+	});
+
+	it('encodes Basic credentials as base64', () => {
+		const result = applyAuth(
+			base,
+			url,
+			auth({ type: 'basic', username: 'user', password: 'pass' })
+		);
+		expect(result.headers).toContainEqual(['Authorization', `Basic ${btoa('user:pass')}`]);
+	});
+
+	it('encodes UTF-8 Basic credentials safely', () => {
+		const result = applyAuth(base, url, auth({ type: 'basic', username: 'résumé', password: '✓' }));
+		const header = result.headers.find(([k]) => k === 'Authorization')?.[1] ?? '';
+		expect(header.startsWith('Basic ')).toBe(true);
+		expect(atob(header.slice('Basic '.length))).not.toBe('résumé:✓'); // base64 of UTF-8 bytes, not Latin1
+	});
+
+	it('adds an API key as a header', () => {
+		const result = applyAuth(
+			base,
+			url,
+			auth({ type: 'apikey', apiKeyName: 'X-Api-Key', apiKeyValue: 'k1' })
+		);
+		expect(result.headers).toContainEqual(['X-Api-Key', 'k1']);
+		expect(result.url).toBe(url);
+	});
+
+	it('adds an API key as a query parameter', () => {
+		const result = applyAuth(
+			base,
+			url,
+			auth({
+				type: 'apikey',
+				apiKeyName: 'api_key',
+				apiKeyValue: 'k1',
+				apiKeyLocation: 'query',
+			})
+		);
+		expect(result.headers).toEqual(base);
+		expect(result.url).toBe('https://example.com/api?api_key=k1');
+	});
+
+	it('skips API key when the name is empty', () => {
+		expect(applyAuth(base, url, auth({ type: 'apikey', apiKeyValue: 'k1' }))).toEqual({
+			headers: base,
+			url,
+		});
 	});
 });

--- a/src/lib/services/rest-client.ts
+++ b/src/lib/services/rest-client.ts
@@ -97,6 +97,78 @@ export const buildUrlWithParams = (url: string, params: readonly QueryParam[]): 
 	return `${base}${query.length > 0 ? `?${query}` : ''}${fragment}`;
 };
 
+/** Authentication scheme applied to the request at send time. */
+export type AuthType = 'none' | 'bearer' | 'basic' | 'apikey';
+
+/** Where an API-key credential is attached. */
+export type ApiKeyLocation = 'header' | 'query';
+
+/**
+ * Auth configuration owned by the UI. Credentials are folded into the effective
+ * request headers / URL by {@link applyAuth} only at send time, so the stored
+ * header rows stay clean and the chosen scheme can change without rewriting them.
+ */
+export interface AuthConfig {
+	readonly type: AuthType;
+	readonly token: string;
+	readonly username: string;
+	readonly password: string;
+	readonly apiKeyName: string;
+	readonly apiKeyValue: string;
+	readonly apiKeyLocation: ApiKeyLocation;
+}
+
+export const DEFAULT_AUTH: AuthConfig = {
+	type: 'none',
+	token: '',
+	username: '',
+	password: '',
+	apiKeyName: '',
+	apiKeyValue: '',
+	apiKeyLocation: 'header',
+};
+
+/** UTF-8-safe base64 for Basic credentials (btoa alone mangles non-Latin1). */
+const utf8ToBase64 = (input: string): string => {
+	const bytes = new TextEncoder().encode(input);
+	const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join('');
+	return btoa(binary);
+};
+
+const appendQueryParam = (url: string, key: string, value: string): string =>
+	buildUrlWithParams(url, [...parseQueryParams(url), { id: 'auth', key, value, enabled: true }]);
+
+/**
+ * Fold the auth scheme into the request. Returns the effective headers and URL;
+ * an incomplete configuration (e.g. empty token) is a no-op so partial input
+ * never sends a malformed credential.
+ */
+export const applyAuth = (
+	headers: readonly HeaderTuple[],
+	url: string,
+	auth: AuthConfig
+): { readonly headers: readonly HeaderTuple[]; readonly url: string } => {
+	if (auth.type === 'bearer') {
+		const token = auth.token.trim();
+		return token.length > 0
+			? { headers: [...headers, ['Authorization', `Bearer ${token}`]], url }
+			: { headers, url };
+	}
+	if (auth.type === 'basic') {
+		if (auth.username.length === 0 && auth.password.length === 0) return { headers, url };
+		const encoded = utf8ToBase64(`${auth.username}:${auth.password}`);
+		return { headers: [...headers, ['Authorization', `Basic ${encoded}`]], url };
+	}
+	if (auth.type === 'apikey') {
+		const name = auth.apiKeyName.trim();
+		if (name.length === 0) return { headers, url };
+		return auth.apiKeyLocation === 'query'
+			? { headers, url: appendQueryParam(url, name, auth.apiKeyValue) }
+			: { headers: [...headers, [name, auth.apiKeyValue]], url };
+	}
+	return { headers, url };
+};
+
 export interface RestRequest {
 	readonly method: HttpMethod | string;
 	readonly url: string;

--- a/src/routes/rest-client.tsx
+++ b/src/routes/rest-client.tsx
@@ -5,6 +5,7 @@ import {
 	FileText,
 	FlaskConical,
 	Globe,
+	KeyRound,
 	Link2,
 	Loader2,
 	Plus,
@@ -34,9 +35,14 @@ import { Textarea } from '@/lib/components/ui/textarea';
 import { ToneBadge } from '@/lib/components/ui/tone-badge';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
+	type ApiKeyLocation,
+	applyAuth,
+	type AuthConfig,
+	type AuthType,
 	buildUrlWithParams,
 	createEmptyHeader,
 	createHeaderId,
+	DEFAULT_AUTH,
 	exportAsCurl,
 	formatBytes,
 	formatResponseBody,
@@ -66,6 +72,7 @@ interface RestClientOptions {
 	readonly method: HttpMethod;
 	readonly url: string;
 	readonly headers: readonly HeaderEntry[];
+	readonly auth: AuthConfig;
 	readonly body: string;
 	readonly followRedirects: boolean;
 	readonly timeoutMs: number;
@@ -79,6 +86,7 @@ const DEFAULTS: RestClientOptions = {
 	method: 'GET',
 	url: '',
 	headers: DEFAULT_HEADERS,
+	auth: DEFAULT_AUTH,
 	body: '',
 	followRedirects: true,
 	timeoutMs: TIMEOUT_DEFAULT_MS,
@@ -92,12 +100,16 @@ export const Route = createFileRoute('/rest-client')({
 	component: RestClientPage,
 });
 
-type RequestTab = 'params' | 'headers' | 'body';
+type RequestTab = 'params' | 'auth' | 'headers' | 'body';
 type ResponseTab = 'body' | 'headers';
 
 function RestClientPage() {
 	const { value: options, patch } = useRestClientOptions();
 	const { method, url, headers, body, followRedirects, timeoutMs } = options;
+	// `auth` was added after the options store shipped; persisted state from
+	// before that lacks the field, so fall back to the default to stay
+	// backward-compatible with rehydrated stores.
+	const auth = options.auth ?? DEFAULT_AUTH;
 
 	const [response, setResponse] = useState<RestResponse | null>(null);
 	const [error, setError] = useState<string | null>(null);
@@ -196,10 +208,11 @@ function RestClientPage() {
 			toast.error('Enter a URL first');
 			return;
 		}
+		const effective = applyAuth(headersToTuples(headers), url, auth);
 		const command = exportAsCurl({
 			method,
-			url,
-			headers: headersToTuples(headers),
+			url: effective.url,
+			headers: effective.headers,
 			body,
 			followRedirects,
 			timeoutMs,
@@ -217,10 +230,11 @@ function RestClientPage() {
 		setSending(true);
 		setError(null);
 		try {
+			const effective = applyAuth(headersToTuples(headers), url, auth);
 			const res = await sendRequest({
 				method,
-				url,
-				headers: headersToTuples(headers),
+				url: effective.url,
+				headers: effective.headers,
 				body,
 				followRedirects,
 				timeoutMs,
@@ -276,12 +290,14 @@ function RestClientPage() {
 							onTabChange={setRequestTab}
 							params={paramRows}
 							enabledParamCount={enabledParamCount}
+							auth={auth}
 							headers={headers}
 							enabledHeaderCount={enabledHeaderCount}
 							body={body}
 							onParamChange={handleParamChange}
 							onParamRemove={handleParamRemove}
 							onParamAdd={handleParamAdd}
+							onAuthChange={(delta) => patch({ auth: { ...auth, ...delta } })}
 							onHeaderChange={handleHeaderChange}
 							onHeaderRemove={handleHeaderRemove}
 							onHeaderAdd={() => patch({ headers: [...headers, createEmptyHeader()] })}
@@ -477,12 +493,14 @@ interface RequestPanelProps {
 	readonly onTabChange: (tab: RequestTab) => void;
 	readonly params: readonly QueryParam[];
 	readonly enabledParamCount: number;
+	readonly auth: AuthConfig;
 	readonly headers: readonly HeaderEntry[];
 	readonly enabledHeaderCount: number;
 	readonly body: string;
 	readonly onParamChange: (id: string, delta: Partial<QueryParam>) => void;
 	readonly onParamRemove: (id: string) => void;
 	readonly onParamAdd: () => void;
+	readonly onAuthChange: (delta: Partial<AuthConfig>) => void;
 	readonly onHeaderChange: (id: string, delta: Partial<HeaderEntry>) => void;
 	readonly onHeaderRemove: (id: string) => void;
 	readonly onHeaderAdd: () => void;
@@ -494,32 +512,43 @@ function RequestPanel({
 	onTabChange,
 	params,
 	enabledParamCount,
+	auth,
 	headers,
 	enabledHeaderCount,
 	body,
 	onParamChange,
 	onParamRemove,
 	onParamAdd,
+	onAuthChange,
 	onHeaderChange,
 	onHeaderRemove,
 	onHeaderAdd,
 	onBodyChange,
 }: RequestPanelProps) {
 	const handleValueChange = (v: string) => {
-		if (v === 'params' || v === 'headers' || v === 'body') onTabChange(v);
+		if (v === 'params' || v === 'auth' || v === 'headers' || v === 'body') onTabChange(v);
 	};
 
 	return (
 		<Card density="compact">
 			<CardContent className="space-y-3">
 				<Tabs value={activeTab} onValueChange={handleValueChange} className="contents">
-					<TabsList className="grid w-full grid-cols-3">
+					<TabsList className="grid w-full grid-cols-4">
 						<TabsTrigger value="params" className="gap-2">
 							<Link2 className="h-3.5 w-3.5" />
 							Params
 							{enabledParamCount > 0 ? (
 								<Badge variant="secondary" className="ml-1 h-4 px-1.5 text-2xs">
 									{enabledParamCount}
+								</Badge>
+							) : null}
+						</TabsTrigger>
+						<TabsTrigger value="auth" className="gap-2">
+							<KeyRound className="h-3.5 w-3.5" />
+							Auth
+							{auth.type !== 'none' ? (
+								<Badge variant="secondary" className="ml-1 h-4 px-1.5 text-2xs uppercase">
+									{auth.type}
 								</Badge>
 							) : null}
 						</TabsTrigger>
@@ -550,6 +579,10 @@ function RequestPanel({
 							onParamRemove={onParamRemove}
 							onParamAdd={onParamAdd}
 						/>
+					</TabsContent>
+
+					<TabsContent value="auth" className="space-y-3 pt-3">
+						<AuthEditor auth={auth} onAuthChange={onAuthChange} />
 					</TabsContent>
 
 					<TabsContent value="headers" className="space-y-2 pt-3">
@@ -742,6 +775,104 @@ function ParamRow({ entry, onChange, onRemove }: ParamRowProps) {
 				<Trash2 className="h-3.5 w-3.5" />
 			</Button>
 		</div>
+	);
+}
+
+const AUTH_TYPE_OPTIONS: readonly { readonly value: AuthType; readonly label: string }[] = [
+	{ value: 'none', label: 'No Auth' },
+	{ value: 'bearer', label: 'Bearer Token' },
+	{ value: 'basic', label: 'Basic Auth' },
+	{ value: 'apikey', label: 'API Key' },
+];
+
+const API_KEY_LOCATION_OPTIONS: readonly {
+	readonly value: ApiKeyLocation;
+	readonly label: string;
+}[] = [
+	{ value: 'header', label: 'Header' },
+	{ value: 'query', label: 'Query parameter' },
+];
+
+interface AuthEditorProps {
+	readonly auth: AuthConfig;
+	readonly onAuthChange: (delta: Partial<AuthConfig>) => void;
+}
+
+function AuthEditor({ auth, onAuthChange }: AuthEditorProps) {
+	const handleTypeChange = (v: string) => {
+		if (v === 'none' || v === 'bearer' || v === 'basic' || v === 'apikey')
+			onAuthChange({ type: v });
+	};
+	const handleLocationChange = (v: string) => {
+		if (v === 'header' || v === 'query') onAuthChange({ apiKeyLocation: v });
+	};
+
+	return (
+		<>
+			<FormSelect
+				label="Type"
+				value={auth.type}
+				options={AUTH_TYPE_OPTIONS}
+				onValueChange={handleTypeChange}
+				size="compact"
+			/>
+
+			{auth.type === 'bearer' ? (
+				<FormInput
+					label="Token"
+					type="password"
+					value={auth.token}
+					placeholder="Bearer token"
+					onValueChange={(v) => onAuthChange({ token: v })}
+				/>
+			) : null}
+
+			{auth.type === 'basic' ? (
+				<>
+					<FormInput
+						label="Username"
+						value={auth.username}
+						onValueChange={(v) => onAuthChange({ username: v })}
+					/>
+					<FormInput
+						label="Password"
+						type="password"
+						value={auth.password}
+						onValueChange={(v) => onAuthChange({ password: v })}
+					/>
+				</>
+			) : null}
+
+			{auth.type === 'apikey' ? (
+				<>
+					<FormInput
+						label="Key"
+						value={auth.apiKeyName}
+						placeholder="X-API-Key"
+						onValueChange={(v) => onAuthChange({ apiKeyName: v })}
+					/>
+					<FormInput
+						label="Value"
+						type="password"
+						value={auth.apiKeyValue}
+						onValueChange={(v) => onAuthChange({ apiKeyValue: v })}
+					/>
+					<FormSelect
+						label="Add to"
+						value={auth.apiKeyLocation}
+						options={API_KEY_LOCATION_OPTIONS}
+						onValueChange={handleLocationChange}
+						size="compact"
+					/>
+				</>
+			) : null}
+
+			{auth.type === 'none' ? (
+				<p className="text-xs text-muted-foreground">
+					This request will be sent without authentication.
+				</p>
+			) : null}
+		</>
 	);
 }
 


### PR DESCRIPTION
Add an Auth tab to the request panel with four schemes: No Auth, Bearer Token,
Basic Auth, and API Key (attached as a header or query parameter). Credentials
are stored in the persisted options and folded into the effective request
headers / URL only at send time via a new pure `applyAuth` helper, so the saved
header rows stay clean and switching schemes never rewrites them. Basic auth is
base64-encoded UTF-8-safe; cURL export reflects the applied auth. The active
scheme shows as a badge on the tab.

Rehydrated stores from before this change lack the `auth` field, so the page
falls back to the default auth config to stay backward-compatible. Adds unit
tests for every applyAuth scheme.
