### PR TITLE
chore(deps): remove deprecated @types/uuid stub

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -93,7 +93,6 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@types/semver": "^7.7.1",
-        "@types/uuid": "^11.0.0",
         "@vitejs/plugin-react": "^6.0.2",
         "bun-types": "^1.3.14",
         "clsx": "^2.1.1",
@@ -802,8 +801,6 @@
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
-
-    "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
 
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
 

--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
 		"@types/semver": "^7.7.1",
-		"@types/uuid": "^11.0.0",
 		"@vitejs/plugin-react": "^6.0.2",
 		"bun-types": "^1.3.14",
 		"clsx": "^2.1.1",


### PR DESCRIPTION
## Summary

- Remove `@types/uuid`, a deprecated stub package that `uuid` v14 makes redundant.

## Background

npm reports `@types/uuid@11.0.0` as deprecated with the message "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed." Renovate lists it under **Deprecations / Replacements** on the dependency dashboard.

`src/lib/services/uuid.ts` imports `NIL`, `v1`, `v3`, `v4`, `v5`, `v7`, `validate` and `version` from `uuid`. All of those resolve through the type definitions bundled with `uuid` v14.

## Changes

- `package.json`: remove `@types/uuid` from `devDependencies`.
- `bun.lock`: regenerate.

## Test Plan

- `bun run check` — includes `tsc --noEmit`, which is the check that would fail if the removed types were still required.
- `bun run lint`
- `bun run test`

## Checklist

- [x] Type check and validators pass (`bun run check`)
- [x] Lint passes (`bun run lint`)
- [x] Unit tests pass (`bun run test` — 221 tests, 6 files)