### PR TITLE
feat(rest-client): enrich responses with pretty/raw, cURL import, timing, search, and history

### DIFF
--- a/src-tauri/src/rest_client.rs
+++ b/src-tauri/src/rest_client.rs
@@ -43,6 +43,12 @@ pub struct RestResponse {
     pub bytes_received: u64,
     /// Elapsed wall-clock time from request build to body read, in milliseconds.
     pub elapsed_ms: u128,
+    /// Time to first byte: request build until the response headers arrive,
+    /// in milliseconds. Covers DNS, connect, TLS, and server processing.
+    pub ttfb_ms: u128,
+    /// Time spent reading the response body after the headers arrived, in
+    /// milliseconds (`elapsed_ms - ttfb_ms`).
+    pub download_ms: u128,
     /// Final URL after redirects (matches `url` when redirects are disabled).
     pub final_url: String,
 }
@@ -92,6 +98,11 @@ pub async fn rest_client_send(req: RestRequest) -> Result<RestResponse, String> 
         .await
         .map_err(|e| format!("Request failed: {e}"))?;
 
+    // The response future resolves once the status and headers have arrived, so
+    // the elapsed time here is the time to first byte (DNS + connect + TLS +
+    // server processing). The body is streamed separately below.
+    let ttfb_ms = started.elapsed().as_millis();
+
     let status = response.status();
     let status_text = status.canonical_reason().unwrap_or("").to_string();
     let headers: Vec<(String, String)> = response
@@ -108,13 +119,17 @@ pub async fn rest_client_send(req: RestRequest) -> Result<RestResponse, String> 
     let bytes_received = bytes.len() as u64;
     let body = String::from_utf8_lossy(&bytes).into_owned();
 
+    let elapsed_ms = started.elapsed().as_millis();
+
     Ok(RestResponse {
         status: status.as_u16(),
         status_text,
         headers,
         body,
         bytes_received,
-        elapsed_ms: started.elapsed().as_millis(),
+        elapsed_ms,
+        ttfb_ms,
+        download_ms: elapsed_ms.saturating_sub(ttfb_ms),
         final_url,
     })
 }

--- a/src/lib/services/rest-client.test.ts
+++ b/src/lib/services/rest-client.test.ts
@@ -9,6 +9,7 @@ import {
 	formatJson,
 	type HeaderEntry,
 	type HeaderTuple,
+	importCurl,
 	parseQueryParams,
 	parseSetCookie,
 	type QueryParam,
@@ -294,5 +295,62 @@ describe('parseSetCookie', () => {
 	it('drops segments without a valid name', () => {
 		expect(parseSetCookie([cookie('Set-Cookie', 'noequalssign')])).toEqual([]);
 		expect(parseSetCookie([cookie('Set-Cookie', '=novalue')])).toEqual([]);
+	});
+});
+
+describe('importCurl', () => {
+	it('rejects input that does not start with curl', () => {
+		const result = importCurl('wget https://example.com');
+		expect(result.ok).toBe(false);
+	});
+
+	it('maps method, url, and headers', () => {
+		const result = importCurl(
+			"curl -X PUT 'https://example.com/api' -H 'Accept: application/json'"
+		);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.method).toBe('PUT');
+		expect(result.value.url).toBe('https://example.com/api');
+		expect(result.value.headers).toMatchObject([
+			{ key: 'Accept', value: 'application/json', enabled: true },
+		]);
+	});
+
+	it('infers POST and a raw body from a data flag', () => {
+		const result = importCurl("curl https://example.com --data-raw 'hello'");
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.method).toBe('POST');
+		expect(result.value.bodyMode).toBe('raw');
+		expect(result.value.body).toBe('hello');
+	});
+
+	it('upgrades the body mode to json when a JSON content type is present', () => {
+		const result = importCurl(
+			`curl -X POST 'https://example.com' -H 'Content-Type: application/json' --data-raw '{"a":1}'`
+		);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.bodyMode).toBe('json');
+		expect(result.value.body).toBe('{"a":1}');
+	});
+
+	it('converts and clamps a max-time timeout to milliseconds', () => {
+		const within = importCurl('curl https://example.com --max-time 30');
+		expect(within.ok && within.value.timeoutMs).toBe(30_000);
+
+		const clampedHigh = importCurl('curl https://example.com --max-time 600');
+		expect(clampedHigh.ok && clampedHigh.value.timeoutMs).toBe(60_000);
+	});
+
+	it('leaves the timeout unset when no max-time is given', () => {
+		const result = importCurl('curl https://example.com');
+		expect(result.ok && result.value.timeoutMs).toBeNull();
+	});
+
+	it('captures the follow-redirects flag', () => {
+		const result = importCurl('curl -L https://example.com');
+		expect(result.ok && result.value.followRedirects).toBe(true);
 	});
 });

--- a/src/lib/services/rest-client.test.ts
+++ b/src/lib/services/rest-client.test.ts
@@ -6,11 +6,14 @@ import {
 	buildUrlWithParams,
 	DEFAULT_AUTH,
 	encodeFormBody,
+	countMatches,
 	formatJson,
 	formatResponseBody,
 	type HeaderEntry,
 	type HeaderTuple,
 	importCurl,
+	responseFilename,
+	splitHighlight,
 	parseQueryParams,
 	parseSetCookie,
 	type QueryParam,
@@ -327,6 +330,69 @@ describe('formatResponseBody', () => {
 
 	it('leaves a plain-text body unchanged', () => {
 		expect(formatResponseBody('hello world', 'text/plain')).toBe('hello world');
+	});
+});
+
+describe('splitHighlight', () => {
+	it('returns the whole text as one non-match segment for an empty query', () => {
+		expect(splitHighlight('hello world', '')).toEqual([{ text: 'hello world', match: false }]);
+	});
+
+	it('marks matched runs case-insensitively', () => {
+		expect(splitHighlight('Hello hello', 'hello')).toEqual([
+			{ text: 'Hello', match: true },
+			{ text: ' ', match: false },
+			{ text: 'hello', match: true },
+		]);
+	});
+
+	it('treats regex metacharacters literally', () => {
+		expect(splitHighlight('a.b.c', '.')).toEqual([
+			{ text: 'a', match: false },
+			{ text: '.', match: true },
+			{ text: 'b', match: false },
+			{ text: '.', match: true },
+			{ text: 'c', match: false },
+		]);
+	});
+
+	it('reassembles to the original text', () => {
+		const text = 'the quick brown fox';
+		const joined = splitHighlight(text, 'o')
+			.map((s) => s.text)
+			.join('');
+		expect(joined).toBe(text);
+	});
+});
+
+describe('countMatches', () => {
+	it('counts case-insensitive occurrences', () => {
+		expect(countMatches('aAaA', 'a')).toBe(4);
+	});
+
+	it('returns zero for an empty query', () => {
+		expect(countMatches('anything', '')).toBe(0);
+	});
+
+	it('returns zero when there is no match', () => {
+		expect(countMatches('abc', 'z')).toBe(0);
+	});
+});
+
+describe('responseFilename', () => {
+	it('defaults to a text extension without a content type', () => {
+		expect(responseFilename(undefined)).toBe('response.txt');
+	});
+
+	it.each([
+		['application/json; charset=utf-8', 'response.json'],
+		['application/vnd.api+json', 'response.json'],
+		['text/html', 'response.html'],
+		['application/xml', 'response.xml'],
+		['text/csv', 'response.csv'],
+		['text/plain', 'response.txt'],
+	])('maps %s to %s', (contentType, expected) => {
+		expect(responseFilename(contentType)).toBe(expected);
 	});
 });
 

--- a/src/lib/services/rest-client.test.ts
+++ b/src/lib/services/rest-client.test.ts
@@ -7,6 +7,7 @@ import {
 	DEFAULT_AUTH,
 	encodeFormBody,
 	formatJson,
+	formatResponseBody,
 	type HeaderEntry,
 	type HeaderTuple,
 	importCurl,
@@ -295,6 +296,37 @@ describe('parseSetCookie', () => {
 	it('drops segments without a valid name', () => {
 		expect(parseSetCookie([cookie('Set-Cookie', 'noequalssign')])).toEqual([]);
 		expect(parseSetCookie([cookie('Set-Cookie', '=novalue')])).toEqual([]);
+	});
+});
+
+describe('formatResponseBody', () => {
+	it('returns the body unchanged without a content type', () => {
+		expect(formatResponseBody('{"a":1}', undefined)).toBe('{"a":1}');
+	});
+
+	it('pretty-prints JSON for a JSON content type', () => {
+		const result = formatResponseBody('{"a":1}', 'application/json; charset=utf-8');
+		expect(result).toContain('\n');
+		expect(result).toContain('"a"');
+	});
+
+	it('pretty-prints a JSON suffix content type', () => {
+		const result = formatResponseBody('{"a":1}', 'application/vnd.api+json');
+		expect(result).toContain('\n');
+	});
+
+	it('pretty-prints XML for an XML content type', () => {
+		const result = formatResponseBody('<a><b>1</b></a>', 'application/xml');
+		expect(result).toContain('\n');
+		expect(result).toContain('<b>1</b>');
+	});
+
+	it('returns unparseable XML unchanged', () => {
+		expect(formatResponseBody('plain text, not xml', 'text/xml')).toBe('plain text, not xml');
+	});
+
+	it('leaves a plain-text body unchanged', () => {
+		expect(formatResponseBody('hello world', 'text/plain')).toBe('hello world');
 	});
 });
 

--- a/src/lib/services/rest-client.ts
+++ b/src/lib/services/rest-client.ts
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 
 import { type ParsedCurl, parseCurl, type Result } from './curl';
+import { formatXml } from './formatters/xml';
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
 
@@ -326,20 +327,38 @@ export const parseSetCookie = (headers: readonly HeaderTuple[]): readonly Parsed
 		.map(([, v]) => parseCookieString(v))
 		.filter((c): c is ParsedCookie => c !== null);
 
+const isJsonContentType = (lower: string): boolean =>
+	lower.includes('application/json') || lower.includes('+json');
+
+const isXmlContentType = (lower: string): boolean =>
+	lower.includes('xml') || lower.includes('text/html');
+
 /**
- * Pretty-print a response body when the Content-Type indicates JSON.
- * Returns the original body unchanged for non-JSON or invalid JSON payloads.
+ * Pretty-print a response body based on its Content-Type. JSON and XML/HTML
+ * payloads are reformatted with indentation; every other type, and any payload
+ * that fails to parse, is returned unchanged so the raw bytes are never lost.
  */
 export const formatResponseBody = (body: string, contentType: string | undefined): string => {
 	if (!contentType) return body;
 	const lower = contentType.toLowerCase();
-	if (!lower.includes('application/json') && !lower.includes('+json')) return body;
-	try {
-		const parsed = JSON.parse(body) as unknown;
-		return JSON.stringify(parsed, null, 2);
-	} catch {
-		return body;
+	if (isJsonContentType(lower)) {
+		try {
+			return JSON.stringify(JSON.parse(body) as unknown, null, 2);
+		} catch {
+			return body;
+		}
 	}
+	if (isXmlContentType(lower)) {
+		try {
+			// Keep leaf text inline (collapseContent) so data-style XML stays
+			// compact and readable rather than exploding every value onto its own
+			// line. xml-formatter throws on unparseable input; fall back to raw.
+			return formatXml(body, { collapseContent: true });
+		} catch {
+			return body;
+		}
+	}
+	return body;
 };
 
 /** Tone classification used by the response status badge. */

--- a/src/lib/services/rest-client.ts
+++ b/src/lib/services/rest-client.ts
@@ -1,5 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 
+import { type ParsedCurl, parseCurl, type Result } from './curl';
+
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
 
 export const HTTP_METHODS: readonly HttpMethod[] = [
@@ -390,3 +392,61 @@ export const createEmptyHeader = (): HeaderEntry => ({
 	value: '',
 	enabled: true,
 });
+
+/**
+ * Effective request fields decoded from a cURL command. `timeoutMs` is null
+ * when the command does not pin a timeout, so the caller keeps its current
+ * value instead of overwriting it.
+ */
+export interface CurlImport {
+	readonly method: HttpMethod;
+	readonly url: string;
+	readonly headers: readonly HeaderEntry[];
+	readonly bodyMode: BodyMode;
+	readonly body: string;
+	readonly followRedirects: boolean;
+	readonly timeoutMs: number | null;
+}
+
+const hasJsonContentType = (headers: readonly HeaderEntry[]): boolean =>
+	headers.some(
+		(h) =>
+			h.key.toLowerCase() === 'content-type' && h.value.toLowerCase().includes('application/json')
+	);
+
+/**
+ * Map a parsed cURL command onto rest-client request fields. The cURL parser
+ * only distinguishes a raw body, so the body mode is upgraded to `json` when a
+ * JSON Content-Type header accompanies it. A `--max-time` value is converted to
+ * milliseconds and clamped to the timeout slider's bounds.
+ */
+export const restRequestFromCurl = (parsed: ParsedCurl): CurlImport => {
+	const headers: readonly HeaderEntry[] = parsed.headers.map((h) => ({
+		id: createHeaderId(),
+		key: h.key,
+		value: h.value,
+		enabled: true,
+	}));
+	const bodyMode: BodyMode =
+		parsed.bodyMode === 'none' ? 'none' : hasJsonContentType(headers) ? 'json' : 'raw';
+	const timeoutMs =
+		parsed.timeoutSeconds > 0
+			? Math.min(TIMEOUT_MAX_MS, Math.max(TIMEOUT_MIN_MS, Math.round(parsed.timeoutSeconds * 1000)))
+			: null;
+	return {
+		method: parsed.method,
+		url: parsed.url,
+		headers,
+		bodyMode,
+		body: parsed.body,
+		followRedirects: parsed.followRedirects,
+		timeoutMs,
+	};
+};
+
+/** Parse a cURL command string into rest-client request fields. */
+export const importCurl = (command: string): Result<CurlImport> => {
+	const parsed = parseCurl(command);
+	if (!parsed.ok) return parsed;
+	return { ok: true, value: restRequestFromCurl(parsed.value) };
+};

--- a/src/lib/services/rest-client.ts
+++ b/src/lib/services/rest-client.ts
@@ -187,6 +187,10 @@ export interface RestResponse {
 	readonly body: string;
 	readonly bytesReceived: number;
 	readonly elapsedMs: number;
+	/** Time to first byte: DNS, connect, TLS, and server processing (ms). */
+	readonly ttfbMs: number;
+	/** Time spent reading the response body after the headers arrived (ms). */
+	readonly downloadMs: number;
 	readonly finalUrl: string;
 }
 

--- a/src/lib/services/rest-client.ts
+++ b/src/lib/services/rest-client.ts
@@ -361,6 +361,46 @@ export const formatResponseBody = (body: string, contentType: string | undefined
 	return body;
 };
 
+/** A run of body text tagged with whether it matches the active search query. */
+export interface HighlightSegment {
+	readonly text: string;
+	readonly match: boolean;
+}
+
+const escapeRegExp = (input: string): string => input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Split `text` into alternating non-match / match segments for the given
+ * case-insensitive query. An empty query yields the whole text as a single
+ * non-match segment. The capturing split places matches at odd indices, so the
+ * parity of the index marks each segment.
+ */
+export const splitHighlight = (text: string, query: string): readonly HighlightSegment[] => {
+	if (query.length === 0) return [{ text, match: false }];
+	const pattern = new RegExp(`(${escapeRegExp(query)})`, 'gi');
+	return text
+		.split(pattern)
+		.map((part, index) => ({ text: part, match: index % 2 === 1 }))
+		.filter((segment) => segment.text.length > 0);
+};
+
+/** Count case-insensitive occurrences of `query` in `text` (0 for an empty query). */
+export const countMatches = (text: string, query: string): number => {
+	if (query.length === 0) return 0;
+	return splitHighlight(text, query).filter((segment) => segment.match).length;
+};
+
+/** Suggest a download filename for a response body from its Content-Type. */
+export const responseFilename = (contentType: string | undefined): string => {
+	if (!contentType) return 'response.txt';
+	const lower = contentType.toLowerCase();
+	if (isJsonContentType(lower)) return 'response.json';
+	if (lower.includes('html')) return 'response.html';
+	if (lower.includes('xml')) return 'response.xml';
+	if (lower.includes('csv')) return 'response.csv';
+	return 'response.txt';
+};
+
 /** Tone classification used by the response status badge. */
 export type StatusTone = 'success' | 'info' | 'warning' | 'destructive';
 

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -1,5 +1,11 @@
 export { useJsonFormatterOptions, type JsonFormatterOptions } from './json-formatter-options';
 export { MAX_RECENT_TOOLS, useRecentToolsStore } from './recent-tools';
+export {
+	type HistoryEntry,
+	MAX_HISTORY_ENTRIES,
+	type RequestSnapshot,
+	useRestClientHistory,
+} from './rest-client-history';
 export { useSidebarStore } from './sidebar';
 export { useTabStore, useActiveTab } from './tabs';
 export { createToolOptionsStore } from './tool-options';

--- a/src/lib/stores/rest-client-history.ts
+++ b/src/lib/stores/rest-client-history.ts
@@ -1,0 +1,81 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+import type { AuthConfig, BodyMode, HeaderEntry, HttpMethod } from '@/lib/services/rest-client';
+
+/**
+ * Full request configuration captured so a history entry can be restored into
+ * the editor verbatim. Mirrors the rest-client route's options bag.
+ */
+export interface RequestSnapshot {
+	readonly method: HttpMethod;
+	readonly url: string;
+	readonly headers: readonly HeaderEntry[];
+	readonly auth: AuthConfig;
+	readonly bodyMode: BodyMode;
+	readonly body: string;
+	readonly formFields: readonly HeaderEntry[];
+	readonly followRedirects: boolean;
+	readonly timeoutMs: number;
+}
+
+/** Outcome metadata stored alongside a snapshot for the history list. */
+export interface RequestOutcome {
+	readonly status: number;
+	readonly statusText: string;
+	readonly elapsedMs: number;
+}
+
+/** One recorded request: the snapshot to restore plus its outcome and time. */
+export interface HistoryEntry {
+	readonly id: string;
+	readonly request: RequestSnapshot;
+	readonly status: number;
+	readonly statusText: string;
+	readonly elapsedMs: number;
+	/** Wall-clock timestamp (ms) of the request — used for ordering and display. */
+	readonly at: number;
+}
+
+interface RestClientHistoryState {
+	readonly entries: readonly HistoryEntry[];
+	/** Prepend a completed request to the history, trimming to the cap. */
+	record: (request: RequestSnapshot, outcome: RequestOutcome) => void;
+	/** Drop a single entry by id. */
+	remove: (id: string) => void;
+	/** Clear the entire history. */
+	clear: () => void;
+}
+
+/**
+ * Cap on the request history. Twenty entries cover a working session's recent
+ * calls without letting the persisted list grow unbounded; older requests drop
+ * off the tail as new ones arrive.
+ */
+export const MAX_HISTORY_ENTRIES = 20;
+
+const createId = (): string =>
+	`req_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+
+export const useRestClientHistory = create<RestClientHistoryState>()(
+	persist(
+		(set) => ({
+			entries: [],
+			record: (request, outcome) =>
+				set((state) => {
+					const entry: HistoryEntry = {
+						id: createId(),
+						request,
+						status: outcome.status,
+						statusText: outcome.statusText,
+						elapsedMs: outcome.elapsedMs,
+						at: Date.now(),
+					};
+					return { entries: [entry, ...state.entries].slice(0, MAX_HISTORY_ENTRIES) };
+				}),
+			remove: (id) => set((state) => ({ entries: state.entries.filter((e) => e.id !== id) })),
+			clear: () => set({ entries: [] }),
+		}),
+		{ name: 'kogu:rest-client:history', storage: createJSONStorage(() => localStorage) }
+	)
+);

--- a/src/routes/rest-client.tsx
+++ b/src/routes/rest-client.tsx
@@ -1140,7 +1140,7 @@ function ResponseCard({ response, activeTab, onTabChange }: ResponseCardProps) {
 				</div>
 				{response ? (
 					<div className="flex items-center gap-3 text-xs text-muted-foreground">
-						<span>{response.elapsedMs} ms</span>
+						<TimingSummary response={response} />
 						<span>{formatBytes(response.bytesReceived)}</span>
 					</div>
 				) : null}
@@ -1157,6 +1157,30 @@ function ResponseCard({ response, activeTab, onTabChange }: ResponseCardProps) {
 				)}
 			</CardContent>
 		</Card>
+	);
+}
+
+interface TimingSummaryProps {
+	readonly response: RestResponse;
+}
+
+// Show the total elapsed time, plus the wait/download split when the body read
+// took a measurable slice. The breakdown helps separate a slow server (high
+// TTFB) from a large or slow transfer (high download time).
+function TimingSummary({ response }: TimingSummaryProps): ReactNode {
+	const showBreakdown = response.downloadMs > 0;
+	return (
+		<span
+			title={`Wait ${response.ttfbMs} ms · Download ${response.downloadMs} ms`}
+			className="font-mono"
+		>
+			{response.elapsedMs} ms
+			{showBreakdown ? (
+				<span className="ml-1 text-muted-foreground/70">
+					({response.ttfbMs} + {response.downloadMs})
+				</span>
+			) : null}
+		</span>
 	);
 }
 
@@ -1364,6 +1388,7 @@ function StatusBarContent({ response }: StatusBarContentProps): ReactNode {
 				variant={statusVariant}
 			/>
 			<StatItem label="Elapsed" value={`${response.elapsedMs} ms`} />
+			<StatItem label="TTFB" value={`${response.ttfbMs} ms`} />
 			<StatItem label="Size" value={formatBytes(response.bytesReceived)} />
 		</>
 	);

--- a/src/routes/rest-client.tsx
+++ b/src/routes/rest-client.tsx
@@ -33,6 +33,7 @@ import { Checkbox } from '@/lib/components/ui/checkbox';
 import { Input } from '@/lib/components/ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/lib/components/ui/tabs';
 import { Textarea } from '@/lib/components/ui/textarea';
+import { ToggleGroup, ToggleGroupItem } from '@/lib/components/ui/toggle-group';
 import { ToneBadge } from '@/lib/components/ui/tone-badge';
 import { useDocumentTitle } from '@/lib/hooks';
 import {
@@ -1111,7 +1112,7 @@ function ResponseTabs({ response, activeTab, onTabChange }: ResponseTabsProps) {
 			</TabsList>
 
 			<TabsContent value="body" className="pt-3">
-				<ResponseBody body={formattedBody} contentType={contentType} />
+				<ResponseBody raw={response.body} formatted={formattedBody} contentType={contentType} />
 			</TabsContent>
 
 			<TabsContent value="headers" className="pt-3">
@@ -1125,23 +1126,51 @@ function ResponseTabs({ response, activeTab, onTabChange }: ResponseTabsProps) {
 	);
 }
 
+type BodyView = 'pretty' | 'raw';
+
 interface ResponseBodyProps {
-	readonly body: string;
+	readonly raw: string;
+	readonly formatted: string;
 	readonly contentType: string | undefined;
 }
 
-function ResponseBody({ body, contentType }: ResponseBodyProps) {
+function ResponseBody({ raw, formatted, contentType }: ResponseBodyProps) {
+	const [view, setView] = useState<BodyView>('pretty');
+	// Offer the toggle only when pretty-printing actually changed the payload.
+	const canPretty = formatted !== raw;
+	const shown = canPretty && view === 'pretty' ? formatted : raw;
+
 	return (
 		<div className="space-y-2">
 			<div className="flex items-center justify-between gap-2">
 				<span className="font-mono text-xs text-muted-foreground">
 					{contentType ?? 'no content-type'}
 				</span>
-				<CopyButton text={body} toastLabel="Response body" size="sm" />
+				<div className="flex items-center gap-2">
+					{canPretty ? (
+						<ToggleGroup
+							type="single"
+							size="sm"
+							variant="outline"
+							value={view}
+							onValueChange={(v) => {
+								if (v === 'pretty' || v === 'raw') setView(v);
+							}}
+						>
+							<ToggleGroupItem value="pretty" className="text-xs">
+								Pretty
+							</ToggleGroupItem>
+							<ToggleGroupItem value="raw" className="text-xs">
+								Raw
+							</ToggleGroupItem>
+						</ToggleGroup>
+					) : null}
+					<CopyButton text={shown} toastLabel="Response body" size="sm" />
+				</div>
 			</div>
-			{body.length > 0 ? (
+			{shown.length > 0 ? (
 				<pre className="max-h-96 overflow-auto rounded-md bg-muted p-3 font-mono text-xs">
-					{body}
+					{shown}
 				</pre>
 			) : (
 				<p className="text-sm text-muted-foreground">Empty response body.</p>

--- a/src/routes/rest-client.tsx
+++ b/src/routes/rest-client.tsx
@@ -4,6 +4,7 @@ import {
 	ClipboardPaste,
 	Code2,
 	Cookie,
+	Download,
 	FileText,
 	FlaskConical,
 	Globe,
@@ -11,6 +12,7 @@ import {
 	Link2,
 	Loader2,
 	Plus,
+	Search,
 	Send,
 	Settings2,
 	Trash2,
@@ -53,6 +55,7 @@ import {
 	type AuthType,
 	type BodyMode,
 	buildUrlWithParams,
+	countMatches,
 	createEmptyHeader,
 	createHeaderId,
 	type CurlImport,
@@ -62,6 +65,7 @@ import {
 	formatBytes,
 	formatJson,
 	formatResponseBody,
+	type HighlightSegment,
 	HTTP_METHODS,
 	type HeaderEntry,
 	type HttpMethod,
@@ -73,7 +77,9 @@ import {
 	parseSetCookie,
 	type QueryParam,
 	resolveBody,
+	responseFilename,
 	type RestResponse,
+	splitHighlight,
 	validateJson,
 	withContentType,
 	SAMPLE_GET_URL,
@@ -88,6 +94,7 @@ import {
 } from '@/lib/services/rest-client';
 import { createToolOptionsStore } from '@/lib/stores';
 import { cn, getErrorMessage } from '@/lib/utils';
+import { downloadTextFile } from '@/lib/utils/file-operations';
 
 interface RestClientOptions {
 	readonly method: HttpMethod;
@@ -1275,9 +1282,17 @@ interface ResponseBodyProps {
 
 function ResponseBody({ raw, formatted, contentType }: ResponseBodyProps) {
 	const [view, setView] = useState<BodyView>('pretty');
+	const [query, setQuery] = useState('');
 	// Offer the toggle only when pretty-printing actually changed the payload.
 	const canPretty = formatted !== raw;
 	const shown = canPretty && view === 'pretty' ? formatted : raw;
+
+	const segments = useMemo(() => splitHighlight(shown, query), [shown, query]);
+	const matchCount = useMemo(() => countMatches(shown, query), [shown, query]);
+
+	const handleDownload = () => {
+		downloadTextFile(shown, responseFilename(contentType)).catch(() => undefined);
+	};
 
 	return (
 		<div className="space-y-2">
@@ -1304,18 +1319,69 @@ function ResponseBody({ raw, formatted, contentType }: ResponseBodyProps) {
 							</ToggleGroupItem>
 						</ToggleGroup>
 					) : null}
+					<Button
+						variant="ghost"
+						size="icon-sm"
+						className="h-8 w-8 text-muted-foreground"
+						onClick={handleDownload}
+						disabled={shown.length === 0}
+						aria-label="Download response body"
+					>
+						<Download className="h-3.5 w-3.5" />
+					</Button>
 					<CopyButton text={shown} toastLabel="Response body" size="sm" />
 				</div>
 			</div>
 			{shown.length > 0 ? (
-				<pre className="max-h-96 overflow-auto rounded-md bg-muted p-3 font-mono text-xs">
-					{shown}
-				</pre>
+				<>
+					<div className="relative">
+						<Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+						<Input
+							value={query}
+							placeholder="Search response body"
+							className="h-8 pl-8 font-mono text-xs"
+							onChange={(e) => setQuery(e.target.value)}
+						/>
+						{query.length > 0 ? (
+							<span className="absolute right-2.5 top-1/2 -translate-y-1/2 text-2xs text-muted-foreground">
+								{matchCount} {matchCount === 1 ? 'match' : 'matches'}
+							</span>
+						) : null}
+					</div>
+					<pre className="max-h-96 overflow-auto rounded-md bg-muted p-3 font-mono text-xs">
+						<HighlightedBody segments={segments} />
+					</pre>
+				</>
 			) : (
 				<p className="text-sm text-muted-foreground">Empty response body.</p>
 			)}
 		</div>
 	);
+}
+
+interface HighlightedBodyProps {
+	readonly segments: readonly HighlightSegment[];
+}
+
+// Render the body with matched runs wrapped in <mark>. A plain (empty-query)
+// body is a single non-match segment, so this collapses to a bare string. Keys
+// come from the running character offset (strictly increasing) so they stay
+// unique and stable without relying on the array index.
+function HighlightedBody({ segments }: HighlightedBodyProps): ReactNode {
+	return segments.reduce<{ readonly offset: number; readonly nodes: readonly ReactNode[] }>(
+		(acc, segment) => {
+			const key = `${acc.offset}:${segment.text.length}`;
+			const node = segment.match ? (
+				<mark key={key} className="rounded-[2px] bg-warning/40 text-foreground">
+					{segment.text}
+				</mark>
+			) : (
+				<span key={key}>{segment.text}</span>
+			);
+			return { offset: acc.offset + segment.text.length, nodes: [...acc.nodes, node] };
+		},
+		{ offset: 0, nodes: [] }
+	).nodes;
 }
 
 interface ResponseHeadersProps {

--- a/src/routes/rest-client.tsx
+++ b/src/routes/rest-client.tsx
@@ -140,6 +140,9 @@ function RestClientPage() {
 	const formFields = options.formFields ?? [];
 
 	const [response, setResponse] = useState<RestResponse | null>(null);
+	// The effective URL sent with the last request, captured so the response can
+	// flag a redirect by comparing it against the backend's `finalUrl`.
+	const [sentUrl, setSentUrl] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [sending, setSending] = useState(false);
 	const [requestTab, setRequestTab] = useState<RequestTab>('params');
@@ -283,8 +286,10 @@ function RestClientPage() {
 		if (!canSend) return;
 		setSending(true);
 		setError(null);
+		const request = buildEffectiveRequest();
+		setSentUrl(request.url);
 		try {
-			const res = await sendRequest(buildEffectiveRequest());
+			const res = await sendRequest(request);
 			setResponse(res);
 			setResponseTab('body');
 		} catch (e) {
@@ -362,6 +367,7 @@ function RestClientPage() {
 
 						<ResponseCard
 							response={response}
+							requestUrl={sentUrl}
 							activeTab={responseTab}
 							onTabChange={setResponseTab}
 						/>
@@ -1122,11 +1128,14 @@ function AuthEditor({ auth, onAuthChange }: AuthEditorProps) {
 
 interface ResponseCardProps {
 	readonly response: RestResponse | null;
+	readonly requestUrl: string | null;
 	readonly activeTab: ResponseTab;
 	readonly onTabChange: (tab: ResponseTab) => void;
 }
 
-function ResponseCard({ response, activeTab, onTabChange }: ResponseCardProps) {
+function ResponseCard({ response, requestUrl, activeTab, onTabChange }: ResponseCardProps) {
+	const redirected = response !== null && requestUrl !== null && response.finalUrl !== requestUrl;
+
 	return (
 		<Card density="compact">
 			<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
@@ -1145,7 +1154,8 @@ function ResponseCard({ response, activeTab, onTabChange }: ResponseCardProps) {
 					</div>
 				) : null}
 			</CardHeader>
-			<CardContent>
+			<CardContent className="space-y-3">
+				{redirected ? <RedirectNotice finalUrl={response.finalUrl} /> : null}
 				{response ? (
 					<ResponseTabs response={response} activeTab={activeTab} onTabChange={onTabChange} />
 				) : (
@@ -1157,6 +1167,22 @@ function ResponseCard({ response, activeTab, onTabChange }: ResponseCardProps) {
 				)}
 			</CardContent>
 		</Card>
+	);
+}
+
+interface RedirectNoticeProps {
+	readonly finalUrl: string;
+}
+
+// Surface the post-redirect destination so a 200 that silently moved (HTTPS
+// upgrade, trailing-slash, auth redirect) is not mistaken for a direct hit.
+function RedirectNotice({ finalUrl }: RedirectNoticeProps) {
+	return (
+		<div className="flex items-center gap-2 rounded-md border bg-info/10 px-3 py-2 text-xs">
+			<Link2 className="h-3.5 w-3.5 shrink-0 text-info" />
+			<span className="text-muted-foreground">Redirected to</span>
+			<span className="break-all font-mono text-foreground">{finalUrl}</span>
+		</div>
 	);
 }
 

--- a/src/routes/rest-client.tsx
+++ b/src/routes/rest-client.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useEffect, useMemo, useRef, useState, type ChangeEvent, type ReactNode } from 'react';
 import {
+	ClipboardPaste,
 	Code2,
 	Cookie,
 	FileText,
@@ -30,6 +31,15 @@ import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/lib/components/ui/card';
 import { Checkbox } from '@/lib/components/ui/checkbox';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from '@/lib/components/ui/dialog';
 import { Input } from '@/lib/components/ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/lib/components/ui/tabs';
 import { Textarea } from '@/lib/components/ui/textarea';
@@ -45,8 +55,10 @@ import {
 	buildUrlWithParams,
 	createEmptyHeader,
 	createHeaderId,
+	type CurlImport,
 	DEFAULT_AUTH,
 	exportAsCurl,
+	importCurl,
 	formatBytes,
 	formatJson,
 	formatResponseBody,
@@ -235,6 +247,24 @@ function RestClientPage() {
 		};
 	};
 
+	// Replace the whole request with the decoded cURL command. Auth and form
+	// fields reset so only the imported headers/body define the wire request,
+	// avoiding a stale credential folding in on top of the import.
+	const handleImportCurl = (imported: CurlImport) => {
+		patch({
+			method: imported.method,
+			url: imported.url,
+			headers: [...imported.headers],
+			auth: DEFAULT_AUTH,
+			bodyMode: imported.bodyMode,
+			body: imported.body,
+			formFields: [],
+			followRedirects: imported.followRedirects,
+			...(imported.timeoutMs !== null ? { timeoutMs: imported.timeoutMs } : {}),
+		});
+		setRequestTab(imported.bodyMode === 'none' ? 'headers' : 'body');
+	};
+
 	const handleCopyCurl = async () => {
 		if (!url.trim()) {
 			toast.error('Enter a URL first');
@@ -276,6 +306,7 @@ function RestClientPage() {
 			onLoadGetSample={handleLoadGetSample}
 			onLoadPostSample={handleLoadPostSample}
 			onCopyCurl={handleCopyCurl}
+			onImportCurl={handleImportCurl}
 		/>
 	);
 
@@ -351,6 +382,7 @@ interface RestClientRailProps {
 	readonly onLoadGetSample: () => void;
 	readonly onLoadPostSample: () => void;
 	readonly onCopyCurl: () => void;
+	readonly onImportCurl: (imported: CurlImport) => void;
 }
 
 function RestClientRail({
@@ -363,6 +395,7 @@ function RestClientRail({
 	onLoadGetSample,
 	onLoadPostSample,
 	onCopyCurl,
+	onImportCurl,
 }: RestClientRailProps) {
 	return (
 		<>
@@ -409,6 +442,10 @@ function RestClientRail({
 				</Button>
 			</FormSection>
 
+			<FormSection title="Import">
+				<ImportCurlDialog onImport={onImportCurl} />
+			</FormSection>
+
 			<FormSection title="Export">
 				<Button variant="outline" size="sm" className="w-full" onClick={onCopyCurl}>
 					<Code2 className="h-3.5 w-3.5" />
@@ -452,6 +489,58 @@ function SendButtonContent({ sending, label }: SendButtonContentProps) {
 			<Send className="h-4 w-4" />
 			{label}
 		</>
+	);
+}
+
+interface ImportCurlDialogProps {
+	readonly onImport: (imported: CurlImport) => void;
+}
+
+function ImportCurlDialog({ onImport }: ImportCurlDialogProps) {
+	const [open, setOpen] = useState(false);
+	const [text, setText] = useState('');
+
+	const handleImport = () => {
+		const result = importCurl(text);
+		if (!result.ok) {
+			toast.error('Could not parse cURL', { description: result.error });
+			return;
+		}
+		onImport(result.value);
+		toast.success('Imported cURL command');
+		setText('');
+		setOpen(false);
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<Button variant="outline" size="sm" className="w-full">
+					<ClipboardPaste className="h-3.5 w-3.5" />
+					Import cURL
+				</Button>
+			</DialogTrigger>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Import cURL command</DialogTitle>
+					<DialogDescription>
+						Paste a cURL command to populate the method, URL, headers, and body.
+					</DialogDescription>
+				</DialogHeader>
+				<Textarea
+					value={text}
+					placeholder="curl 'https://example.com/api' -H 'Accept: application/json'"
+					rows={8}
+					className="font-mono text-xs"
+					onChange={(e) => setText(e.target.value)}
+				/>
+				<DialogFooter>
+					<Button onClick={handleImport} disabled={text.trim().length === 0}>
+						Import
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
 	);
 }
 

--- a/src/routes/rest-client.tsx
+++ b/src/routes/rest-client.tsx
@@ -92,21 +92,18 @@ import {
 	TIMEOUT_MIN_MS,
 	TIMEOUT_STEP_MS,
 } from '@/lib/services/rest-client';
-import { createToolOptionsStore } from '@/lib/stores';
+import {
+	createToolOptionsStore,
+	type HistoryEntry,
+	type RequestSnapshot,
+	useRestClientHistory,
+} from '@/lib/stores';
 import { cn, getErrorMessage } from '@/lib/utils';
 import { downloadTextFile } from '@/lib/utils/file-operations';
 
-interface RestClientOptions {
-	readonly method: HttpMethod;
-	readonly url: string;
-	readonly headers: readonly HeaderEntry[];
-	readonly auth: AuthConfig;
-	readonly bodyMode: BodyMode;
-	readonly body: string;
-	readonly formFields: readonly HeaderEntry[];
-	readonly followRedirects: boolean;
-	readonly timeoutMs: number;
-}
+// The persisted options bag is exactly a restorable request snapshot, so the
+// history store and the editor share one shape.
+type RestClientOptions = RequestSnapshot;
 
 const DEFAULT_HEADERS: readonly HeaderEntry[] = [
 	{ id: 'hdr_default_accept', key: 'Accept', value: '*/*', enabled: true },
@@ -136,7 +133,8 @@ type RequestTab = 'params' | 'auth' | 'headers' | 'body';
 type ResponseTab = 'body' | 'headers' | 'cookies';
 
 function RestClientPage() {
-	const { value: options, patch } = useRestClientOptions();
+	const { value: options, patch, set } = useRestClientOptions();
+	const recordHistory = useRestClientHistory((s) => s.record);
 	const { method, url, headers, body, followRedirects, timeoutMs } = options;
 	// `auth`, `bodyMode`, and `formFields` were added after the options store
 	// shipped; persisted state from before that lacks the fields, so fall back to
@@ -295,16 +293,33 @@ function RestClientPage() {
 		setError(null);
 		const request = buildEffectiveRequest();
 		setSentUrl(request.url);
+		// Snapshot the editor state (with resolved fallbacks) so a restored
+		// history entry reproduces the exact form, not the auth-folded wire URL.
+		const snapshot: RequestSnapshot = { ...options, auth, bodyMode, formFields };
 		try {
 			const res = await sendRequest(request);
 			setResponse(res);
 			setResponseTab('body');
+			recordHistory(snapshot, {
+				status: res.status,
+				statusText: res.statusText,
+				elapsedMs: res.elapsedMs,
+			});
 		} catch (e) {
 			setError(getErrorMessage(e));
 			setResponse(null);
 		} finally {
 			setSending(false);
 		}
+	};
+
+	// Restore a past request into the editor. Clearing the error and response
+	// avoids showing a stale outcome next to the freshly loaded request.
+	const handleRestoreHistory = (entry: HistoryEntry) => {
+		set(entry.request);
+		setError(null);
+		setResponse(null);
+		setRequestTab(entry.request.bodyMode === 'none' ? 'params' : 'body');
 	};
 
 	const rail = (
@@ -319,6 +334,7 @@ function RestClientPage() {
 			onLoadPostSample={handleLoadPostSample}
 			onCopyCurl={handleCopyCurl}
 			onImportCurl={handleImportCurl}
+			onRestoreHistory={handleRestoreHistory}
 		/>
 	);
 
@@ -396,6 +412,7 @@ interface RestClientRailProps {
 	readonly onLoadPostSample: () => void;
 	readonly onCopyCurl: () => void;
 	readonly onImportCurl: (imported: CurlImport) => void;
+	readonly onRestoreHistory: (entry: HistoryEntry) => void;
 }
 
 function RestClientRail({
@@ -409,6 +426,7 @@ function RestClientRail({
 	onLoadPostSample,
 	onCopyCurl,
 	onImportCurl,
+	onRestoreHistory,
 }: RestClientRailProps) {
 	return (
 		<>
@@ -464,6 +482,10 @@ function RestClientRail({
 					<Code2 className="h-3.5 w-3.5" />
 					Copy as cURL
 				</Button>
+			</FormSection>
+
+			<FormSection title="History">
+				<HistoryPanel onRestore={onRestoreHistory} />
 			</FormSection>
 
 			<ToolFooter
@@ -554,6 +576,81 @@ function ImportCurlDialog({ onImport }: ImportCurlDialogProps) {
 				</DialogFooter>
 			</DialogContent>
 		</Dialog>
+	);
+}
+
+const METHOD_CLASS: Record<HttpMethod, string> = {
+	GET: 'text-info',
+	POST: 'text-success',
+	PUT: 'text-warning',
+	PATCH: 'text-warning',
+	DELETE: 'text-destructive',
+	HEAD: 'text-muted-foreground',
+	OPTIONS: 'text-muted-foreground',
+};
+
+// Compact relative time for the history list; falls back to a date once an
+// entry is older than a day so the label stays meaningful across sessions.
+function formatTimeAgo(at: number): string {
+	const seconds = Math.round((Date.now() - at) / 1000);
+	if (seconds < 60) return 'just now';
+	if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+	if (seconds < 86_400) return `${Math.floor(seconds / 3600)}h ago`;
+	return new Date(at).toLocaleDateString();
+}
+
+interface HistoryPanelProps {
+	readonly onRestore: (entry: HistoryEntry) => void;
+}
+
+function HistoryPanel({ onRestore }: HistoryPanelProps) {
+	const entries = useRestClientHistory((s) => s.entries);
+	const remove = useRestClientHistory((s) => s.remove);
+	const clear = useRestClientHistory((s) => s.clear);
+
+	if (entries.length === 0) {
+		return <p className="text-xs text-muted-foreground">Sent requests appear here.</p>;
+	}
+
+	return (
+		<div className="space-y-1.5">
+			{entries.map((entry) => (
+				<div key={entry.id} className="group flex items-center gap-1">
+					<button
+						type="button"
+						className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-accent"
+						onClick={() => onRestore(entry)}
+						title={`${entry.request.method} ${entry.request.url} — ${entry.status} ${entry.statusText} · ${entry.elapsedMs} ms · ${formatTimeAgo(entry.at)}`}
+					>
+						<span
+							className={cn(
+								'w-10 shrink-0 font-mono text-2xs font-medium',
+								METHOD_CLASS[entry.request.method]
+							)}
+						>
+							{entry.request.method}
+						</span>
+						<span className="min-w-0 flex-1 truncate font-mono text-xs">{entry.request.url}</span>
+						<ToneBadge tone={statusTone(entry.status)} className="shrink-0 font-mono text-2xs">
+							{entry.status}
+						</ToneBadge>
+					</button>
+					<Button
+						variant="ghost"
+						size="icon-sm"
+						className="h-7 w-7 shrink-0 text-muted-foreground opacity-0 hover:text-destructive group-hover:opacity-100"
+						onClick={() => remove(entry.id)}
+						aria-label="Remove from history"
+					>
+						<Trash2 className="h-3.5 w-3.5" />
+					</Button>
+				</div>
+			))}
+			<Button variant="outline" size="sm" className="w-full" onClick={clear}>
+				<Trash2 className="h-3.5 w-3.5" />
+				Clear history
+			</Button>
+		</div>
 	);
 }
 


### PR DESCRIPTION
## Summary

Enrich the HTTP REST Client across the request and response lifecycle.

- Import a request from a `curl` command, and toggle the response body between pretty and raw
- Pretty-print XML responses, flag redirects, and report a TTFB/download timing breakdown
- Search and download the response body, and keep a restorable history of sent requests

## Changes

### Added

- `importCurl` / `restRequestFromCurl` in `rest-client.ts` — parse a `curl` command into a request, upgrading the body mode to `json` when a JSON content-type header is present and clamping `--max-time` to the timeout bounds
- `formatResponseBody` with JSON/XML content-type detection; XML uses `formatXml` with a plain-text fallback
- `splitHighlight` / `countMatches` / `responseFilename` for in-response search and download
- `useRestClientHistory` Zustand store (persisted, capped at 20 entries) and a `RequestSnapshot` type shared with the route options bag
- `ttfb_ms` / `download_ms` on the Rust `RestResponse`, captured at the `send()`/`bytes()` boundary
- Route UI: `ImportCurlDialog`, `TimingSummary`, `RedirectNotice`, `HighlightedBody`, `HistoryPanel`

### Changed

- `RestClientOptions` is now an alias of `RequestSnapshot`, so persisted options and restorable history entries share one type
- `handleSend` builds the request once and records a history entry on success

## Test Plan

- [x] `bun run check` — TypeScript + validate-pages + audit-design pass
- [x] `bun run test` — 221 tests pass (6 files); new service-layer coverage for cURL import, response formatting, search, and filename
- [x] `bun run format:check` — Prettier clean
- [x] Biome lint — no warnings on changed files
- [x] `cargo clippy` — clean

https://claude.ai/code/session_01Kgm7jDnL2Q6nLPRpfcewQ9
