### PR TITLE
fix(tauri): replace assert! with assert_eq! in hash_batch test

### DIFF
--- a/src-tauri/src/hash_batch.rs
+++ b/src-tauri/src/hash_batch.rs
@@ -286,7 +286,7 @@ mod tests {
             res[0].hashes.get("sha256").unwrap(),
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
         );
-        assert!(res[0].hashes.get("sha512").unwrap().len() == 128);
+        assert_eq!(res[0].hashes.get("sha512").unwrap().len(), 128);
         assert_eq!(res[0].size_bytes, 3);
     }
 


### PR DESCRIPTION
## Summary

- Fix the Clippy `manual_assert_eq` error that blocks every open pull request
- Align the assertion with the project Rust testing guidelines

## Changes

### Fixed

- `src-tauri/src/hash_batch.rs`: replaced `assert!(... .len() == 128)` with `assert_eq!(... .len(), 128)`

## Background

Clippy 1.97 (released 2026-07-14) added the `manual_assert_eq` lint. The CI
clippy step runs with `-D warnings`, so the lint became a hard error:

```
error: used `assert!` with an equality comparison
   --> src/hash_batch.rs:289:9
    = note: `-D clippy::manual-assert-eq` implied by `-D warnings`
```

The default branch has had no CI run since 2026-07-05, so the breakage first
surfaced on the open dependency update pull requests. All 11 of them fail the
required `Test Backend` check for this single reason, and none of them touch
this file.

Only the `ubuntu-latest` matrix leg reports the failure because `fmt` and
`clippy` are gated on that leg; the compile itself succeeds everywhere.

## Test Plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes locally (Rust 1.97.1, same version as CI)
- [x] `cargo test --lib hash_batch` passes (5 passed, 0 failed)