### PR TITLE
feat(rest-client): add a response cookies tab

### DIFF
--- a/src/lib/services/rest-client.test.ts
+++ b/src/lib/services/rest-client.test.ts
@@ -8,7 +8,9 @@ import {
 	encodeFormBody,
 	formatJson,
 	type HeaderEntry,
+	type HeaderTuple,
 	parseQueryParams,
+	parseSetCookie,
 	type QueryParam,
 	resolveBody,
 	validateJson,
@@ -244,5 +246,53 @@ describe('formatJson', () => {
 
 	it('returns invalid JSON unchanged', () => {
 		expect(formatJson('{a:1}')).toBe('{a:1}');
+	});
+});
+
+describe('parseSetCookie', () => {
+	const cookie = (key: string, value: string): HeaderTuple => [key, value];
+
+	it('ignores responses without Set-Cookie headers', () => {
+		expect(parseSetCookie([cookie('Content-Type', 'text/html')])).toEqual([]);
+	});
+
+	it('matches the Set-Cookie header case-insensitively', () => {
+		const cookies = parseSetCookie([cookie('set-cookie', 'sid=abc')]);
+		expect(cookies).toMatchObject([{ name: 'sid', value: 'abc', attributes: [] }]);
+	});
+
+	it('parses attributes and boolean flags in order', () => {
+		const cookies = parseSetCookie([
+			cookie('Set-Cookie', 'sid=abc; Path=/; HttpOnly; Secure; SameSite=Lax'),
+		]);
+		expect(cookies[0]).toMatchObject({
+			name: 'sid',
+			value: 'abc',
+			attributes: [
+				['Path', '/'],
+				['HttpOnly', ''],
+				['Secure', ''],
+				['SameSite', 'Lax'],
+			],
+		});
+	});
+
+	it('keeps a value that contains an equals sign', () => {
+		const cookies = parseSetCookie([cookie('Set-Cookie', 'token=a=b=c; Path=/')]);
+		expect(cookies[0]).toMatchObject({ name: 'token', value: 'a=b=c' });
+	});
+
+	it('collects every Set-Cookie header', () => {
+		const cookies = parseSetCookie([
+			cookie('Set-Cookie', 'a=1'),
+			cookie('Content-Type', 'text/html'),
+			cookie('Set-Cookie', 'b=2'),
+		]);
+		expect(cookies.map((c) => c.name)).toEqual(['a', 'b']);
+	});
+
+	it('drops segments without a valid name', () => {
+		expect(parseSetCookie([cookie('Set-Cookie', 'noequalssign')])).toEqual([]);
+		expect(parseSetCookie([cookie('Set-Cookie', '=novalue')])).toEqual([]);
 	});
 });

--- a/src/lib/services/rest-client.ts
+++ b/src/lib/services/rest-client.ts
@@ -281,6 +281,45 @@ export const headerValue = (headers: readonly HeaderTuple[], name: string): stri
 	return headers.find(([k]) => k.toLowerCase() === lower)?.[1];
 };
 
+/** A single cookie parsed from a Set-Cookie response header. */
+export interface ParsedCookie {
+	readonly name: string;
+	readonly value: string;
+	/** Attribute pairs in source order. Boolean flags carry an empty value. */
+	readonly attributes: readonly HeaderTuple[];
+}
+
+/**
+ * Parse one Set-Cookie header value into a name/value pair plus attributes.
+ * Returns null when the segment has no valid `name=value` lead.
+ */
+const parseCookieString = (raw: string): ParsedCookie | null => {
+	const segments = raw
+		.split(';')
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+	const [nameValue, ...attrSegments] = segments;
+	if (!nameValue) return null;
+	const eq = nameValue.indexOf('=');
+	if (eq < 0) return null;
+	const name = nameValue.slice(0, eq).trim();
+	if (name.length === 0) return null;
+	const value = nameValue.slice(eq + 1).trim();
+	const attributes = attrSegments.map((seg): HeaderTuple => {
+		const i = seg.indexOf('=');
+		if (i < 0) return [seg, ''];
+		return [seg.slice(0, i).trim(), seg.slice(i + 1).trim()];
+	});
+	return { name, value, attributes };
+};
+
+/** Extract and parse every Set-Cookie header from a response. */
+export const parseSetCookie = (headers: readonly HeaderTuple[]): readonly ParsedCookie[] =>
+	headers
+		.filter(([k]) => k.toLowerCase() === 'set-cookie')
+		.map(([, v]) => parseCookieString(v))
+		.filter((c): c is ParsedCookie => c !== null);
+
 /**
  * Pretty-print a response body when the Content-Type indicates JSON.
  * Returns the original body unchanged for non-JSON or invalid JSON payloads.

--- a/src/routes/rest-client.tsx
+++ b/src/routes/rest-client.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { useEffect, useMemo, useRef, useState, type ChangeEvent, type ReactNode } from 'react';
 import {
 	Code2,
+	Cookie,
 	FileText,
 	FlaskConical,
 	Globe,
@@ -54,7 +55,9 @@ import {
 	headerValue,
 	headersToTuples,
 	isHttpMethod,
+	type ParsedCookie,
 	parseQueryParams,
+	parseSetCookie,
 	type QueryParam,
 	resolveBody,
 	type RestResponse,
@@ -110,7 +113,7 @@ export const Route = createFileRoute('/rest-client')({
 });
 
 type RequestTab = 'params' | 'auth' | 'headers' | 'body';
-type ResponseTab = 'body' | 'headers';
+type ResponseTab = 'body' | 'headers' | 'cookies';
 
 function RestClientPage() {
 	const { value: options, patch } = useRestClientOptions();
@@ -1076,14 +1079,15 @@ interface ResponseTabsProps {
 function ResponseTabs({ response, activeTab, onTabChange }: ResponseTabsProps) {
 	const contentType = headerValue(response.headers, 'content-type');
 	const formattedBody = formatResponseBody(response.body, contentType);
+	const cookies = parseSetCookie(response.headers);
 
 	const handleValueChange = (v: string) => {
-		if (v === 'body' || v === 'headers') onTabChange(v);
+		if (v === 'body' || v === 'headers' || v === 'cookies') onTabChange(v);
 	};
 
 	return (
 		<Tabs value={activeTab} onValueChange={handleValueChange} className="contents">
-			<TabsList className="grid w-full grid-cols-2">
+			<TabsList className="grid w-full grid-cols-3">
 				<TabsTrigger value="body" className="gap-2">
 					<FileText className="h-3.5 w-3.5" />
 					Body
@@ -1095,6 +1099,15 @@ function ResponseTabs({ response, activeTab, onTabChange }: ResponseTabsProps) {
 						{response.headers.length}
 					</Badge>
 				</TabsTrigger>
+				<TabsTrigger value="cookies" className="gap-2">
+					<Cookie className="h-3.5 w-3.5" />
+					Cookies
+					{cookies.length > 0 ? (
+						<Badge variant="secondary" className="ml-1 h-4 px-1.5 text-2xs">
+							{cookies.length}
+						</Badge>
+					) : null}
+				</TabsTrigger>
 			</TabsList>
 
 			<TabsContent value="body" className="pt-3">
@@ -1103,6 +1116,10 @@ function ResponseTabs({ response, activeTab, onTabChange }: ResponseTabsProps) {
 
 			<TabsContent value="headers" className="pt-3">
 				<ResponseHeaders headers={response.headers} />
+			</TabsContent>
+
+			<TabsContent value="cookies" className="pt-3">
+				<ResponseCookies cookies={cookies} />
 			</TabsContent>
 		</Tabs>
 	);
@@ -1158,6 +1175,51 @@ function ResponseHeaders({ headers }: ResponseHeadersProps): ReactNode {
 				>
 					<span className="break-all font-mono text-xs font-medium">{row.key}</span>
 					<span className="break-all font-mono text-xs text-muted-foreground">{row.value}</span>
+				</div>
+			))}
+		</div>
+	);
+}
+
+interface ResponseCookiesProps {
+	readonly cookies: readonly ParsedCookie[];
+}
+
+function ResponseCookies({ cookies }: ResponseCookiesProps): ReactNode {
+	if (cookies.length === 0) {
+		return <p className="text-sm text-muted-foreground">No cookies set by this response.</p>;
+	}
+	// Disambiguate cookies that share a name so React keys stay stable across
+	// re-renders, mirroring the occurrence-counting in ResponseHeaders.
+	const seen = new Map<string, number>();
+	const rows = cookies.map((cookie) => {
+		const occurrence = (seen.get(cookie.name) ?? 0) + 1;
+		seen.set(cookie.name, occurrence);
+		return { id: `${cookie.name}#${occurrence}`, cookie };
+	});
+	return (
+		<div className="space-y-2">
+			{rows.map(({ id, cookie }) => (
+				<div key={id} className="space-y-1.5 rounded-md border px-3 py-2">
+					<div className="flex items-baseline gap-2">
+						<span className="break-all font-mono text-xs font-medium">{cookie.name}</span>
+						<span className="break-all font-mono text-xs text-muted-foreground">
+							{cookie.value}
+						</span>
+					</div>
+					{cookie.attributes.length > 0 ? (
+						<div className="flex flex-wrap gap-1">
+							{cookie.attributes.map(([key, value]) => (
+								<Badge
+									key={`${id}:${key}`}
+									variant="outline"
+									className="font-mono text-2xs font-normal"
+								>
+									{value.length > 0 ? `${key}=${value}` : key}
+								</Badge>
+							))}
+						</div>
+					) : null}
 				</div>
 			))}
 		</div>


### PR DESCRIPTION
## Summary

- Adds a **Cookies** tab to the HTTP REST client response viewer, beside Body and Headers
- Parses every `Set-Cookie` response header into a name/value pair plus ordered attributes
- Shows a count badge, with an empty state when a response sets no cookies

## Changes

### Added

- `ParsedCookie` type and `parseSetCookie` in `rest-client.ts`
- `ResponseCookies` component plus a third response tab in `rest-client.tsx`
- 6 unit tests for `parseSetCookie` (38 total in `rest-client.test.ts`)

### Changed

- Response tab list grows from two columns to three

## Parsing rules

- Splits each `Set-Cookie` value on the first `=` for the name/value lead, preserving values that contain `=` (e.g. `token=a=b=c`)
- Treats valueless segments as boolean attributes (`Secure`, `HttpOnly`)
- Matches the `Set-Cookie` header name case-insensitively and collects every occurrence

## Test Plan

- [x] `bun run check` (tsc + validate-pages + validate-tokens + audit-design) passes
- [x] `bunx vitest run rest-client.test.ts` — 38 passed
- [x] In-app: `GET https://www.google.com/` returns 4 `Set-Cookie` headers; the Cookies tab badge shows `4`
- [x] In-app: a response with no `Set-Cookie` shows the empty state
- [x] Cookies tab renders full-width within the three-column tab layout
