### PR TITLE
feat(rest-client): add request body modes

### DIFF
--- a/src/lib/services/rest-client.test.ts
+++ b/src/lib/services/rest-client.test.ts
@@ -5,9 +5,22 @@ import {
 	type AuthConfig,
 	buildUrlWithParams,
 	DEFAULT_AUTH,
+	encodeFormBody,
+	formatJson,
+	type HeaderEntry,
 	parseQueryParams,
 	type QueryParam,
+	resolveBody,
+	validateJson,
+	withContentType,
 } from './rest-client';
+
+const field = (key: string, value: string, enabled = true): HeaderEntry => ({
+	id: `${key}-${value}`,
+	key,
+	value,
+	enabled,
+});
 
 const auth = (overrides: Partial<AuthConfig>): AuthConfig => ({ ...DEFAULT_AUTH, ...overrides });
 
@@ -150,5 +163,86 @@ describe('applyAuth', () => {
 			headers: base,
 			url,
 		});
+	});
+});
+
+describe('encodeFormBody', () => {
+	it('url-encodes enabled rows', () => {
+		expect(encodeFormBody([field('a', '1'), field('q', 'hello world')])).toBe(
+			'a=1&q=hello%20world'
+		);
+	});
+
+	it('drops disabled and empty-key rows', () => {
+		expect(encodeFormBody([field('a', '1'), field('b', '2', false), field('', 'x')])).toBe('a=1');
+	});
+});
+
+describe('resolveBody', () => {
+	const fields = [field('a', '1')];
+
+	it('sends nothing for none', () => {
+		expect(resolveBody('none', 'ignored', fields)).toEqual({ body: '', contentType: null });
+	});
+
+	it('keeps the raw body with no implied type', () => {
+		expect(resolveBody('raw', 'plain', fields)).toEqual({ body: 'plain', contentType: null });
+	});
+
+	it('applies the JSON content type', () => {
+		expect(resolveBody('json', '{"a":1}', fields)).toEqual({
+			body: '{"a":1}',
+			contentType: 'application/json',
+		});
+	});
+
+	it('encodes form fields with the urlencoded type', () => {
+		expect(resolveBody('form', 'ignored', fields)).toEqual({
+			body: 'a=1',
+			contentType: 'application/x-www-form-urlencoded',
+		});
+	});
+});
+
+describe('withContentType', () => {
+	it('appends the type when none is present', () => {
+		expect(withContentType([['Accept', '*/*']], 'application/json')).toContainEqual([
+			'Content-Type',
+			'application/json',
+		]);
+	});
+
+	it('respects an existing Content-Type (case-insensitive)', () => {
+		const headers = [['content-type', 'text/plain']] as const;
+		expect(withContentType(headers, 'application/json')).toEqual(headers);
+	});
+
+	it('is a no-op when the type is null', () => {
+		const headers = [['Accept', '*/*']] as const;
+		expect(withContentType(headers, null)).toBe(headers);
+	});
+});
+
+describe('validateJson', () => {
+	it('returns null for empty input', () => {
+		expect(validateJson('   ')).toBeNull();
+	});
+
+	it('returns true for valid JSON', () => {
+		expect(validateJson('{"a":1}')).toBe(true);
+	});
+
+	it('returns false for invalid JSON', () => {
+		expect(validateJson('{a:1}')).toBe(false);
+	});
+});
+
+describe('formatJson', () => {
+	it('pretty-prints valid JSON', () => {
+		expect(formatJson('{"a":1}')).toBe('{\n\t"a": 1\n}'.replace(/\t/g, '  '));
+	});
+
+	it('returns invalid JSON unchanged', () => {
+		expect(formatJson('{a:1}')).toBe('{a:1}');
 	});
 });

--- a/src/lib/services/rest-client.ts
+++ b/src/lib/services/rest-client.ts
@@ -212,6 +212,69 @@ export const headersToTuples = (entries: readonly HeaderEntry[]): readonly Heade
 		.filter((h) => h.enabled && h.key.trim().length > 0)
 		.map((h) => [h.key.trim(), h.value] as const);
 
+/** How the request body is composed. */
+export type BodyMode = 'none' | 'json' | 'form' | 'raw';
+
+/** Encode key/value rows as an `application/x-www-form-urlencoded` body. */
+export const encodeFormBody = (fields: readonly HeaderEntry[]): string =>
+	fields
+		.filter((f) => f.enabled && f.key.trim().length > 0)
+		.map((f) => `${encodeURIComponent(f.key.trim())}=${encodeURIComponent(f.value)}`)
+		.join('&');
+
+/**
+ * Resolve the effective request body for a body mode, plus the Content-Type the
+ * mode implies (`null` when the mode dictates none). `json` and `form` carry a
+ * canonical type; `raw` leaves the type to the user's headers; `none` sends no
+ * body.
+ */
+export const resolveBody = (
+	mode: BodyMode,
+	body: string,
+	formFields: readonly HeaderEntry[]
+): { readonly body: string; readonly contentType: string | null } => {
+	if (mode === 'none') return { body: '', contentType: null };
+	if (mode === 'json') return { body, contentType: 'application/json' };
+	if (mode === 'form') {
+		return { body: encodeFormBody(formFields), contentType: 'application/x-www-form-urlencoded' };
+	}
+	return { body, contentType: null };
+};
+
+/**
+ * Append a Content-Type header only when the request does not already declare
+ * one (case-insensitive), so an explicit user header always wins over the body
+ * mode's implied type.
+ */
+export const withContentType = (
+	headers: readonly HeaderTuple[],
+	contentType: string | null
+): readonly HeaderTuple[] => {
+	if (contentType === null) return headers;
+	const hasContentType = headers.some(([k]) => k.toLowerCase() === 'content-type');
+	return hasContentType ? headers : [...headers, ['Content-Type', contentType]];
+};
+
+/** Validate a JSON string. Returns null for an empty string (nothing to check). */
+export const validateJson = (text: string): boolean | null => {
+	if (text.trim().length === 0) return null;
+	try {
+		JSON.parse(text);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/** Pretty-print a JSON string; returns the input unchanged when it is invalid. */
+export const formatJson = (text: string): string => {
+	try {
+		return JSON.stringify(JSON.parse(text), null, 2);
+	} catch {
+		return text;
+	}
+};
+
 /** Case-insensitive lookup for a header value. */
 export const headerValue = (headers: readonly HeaderTuple[], name: string): string | undefined => {
 	const lower = name.toLowerCase();

--- a/src/routes/rest-client.tsx
+++ b/src/routes/rest-client.tsx
@@ -39,12 +39,14 @@ import {
 	applyAuth,
 	type AuthConfig,
 	type AuthType,
+	type BodyMode,
 	buildUrlWithParams,
 	createEmptyHeader,
 	createHeaderId,
 	DEFAULT_AUTH,
 	exportAsCurl,
 	formatBytes,
+	formatJson,
 	formatResponseBody,
 	HTTP_METHODS,
 	type HeaderEntry,
@@ -54,7 +56,10 @@ import {
 	isHttpMethod,
 	parseQueryParams,
 	type QueryParam,
+	resolveBody,
 	type RestResponse,
+	validateJson,
+	withContentType,
 	SAMPLE_GET_URL,
 	SAMPLE_POST_BODY,
 	SAMPLE_POST_URL,
@@ -73,7 +78,9 @@ interface RestClientOptions {
 	readonly url: string;
 	readonly headers: readonly HeaderEntry[];
 	readonly auth: AuthConfig;
+	readonly bodyMode: BodyMode;
 	readonly body: string;
+	readonly formFields: readonly HeaderEntry[];
 	readonly followRedirects: boolean;
 	readonly timeoutMs: number;
 }
@@ -87,7 +94,9 @@ const DEFAULTS: RestClientOptions = {
 	url: '',
 	headers: DEFAULT_HEADERS,
 	auth: DEFAULT_AUTH,
+	bodyMode: 'none',
 	body: '',
+	formFields: [],
 	followRedirects: true,
 	timeoutMs: TIMEOUT_DEFAULT_MS,
 };
@@ -106,10 +115,13 @@ type ResponseTab = 'body' | 'headers';
 function RestClientPage() {
 	const { value: options, patch } = useRestClientOptions();
 	const { method, url, headers, body, followRedirects, timeoutMs } = options;
-	// `auth` was added after the options store shipped; persisted state from
-	// before that lacks the field, so fall back to the default to stay
-	// backward-compatible with rehydrated stores.
+	// `auth`, `bodyMode`, and `formFields` were added after the options store
+	// shipped; persisted state from before that lacks the fields, so fall back to
+	// defaults to stay backward-compatible with rehydrated stores. An existing
+	// body with no mode keeps sending as raw rather than silently dropping.
 	const auth = options.auth ?? DEFAULT_AUTH;
+	const bodyMode = options.bodyMode ?? (body.trim().length > 0 ? 'raw' : 'none');
+	const formFields = options.formFields ?? [];
 
 	const [response, setResponse] = useState<RestResponse | null>(null);
 	const [error, setError] = useState<string | null>(null);
@@ -180,27 +192,43 @@ function RestClientPage() {
 		patch({ headers: headers.filter((h) => h.id !== id) });
 	};
 
+	const handleFormFieldChange = (id: string, delta: Partial<HeaderEntry>) => {
+		patch({ formFields: formFields.map((f) => (f.id === id ? { ...f, ...delta } : f)) });
+	};
+
+	const handleFormFieldRemove = (id: string) => {
+		patch({ formFields: formFields.filter((f) => f.id !== id) });
+	};
+
+	const handleFormatJson = () => {
+		patch({ body: formatJson(body) });
+	};
+
 	const handleLoadGetSample = () => {
-		patch({ method: 'GET', url: SAMPLE_GET_URL, body: '' });
-		setRequestTab('headers');
+		patch({ method: 'GET', url: SAMPLE_GET_URL, bodyMode: 'none', body: '' });
+		setRequestTab('params');
 	};
 
 	const handleLoadPostSample = () => {
-		patch({
-			method: 'POST',
-			url: SAMPLE_POST_URL,
-			body: SAMPLE_POST_BODY,
-			headers: [
-				...headers.filter((h) => h.key.trim().toLowerCase() !== 'content-type' || !h.enabled),
-				{
-					id: createHeaderId(),
-					key: 'Content-Type',
-					value: 'application/json',
-					enabled: true,
-				},
-			],
-		});
+		// The JSON body mode supplies Content-Type at send time, so the sample no
+		// longer needs to inject a header row.
+		patch({ method: 'POST', url: SAMPLE_POST_URL, bodyMode: 'json', body: SAMPLE_POST_BODY });
 		setRequestTab('body');
+	};
+
+	// Compose the wire request: fold auth into headers/URL, resolve the body for
+	// the selected mode, and add the mode's Content-Type unless the user set one.
+	const buildEffectiveRequest = () => {
+		const withAuth = applyAuth(headersToTuples(headers), url, auth);
+		const resolved = resolveBody(bodyMode, body, formFields);
+		return {
+			method,
+			url: withAuth.url,
+			headers: withContentType(withAuth.headers, resolved.contentType),
+			body: resolved.body,
+			followRedirects,
+			timeoutMs,
+		};
 	};
 
 	const handleCopyCurl = async () => {
@@ -208,15 +236,7 @@ function RestClientPage() {
 			toast.error('Enter a URL first');
 			return;
 		}
-		const effective = applyAuth(headersToTuples(headers), url, auth);
-		const command = exportAsCurl({
-			method,
-			url: effective.url,
-			headers: effective.headers,
-			body,
-			followRedirects,
-			timeoutMs,
-		});
+		const command = exportAsCurl(buildEffectiveRequest());
 		try {
 			await navigator.clipboard.writeText(command);
 			toast.success('cURL command copied to clipboard');
@@ -230,15 +250,7 @@ function RestClientPage() {
 		setSending(true);
 		setError(null);
 		try {
-			const effective = applyAuth(headersToTuples(headers), url, auth);
-			const res = await sendRequest({
-				method,
-				url: effective.url,
-				headers: effective.headers,
-				body,
-				followRedirects,
-				timeoutMs,
-			});
+			const res = await sendRequest(buildEffectiveRequest());
 			setResponse(res);
 			setResponseTab('body');
 		} catch (e) {
@@ -293,7 +305,9 @@ function RestClientPage() {
 							auth={auth}
 							headers={headers}
 							enabledHeaderCount={enabledHeaderCount}
+							bodyMode={bodyMode}
 							body={body}
+							formFields={formFields}
 							onParamChange={handleParamChange}
 							onParamRemove={handleParamRemove}
 							onParamAdd={handleParamAdd}
@@ -301,7 +315,12 @@ function RestClientPage() {
 							onHeaderChange={handleHeaderChange}
 							onHeaderRemove={handleHeaderRemove}
 							onHeaderAdd={() => patch({ headers: [...headers, createEmptyHeader()] })}
+							onBodyModeChange={(m) => patch({ bodyMode: m })}
 							onBodyChange={(e) => patch({ body: e.target.value })}
+							onFormFieldChange={handleFormFieldChange}
+							onFormFieldRemove={handleFormFieldRemove}
+							onFormFieldAdd={() => patch({ formFields: [...formFields, createEmptyHeader()] })}
+							onFormatJson={handleFormatJson}
 						/>
 
 						{error ? <ErrorDisplay variant="banner" message={error} /> : null}
@@ -496,7 +515,9 @@ interface RequestPanelProps {
 	readonly auth: AuthConfig;
 	readonly headers: readonly HeaderEntry[];
 	readonly enabledHeaderCount: number;
+	readonly bodyMode: BodyMode;
 	readonly body: string;
+	readonly formFields: readonly HeaderEntry[];
 	readonly onParamChange: (id: string, delta: Partial<QueryParam>) => void;
 	readonly onParamRemove: (id: string) => void;
 	readonly onParamAdd: () => void;
@@ -504,7 +525,12 @@ interface RequestPanelProps {
 	readonly onHeaderChange: (id: string, delta: Partial<HeaderEntry>) => void;
 	readonly onHeaderRemove: (id: string) => void;
 	readonly onHeaderAdd: () => void;
+	readonly onBodyModeChange: (mode: BodyMode) => void;
 	readonly onBodyChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
+	readonly onFormFieldChange: (id: string, delta: Partial<HeaderEntry>) => void;
+	readonly onFormFieldRemove: (id: string) => void;
+	readonly onFormFieldAdd: () => void;
+	readonly onFormatJson: () => void;
 }
 
 function RequestPanel({
@@ -515,7 +541,9 @@ function RequestPanel({
 	auth,
 	headers,
 	enabledHeaderCount,
+	bodyMode,
 	body,
+	formFields,
 	onParamChange,
 	onParamRemove,
 	onParamAdd,
@@ -523,7 +551,12 @@ function RequestPanel({
 	onHeaderChange,
 	onHeaderRemove,
 	onHeaderAdd,
+	onBodyModeChange,
 	onBodyChange,
+	onFormFieldChange,
+	onFormFieldRemove,
+	onFormFieldAdd,
+	onFormatJson,
 }: RequestPanelProps) {
 	const handleValueChange = (v: string) => {
 		if (v === 'params' || v === 'auth' || v === 'headers' || v === 'body') onTabChange(v);
@@ -564,9 +597,9 @@ function RequestPanel({
 						<TabsTrigger value="body" className="gap-2">
 							<FileText className="h-3.5 w-3.5" />
 							Body
-							{body.trim().length > 0 ? (
-								<Badge variant="secondary" className="ml-1 h-4 px-1.5 text-2xs">
-									{body.length}
+							{bodyMode !== 'none' ? (
+								<Badge variant="secondary" className="ml-1 h-4 px-1.5 text-2xs uppercase">
+									{bodyMode}
 								</Badge>
 							) : null}
 						</TabsTrigger>
@@ -594,18 +627,18 @@ function RequestPanel({
 						/>
 					</TabsContent>
 
-					<TabsContent value="body" className="space-y-2 pt-3">
-						<Textarea
-							value={body}
-							placeholder='{"key": "value"}'
-							rows={10}
-							className="font-mono text-sm"
-							onChange={onBodyChange}
+					<TabsContent value="body" className="space-y-3 pt-3">
+						<BodyEditor
+							bodyMode={bodyMode}
+							body={body}
+							formFields={formFields}
+							onBodyModeChange={onBodyModeChange}
+							onBodyChange={onBodyChange}
+							onFormFieldChange={onFormFieldChange}
+							onFormFieldRemove={onFormFieldRemove}
+							onFormFieldAdd={onFormFieldAdd}
+							onFormatJson={onFormatJson}
 						/>
-						<p className="text-xs text-muted-foreground">
-							Content-Type defaults to <code className="font-mono">text/plain</code> unless set in
-							Headers.
-						</p>
 					</TabsContent>
 				</Tabs>
 			</CardContent>
@@ -776,6 +809,124 @@ function ParamRow({ entry, onChange, onRemove }: ParamRowProps) {
 			</Button>
 		</div>
 	);
+}
+
+const BODY_MODE_OPTIONS: readonly { readonly value: BodyMode; readonly label: string }[] = [
+	{ value: 'none', label: 'None' },
+	{ value: 'json', label: 'JSON' },
+	{ value: 'form', label: 'Form URL-encoded' },
+	{ value: 'raw', label: 'Raw' },
+];
+
+interface BodyEditorProps {
+	readonly bodyMode: BodyMode;
+	readonly body: string;
+	readonly formFields: readonly HeaderEntry[];
+	readonly onBodyModeChange: (mode: BodyMode) => void;
+	readonly onBodyChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
+	readonly onFormFieldChange: (id: string, delta: Partial<HeaderEntry>) => void;
+	readonly onFormFieldRemove: (id: string) => void;
+	readonly onFormFieldAdd: () => void;
+	readonly onFormatJson: () => void;
+}
+
+function BodyEditor({
+	bodyMode,
+	body,
+	formFields,
+	onBodyModeChange,
+	onBodyChange,
+	onFormFieldChange,
+	onFormFieldRemove,
+	onFormFieldAdd,
+	onFormatJson,
+}: BodyEditorProps) {
+	const handleModeChange = (v: string) => {
+		if (v === 'none' || v === 'json' || v === 'form' || v === 'raw') onBodyModeChange(v);
+	};
+	const jsonValid = bodyMode === 'json' ? validateJson(body) : null;
+
+	return (
+		<>
+			<FormSelect
+				label="Body type"
+				value={bodyMode}
+				options={BODY_MODE_OPTIONS}
+				onValueChange={handleModeChange}
+				size="compact"
+			/>
+
+			{bodyMode === 'none' ? (
+				<p className="text-xs text-muted-foreground">This request will be sent without a body.</p>
+			) : null}
+
+			{bodyMode === 'json' ? (
+				<>
+					<div className="flex items-center justify-between gap-2">
+						<JsonValidity valid={jsonValid} />
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={onFormatJson}
+							disabled={jsonValid !== true}
+						>
+							Format
+						</Button>
+					</div>
+					<Textarea
+						value={body}
+						placeholder='{"key": "value"}'
+						rows={10}
+						className="font-mono text-sm"
+						onChange={onBodyChange}
+					/>
+				</>
+			) : null}
+
+			{bodyMode === 'form' ? (
+				<>
+					{formFields.length === 0 ? (
+						<EmbeddedEmptyState
+							icon={FileText}
+							title="No form fields"
+							description="Add fields sent as application/x-www-form-urlencoded."
+						/>
+					) : (
+						<div className="space-y-1.5">
+							{formFields.map((entry) => (
+								<ParamRow
+									key={entry.id}
+									entry={entry}
+									onChange={(delta) => onFormFieldChange(entry.id, delta)}
+									onRemove={() => onFormFieldRemove(entry.id)}
+								/>
+							))}
+						</div>
+					)}
+					<Button variant="outline" size="sm" onClick={onFormFieldAdd}>
+						<Plus className="h-3.5 w-3.5" />
+						Add field
+					</Button>
+				</>
+			) : null}
+
+			{bodyMode === 'raw' ? (
+				<Textarea
+					value={body}
+					placeholder="Raw request body"
+					rows={10}
+					className="font-mono text-sm"
+					onChange={onBodyChange}
+				/>
+			) : null}
+		</>
+	);
+}
+
+function JsonValidity({ valid }: { readonly valid: boolean | null }): ReactNode {
+	if (valid === true) return <ToneBadge tone="success">Valid JSON</ToneBadge>;
+	if (valid === false) return <ToneBadge tone="destructive">Invalid JSON</ToneBadge>;
+	return <span className="text-xs text-muted-foreground">Enter a JSON body</span>;
 }
 
 const AUTH_TYPE_OPTIONS: readonly { readonly value: AuthType; readonly label: string }[] = [


### PR DESCRIPTION
## Summary

- Adds a **Body** tab to the HTTP REST client with four content modes
- JSON mode validates live and offers a one-click pretty-print
- Body composition shares one pipeline with auth, so send and cURL export stay in sync

## Changes

### Added

- `BodyMode` type (`none` / `json` / `form` / `raw`) plus `encodeFormBody`, `resolveBody`, `withContentType`, `validateJson`, `formatJson` in `rest-client.ts`
- `BodyEditor`, `JsonValidity`, and `buildEffectiveRequest` in `rest-client.tsx`
- 17 unit tests covering the new body helpers (32 total in `rest-client.test.ts`)

### Changed

- `RequestPanel` gains a fourth tab; the tab badge shows the active body mode
- `RestClientOptions` persists `bodyMode` / `body` / `formFields`; rehydrate falls back to safe defaults so existing users do not crash
- GET/POST sample loaders set the body mode (POST seeds JSON; Content-Type is now derived, not injected as a header)

## Mode behavior

| Mode | Editor | Content-Type |
| --- | --- | --- |
| None | hint only | — |
| JSON | textarea + validity badge + Format | `application/json` |
| Form | key/value rows | `application/x-www-form-urlencoded` |
| Raw | textarea | — |

Auto Content-Type is skipped when the user already set one (case-insensitive).

## Test Plan

- [x] `bun run check` (tsc + validate-pages + validate-tokens + audit-design) passes
- [x] `bunx vitest run rest-client.test.ts` — 32 passed
- [x] In-app: Body tab renders full-width; None shows a hint, JSON shows the validity badge + Format + textarea (sample loads as "Valid JSON")
- [x] Body type select and editors span full width (no squished layout)
